### PR TITLE
feat: add setup diagnostics commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ pip install areno --no-build-isolation
 `--no-build-isolation` is required so that pip uses your existing CUDA-enabled PyTorch instead of installing a CPU-only torch in an isolated build environment.
 Because build isolation is disabled, build-time helpers are not installed automatically; `psutil` must already be present because PyTorch's CUDA extension builder imports it while sizing parallel compile jobs.
 
+After installation, run `areno check` for an actionable readiness check. Use
+`areno env --json` when opening an issue so maintainers can see the Python,
+CUDA, PyTorch, GPU, and extension state without guessing from low-level build
+errors.
+
 **From source** (recommended if you want the examples or plan to contribute):
 
 ```bash
@@ -191,6 +196,24 @@ See the documentation for the full `Trainer` API.
 ## Command Line Interface (CLI)
 
 You can use the AReno Command Line Interface (CLI) to quickly get started with post-training without writing any Python.
+
+### Diagnostics
+
+Check whether the current machine is ready to run AReno:
+
+```bash
+areno check
+```
+
+`areno check` prints `OK`, `WARN`, and `FAIL` statuses with concrete next steps for common setup issues such as missing CUDA, CPU-only PyTorch, missing `CUDA_HOME`, unavailable `nvcc`, missing optional runtime dependencies, or a missing `areno_accel` extension.
+
+For issue reports, collect a descriptive environment report:
+
+```bash
+areno env --json
+```
+
+The report includes AReno, Python, platform, PyTorch/CUDA, GPU, `nvcc`, dependency import status, and relevant environment variables.
 
 ### Training
 

--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -1,0 +1,463 @@
+"""Setup diagnostics for the AReno command line.
+
+These commands intentionally avoid importing AReno engine/model modules. They
+only inspect the Python environment, optional dependencies, CUDA toolchain, and
+the compiled extension importability.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from importlib import import_module
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any
+
+import click
+
+_ENV_VARS = (
+    "CUDA_HOME",
+    "CUDA_PATH",
+    "CUDA_VISIBLE_DEVICES",
+    "MAX_JOBS",
+    "TORCH_CUDA_ARCH_LIST",
+    "ARENO_BUILD_EXT",
+    "HF_HOME",
+    "HF_HUB_CACHE",
+)
+
+
+@click.command(name="env", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON support report.")
+def env_command(as_json: bool) -> None:
+    """Print an AReno environment/support report."""
+
+    report = collect_env()
+    if as_json:
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+    _print_env_report(report)
+
+
+@click.command(name="check", context_settings={"help_option_names": ["-h", "--help"]})
+def check_command() -> None:
+    """Check whether this machine is ready to run AReno."""
+
+    report = collect_env()
+    results = run_checks(report)
+    failed = any(result.status == "FAIL" for result in results)
+    click.echo(f"AReno check: {'not ready' if failed else 'ready'}")
+    click.echo()
+    for result in results:
+        click.echo(f"{result.status:<4} {result.name}")
+        if result.detail:
+            click.echo(f"     {result.detail}")
+    next_steps = [result.next_step for result in results if result.status in {"FAIL", "WARN"} and result.next_step]
+    if next_steps:
+        click.echo()
+        click.echo("Next:")
+        for step in next_steps:
+            click.echo(f"  {step}")
+    if failed:
+        raise click.exceptions.Exit(1)
+
+
+def collect_env() -> dict[str, Any]:
+    """Collect a lightweight support report without initializing the engine."""
+
+    torch_info = _torch_info()
+    cuda_home = _cuda_home()
+    nvcc_path = shutil.which("nvcc")
+    return {
+        "areno": {"version": _package_version("areno")},
+        "python": {"version": platform.python_version(), "executable": sys.executable},
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "platform": platform.platform(),
+        },
+        "torch": torch_info,
+        "cuda": {
+            "cuda_home": os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH"),
+            "inferred_cuda_home": cuda_home,
+            "nvcc": _nvcc_info(nvcc_path),
+            "driver": _nvidia_smi_driver_info(),
+        },
+        "gpus": torch_info.get("gpus", []),
+        "dependencies": {
+            "flash_attn": _dependency_info("flash-attn", "flash_attn"),
+            "flash_linear_attention": _dependency_info("flash-linear-attention", "fla"),
+            "areno_accel": _dependency_info(None, "areno.accel._areno_accel"),
+        },
+        "env": {name: os.environ.get(name) for name in _ENV_VARS},
+        "paths": {
+            "metrics_log_dir": "/tmp/areno/tfevent",
+            "hf_cache": os.environ.get("HF_HUB_CACHE") or str(Path.home() / ".cache" / "huggingface" / "hub"),
+        },
+    }
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    status: str
+    name: str
+    detail: str = ""
+    next_step: str = ""
+
+
+def run_checks(report: dict[str, Any]) -> list[CheckResult]:
+    """Return readiness checks with actionable statuses."""
+
+    results: list[CheckResult] = []
+    py_version = sys.version_info
+    results.append(
+        _result(
+            py_version >= (3, 10),
+            "Python >= 3.10",
+            f"found {platform.python_version()}",
+            "Use Python 3.10 or newer.",
+        )
+    )
+
+    system = report["platform"]["system"]
+    machine = report["platform"]["machine"]
+    platform_ok = system == "Linux"
+    results.append(
+        _result(
+            platform_ok,
+            "Supported platform",
+            f"{system} {machine}",
+            "Run AReno on Linux with an NVIDIA CUDA GPU. On Windows, use WSL2.",
+        )
+    )
+
+    torch_info = report["torch"]
+    torch_imported = bool(torch_info["imported"])
+    results.append(
+        _result(
+            torch_imported,
+            "PyTorch import",
+            torch_info.get("version") or torch_info.get("error", ""),
+            "Install CUDA-enabled PyTorch matching your CUDA version.",
+        )
+    )
+    results.append(
+        _result(
+            torch_imported and _version_at_least(torch_info.get("version"), (2, 6)),
+            "PyTorch >= 2.6",
+            torch_info.get("version") or "not importable",
+            "Install PyTorch 2.6 or newer with CUDA support.",
+        )
+    )
+    results.append(
+        _result(
+            torch_imported and bool(torch_info.get("cuda_build")),
+            "PyTorch CUDA build",
+            f"torch.version.cuda={torch_info.get('cuda_build')}",
+            "Install a CUDA-enabled PyTorch build; CPU-only torch cannot run AReno.",
+        )
+    )
+    results.append(
+        _result(
+            torch_imported and bool(torch_info.get("cuda_available")),
+            "torch.cuda.is_available()",
+            f"visible_gpus={torch_info.get('device_count')}",
+            "Check NVIDIA driver installation, CUDA_VISIBLE_DEVICES, and PyTorch CUDA compatibility.",
+        )
+    )
+    results.append(
+        _result(
+            bool(report["gpus"]),
+            "NVIDIA GPU visibility",
+            ", ".join(gpu["name"] for gpu in report["gpus"]) if report["gpus"] else "no GPUs reported by torch",
+            "Make at least one NVIDIA GPU visible to the process.",
+        )
+    )
+
+    for label in ("flash_attn", "flash_linear_attention"):
+        dep = report["dependencies"][label]
+        results.append(
+            _result(
+                bool(dep["imported"]),
+                f"{label} import",
+                dep.get("version") or dep.get("error", ""),
+                f"Install {dep['distribution']} before installing AReno.",
+                warn=True,
+            )
+        )
+
+    accel = report["dependencies"]["areno_accel"]
+    accel_imported = bool(accel["imported"])
+    cuda_home = report["cuda"]["cuda_home"]
+    results.append(_cuda_toolkit_result("CUDA_HOME", cuda_home or "not set", bool(cuda_home), accel_imported))
+    nvcc = report["cuda"]["nvcc"]
+    results.append(
+        _cuda_toolkit_result(
+            "nvcc",
+            nvcc["version"] or nvcc["path"] or "not found",
+            bool(nvcc["path"]),
+            accel_imported,
+        )
+    )
+    results.append(
+        _result(
+            accel_imported,
+            "areno_accel import",
+            accel.get("error", "imported") if not accel["imported"] else "imported",
+            "Reinstall AReno from source with CUDA enabled: pip install -e . --no-build-isolation",
+        )
+    )
+
+    for label, path in report["paths"].items():
+        results.append(_writable_path_check(label, path))
+    return results
+
+
+def _cuda_toolkit_result(name: str, detail: str, present: bool, runtime_ready: bool) -> CheckResult:
+    if present:
+        return CheckResult("OK", name, detail)
+    if runtime_ready:
+        return CheckResult("OK", name, f"{detail} (not required for runtime; areno_accel imports)")
+    next_step = (
+        "export CUDA_HOME=/usr/local/cuda"
+        if name == "CUDA_HOME"
+        else "Add CUDA's bin directory to PATH, for example: export PATH=$CUDA_HOME/bin:$PATH"
+    )
+    return CheckResult("WARN", name, detail, next_step)
+
+
+def _result(ok: bool, name: str, detail: str, next_step: str, *, warn: bool = False) -> CheckResult:
+    if ok:
+        return CheckResult("OK", name, detail)
+    return CheckResult("WARN" if warn else "FAIL", name, detail, next_step)
+
+
+def _writable_path_check(label: str, path_text: str) -> CheckResult:
+    path = Path(path_text).expanduser()
+    if path.exists() and not path.is_dir():
+        return CheckResult(
+            "WARN",
+            f"{label} writable",
+            f"{path} (exists but is a file, not a directory)",
+            "Remove the file or choose a different directory path.",
+        )
+    parent = path if path.is_dir() else _nearest_existing_parent(path)
+    ok = os.access(parent, os.W_OK)
+    return _result(
+        ok,
+        f"{label} writable",
+        str(path),
+        f"Create the directory or choose a writable path: mkdir -p {parent}",
+        warn=True,
+    )
+
+
+def _nearest_existing_parent(path: Path) -> Path:
+    current = path
+    while not current.exists() and current.parent != current:
+        current = current.parent
+    return current
+
+
+def _torch_info() -> dict[str, Any]:
+    try:
+        torch = import_module("torch")
+    except Exception as exc:
+        return {
+            "imported": False,
+            "error": f"{type(exc).__name__}: {exc}",
+            "version": None,
+            "cuda_build": None,
+            "cuda_runtime": None,
+            "cuda_runtime_error": None,
+            "cuda_available": False,
+            "device_count": 0,
+            "gpus": [],
+        }
+    cuda_available = bool(torch.cuda.is_available())
+    runtime_version = None
+    runtime_error = None
+    if cuda_available:
+        try:
+            runtime_version = _format_cuda_version(int(torch.cuda.cudart().cudaRuntimeGetVersion()))
+        except Exception as exc:
+            runtime_error = f"{type(exc).__name__}: {exc}"
+    device_count = int(torch.cuda.device_count()) if cuda_available else 0
+    gpus = []
+    for idx in range(device_count):
+        try:
+            major, minor = torch.cuda.get_device_capability(idx)
+            capability = f"{major}.{minor}"
+            name = torch.cuda.get_device_name(idx)
+        except Exception as exc:
+            capability = None
+            name = f"unavailable ({type(exc).__name__}: {exc})"
+        gpus.append({"index": idx, "name": name, "capability": capability})
+    return {
+        "imported": True,
+        "error": None,
+        "version": torch.__version__,
+        "cuda_build": getattr(torch.version, "cuda", None),
+        "cuda_runtime": runtime_version,
+        "cuda_runtime_error": runtime_error,
+        "cuda_available": cuda_available,
+        "device_count": device_count,
+        "gpus": gpus,
+    }
+
+
+def _format_cuda_version(version: int) -> str:
+    major = version // 1000
+    minor = (version % 1000) // 10
+    patch = version % 10
+    return f"{major}.{minor}.{patch}"
+
+
+def _version_at_least(version: str | None, minimum: tuple[int, int]) -> bool:
+    if not version:
+        return False
+    parts: list[int] = []
+    for piece in version.split("+", 1)[0].split("."):
+        digits = ""
+        for char in piece:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    while len(parts) < len(minimum):
+        parts.append(0)
+    return tuple(parts[: len(minimum)]) >= minimum
+
+
+def _dependency_info(package_name: str | None, module: str, *, distribution: str | None = None) -> dict[str, Any]:
+    dist_name = distribution if distribution is not None else package_name
+    version = _package_version(dist_name) if dist_name else None
+    try:
+        import_module(module)
+    except Exception as exc:
+        return {
+            "distribution": dist_name,
+            "module": module,
+            "version": version,
+            "imported": False,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return {"distribution": dist_name, "module": module, "version": version, "imported": True, "error": None}
+
+
+def _package_version(name: str | None) -> str | None:
+    if not name:
+        return None
+    try:
+        return importlib_metadata.version(name)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def _cuda_home() -> str | None:
+    for name in ("CUDA_HOME", "CUDA_PATH"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    nvcc = shutil.which("nvcc")
+    if nvcc:
+        return str(Path(nvcc).resolve().parents[1])
+    return None
+
+
+def _nvcc_info(path: str | None) -> dict[str, str | None]:
+    if not path:
+        return {"path": None, "version": None}
+    try:
+        proc = subprocess.run(
+            [path, "--version"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+    except Exception as exc:
+        return {"path": path, "version": f"{type(exc).__name__}: {exc}"}
+    lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return {"path": path, "version": lines[-1] if lines else None}
+
+
+def _nvidia_smi_driver_info() -> dict[str, str | None]:
+    smi = shutil.which("nvidia-smi")
+    if not smi:
+        return {"path": None, "driver_version": None, "cuda_version": None, "error": "nvidia-smi not found"}
+    try:
+        proc = subprocess.run(
+            [smi, "--query-gpu=driver_version,cuda_version", "--format=csv,noheader", "-i", "0"],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except Exception as exc:
+        return {"path": smi, "driver_version": None, "cuda_version": None, "error": f"{type(exc).__name__}: {exc}"}
+    if proc.returncode != 0:
+        return {"path": smi, "driver_version": None, "cuda_version": None, "error": proc.stderr.strip()}
+    output = proc.stdout.strip()
+    if not output:
+        return {
+            "path": smi,
+            "driver_version": None,
+            "cuda_version": None,
+            "error": "nvidia-smi returned empty output",
+        }
+    values = [part.strip() for part in output.split(",", 1)]
+    return {
+        "path": smi,
+        "driver_version": values[0] if values else None,
+        "cuda_version": values[1] if len(values) > 1 else None,
+        "error": None,
+    }
+
+
+def _print_env_report(report: dict[str, Any]) -> None:
+    click.echo("AReno environment")
+    click.echo(f"  AReno: {report['areno']['version'] or 'unknown'}")
+    click.echo(f"  Python: {report['python']['version']} ({report['python']['executable']})")
+    platform_info = report["platform"]
+    click.echo(f"  Platform: {platform_info['platform']} [{platform_info['machine']}]")
+    torch_info = report["torch"]
+    click.echo(f"  PyTorch: {torch_info.get('version') or 'not importable'}")
+    click.echo(f"  PyTorch CUDA build: {torch_info.get('cuda_build') or 'none'}")
+    click.echo(f"  CUDA runtime: {torch_info.get('cuda_runtime') or 'unavailable'}")
+    click.echo(f"  torch.cuda.is_available: {torch_info.get('cuda_available')}")
+    click.echo(f"  CUDA_HOME: {report['cuda']['cuda_home'] or 'not set'}")
+    if report["cuda"].get("inferred_cuda_home") and report["cuda"].get("inferred_cuda_home") != report["cuda"].get(
+        "cuda_home"
+    ):
+        click.echo(f"  inferred CUDA_HOME: {report['cuda']['inferred_cuda_home']}")
+    nvcc = report["cuda"]["nvcc"]
+    click.echo(f"  nvcc: {nvcc['path'] or 'not found'}")
+    if nvcc["version"]:
+        click.echo(f"    {nvcc['version']}")
+    driver = report["cuda"]["driver"]
+    click.echo(f"  nvidia-smi: {driver['path'] or 'not found'}")
+    if driver.get("driver_version") or driver.get("cuda_version"):
+        click.echo(f"    driver={driver.get('driver_version')} cuda={driver.get('cuda_version')}")
+    elif driver.get("error"):
+        click.echo(f"    {driver['error']}")
+    click.echo("  GPUs:")
+    if report["gpus"]:
+        for gpu in report["gpus"]:
+            click.echo(f"    [{gpu['index']}] {gpu['name']} (cc {gpu['capability']})")
+    else:
+        click.echo("    none visible")
+    click.echo("  Dependencies:")
+    for name, dep in report["dependencies"].items():
+        status = "ok" if dep["imported"] else "missing"
+        version = dep["version"] or "unknown"
+        click.echo(f"    {name}: {status} (version={version})")
+        if dep["error"]:
+            click.echo(f"      {dep['error']}")
+    click.echo("  Environment variables:")
+    for name, value in report["env"].items():
+        click.echo(f"    {name}={value if value is not None else '<unset>'}")

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -15,6 +15,8 @@ class ArenoCli(click.Group):
     """Click group that imports heavy subcommands only when selected."""
 
     _COMMANDS = {
+        "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
+        "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
     }

--- a/docs/cli/diagnostics.rst
+++ b/docs/cli/diagnostics.rst
@@ -1,0 +1,78 @@
+Diagnostics CLI reference
+=========================
+
+``areno env`` and ``areno check`` help diagnose setup problems before a user
+hits low-level Python, CUDA, or PyTorch errors.
+
+``areno env`` is a descriptive support report. It does not initialize the AReno
+engine or load model weights. Use it when collecting information for an issue.
+
+.. code-block:: bash
+
+   areno env
+
+For machine-readable issue reports:
+
+.. code-block:: bash
+
+   areno env --json
+
+The report includes:
+
+* AReno version
+* Python version and executable
+* OS, platform, and architecture
+* PyTorch version, CUDA build, CUDA runtime, and CUDA availability
+* CUDA driver information from ``nvidia-smi`` when available
+* visible GPU count, names, and compute capability
+* ``CUDA_HOME`` and inferred CUDA toolkit location
+* ``nvcc`` path and version
+* ``flash-attn`` import status and version
+* ``flash-linear-attention`` import status and version
+* ``areno_accel`` import status
+* selected environment variables such as ``MAX_JOBS``,
+  ``CUDA_VISIBLE_DEVICES``, and ``TORCH_CUDA_ARCH_LIST``
+
+areno check
+-----------
+
+``areno check`` validates whether the machine is ready to run AReno training
+and serving. It classifies each check as ``OK``, ``WARN``, or ``FAIL`` and
+prints concrete next steps for failures.
+
+.. code-block:: bash
+
+   areno check
+
+Example output:
+
+.. code-block:: text
+
+   AReno check: not ready
+
+   OK   Python >= 3.10
+        found 3.11.8
+   OK   PyTorch CUDA build
+        torch.version.cuda=12.4
+   OK   CUDA_HOME
+        not set (not required for runtime; areno_accel imports)
+
+``CUDA_HOME`` and ``nvcc`` are only warnings when AReno needs to build its CUDA
+extension. If the installed ``areno_accel`` extension imports successfully,
+they are not required for runtime readiness.
+
+Checks include:
+
+* Python version
+* supported platform
+* PyTorch import and version
+* PyTorch CUDA build
+* ``torch.cuda.is_available()``
+* NVIDIA GPU visibility
+* ``CUDA_HOME`` and ``nvcc``
+* optional runtime dependency imports
+* ``areno_accel`` import
+* writable cache/log locations
+
+``WARN`` items usually indicate degraded or incomplete setup. ``FAIL`` items
+mean AReno is not ready to run the CUDA training/inference engine.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,14 @@ Install in an existing CUDA + PyTorch environment:
    pip install flash-attn flash-linear-attention
    pip install -e . --no-build-isolation
 
+Check whether the environment is ready:
+
+.. code-block:: bash
+
+   areno check
+
+Use ``areno env --json`` when filing setup issues.
+
 Run a tiny training smoke test when you only want to verify the wiring:
 
 .. code-block:: bash
@@ -130,4 +138,5 @@ What areno owns
 
    cli/training
    cli/inference
+   cli/diagnostics
    sdk/trainer

--- a/tests/test_cli_diagnostics_cpu.py
+++ b/tests/test_cli_diagnostics_cpu.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.cli import diagnostics
+from areno.cli.main import main
+
+
+def _ready_report(tmp_path: str) -> dict:
+    return {
+        "areno": {"version": "0.1.0"},
+        "python": {"version": "3.11.0", "executable": "/python"},
+        "platform": {"system": "Linux", "release": "6.0", "machine": "x86_64", "platform": "Linux"},
+        "torch": {
+            "imported": True,
+            "error": None,
+            "version": "2.6.0",
+            "cuda_build": "12.4",
+            "cuda_runtime": "12.4.0",
+            "cuda_runtime_error": None,
+            "cuda_available": True,
+            "device_count": 1,
+            "gpus": [{"index": 0, "name": "NVIDIA H100", "capability": "9.0"}],
+        },
+        "cuda": {
+            "cuda_home": "/usr/local/cuda",
+            "inferred_cuda_home": "/usr/local/cuda",
+            "nvcc": {"path": "/usr/local/cuda/bin/nvcc", "version": "release 12.4"},
+            "driver": {"path": "/usr/bin/nvidia-smi", "driver_version": "550.0", "cuda_version": "12.4", "error": None},
+        },
+        "gpus": [{"index": 0, "name": "NVIDIA H100", "capability": "9.0"}],
+        "dependencies": {
+            "flash_attn": {
+                "distribution": "flash-attn",
+                "module": "flash_attn",
+                "version": "2.7.0",
+                "imported": True,
+                "error": None,
+            },
+            "flash_linear_attention": {
+                "distribution": "flash-linear-attention",
+                "module": "fla",
+                "version": "0.2.0",
+                "imported": True,
+                "error": None,
+            },
+            "areno_accel": {
+                "distribution": None,
+                "module": "areno.accel._areno_accel",
+                "version": None,
+                "imported": True,
+                "error": None,
+            },
+        },
+        "env": {"CUDA_HOME": "/usr/local/cuda", "MAX_JOBS": "8"},
+        "paths": {"metrics_log_dir": tmp_path, "hf_cache": tmp_path},
+    }
+
+
+class CliDiagnosticsTest(unittest.TestCase):
+    def test_top_level_cli_lists_env_and_check(self):
+        result = CliRunner().invoke(main, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("env", result.output)
+        self.assertIn("check", result.output)
+
+    def test_env_json_emits_machine_readable_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = CliRunner().invoke(diagnostics.env_command, ["--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["areno"]["version"], "0.1.0")
+        self.assertEqual(parsed["gpus"][0]["name"], "NVIDIA H100")
+
+    def test_check_reports_failures_with_next_steps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["torch"]["cuda_available"] = False
+            report["torch"]["device_count"] = 0
+            report["torch"]["gpus"] = []
+            report["gpus"] = []
+            report["cuda"]["cuda_home"] = None
+            report["cuda"]["nvcc"] = {"path": None, "version": None}
+            report["dependencies"]["areno_accel"]["imported"] = False
+            report["dependencies"]["areno_accel"]["error"] = "ModuleNotFoundError: missing extension"
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = CliRunner().invoke(diagnostics.check_command)
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("AReno check: not ready", result.output)
+        self.assertIn("WARN CUDA_HOME", result.output)
+        self.assertIn("WARN nvcc", result.output)
+        self.assertIn("export CUDA_HOME=/usr/local/cuda", result.output)
+        self.assertIn("FAIL areno_accel import", result.output)
+
+    def test_cuda_toolkit_is_optional_when_runtime_extension_imports(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["cuda"]["cuda_home"] = None
+            report["cuda"]["nvcc"] = {"path": None, "version": None}
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = CliRunner().invoke(diagnostics.check_command)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("AReno check: ready", result.output)
+        self.assertIn("OK   CUDA_HOME", result.output)
+        self.assertIn("not required for runtime", result.output)
+        self.assertIn("OK   nvcc", result.output)
+
+    def test_writable_path_check_warns_for_missing_parent(self):
+        result = diagnostics._writable_path_check("cache", "/definitely/missing/areno/path")
+
+        self.assertEqual(result.status, "WARN")
+        self.assertIn("mkdir -p", result.next_step)
+
+    def test_writable_path_check_warns_for_existing_file(self):
+        with tempfile.NamedTemporaryFile() as tmp_file:
+            result = diagnostics._writable_path_check("cache", tmp_file.name)
+
+        self.assertEqual(result.status, "WARN")
+        self.assertIn("exists but is a file", result.detail)
+
+    def test_version_check_pads_short_versions(self):
+        self.assertTrue(diagnostics._version_at_least("3", (2, 6)))
+        self.assertFalse(diagnostics._version_at_least("2", (2, 6)))
+
+    def test_torch_info_handles_missing_cuda_build_attr(self):
+        fake_torch = types.SimpleNamespace(
+            __version__="2.6.0",
+            cuda=types.SimpleNamespace(is_available=lambda: False, device_count=lambda: 0),
+            version=types.SimpleNamespace(),
+        )
+        with patch.object(diagnostics, "import_module", return_value=fake_torch):
+            info = diagnostics._torch_info()
+
+        self.assertTrue(info["imported"])
+        self.assertIsNone(info["cuda_build"])
+
+    def test_nvidia_smi_empty_output_is_reported(self):
+        completed = subprocess.CompletedProcess(args=["nvidia-smi"], returncode=0, stdout="", stderr="")
+        with (
+            patch.object(diagnostics.shutil, "which", return_value="/usr/bin/nvidia-smi"),
+            patch.object(diagnostics.subprocess, "run", return_value=completed),
+        ):
+            info = diagnostics._nvidia_smi_driver_info()
+
+        self.assertEqual(info["error"], "nvidia-smi returned empty output")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add top-level `areno env` and `areno env --json` support reports
- add top-level `areno check` readiness checks with `OK` / `WARN` / `FAIL` statuses and next steps
- document diagnostics in README and CLI docs
- add CPU tests for diagnostics output and status classification

Closes #4

## Verification

```bash
pytest tests/test_cli_diagnostics_cpu.py -q
```

```text
....                                                                     [100%]
4 passed in 0.03s
```

### areno check

```text
AReno check: ready

