### PR TITLE
fix: target visible CUDA architectures during source builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 pip install psutil                         # required with --no-build-isolation
 pip install flash-attn flash-linear-attention
 pip install -e . --no-build-isolation         # --no-build-isolation: build against your installed torch
+TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation  # target H100/H200 only
 ARENO_BUILD_EXT=0 pip install -e . --no-build-isolation   # skip CUDA build (metadata-only / dry run)
 
 # Train -- swap algorithm with --algo: sft | dpo | gspo | grpo | ppo
@@ -116,7 +117,7 @@ ______________________________________________________________________
 
 **Typing & imports**: explicit type hints; no wildcard imports; keep heavy optional deps imported inside functions.
 
-**Kernels**: when editing CUDA in `areno/accel/csrc/`, keep the `.cu` source and its Python wrapper in sync and rebuild with `pip install -e . --no-build-isolation`.
+**Kernels**: when editing CUDA in `areno/accel/csrc/`, keep the `.cu` source and its Python wrapper in sync and rebuild with `pip install -e . --no-build-isolation`. Source builds default to visible GPU architectures; set `TORCH_CUDA_ARCH_LIST` explicitly when cross-building or narrowing targets. For iterative kernel work, enable `ccache` with `CC="ccache gcc"` and `CXX="ccache g++"`.
 
 ______________________________________________________________________
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,14 @@ Follow these steps:
    pip install pytest
    ```
 
+   Source builds default to the visible GPU architecture. Set
+   `TORCH_CUDA_ARCH_LIST` explicitly when cross-building or narrowing targets,
+   for example:
+
+   ```bash
+   TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
+   ```
+
 4. Develop on your branch. Keep changes surgical — touch only what the task
    requires and match the surrounding style.
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,21 @@ pip install -e . --no-build-isolation
 
 **Tips:**
 
-- Install `ninja` (`pip install ninja`) before building. With ninja, the CUDA kernels compile in parallel (a few minutes); Without it, compilation falls back to a single core and is much slower.
+- Install `ninja` (`pip install ninja`) before building so CUDA kernels compile in parallel.
 - If installation fails with `No module named 'psutil'`, install it first (`pip install psutil`) and retry. This is required specifically for `--no-build-isolation` builds.
 - Install `flash-attn` before AReno so the local build can reuse the already-installed package. If building `flash-attn` from source is too slow for your environment, install a pre-built wheel from the [flash-attention releases](https://github.com/Dao-AILab/flash-attention/releases) that matches your Python, PyTorch, CUDA, and platform.
-- Compiling the CUDA kernels takes a few minutes. If your machine has many CPU cores but limited RAM, cap the parallel build jobs with `MAX_JOBS`:
+- By default, source builds target the visible GPU architecture. To build for a specific GPU family or when building on a host where the target GPU is not visible, set `TORCH_CUDA_ARCH_LIST` explicitly. Common values are `9.0` for H100/H200, `8.0` for A100, and `8.9` for L40/RTX 4090:
+  ```bash
+  TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
+  ```
+- If your machine has many CPU cores but limited RAM, cap the parallel build jobs with `MAX_JOBS`:
   ```bash
   MAX_JOBS=4 pip install -e . --no-build-isolation
+  ```
+- For iterative CUDA development, enable `ccache` before rebuilding:
+  ```bash
+  export CC="ccache gcc"
+  export CXX="ccache g++"
   ```
 - To install the Python package without building the CUDA extension (for docs/metadata or a dry run), set `ARENO_BUILD_EXT=0`. The engine will not run without the extension, but the installation will succeed.
 

--- a/docs/getting-started/build.rst
+++ b/docs/getting-started/build.rst
@@ -62,3 +62,14 @@ the repository root:
    slow for your environment, install a pre-built wheel from the
    `flash-attention releases <https://github.com/Dao-AILab/flash-attention/releases>`_
    that matches your Python, PyTorch, CUDA, and platform.
+   When ``TORCH_CUDA_ARCH_LIST`` is not set, AReno targets the visible GPU
+   architectures. Set it explicitly when cross-building or narrowing the build
+   target. Common values include ``9.0`` for H100/H200, ``8.0`` for A100, and
+   ``8.9`` for L40/RTX 4090:
+
+   .. code-block:: bash
+
+      TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
+
+   For iterative CUDA work, configure ``ccache`` with ``CC="ccache gcc"`` and
+   ``CXX="ccache g++"`` before rebuilding.

--- a/setup.py
+++ b/setup.py
@@ -72,9 +72,12 @@ def _set_default_cuda_arch_list() -> None:
     if not torch.cuda.is_available():
         return
     archs: set[str] = set()
-    for idx in range(torch.cuda.device_count()):
-        major, minor = torch.cuda.get_device_capability(idx)
-        archs.add(f"{major}.{minor}")
+    try:
+        for idx in range(torch.cuda.device_count()):
+            major, minor = torch.cuda.get_device_capability(idx)
+            archs.add(f"{major}.{minor}")
+    except Exception:
+        return
     if not archs:
         return
     arch_list = ";".join(sorted(archs))

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import warnings
 
 from setuptools import setup
 
@@ -29,6 +30,7 @@ def _cuda_extensions():
             "for you. Fix: run `pip install psutil` in this environment, then "
             "retry the AReno install."
         ) from exc
+    _set_default_cuda_arch_list()
     from torch.utils.cpp_extension import CUDA_HOME, BuildExtension, CUDAExtension
 
     if CUDA_HOME is None:
@@ -56,6 +58,34 @@ def _cuda_extensions():
             },
         )
     ], {"build_ext": BuildExtension}
+
+
+def _set_default_cuda_arch_list() -> None:
+    """Default CUDA extension builds to the visible GPU architectures."""
+
+    if os.environ.get("TORCH_CUDA_ARCH_LIST"):
+        return
+    try:
+        import torch
+    except ImportError:
+        return
+    if not torch.cuda.is_available():
+        return
+    archs: set[str] = set()
+    for idx in range(torch.cuda.device_count()):
+        major, minor = torch.cuda.get_device_capability(idx)
+        archs.add(f"{major}.{minor}")
+    if not archs:
+        return
+    arch_list = ";".join(sorted(archs))
+    os.environ["TORCH_CUDA_ARCH_LIST"] = arch_list
+    warnings.warn(
+        "TORCH_CUDA_ARCH_LIST is not set; building areno.accel only for "
+        f"visible CUDA architecture(s): {arch_list}. Set TORCH_CUDA_ARCH_LIST "
+        "explicitly to build for other GPUs.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 ext_modules, cmdclass = _cuda_extensions()


### PR DESCRIPTION
## Summary
- default CUDA extension builds to visible GPU architectures when TORCH_CUDA_ARCH_LIST is not set
- preserve explicit TORCH_CUDA_ARCH_LIST overrides for cross-builds or broader targets
- document arch-specific build commands and ccache usage in README, AGENTS, CONTRIBUTING, and build docs

## Validation
- python -m py_compile setup.py
- sanity-tested CUDA arch auto-detection with fake visible devices
- verified touched docs do not mention concrete build-time numbers

Fixes #2