### PR TITLE
docs: install flash attention dependencies first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 ```bash
 # Install (requires an existing Linux + NVIDIA GPU + CUDA + PyTorch >= 2.6 env)
 pip install psutil                         # required with --no-build-isolation
-pip install -e . --no-build-isolation         # --no-build-isolation: build against your installed torch
 pip install flash-attn flash-linear-attention
+pip install -e . --no-build-isolation         # --no-build-isolation: build against your installed torch
 ARENO_BUILD_EXT=0 pip install -e . --no-build-isolation   # skip CUDA build (metadata-only / dry run)
 
 # Train -- swap algorithm with --algo: sft | dpo | gspo | grpo | ppo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,9 @@ Follow these steps:
 
    ```bash
    pip install psutil
+   pip install flash-attn flash-linear-attention
    pip install -e . --no-build-isolation
-   pip install flash-attn flash-linear-attention pytest
+   pip install pytest
    ```
 
 4. Develop on your branch. Keep changes surgical — touch only what the task

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ AReno's mission is to make LLM RL **accessible** for a broad community of resear
 
 ```bash
 pip install psutil
-pip install areno --no-build-isolation
 pip install flash-attn flash-linear-attention
+pip install areno --no-build-isolation
 ```
 
 `--no-build-isolation` is required so that pip uses your existing CUDA-enabled PyTorch instead of installing a CPU-only torch in an isolated build environment.
@@ -63,14 +63,15 @@ Because build isolation is disabled, build-time helpers are not installed automa
 git clone https://github.com/inclusionAI/asystem-areno.git
 cd asystem-areno
 pip install psutil
-pip install -e . --no-build-isolation
 pip install flash-attn flash-linear-attention
+pip install -e . --no-build-isolation
 ```
 
 **Tips:**
 
 - Install `ninja` (`pip install ninja`) before building. With ninja, the CUDA kernels compile in parallel (a few minutes); Without it, compilation falls back to a single core and is much slower.
 - If installation fails with `No module named 'psutil'`, install it first (`pip install psutil`) and retry. This is required specifically for `--no-build-isolation` builds.
+- Install `flash-attn` before AReno so the local build can reuse the already-installed package. If building `flash-attn` from source is too slow for your environment, install a pre-built wheel from the [flash-attention releases](https://github.com/Dao-AILab/flash-attention/releases) that matches your Python, PyTorch, CUDA, and platform.
 - Compiling the CUDA kernels takes a few minutes. If your machine has many CPU cores but limited RAM, cap the parallel build jobs with `MAX_JOBS`:
   ```bash
   MAX_JOBS=4 pip install -e . --no-build-isolation
@@ -243,6 +244,7 @@ If you want to contribute to AReno or customize it for your own needs, read the 
 git clone https://github.com/inclusionAI/asystem-areno.git
 cd asystem-areno
 pip install psutil
+pip install flash-attn flash-linear-attention
 pip install -e . --no-build-isolation
 ```
 

--- a/docs/getting-started/build.rst
+++ b/docs/getting-started/build.rst
@@ -47,8 +47,8 @@ the repository root:
 .. code-block:: bash
 
    pip install psutil
-   pip install -e . --no-build-isolation
    pip install flash-attn flash-linear-attention
+   pip install -e . --no-build-isolation
 
 .. note::
 
@@ -57,3 +57,8 @@ the repository root:
    builder imports it while sizing parallel compile jobs. ``flash-attn``,
    CUDA, and PyTorch must be ABI compatible. The editable install builds the
    ``areno_accel`` CUDA extension used by local kernels.
+   Install ``flash-attn`` before AReno so the local build can reuse the
+   already-installed package. If building ``flash-attn`` from source is too
+   slow for your environment, install a pre-built wheel from the
+   `flash-attention releases <https://github.com/Dao-AILab/flash-attention/releases>`_
+   that matches your Python, PyTorch, CUDA, and platform.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,8 +34,8 @@ Install in an existing CUDA + PyTorch environment:
 .. code-block:: bash
 
    pip install psutil
-   pip install -e . --no-build-isolation
    pip install flash-attn flash-linear-attention
+   pip install -e . --no-build-isolation
 
 Run GSPO on a GSM8K-style dataset:
 


### PR DESCRIPTION
## Summary
- move flash-attn and flash-linear-attention installation before AReno source/package install examples
- document that flash-attn should be installed before AReno so local builds can reuse it
- point users to flash-attention release wheels when source builds are too slow for their environment

## Validation
- git diff --check