### PR TITLE
Add pull request unit test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             pydantic \
             click \
             fastapi \
+            openai \
             uvicorn \
             safetensors \
             transformers \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    name: unittest
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ARENO_CHECK_TOKEN_IDS: "1"
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install CPU test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade \
+            pytest \
+            psutil \
+            numpy \
+            pydantic \
+            click \
+            fastapi \
+            uvicorn \
+            safetensors \
+            transformers \
+            huggingface-hub \
+            datasets \
+            tensorboard \
+            tqdm
+          python -m pip install --upgrade "torch>=2.6" --index-url https://download.pytorch.org/whl/cpu
+          ARENO_BUILD_EXT=0 python -m pip install -e . --no-build-isolation --no-deps
+
+      - name: Run unit tests
+        run: python -m pytest tests/ -k cpu


### PR DESCRIPTION
## Summary
- add a CI workflow for pull requests targeting main
- run the full CPU unit test suite with pytest tests/ -k cpu
- install CPU torch>=2.6 and the Python dependencies needed by the tests
- disable third-party pytest plugin autoload and enable token id guard checks for deterministic CI

## Validation
- conda run -n share env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ARENO_CHECK_TOKEN_IDS=1 python -m pytest tests/ -k cpu
- 169 passed, 5 warnings

## Required check note
The workflow exposes a stable required-check candidate named unittest. I attempted to inspect/configure main branch protection, but GitHub returned HTTP 403 because branch protection for this private repository requires GitHub Pro or making the repository public.