OK   Python >= 3.10
     found 3.10.16
OK   Supported platform
     Linux x86_64
OK   PyTorch import
     2.6.0+cu126
OK   PyTorch >= 2.6
     2.6.0+cu126
OK   PyTorch CUDA build
     torch.version.cuda=12.6
OK   torch.cuda.is_available()
     visible_gpus=8
OK   NVIDIA GPU visibility
     NVIDIA H20, NVIDIA H20, NVIDIA H20, NVIDIA H20, NVIDIA H20, NVIDIA H20, NVIDIA H20, NVIDIA H20
OK   flash_attn import
     2.7.2
OK   flash_linear_attention import
OK   areno_accel import
     imported
OK   CUDA_HOME
     not set (not required for runtime; areno_accel imports)
OK   nvcc
     not found (not required for runtime; areno_accel imports)
OK   metrics_log_dir writable
     /tmp/areno/tfevent
OK   hf_cache writable
     /root/.cache/huggingface/hub
```

### areno env

```text
AReno environment
  AReno: 0.1.0
  Python: 3.10.16 (/opt/conda/bin/python)
  Platform: Linux-5.10.134-16.3.al8.x86_64-x86_64-with-glibc2.32 [x86_64]
  PyTorch: 2.6.0+cu126
  PyTorch CUDA build: 12.6
  CUDA runtime: unavailable
  torch.cuda.is_available: True
  CUDA_HOME: not set
  nvcc: not found
  nvidia-smi: /usr/bin/nvidia-smi
  GPUs:
    [0] NVIDIA H20 (cc 9.0)
    [1] NVIDIA H20 (cc 9.0)
    [2] NVIDIA H20 (cc 9.0)
    [3] NVIDIA H20 (cc 9.0)
    [4] NVIDIA H20 (cc 9.0)
    [5] NVIDIA H20 (cc 9.0)
    [6] NVIDIA H20 (cc 9.0)
    [7] NVIDIA H20 (cc 9.0)
  Dependencies:
    flash_attn: ok (version=2.7.2)
    flash_linear_attention: ok (version=unknown)
    areno_accel: ok (version=unknown)
  Environment variables:
    CUDA_HOME=<unset>
    CUDA_PATH=<unset>
    CUDA_VISIBLE_DEVICES=<unset>
    MAX_JOBS=<unset>
    TORCH_CUDA_ARCH_LIST=<unset>
    ARENO_BUILD_EXT=<unset>
    HF_HOME=<unset>
    HF_HUB_CACHE=<unset>
