### PR TITLE
feat: print resolved train config summary

### DIFF
--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -13,6 +13,8 @@ The flow is:
 
 import importlib.util
 import logging
+import shutil
+import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -20,7 +22,13 @@ import click
 
 from areno.api.algorithms import get_algorithm
 from areno.api.defaults import DEFAULT_METRICS_LOG_DIR
-from areno.api.trainer_config import DPOTrainerConfig, PolicyTrainerConfig, PPOTrainerConfig, TrainerConfig
+from areno.api.trainer_config import (
+    DPOTrainerConfig,
+    PolicyTrainerConfig,
+    PPOTrainerConfig,
+    RolloutTrainerConfig,
+    TrainerConfig,
+)
 from areno.cli.model_refs import resolve_model_refs_for_config
 
 
@@ -99,6 +107,153 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
 def _require_positive_float(value: float, option_name: str) -> None:
     if value <= 0:
         raise click.UsageError(f"{option_name} must be positive")
+
+
+def _format_training_config_summary(
+    config: TrainerConfig, *, reward_ckpt: str | None = None, color: bool = False
+) -> str:
+    """Return a concise user-facing summary of the resolved train config."""
+
+    algorithm = get_algorithm(config.algo)
+    sections = [
+        (
+            "Algorithm",
+            [
+                ("name", algorithm.name),
+                ("default_loss", _callable_name(algorithm.default_loss_fn)),
+                ("requires_rollout", _format_bool(algorithm.requires_rollout)),
+            ],
+        ),
+        (
+            "Inputs",
+            [
+                ("ckpt", config.ckpt),
+                ("dataset_path", config.dataset_path),
+                ("dataset_loader", _format_optional(config.dataset_loader_fn)),
+                (
+                    "reward_fn",
+                    _format_optional(config.reward_fn_path) if isinstance(config, PolicyTrainerConfig) else "n/a",
+                ),
+                ("reward_ckpt", _format_optional(_reward_ckpt_for_summary(config, reward_ckpt))),
+                ("agent_fn", _format_optional(config.agent_fn)),
+            ],
+        ),
+        (
+            "Runtime",
+            [
+                ("world_size", str(config.world_size)),
+                ("tp_size", str(config.tp_size)),
+                ("dp_size", _resolved_dp_size_for_summary(config)),
+            ],
+        ),
+        ("Rollout", _rollout_summary_rows(config)),
+        (
+            "Training",
+            [
+                ("mini_bs", str(config.mini_bs)),
+                ("gradient_accumulation_steps", _format_optional(config.gradient_accumulation_steps, default="auto")),
+                (
+                    "optimizer",
+                    (
+                        f"lr={config.optimizer_lr}, min_lr={config.optimizer_min_lr}, "
+                        f"decay={config.lr_decay_style}/{config.lr_decay_steps}, "
+                        f"betas=({config.optimizer_beta1}, {config.optimizer_beta2}), "
+                        f"weight_decay={config.weight_decay}, adam_8bit={_format_bool(config.adam_8bit)}"
+                    ),
+                ),
+                ("grad_clip_norm", str(config.grad_clip_norm)),
+            ],
+        ),
+        (
+            "Outputs",
+            [
+                ("save_path", _format_optional(config.save_path)),
+                ("save_interval", str(config.save_interval)),
+                ("metrics_log_dir", _format_optional(config.metrics_log_dir)),
+            ],
+        ),
+    ]
+    lines = [_style("AReno training config", fg="bright_white", bold=True, color=color)]
+    for section, rows in sections:
+        lines.extend(_format_summary_section(section, rows, color=color))
+    if config.save_path is None:
+        lines.append(
+            _style("WARNING", fg="yellow", bold=True, color=color)
+            + ": no checkpoint output path configured (--save-path); checkpoints will not be saved."
+        )
+    return "\n".join(lines)
+
+
+def _print_training_config_summary(config: TrainerConfig, *, reward_ckpt: str | None = None) -> None:
+    click.echo(_format_training_config_summary(config, reward_ckpt=reward_ckpt, color=True), color=True)
+
+
+def _format_summary_section(section: str, rows: list[tuple[str, str]], *, color: bool) -> list[str]:
+    field_width = max([len("Field"), *(len(field) for field, _ in rows)])
+    terminal_width = shutil.get_terminal_size(fallback=(100, 24)).columns
+    value_width = max(20, terminal_width - field_width - 4)
+    label = _style(section, fg="bright_blue", bold=True, color=color)
+    rule = _style("-" * len(section), fg="bright_black", color=color)
+    lines = ["", label, rule]
+    for field, value in rows:
+        wrapped = textwrap.wrap(value, width=value_width, break_long_words=True, break_on_hyphens=False) or [""]
+        lines.append("  " + _style(field.ljust(field_width), fg="bright_black", color=color) + "  " + wrapped[0])
+        padding = "  " + " " * field_width + "  "
+        lines.extend(padding + line for line in wrapped[1:])
+    return lines
+
+
+def _rollout_summary_rows(config: TrainerConfig) -> list[tuple[str, str]]:
+    base = [
+        ("batch_size", str(config.batch_size)),
+        ("max_prompt_tokens", str(config.max_prompt_tokens)),
+        ("max_new_tokens", str(config.max_new_tokens)),
+    ]
+    if not isinstance(config, RolloutTrainerConfig):
+        return [
+            *base,
+            ("n_samples", "n/a"),
+            ("max_running_prompts", "n/a"),
+            ("sampling", "n/a"),
+        ]
+    return [
+        *base,
+        ("n_samples", str(config.n_samples)),
+        ("max_running_prompts", str(config.resolved_max_running_prompts())),
+        (
+            "sampling",
+            (
+                f"greedy={_format_bool(config.greedy)}, "
+                f"temperature={config.temperature}, top_k={config.top_k}, top_p={config.top_p}"
+            ),
+        ),
+    ]
+
+
+def _reward_ckpt_for_summary(config: TrainerConfig, reward_ckpt: str | None) -> str | None:
+    if isinstance(config, PPOTrainerConfig):
+        return config.reward_ckpt
+    return reward_ckpt
+
+
+def _callable_name(fn) -> str:
+    return getattr(fn, "__name__", type(fn).__name__)
+
+
+def _resolved_dp_size_for_summary(config: TrainerConfig) -> str:
+    return str(config.world_size // config.tp_size) if config.tp_size else "n/a"
+
+
+def _format_bool(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _format_optional(value, *, default: str = "none") -> str:
+    return str(value) if value is not None else default
+
+
+def _style(text: str, *, color: bool, fg: str | None = None, bold: bool = False) -> str:
+    return click.style(text, fg=fg, bold=bold) if color else text
 
 
 def _trainer_config_from_args(args) -> TrainerConfig:
@@ -574,6 +729,7 @@ def train_command(**options) -> None:
 
     trainer_config = _trainer_config_from_options(**options)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    _print_training_config_summary(trainer_config, reward_ckpt=options.get("reward_ckpt"))
     run(trainer_config)
 
 

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import pytest
-from click import UsageError
+from click import UsageError, unstyle
+from click.testing import CliRunner
 
 from areno.api.trainer_config import DPOTrainerConfig, PolicyTrainerConfig, PPOTrainerConfig, TrainerConfig
-from areno.cli.train import _trainer_config_from_options
+from areno.cli import train as train_cli
+from areno.cli.train import (
+    _callable_name,
+    _format_summary_section,
+    _format_training_config_summary,
+    _trainer_config_from_options,
+)
 
 
 def test_train_config_requires_ckpt():
@@ -218,6 +225,145 @@ def test_train_config_ppo_preserves_reward_ckpt_as_role_checkpoint():
     assert isinstance(cfg, PPOTrainerConfig)
     assert cfg.reward_fn_path is None
     assert cfg.reward_ckpt == "reward-model"
+
+
+def test_training_config_summary_shows_resolved_values_and_warning():
+    cfg = _trainer_config_from_options(
+        **_options(
+            algo="gspo",
+            reward_fn_path=None,
+            reward_ckpt="reward-model",
+            save_path=None,
+            world_size=8,
+            tp_size=2,
+            batch_size=4,
+            n_samples=3,
+            max_running_prompts=None,
+            temperature=0.7,
+            top_k=20,
+            top_p=0.9,
+            lr=2e-6,
+            min_lr=0.0,
+            metrics_log_dir="/tmp/metrics",
+        )
+    )
+
+    summary = _format_training_config_summary(cfg, reward_ckpt="reward-model")
+
+    assert "AReno training config" in summary
+    assert "Algorithm\n---------" in summary
+    assert "name              gspo" in summary
+    assert "default_loss      gspo_loss_fn" in summary
+    assert "requires_rollout  yes" in summary
+    assert "ckpt            actor" in summary
+    assert "dataset_path    dataset" in summary
+    assert "reward_fn       none" in summary
+    assert "reward_ckpt     reward-model" in summary
+    assert "dp_size     4" in summary
+    assert "max_running_prompts  12" in summary
+    assert "sampling             greedy=no, temperature=0.7, top_k=20, top_p=0.9" in summary
+    assert "optimizer                    lr=2e-06, min_lr=0.0, decay=cosine/100" in summary
+    assert "metrics_log_dir  /tmp/metrics" in summary
+    assert "WARNING: no checkpoint output path configured (--save-path)" in summary
+
+
+def test_training_config_summary_can_colorize_output():
+    cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None))
+
+    summary = _format_training_config_summary(cfg, color=True)
+
+    assert "\x1b[" in summary
+    assert "AReno training config" in summary
+
+
+def test_training_config_summary_wraps_for_narrow_terminals(monkeypatch):
+    monkeypatch.setattr(
+        train_cli.shutil, "get_terminal_size", lambda fallback: train_cli.shutil.os.terminal_size((48, 24))
+    )
+    cfg = _trainer_config_from_options(
+        **_options(
+            algo="sft",
+            reward_fn_path=None,
+            reward_ckpt=None,
+            metrics_log_dir="/tmp/areno/a/very/long/path/that/should/wrap",
+        )
+    )
+
+    summary = _format_training_config_summary(cfg)
+
+    lines = summary.splitlines()
+    row_idx = next(idx for idx, line in enumerate(lines) if line.startswith("  metrics_log_dir"))
+    assert lines[row_idx].startswith("  metrics_log_dir  ")
+    assert lines[row_idx + 1].startswith(" " * 19)
+
+
+def test_training_config_summary_marks_non_rollout_fields_not_applicable():
+    cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None))
+
+    summary = _format_training_config_summary(cfg)
+
+    assert "name              sft" in summary
+    assert "requires_rollout  no" in summary
+    assert "reward_fn       n/a" in summary
+    assert "n_samples            n/a" in summary
+    assert "max_running_prompts  n/a" in summary
+    assert "sampling             n/a" in summary
+
+
+def test_training_config_summary_handles_invalid_tp_size_defensively():
+    cfg = TrainerConfig(algo="sft", ckpt="actor", dataset_path="dataset", tp_size=0, world_size=8)
+
+    summary = _format_training_config_summary(cfg)
+
+    assert "tp_size     0" in summary
+    assert "dp_size     n/a" in summary
+
+
+def test_training_config_summary_section_handles_empty_rows():
+    assert _format_summary_section("Empty", [], color=False) == ["", "Empty", "-----"]
+
+
+def test_training_config_summary_callable_name_handles_callable_objects():
+    class CallableLoss:
+        def __call__(self):
+            return None
+
+    assert _callable_name(CallableLoss()) == "CallableLoss"
+
+
+def test_train_command_prints_summary_before_run(monkeypatch):
+    events = []
+
+    def fake_run(config):
+        events.append(("run", config.algo))
+
+    monkeypatch.setattr(train_cli, "run", fake_run)
+
+    result = CliRunner().invoke(
+        train_cli.train_command,
+        [
+            "--algo",
+            "sft",
+            "--ckpt",
+            "actor",
+            "--dataset-path",
+            "dataset",
+            "--world-size",
+            "2",
+            "--tp-size",
+            "1",
+            "--save-path",
+            "out",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert output.startswith("AReno training config\n")
+    assert "dp_size     2" in output
+    assert "save_path        out" in output
+    assert "WARNING: no checkpoint output path configured" not in output
+    assert events == [("run", "sft")]
 
 
 def _options(**overrides):


### PR DESCRIPTION
Closes https://github.com/inclusionAI/asystem-areno/issues/10

## Summary
- print a concise resolved `areno train` config summary before backend/model initialization
- show algorithm metadata, input hooks, inferred `dp_size`, resolved rollout concurrency, optimizer settings, and output paths
- colorize the CLI output while keeping the formatter testable without ANSI escape codes
- wrap long values based on terminal width so paths and optimizer summaries remain readable
- handle defensive formatter edge cases for invalid `tp_size`, empty sections, and callable objects without `__name__`

Note: the summary intentionally prints before model reference resolution so it does not trigger Hugging Face downloads or other heavy setup before the preflight display.

## Example
<img width="1860" height="1280" alt="image" src="https://github.com/user-attachments/assets/87478510-37c8-4dc8-b1e4-8667963f62b1" />



## Tests
```bash
ruff check areno/cli/train.py tests/test_train_cli_config_cpu.py
ruff format --check areno/cli/train.py tests/test_train_cli_config_cpu.py
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_train_cli_config_cpu.py -q
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests -q
```

Result: full CPU suite passed, 232 passed, 5 warnings.