### PR TITLE
fix: document psutil for no-build-isolation installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 
 ```bash
 # Install (requires an existing Linux + NVIDIA GPU + CUDA + PyTorch >= 2.6 env)
+pip install psutil                         # required with --no-build-isolation
 pip install -e . --no-build-isolation         # --no-build-isolation: build against your installed torch
 pip install flash-attn flash-linear-attention
 ARENO_BUILD_EXT=0 pip install -e . --no-build-isolation   # skip CUDA build (metadata-only / dry run)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,7 @@ Follow these steps:
    + PyTorch already present):
 
    ```bash
+   pip install psutil
    pip install -e . --no-build-isolation
    pip install flash-attn flash-linear-attention pytest
    ```

--- a/README.md
+++ b/README.md
@@ -49,17 +49,20 @@ AReno's mission is to make LLM RL **accessible** for a broad community of resear
 **To install:**
 
 ```bash
+pip install psutil
 pip install areno --no-build-isolation
 pip install flash-attn flash-linear-attention
 ```
 
 `--no-build-isolation` is required so that pip uses your existing CUDA-enabled PyTorch instead of installing a CPU-only torch in an isolated build environment.
+Because build isolation is disabled, build-time helpers are not installed automatically; `psutil` must already be present because PyTorch's CUDA extension builder imports it while sizing parallel compile jobs.
 
 **From source** (recommended if you want the examples or plan to contribute):
 
 ```bash
 git clone https://github.com/inclusionAI/asystem-areno.git
 cd asystem-areno
+pip install psutil
 pip install -e . --no-build-isolation
 pip install flash-attn flash-linear-attention
 ```
@@ -67,6 +70,7 @@ pip install flash-attn flash-linear-attention
 **Tips:**
 
 - Install `ninja` (`pip install ninja`) before building. With ninja, the CUDA kernels compile in parallel (a few minutes); Without it, compilation falls back to a single core and is much slower.
+- If installation fails with `No module named 'psutil'`, install it first (`pip install psutil`) and retry. This is required specifically for `--no-build-isolation` builds.
 - Compiling the CUDA kernels takes a few minutes. If your machine has many CPU cores but limited RAM, cap the parallel build jobs with `MAX_JOBS`:
   ```bash
   MAX_JOBS=4 pip install -e . --no-build-isolation
@@ -238,6 +242,7 @@ If you want to contribute to AReno or customize it for your own needs, read the 
 ```bash
 git clone https://github.com/inclusionAI/asystem-areno.git
 cd asystem-areno
+pip install psutil
 pip install -e . --no-build-isolation
 ```
 

--- a/docs/getting-started/build.rst
+++ b/docs/getting-started/build.rst
@@ -46,10 +46,14 @@ the repository root:
 
 .. code-block:: bash
 
+   pip install psutil
    pip install -e . --no-build-isolation
    pip install flash-attn flash-linear-attention
 
 .. note::
 
-   ``flash-attn``, CUDA, and PyTorch must be ABI compatible. The editable
-   install builds the ``areno_accel`` CUDA extension used by local kernels.
+   ``--no-build-isolation`` uses the packages already installed in your
+   environment. Install ``psutil`` first because PyTorch's CUDA extension
+   builder imports it while sizing parallel compile jobs. ``flash-attn``,
+   CUDA, and PyTorch must be ABI compatible. The editable install builds the
+   ``areno_accel`` CUDA extension used by local kernels.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Install in an existing CUDA + PyTorch environment:
 
 .. code-block:: bash
 
+   pip install psutil
    pip install -e . --no-build-isolation
    pip install flash-attn flash-linear-attention
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,17 @@ def _cuda_extensions():
     mode = os.environ.get("ARENO_BUILD_EXT", "1").lower()
     if mode in {"0", "false", "no", "off"}:
         return [], {}
+    try:
+        import psutil  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "building areno.accel requires psutil to be installed before running "
+            "`pip install ... --no-build-isolation`. PyTorch's CUDA extension "
+            "builder imports psutil to size parallel compile jobs, and build "
+            "isolation is disabled so pip will not install build-time dependencies "
+            "for you. Fix: run `pip install psutil` in this environment, then "
+            "retry the AReno install."
+        ) from exc
     from torch.utils.cpp_extension import CUDA_HOME, BuildExtension, CUDAExtension
 
     if CUDA_HOME is None:


### PR DESCRIPTION
## Summary
- fail early with an actionable psutil error before importing PyTorch CUDA extension helpers
- document psutil as a required preinstall for --no-build-isolation install paths
- update README, docs, and contributor setup snippets

## Validation
- python -m py_compile setup.py
- simulated missing psutil and verified the RuntimeError explains why psutil is needed and how to fix it

Fixes #1