### PR TITLE
fix: expose trainer from top-level package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ python -c "import torch; print('GPU:', torch.cuda.is_available())"
 
 - Read relevant files before modifying code; follow existing patterns in the same module.
 - Before using a symbol (function, class, type, constant), confirm it exists -- read its definition or `grep -r "name" areno/`; check `pyproject.toml` for a dependency. If you skip this, prefix the code with `# UNVERIFIED:`.
-- Use `from areno.api import Trainer` -- the public SDK surface. `from areno import Trainer` does **not** work.
+- Use `from areno import Trainer` -- the public SDK surface.
 - Add a CPU test under `tests/` for new algorithm / loss / config behavior.
 - Register new capabilities (algorithms, model adapters) instead of editing a factory.
 - Ask for decisions with short, structured options rather than broad open-ended questions.
@@ -143,7 +143,7 @@ ______________________________________________________________________
 
 - Each algorithm gets the narrowest config dataclass it needs (offline trainers omit rollout/reward fields by construction).
 - Public configs, exported symbols, and CLI options are public API -- add fields with defaults, deprecate before removing, avoid type changes.
-- The SDK entry is `from areno.api import Trainer`; keep the top-level package free of kernel-heavy imports.
+- The SDK entry is `from areno import Trainer`; keep top-level exports lazy so package import stays free of kernel-heavy imports.
 
 ______________________________________________________________________
 

--- a/areno/__init__.py
+++ b/areno/__init__.py
@@ -52,6 +52,10 @@ def __getattr__(name: str):
         from areno.engine import data
 
         return getattr(data, name)
+    if name == "Trainer":
+        from areno.api.trainer import Trainer
+
+        return Trainer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -64,4 +68,5 @@ __all__ = [
     "RuntimeConfig",
     "SamplingParams",
     "TrainStats",
+    "Trainer",
 ]

--- a/tests/test_trainer_api_cpu.py
+++ b/tests/test_trainer_api_cpu.py
@@ -4,9 +4,10 @@ import asyncio
 import unittest
 
 import areno.api.trainer as trainer_mod
+from areno import Trainer
 from areno.api.context import Context
 from areno.api.models import SamplingParams
-from areno.api.trainer import Trainer
+from areno.api.trainer import Trainer as ApiTrainer
 from tests.helpers import PatchedContext
 
 
@@ -26,6 +27,9 @@ def _encode_from_record_prompt(_tokenizer, prompt: str) -> list[int]:
 
 class TrainerPromptBatchTest(unittest.TestCase):
     """Prompt batching tests avoid backend initialization and tokenizer loading."""
+
+    def test_top_level_trainer_export_matches_api_trainer(self):
+        self.assertIs(Trainer, ApiTrainer)
 
     def test_load_prompt_batches_skips_long_prompts_and_keeps_records(self):
         """Overlong prompts should be skipped without dropping record metadata."""


### PR DESCRIPTION
## Summary

- expose `Trainer` from the top-level `areno` package via lazy `__getattr__`
- update AGENTS guidance to use `from areno import Trainer`
- add a CPU test asserting the top-level export matches `areno.api.trainer.Trainer`

Closes #7

## Verification

```bash
conda run -n share python -c "from areno import Trainer; from areno.api.trainer import Trainer as ApiTrainer; assert Trainer is ApiTrainer; print(Trainer.__name__)"
```

```text
Trainer
```

```bash
conda run -n share env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_trainer_api_cpu.py -q
```

```text
10 passed, 1 warning in 3.56s
```

```bash
ruff check areno/__init__.py tests/test_trainer_api_cpu.py
ruff format --check areno/__init__.py tests/test_trainer_api_cpu.py
```
