### PR TITLE
fix: support qwen angle tool calls

### DIFF
--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
 from typing import Any
@@ -20,8 +21,27 @@ def normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # the tool_calls payload.
         if item.get("content") is None:
             item["content"] = ""
+        if isinstance(item.get("tool_calls"), list):
+            item["tool_calls"] = [_normalize_message_tool_call(call) for call in item["tool_calls"]]
         normalized.append(item)
     return normalized
+
+
+def _normalize_message_tool_call(call: Any) -> Any:
+    if not isinstance(call, dict):
+        return call
+    item = dict(call)
+    function = item.get("function")
+    if isinstance(function, dict):
+        function = dict(function)
+        arguments = function.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                function["arguments"] = json.loads(arguments or "{}")
+            except json.JSONDecodeError:
+                pass
+        item["function"] = function
+    return item
 
 
 def messages_to_prompt_tokens(
@@ -41,9 +61,36 @@ def messages_to_prompt_tokens(
         try:
             return tokenizer.apply_chat_template(messages, **kwargs)
         except TypeError:
+            if tools:
+                kwargs["tools"] = _normalize_tools_for_chat_template(tools)
+                try:
+                    return tokenizer.apply_chat_template(messages, **kwargs)
+                except TypeError:
+                    pass
             kwargs.pop("tools", None)
             return tokenizer.apply_chat_template(messages, **kwargs)
     return tokenizer.encode(messages_to_text(messages) or fallback_prompt)
+
+
+def _normalize_tools_for_chat_template(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        item = dict(tool)
+        function = item.get("function")
+        if isinstance(function, dict):
+            function = dict(function)
+            parameters = function.get("parameters")
+            if not isinstance(parameters, dict):
+                function["parameters"] = {"type": "object", "properties": {}}
+            elif not isinstance(parameters.get("properties", {}), dict):
+                parameters = dict(parameters)
+                parameters["properties"] = {}
+                function["parameters"] = parameters
+            item["function"] = function
+        normalized.append(item)
+    return normalized
 
 
 def messages_to_text(messages: list[dict[str, Any]]) -> str:

--- a/areno/api/tool_call_parser.py
+++ b/areno/api/tool_call_parser.py
@@ -103,6 +103,7 @@ class QwenToolCallParser(JsonToolCallParser):
         calls: list[dict[str, Any]] = []
         for block in self._block_re.findall(content):
             calls.extend(_parse_json_tool_calls(block, tools, _chosen_tool_name(tools, tool_choice)))
+            calls.extend(_parse_angle_tool_calls(block, tools, tool_choice))
         if calls:
             normal = content[: content.find("<tool_call>")].strip()
             return ToolCallParseResult(normal_text=normal, tool_calls=calls)
@@ -145,13 +146,10 @@ class MiniCPMToolCallParser(JsonToolCallParser):
     name = "minicpm"
     _function_re = re.compile(r"<function\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</function>", re.DOTALL | re.IGNORECASE)
     _param_re = re.compile(r"<param\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</param>", re.DOTALL | re.IGNORECASE)
-    _tool_block_re = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTALL | re.IGNORECASE)
-    _angle_function_re = re.compile(r"<function=([^>\s]+)>\s*(.*?)</function>", re.DOTALL | re.IGNORECASE)
-    _angle_param_re = re.compile(r"<parameter=([^>\s]+)>\s*(.*?)</parameter>", re.DOTALL | re.IGNORECASE)
 
     def parse(self, content: str, tools: list[dict[str, Any]], tool_choice: Any) -> ToolCallParseResult:
         calls: list[dict[str, Any]] = []
-        calls.extend(self._parse_v46_tool_blocks(content, tools, tool_choice))
+        calls.extend(_parse_angle_tool_call_blocks(content, tools, tool_choice))
         for name, body in self._function_re.findall(content):
             if not _tool_name_allowed(name, tools, tool_choice):
                 continue
@@ -164,21 +162,6 @@ class MiniCPMToolCallParser(JsonToolCallParser):
             normal = content[:first_tool].strip() if first_tool is not None else ""
             return ToolCallParseResult(normal_text=normal, tool_calls=calls)
         return super().parse(content, tools, tool_choice)
-
-    def _parse_v46_tool_blocks(
-        self, content: str, tools: list[dict[str, Any]], tool_choice: Any
-    ) -> list[dict[str, Any]]:
-        calls: list[dict[str, Any]] = []
-        for block in self._tool_block_re.findall(content):
-            for name, body in self._angle_function_re.findall(block):
-                if not _tool_name_allowed(name, tools, tool_choice):
-                    continue
-                args = {
-                    key.strip(): _parse_minicpm_param_value(value.strip())
-                    for key, value in self._angle_param_re.findall(body)
-                }
-                calls.append(_openai_tool_call(name.strip(), args))
-        return calls
 
 
 def _safe_tokenizer(trainer: Any) -> Any:
@@ -441,6 +424,28 @@ def _parse_minicpm_param_value(value: str) -> Any:
         return float(value)
     except ValueError:
         return value
+
+
+_ANGLE_TOOL_BLOCK_RE = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTALL | re.IGNORECASE)
+_ANGLE_FUNCTION_RE = re.compile(r"<function=([^>\s]+)>\s*(.*?)</function>", re.DOTALL | re.IGNORECASE)
+_ANGLE_PARAM_RE = re.compile(r"<parameter=([^>\s]+)>\s*(.*?)</parameter>", re.DOTALL | re.IGNORECASE)
+
+
+def _parse_angle_tool_call_blocks(content: str, tools: list[dict[str, Any]], tool_choice: Any) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    for block in _ANGLE_TOOL_BLOCK_RE.findall(content):
+        calls.extend(_parse_angle_tool_calls(block, tools, tool_choice))
+    return calls
+
+
+def _parse_angle_tool_calls(content: str, tools: list[dict[str, Any]], tool_choice: Any) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    for name, body in _ANGLE_FUNCTION_RE.findall(content):
+        if not _tool_name_allowed(name, tools, tool_choice):
+            continue
+        args = {key.strip(): _parse_minicpm_param_value(value.strip()) for key, value in _ANGLE_PARAM_RE.findall(body)}
+        calls.append(_openai_tool_call(name.strip(), args))
+    return calls
 
 
 def _first_nonnegative(*values: int) -> int | None:

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -163,6 +163,29 @@ def test_normalize_messages_rewrites_null_tool_call_content_for_templates():
     assert messages[1]["content"] == ""
 
 
+def test_messages_to_prompt_tokens_normalizes_tool_call_arguments_for_templates():
+    tokenizer = _ToolCallArgumentsMappingTokenizer()
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "inspect_tree", "arguments": '{"path":".","max_depth":3}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "{}"},
+    ]
+
+    tokens = agentic._messages_to_prompt_tokens(tokenizer, messages, tools=[], fallback_prompt="fallback")
+
+    assert tokens == [3]
+
+
 def test_explicit_trajectory_tokenization_normalizes_null_tool_call_content():
     trainer = _FakeTrainer(world_size=1, tp_size=1)
     trainer.tokenizer = _StrictContentTokenizer()
