### PR TITLE
docs: rename repo URLs from asystem-areno to AReno

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: "Thanks for taking the time to file a bug report! Before submitting, please **search the [issue tracker](https://github.com/inclusionAI/asystem-areno/issues)** to make sure the bug was not already reported."
+      value: "Thanks for taking the time to file a bug report! Before submitting, please **search the [issue tracker](https://github.com/inclusionAI/AReno/issues)** to make sure the bug was not already reported."
 
   - type: checkboxes
     id: prerequisites

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📖 Contribution guide
-    url: https://github.com/inclusionAI/asystem-areno/blob/main/CONTRIBUTING.md
+    url: https://github.com/inclusionAI/AReno/blob/main/CONTRIBUTING.md
     about: Read this before opening an issue or pull request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@ labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
-      value: "Thanks for suggesting a feature! For a new post-training **algorithm**, please also skim the [contribution guide](https://github.com/inclusionAI/asystem-areno/blob/main/CONTRIBUTING.md#do-you-want-to-implement-a-new-algorithm) first — good candidates favor simplicity or single-node efficiency."
+      value: "Thanks for suggesting a feature! For a new post-training **algorithm**, please also skim the [contribution guide](https://github.com/inclusionAI/AReno/blob/main/CONTRIBUTING.md#do-you-want-to-implement-a-new-algorithm) first — good candidates favor simplicity or single-node efficiency."
 
   - type: textarea
     id: motivation

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -4,7 +4,7 @@ labels: ["question"]
 body:
   - type: markdown
     attributes:
-      value: "Have a usage question? Please first skim the [README](https://github.com/inclusionAI/asystem-areno/blob/main/README.md) and the [docs](https://github.com/inclusionAI/asystem-areno/tree/main/docs), and search existing issues — your question may already be answered."
+      value: "Have a usage question? Please first skim the [README](https://github.com/inclusionAI/AReno/blob/main/README.md) and the [docs](https://github.com/inclusionAI/AReno/tree/main/docs), and search existing issues — your question may already be answered."
 
   - type: textarea
     id: question

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ and improving the documentation are all immensely valuable.
 
 It also helps if you spread the word — reference AReno in blog posts about the
 projects it made possible, shout it out when it helps you, or simply ⭐️ the
-[repository](https://github.com/inclusionAI/asystem-areno) to say thank you.
+[repository](https://github.com/inclusionAI/AReno) to say thank you.
 
 ## AI usage policy
 
@@ -98,13 +98,13 @@ working on the same thing. If unsure, open an issue first to get feedback.
 
 Follow these steps:
 
-1. Fork the [repository](https://github.com/inclusionAI/asystem-areno) and clone
+1. Fork the [repository](https://github.com/inclusionAI/AReno) and clone
    your fork, adding the base repo as a remote:
 
    ```bash
-   git clone git@github.com:<your-handle>/asystem-areno.git
-   cd asystem-areno
-   git remote add upstream https://github.com/inclusionAI/asystem-areno.git
+   git clone git@github.com:<your-handle>/AReno.git
+   cd AReno
+   git remote add upstream https://github.com/inclusionAI/AReno.git
    # Pull from upstream, but never push to it — push only to your fork (origin)
    git remote set-url --push upstream no-pushing
    ```

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ errors.
 **From source** (recommended if you want the examples or plan to contribute):
 
 ```bash
-git clone https://github.com/inclusionAI/asystem-areno.git
-cd asystem-areno
+git clone https://github.com/inclusionAI/AReno.git
+cd AReno
 pip install psutil
 pip install flash-attn flash-linear-attention
 pip install -e . --no-build-isolation
@@ -291,8 +291,8 @@ Point any OpenAI client at `http://localhost:8000/v1/chat/completions` to start 
 If you want to contribute to AReno or customize it for your own needs, read the [contribution guide](CONTRIBUTING.md) and make a development install:
 
 ```bash
-git clone https://github.com/inclusionAI/asystem-areno.git
-cd asystem-areno
+git clone https://github.com/inclusionAI/AReno.git
+cd AReno
 pip install psutil
 pip install flash-attn flash-linear-attention
 pip install -e . --no-build-isolation
@@ -313,7 +313,7 @@ If you find the project helpful, please cite:
   title        = {AReno: A Self-Contained, Full-Stack Toolkit for Single-Node LLM RL Post-Training},
   author       = {Zibo He and Le Su and Zongyu Li and Xiaowei Zhu and Cheng Wang and Zhenxuan Pan},
   year         = {2026},
-  url          = {https://github.com/inclusionAI/asystem-areno},
+  url          = {https://github.com/inclusionAI/AReno},
   license      = {Apache-2.0}
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/inclusionAI/asystem-areno"
-Repository = "https://github.com/inclusionAI/asystem-areno"
-Issues = "https://github.com/inclusionAI/asystem-areno/issues"
+Homepage = "https://github.com/inclusionAI/AReno"
+Repository = "https://github.com/inclusionAI/AReno"
+Issues = "https://github.com/inclusionAI/AReno/issues"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## What

Replaces all `inclusionAI/asystem-areno` references with `inclusionAI/AReno` across docs and project metadata, ahead of renaming the GitHub repository to `inclusionAI/AReno`.

Only repo/clone URLs and paths changed. The pip package name (`name = "areno"`), `import areno`, and the `areno` CLI command stay lowercase — those are identifiers, not branding.

## Changes (17 references across 7 files)

- `README.md` (5) — clone URLs, `cd` paths, citation `url`
- `CONTRIBUTING.md` (4) — repo link, fork/clone steps, upstream remote
- `pyproject.toml` (3) — Homepage / Repository / Issues URLs
- `.github/ISSUE_TEMPLATE/` (4) — doc links in config / bug_report / feature_request / question

## Follow-ups (outside this PR)

1. Rename the GitHub repo `inclusionAI/asystem-areno` → `inclusionAI/AReno`.
2. Update local remote: `git remote set-url origin git@github.com:inclusionAI/AReno.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)