### PR TITLE
docs: add training smoke sanity path

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ You can use the AReno Command Line Interface (CLI) to quickly get started with p
 
 ### Training
 
+#### Tiny training smoke test
+
+Use this command when you only want to check that a machine can run one small official training task end to end:
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path gsm8k:main \
+  --dataset-loader-fn examples/math/dataset_loader.py \
+  --reward-fn-path examples/math/math_verify_reward.py \
+  --algo gspo \
+  --tp-size 1 \
+  --world-size 1 \
+  --batch-size 1
+```
+
+This is a smoke/sanity task for the CLI, dataset loader, reward function, rollout, and training-step wiring. It is not a quality benchmark. It requires a CUDA-capable NVIDIA GPU; CPU-only machines can install the package for docs and metadata checks, but cannot run the AReno training engine. A successful run should reach rollout logs and a `train_stats=...` line without raising an exception.
+
 Run GSPO on a GSM8K-style dataset with a reward function:
 
 ```bash

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -290,6 +290,27 @@ PPO
 Examples
 --------
 
+Tiny training smoke test
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this command when you only want to check that a machine can run one small
+official training task end to end:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 1
+
+This verifies the training wiring; it is not intended to measure final model
+quality.
+
 GSPO math training
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,24 @@ Install in an existing CUDA + PyTorch environment:
    pip install flash-attn flash-linear-attention
    pip install -e . --no-build-isolation
 
+Run a tiny training smoke test when you only want to verify the wiring:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 1
+
+This is a smoke/sanity task for wiring, not a quality benchmark. It requires a
+CUDA-capable NVIDIA GPU; CPU-only machines cannot run the AReno training
+engine.
+
 Run GSPO on a GSM8K-style dataset:
 
 .. code-block:: bash


### PR DESCRIPTION
## Summary
- add a tiny GSM8K/Qwen3-0.6B training smoke command to README and docs
- mark the path as a sanity check rather than a quality benchmark
- document CUDA GPU requirement and CPU-only limitation

Closes #12