@@ -753,6 +776,47 @@ def test_qwen_tool_call_parser_supports_chat_completions_tools():
     assert '"direction":"right"' in parsed.tool_calls[0]["function"]["arguments"]
 
 
+def test_qwen_tool_call_parser_supports_angle_function_blocks():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "inspect_tree",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "max_depth": {"type": "integer"},
+                    },
+                },
+            },
+        }
+    ]
+
+    parsed = QwenToolCallParser().parse(
+        "Let me start by inspecting the repository structure.\n"
+        "</think>\n\n"
+        "<tool_call>\n"
+        "<function=inspect_tree>\n"
+        "<parameter=path>\n"
+        ".\n"
+        "</parameter>\n"
+        "<parameter=max_depth>\n"
+        "3\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>",
+        tools,
+        "required",
+    )
+
+    assert parsed.normal_text == "Let me start by inspecting the repository structure.\n</think>"
+    assert len(parsed.tool_calls) == 1
+    assert parsed.tool_calls[0]["function"]["name"] == "inspect_tree"
+    assert '"path":"."' in parsed.tool_calls[0]["function"]["arguments"]
+    assert '"max_depth":3' in parsed.tool_calls[0]["function"]["arguments"]
+
+
 def test_gemma4_tool_call_parser_supports_chat_completions_tools():
     tools = [
         {
@@ -997,6 +1061,17 @@ class _StrictContentTokenizer(_FakeTokenizer):
         for message in messages:
             assert isinstance(message.get("content"), str)
         return [len(messages)]
+
+
+class _ToolCallArgumentsMappingTokenizer(_StrictContentTokenizer):
+    def apply_chat_template(self, messages, *, tokenize, add_generation_prompt, tools=None):
+        for message in messages:
+            for call in message.get("tool_calls") or []:
+                assert isinstance(call["function"]["arguments"], dict)
+                list(call["function"]["arguments"].items())
+        return super().apply_chat_template(
+            messages, tokenize=tokenize, add_generation_prompt=add_generation_prompt, tools=tools
+        )
 
 
 class _ToolRejectingTokenizer(_FakeTokenizer):


### PR DESCRIPTION
## Summary

- add Qwen parser support for `<tool_call><function=...><parameter=...>` angle-style tool calls
- share the angle-style parser with the existing MiniCPM v46 path
- normalize historical assistant `tool_calls[].function.arguments` from JSON strings to mappings before chat-template rendering

## Tests

```bash
ruff check areno/api/openai_chat.py areno/api/tool_call_parser.py tests/test_agentic_cpu.py
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_agentic_cpu.py::test_messages_to_prompt_tokens_normalizes_tool_call_arguments_for_templates tests/test_agentic_cpu.py::test_qwen_tool_call_parser_supports_chat_completions_tools tests/test_agentic_cpu.py::test_qwen_tool_call_parser_supports_angle_function_blocks tests/test_agentic_cpu.py::test_minicpm_tool_call_parser_supports_v46_tool_call_blocks tests/test_serve_cli_cpu.py::test_serve_response_reuses_tool_call_parser -q
```

Closes #27
