### PR TITLE
fix(cli): preflight train task hook validation

### DIFF
--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -11,6 +11,7 @@ The flow is:
        function), and runs the trainer to completion.
 """
 
+import ast
 import importlib.util
 import logging
 import shutil
@@ -101,6 +102,7 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         _require_positive_float(args.lam, "--lam")
     if args.critic_warmup_steps < 0:
         raise click.UsageError("--critic-warmup-steps must be non-negative")
+    _preflight_task_hooks(args, algorithm)
     return _trainer_config_from_args(args)
 
 
@@ -254,6 +256,80 @@ def _format_optional(value, *, default: str = "none") -> str:
 
 def _style(text: str, *, color: bool, fg: str | None = None, bold: bool = False) -> str:
     return click.style(text, fg=fg, bold=bold) if color else text
+
+
+def _preflight_task_hooks(args, algorithm) -> None:
+    """Validate user task hook files before backend/model initialization."""
+
+    if args.dataset_loader_fn is not None:
+        try:
+            loader_path, fn_name = _split_loader_fn_spec(args.dataset_loader_fn)
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
+        _validate_python_callable(
+            loader_path,
+            fn_name,
+            option_name="--dataset-loader-fn",
+            expected=f"{fn_name}(...)",
+            positional_args=1,
+        )
+    if algorithm.requires_rollout and args.reward_fn_path is not None:
+        _validate_python_callable(
+            Path(args.reward_fn_path).expanduser().resolve(),
+            "reward_fn",
+            option_name="--reward-fn-path",
+            expected="reward_fn(record)",
+            positional_args=1,
+        )
+    if args.agent_fn is not None:
+        _validate_python_callable(
+            Path(args.agent_fn).expanduser().resolve(),
+            "run_agent",
+            option_name="--agent-fn",
+            expected="run_agent(ctx, batch)",
+            positional_args=2,
+        )
+
+
+def _validate_python_callable(
+    path: Path,
+    symbol_name: str,
+    *,
+    option_name: str,
+    expected: str,
+    positional_args: int | None = None,
+) -> None:
+    if not path.exists():
+        raise click.UsageError(f"{option_name} file does not exist: {path}; expected callable {expected}")
+    if not path.is_file():
+        raise click.UsageError(f"{option_name} path is not a file: {path}; expected callable {expected}")
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+        raise click.UsageError(
+            f"{option_name} cannot parse Python file: {path}; expected callable {expected}; {type(exc).__name__}: {exc}"
+        ) from exc
+    function = _find_top_level_function(tree, symbol_name)
+    if function is None:
+        raise click.UsageError(f"{option_name} {path} must define callable {expected}")
+    if positional_args is not None and not _function_accepts_positional_args(function, positional_args):
+        raise click.UsageError(f"{option_name} {path} must define callable {expected}")
+
+
+def _find_top_level_function(tree: ast.Module, symbol_name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == symbol_name:
+            return node
+    return None
+
+
+def _function_accepts_positional_args(function: ast.FunctionDef | ast.AsyncFunctionDef, count: int) -> bool:
+    args = function.args
+    positional_count = len(args.posonlyargs) + len(args.args)
+    required_count = positional_count - len(args.defaults)
+    if args.vararg is not None:
+        return required_count <= count
+    return required_count <= count <= positional_count
 
 
 def _trainer_config_from_args(args) -> TrainerConfig:

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -54,7 +54,7 @@ Dataset and reward hooks
    ``file.py:function``.
 
 ``--reward-fn-path TEXT``
-   Python file defining ``reward_fn(example, completions)``.
+   Python file defining ``reward_fn(record)``.
 
 Use ``--dataset-loader-fn`` when the raw dataset does not already match the
 trainer schema. Without a loader, Areno passes dataset rows through unchanged.
@@ -63,8 +63,8 @@ Reward files should expose:
 
 .. code-block:: python
 
-   def reward_fn(example, completions):
-       return [0.0 for _ in completions]
+   def reward_fn(record):
+       return 0.0
 
 Algorithm selection
 ~~~~~~~~~~~~~~~~~~~

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -4,8 +4,11 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
+import click
 import torch
+from click.testing import CliRunner
 
 from areno.api.data import PromptBatch, PromptItem
 from areno.api.trainer_config import RolloutTrainerConfig, TrainerConfig
@@ -164,6 +167,174 @@ class ConfigAndDataTest(unittest.TestCase):
 
         self.assertEqual(dataset, [{"prompt": "loaded"}])
 
+    def test_train_cli_preflight_rejects_missing_dataset_loader_file(self):
+        """Dataset loader path failures should be UsageError before backend init."""
+        missing = Path(tempfile.gettempdir()) / "areno_missing_loader.py"
+
+        with self.assertRaisesRegex(
+            click.UsageError,
+            r"--dataset-loader-fn file does not exist: .*areno_missing_loader.py; expected callable normalize",
+        ):
+            train_cli._trainer_config_from_options(
+                **_train_options(algo="sft", dataset_loader_fn=f"{missing}:normalize")
+            )
+
+    def test_train_cli_preflight_rejects_malformed_dataset_loader_spec(self):
+        """Malformed dataset loader specs should not escape as raw ValueError."""
+        with self.assertRaisesRegex(click.UsageError, r"Invalid --dataset-loader-fn value: :"):
+            train_cli._trainer_config_from_options(**_train_options(algo="sft", dataset_loader_fn=":"))
+
+    def test_train_cli_preflight_does_not_execute_hook_modules(self):
+        """Static preflight should not trigger module-level side effects."""
+        with tempfile.TemporaryDirectory() as tmp:
+            loader_path = Path(tmp) / "loader.py"
+            loader_path.write_text(
+                "def load_training_dataset(*args, **kwargs):\n    return []\n"
+                "raise RuntimeError('module executed during preflight')\n",
+                encoding="utf-8",
+            )
+
+            cfg = train_cli._trainer_config_from_options(
+                **_train_options(algo="sft", dataset_loader_fn=str(loader_path))
+            )
+
+        self.assertEqual(cfg.dataset_loader_fn, str(loader_path))
+
+    def test_train_cli_preflight_rejects_dataset_loader_missing_function(self):
+        """Dataset loader files should name the missing expected symbol."""
+        with tempfile.TemporaryDirectory() as tmp:
+            loader_path = Path(tmp) / "loader.py"
+            loader_path.write_text("def other():\n    return []\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError, r"--dataset-loader-fn .*loader.py must define callable normalize\(\.\.\.\)"
+            ):
+                train_cli._trainer_config_from_options(
+                    **_train_options(algo="sft", dataset_loader_fn=f"{loader_path}:normalize")
+                )
+
+    def test_train_cli_preflight_rejects_dataset_loader_non_callable(self):
+        """Dataset loader symbol must be callable."""
+        with tempfile.TemporaryDirectory() as tmp:
+            loader_path = Path(tmp) / "loader.py"
+            loader_path.write_text("load_training_dataset = 1\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError,
+                r"--dataset-loader-fn .*loader.py must define callable load_training_dataset\(\.\.\.\)",
+            ):
+                train_cli._trainer_config_from_options(**_train_options(algo="sft", dataset_loader_fn=str(loader_path)))
+
+    def test_train_cli_preflight_rejects_dataset_loader_without_dataset_path_arg(self):
+        """Dataset loader hook should accept at least the dataset path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            loader_path = Path(tmp) / "loader.py"
+            loader_path.write_text("def load_training_dataset():\n    return []\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError,
+                r"--dataset-loader-fn .*loader.py must define callable load_training_dataset\(\.\.\.\)",
+            ):
+                train_cli._trainer_config_from_options(**_train_options(algo="sft", dataset_loader_fn=str(loader_path)))
+
+    def test_train_cli_preflight_rejects_missing_reward_file(self):
+        """Reward file failures should happen while constructing CLI config."""
+        missing = Path(tempfile.gettempdir()) / "areno_missing_reward.py"
+
+        with self.assertRaisesRegex(
+            click.UsageError,
+            r"--reward-fn-path file does not exist: .*areno_missing_reward.py; expected callable reward_fn\(record\)",
+        ):
+            train_cli._trainer_config_from_options(**_train_options(algo="gspo", reward_fn_path=str(missing)))
+
+    def test_train_cli_preflight_rejects_reward_file_without_callable_reward_fn(self):
+        """Reward files should define callable reward_fn(record)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            reward_path = Path(tmp) / "reward.py"
+            reward_path.write_text("reward_fn = 1\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError, r"--reward-fn-path .*reward.py must define callable reward_fn\(record\)"
+            ):
+                train_cli._trainer_config_from_options(**_train_options(algo="gspo", reward_fn_path=str(reward_path)))
+
+    def test_train_cli_preflight_rejects_reward_fn_without_record_arg(self):
+        """Reward hook should accept the training record argument."""
+        with tempfile.TemporaryDirectory() as tmp:
+            reward_path = Path(tmp) / "reward.py"
+            reward_path.write_text("def reward_fn():\n    return 0.0\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError, r"--reward-fn-path .*reward.py must define callable reward_fn\(record\)"
+            ):
+                train_cli._trainer_config_from_options(**_train_options(algo="gspo", reward_fn_path=str(reward_path)))
+
+    def test_train_cli_preflight_skips_unused_reward_file_for_offline_algorithms(self):
+        """SFT/DPO should not validate an unused reward hook path."""
+        missing = Path(tempfile.gettempdir()) / "areno_missing_unused_reward.py"
+
+        sft_cfg = train_cli._trainer_config_from_options(
+            **_train_options(algo="sft", reward_fn_path=str(missing), reward_ckpt=None)
+        )
+        dpo_cfg = train_cli._trainer_config_from_options(
+            **_train_options(algo="dpo", reward_fn_path=str(missing), reward_ckpt=None, ref_ckpt="reference")
+        )
+
+        self.assertEqual(sft_cfg.algo, "sft")
+        self.assertEqual(dpo_cfg.algo, "dpo")
+
+    def test_train_cli_preflight_rejects_agent_file_without_callable_run_agent(self):
+        """Agent hooks should fail before rollout/backend-heavy work."""
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_path = Path(tmp) / "agent.py"
+            agent_path.write_text("def helper():\n    pass\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError, r"--agent-fn .*agent.py must define callable run_agent\(ctx, batch\)"
+            ):
+                train_cli._trainer_config_from_options(
+                    **_train_options(algo="gspo", reward_ckpt="reward-model", agent_fn=str(agent_path))
+                )
+
+    def test_train_cli_preflight_rejects_agent_fn_without_ctx_and_batch_args(self):
+        """Agent hook should accept both ctx and batch arguments."""
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_path = Path(tmp) / "agent.py"
+            agent_path.write_text("def run_agent(ctx):\n    return []\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                click.UsageError, r"--agent-fn .*agent.py must define callable run_agent\(ctx, batch\)"
+            ):
+                train_cli._trainer_config_from_options(
+                    **_train_options(algo="gspo", reward_ckpt="reward-model", agent_fn=str(agent_path))
+                )
+
+    def test_train_command_reports_hook_usage_error_before_run(self):
+        """Malformed hooks should stop the CLI before backend/model setup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            reward_path = Path(tmp) / "reward.py"
+            reward_path.write_text("def other(record):\n    return 0.0\n", encoding="utf-8")
+
+            with patch.object(train_cli, "run") as run_mock:
+                result = CliRunner().invoke(
+                    train_cli.train_command,
+                    [
+                        "--algo",
+                        "gspo",
+                        "--ckpt",
+                        "actor",
+                        "--dataset-path",
+                        "dataset",
+                        "--reward-fn-path",
+                        str(reward_path),
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--reward-fn-path", result.output)
+        self.assertIn("reward_fn(record)", result.output)
+        run_mock.assert_not_called()
+
 
 def _train_args(**overrides):
     defaults = dict(
@@ -224,6 +395,10 @@ def _train_args(**overrides):
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+def _train_options(**overrides):
+    return vars(_train_args(**overrides))
 
 
 if __name__ == "__main__":

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -148,7 +148,6 @@ def test_train_config_builds_policy_shape_for_gspo_and_grpo(algo, clip_attr, cli
     cfg = _trainer_config_from_options(
         **_options(
             algo=algo,
-            reward_fn_path="reward.py",
             n_samples=3,
             max_running_prompts=12,
             temperature=0.7,
@@ -161,7 +160,7 @@ def test_train_config_builds_policy_shape_for_gspo_and_grpo(algo, clip_attr, cli
     assert isinstance(cfg, PolicyTrainerConfig)
     assert type(cfg) is PolicyTrainerConfig
     assert cfg.algo == algo
-    assert cfg.reward_fn_path == "reward.py"
+    assert cfg.reward_fn_path is None
     assert cfg.n_samples == 3
     assert cfg.resolved_max_running_prompts() == 12
     assert cfg.temperature == 0.7
@@ -175,7 +174,6 @@ def test_train_config_builds_ppo_shape_and_role_checkpoints():
     cfg = _trainer_config_from_options(
         **_options(
             algo="ppo",
-            reward_fn_path="reward.py",
             ref_ckpt="reference",
             reward_ckpt="reward-model",
             critic_ckpt="critic",
@@ -372,7 +370,7 @@ def _options(**overrides):
         ckpt="actor",
         dataset_path="dataset",
         dataset_loader_fn=None,
-        reward_fn_path="reward.py",
+        reward_fn_path=None,
         save_path="save",
         save_interval=10,
         epochs=2,
@@ -409,7 +407,7 @@ def _options(**overrides):
         grpo_clip_eps=0.2,
         ref_ckpt=None,
         dpo_beta=0.1,
-        reward_ckpt=None,
+        reward_ckpt="reward-model",
         critic_ckpt=None,
         critic_lr=1e-5,
         use_kl_loss=True,


### PR DESCRIPTION
Closes https://github.com/inclusionAI/asystem-areno/issues/9

## Summary
- validate dataset loader, reward function, and agent function hooks before backend/model initialization
- use static AST checks for preflight so hook modules are not executed before distributed/CUDA setup
- check hook callable signatures for dataset loader, reward function, and agent function entrypoints
- report malformed hook files/specs as click UsageError messages that include the option, file path, and expected callable symbol
- validate reward hooks only for rollout algorithms, keeping SFT/DPO unused reward paths from failing preflight
- update CLI docs to use the current reward_fn(record) contract
- add CPU tests for missing/malformed hook files, invalid signatures, non-executing preflight checks, and CLI stop-before-run behavior

## Tests
```bash
ruff check areno/cli/train.py tests/test_config_data_cpu.py tests/test_train_cli_config_cpu.py
ruff format --check areno/cli/train.py tests/test_config_data_cpu.py tests/test_train_cli_config_cpu.py
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_data_cpu.py tests/test_train_cli_config_cpu.py -q
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests -q
```

Result: full CPU suite passed after rebasing on latest main, 245 passed, 5 warnings.