```

### areno env --json

Displayed partial output:

```json
{
  "areno": {
    "version": "0.1.0"
  },
  "cuda": {
    "cuda_home": null,
    "driver": {
      "cuda_version": null,
      "driver_version": null,
      "error": "",
      "path": "/usr/bin/nvidia-smi"
    },
    "inferred_cuda_home": null,
    "nvcc": {
      "path": null,
      "version": null
    }
  },
  "dependencies": {
    "areno_accel": {
      "distribution": null,
      "error": null,
      "imported": true,
      "module": "areno.accel._areno_accel",
      "version": null
    },
    "flash_attn": {
      "distribution": "flash-attn",
      "error": null,
      "imported": true,
      "module": "flash_attn",
      "version": "2.7.2"
    },
    "flash_linear_attention": {
      "distribution": "flash-linear-attention",
      "error": null,
      "imported": true,
      "module": "fla",
      "version": null
    }
  },
  "env": {
    "ARENO_BUILD_EXT": null,
    "CUDA_HOME": null,
    "CUDA_PATH": null,
    "CUDA_VISIBLE_DEVICES": null,
    "HF_HOME": null,
    "HF_HUB_CACHE": null,
    "MAX_JOBS": null,
    "TORCH_CUDA_ARCH_LIST": null
  },
  "gpus": [
    {
      "capability": "9.0",
      "index": 0,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 1,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 2,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 3,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 4,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 5,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 6,
      "name": "NVIDIA H20"
    },
    {
      "capability": "9.0",
      "index": 7,
      "name": "NVIDIA H20"
    }
  ],
  "paths": {
    "hf_cache": "/root/.cache/huggingface/hub",
    "metrics_log_dir": "/tmp/areno/tfevent"
  },
  "platform": {
    "machine": "x86_64",
    "platform": "Linux-5.10.134-16.3.al8.x86_64-x86_64-with-glibc2.32",
    "release": "5.10.134-16.3.al8.x86_64",
    "system": "Linux"
  },
  "python": {
    "executable": "/opt/conda/bin/python",
    "version": "3.10.16"
  },
  "torch": {
    "cuda_available": true,
    "cuda_build": "12.6",
    "cuda_runtime": null,
    "cuda_runtime_error": "AttributeError: module 'torch._C._cudart' has no attribute 'cudaRuntimeGetVersion'",
    "device_count": 8,
    "error": null,
    "gpus": [
      {
        "capability": "9.0",
        "index": 0,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 1,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 2,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 3,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 4,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 5,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 6,
        "name": "NVIDIA H20"
      },
      {
        "capability": "9.0",
        "index": 7,
        "name": "NVIDIA H20"
      }
    ],
    "imported": true,
    "version": "2.6.0+cu126"
  }
}
```
