### PR TITLE
feat: add native attention backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,13 @@
 
 ## Quick reference
 
-**Tech stack**: Python 3.10+ | CUDA | PyTorch ≥ 2.6 | FlashAttention | flash-linear-attention | Transformers | safetensors
+**Tech stack**: Python 3.10+ | CUDA | PyTorch ≥ 2.6 | optional FlashAttention | flash-linear-attention | Transformers | safetensors
 
 ```bash
 # Install (requires an existing Linux + NVIDIA GPU + CUDA + PyTorch >= 2.6 env)
 pip install psutil                         # required with --no-build-isolation
-pip install flash-attn flash-linear-attention
+pip install flash-linear-attention
+pip install flash-attn                     # optional unless using --attn-backend flash
 pip install -e . --no-build-isolation         # --no-build-isolation: build against your installed torch
 TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation  # target H100/H200 only
 ARENO_BUILD_EXT=0 pip install -e . --no-build-isolation   # skip CUDA build (metadata-only / dry run)

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ AReno's mission is to make LLM RL **accessible** for a broad community of resear
 
 ```bash
 pip install psutil
-pip install flash-attn flash-linear-attention
+pip install flash-linear-attention
 pip install areno --no-build-isolation
 ```
 
 `--no-build-isolation` is required so that pip uses your existing CUDA-enabled PyTorch instead of installing a CPU-only torch in an isolated build environment.
 Because build isolation is disabled, build-time helpers are not installed automatically; `psutil` must already be present because PyTorch's CUDA extension builder imports it while sizing parallel compile jobs.
+Install `flash-attn` only when using the default high-throughput `--attn-backend flash` path. If you run with `--attn-backend native`, or AReno automatically falls back to native attention on Turing GPUs like T4, `flash-attn` is optional and does not need to be installed.
 
 After installation, run `areno check` for an actionable readiness check. Use
 `areno env --json` when opening an issue so maintainers can see the Python,
@@ -68,7 +69,7 @@ errors.
 git clone https://github.com/inclusionAI/asystem-areno.git
 cd asystem-areno
 pip install psutil
-pip install flash-attn flash-linear-attention
+pip install flash-linear-attention
 pip install -e . --no-build-isolation
 ```
 
@@ -76,7 +77,12 @@ pip install -e . --no-build-isolation
 
 - Install `ninja` (`pip install ninja`) before building so CUDA kernels compile in parallel.
 - If installation fails with `No module named 'psutil'`, install it first (`pip install psutil`) and retry. This is required specifically for `--no-build-isolation` builds.
-- Install `flash-attn` before AReno so the local build can reuse the already-installed package. If building `flash-attn` from source is too slow for your environment, install a pre-built wheel from the [flash-attention releases](https://github.com/Dao-AILab/flash-attention/releases) that matches your Python, PyTorch, CUDA, and platform.
+- Install `flash-attn` before AReno only if you plan to use `--attn-backend flash`, the default high-throughput backend:
+  ```bash
+  pip install flash-attn
+  ```
+  If building `flash-attn` from source is too slow for your environment, install a pre-built wheel from the [flash-attention releases](https://github.com/Dao-AILab/flash-attention/releases) that matches your Python, PyTorch, CUDA, and platform.
+- If you use `--attn-backend native`, `flash-attn` is optional. AReno also automatically falls back to native attention on flash-attn-unsupported GPUs such as Tesla T4 and prints a warning that native attention is a slower compatibility path.
 - By default, source builds target the visible GPU architecture. To build for a specific GPU family or when building on a host where the target GPU is not visible, set `TORCH_CUDA_ARCH_LIST` explicitly. Common values are `9.0` for H100/H200, `8.0` for A100, and `8.9` for L40/RTX 4090:
   ```bash
   TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
@@ -294,7 +300,9 @@ If you want to contribute to AReno or customize it for your own needs, read the 
 git clone https://github.com/inclusionAI/asystem-areno.git
 cd asystem-areno
 pip install psutil
-pip install flash-attn flash-linear-attention
+pip install flash-linear-attention
+# Optional: install flash-attn when developing against --attn-backend flash.
+pip install flash-attn
 pip install -e . --no-build-isolation
 
 # Set up pre-commit hooks (formatting, linting, commit message checks)

--- a/areno/accel/__init__.py
+++ b/areno/accel/__init__.py
@@ -16,6 +16,11 @@ from areno.accel.activations import (
     areno_silu_and_mul,
     areno_softplus,
 )
+from areno.accel.attention import (
+    areno_causal_attention,
+    areno_paged_causal_attention_decode,
+    areno_varlen_causal_attention,
+)
 from areno.accel.conv import (
     areno_depthwise_causal_conv1d_silu,
     areno_depthwise_causal_conv1d_silu_decode,
@@ -34,6 +39,9 @@ __all__ = [
     "areno_depthwise_causal_conv1d_silu_decode",
     "areno_packed_depthwise_causal_conv1d_silu",
     "areno_gelu_tanh_and_mul",
+    "areno_causal_attention",
+    "areno_paged_causal_attention_decode",
+    "areno_varlen_causal_attention",
     "areno_grouped_topk_router",
     "areno_grouped_linear",
     "areno_linear",

--- a/areno/accel/attention.py
+++ b/areno/accel/attention.py
@@ -1,0 +1,314 @@
+"""Unified causal attention shim for consistency diagnostics.
+
+This backend intentionally routes train full-forward, rollout prefill, and
+rollout decode through the same CUDA forward kernel. It is slower than
+flash-attn, but keeps causal/window masking and softmax accumulation identical
+across paths so rollout old-logp and train logp can be compared without mixing
+attention implementations.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from areno.accel._extension import extension as _extension
+
+
+def _window_left(window_left: int | None) -> int:
+    return -1 if window_left is None else int(window_left)
+
+
+def _scale(q: torch.Tensor, softmax_scale: float | None) -> float:
+    return float(softmax_scale if softmax_scale is not None else q.shape[-1] ** -0.5)
+
+
+def _reference_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    query_start: int,
+    window_left: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    scores = torch.matmul(q, k.transpose(-1, -2)) * softmax_scale
+    q_pos = torch.arange(query_start, query_start + q.shape[-2], device=q.device).view(1, 1, q.shape[-2], 1)
+    k_pos = torch.arange(k.shape[-2], device=k.device).view(1, 1, 1, k.shape[-2])
+    mask = k_pos <= q_pos
+    if window_left >= 0:
+        mask = mask & (k_pos >= q_pos - window_left)
+    scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
+    probs = torch.softmax(scores.float(), dim=-1).to(v.dtype)
+    return torch.matmul(probs, v)
+
+
+def _reference_paged_decode_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    window_left: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    outs = []
+    q_heads = q.shape[1]
+    for idx in range(q.shape[0]):
+        length = int(cache_seqlens[idx].item()) + 1
+        blocks = block_table[idx]
+        positions = torch.arange(length, device=q.device)
+        block_cols = torch.div(positions, k_cache.shape[1], rounding_mode="floor")
+        block_offsets = positions % k_cache.shape[1]
+        block_ids = blocks[block_cols]
+        k = k_cache[block_ids, block_offsets]
+        v = v_cache[block_ids, block_offsets]
+        k = k.repeat_interleave(q_heads // k.shape[1], dim=1).transpose(0, 1).unsqueeze(0)
+        v = v.repeat_interleave(q_heads // v.shape[1], dim=1).transpose(0, 1).unsqueeze(0)
+        outs.append(
+            _reference_attention(
+                q[idx : idx + 1].unsqueeze(2),
+                k,
+                v,
+                query_start=length - 1,
+                window_left=window_left,
+                softmax_scale=softmax_scale,
+            ).squeeze(2)
+        )
+    return torch.cat(outs, dim=0)
+
+
+class _ArenoCausalAttention(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        query_start: int,
+        window_left: int,
+        softmax_scale: float,
+    ) -> torch.Tensor:
+        out = _extension().areno_causal_attention_forward(
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            int(query_start),
+            int(window_left),
+            float(softmax_scale),
+        )
+        ctx.save_for_backward(q, k, v, out)
+        ctx.query_start = int(query_start)
+        ctx.window_left = int(window_left)
+        ctx.softmax_scale = float(softmax_scale)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None, None]:
+        q, k, v, out = ctx.saved_tensors
+        dq, dk, dv = _extension().areno_causal_attention_backward(
+            grad_output.contiguous(),
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            out.contiguous(),
+            ctx.query_start,
+            ctx.window_left,
+            ctx.softmax_scale,
+        )
+        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), None, None, None
+
+
+@torch._dynamo.disable
+def areno_causal_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    query_start: int = 0,
+    window_left: int | None = None,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Apply causal attention to ``(batch, heads, seqlen, head_dim)`` tensors."""
+
+    if not (q.is_cuda and k.is_cuda and v.is_cuda):
+        raise RuntimeError("areno_causal_attention requires CUDA q, k, and v tensors")
+    if q.dim() != 4 or k.dim() != 4 or v.dim() != 4:
+        raise ValueError("areno_causal_attention expects q/k/v tensors shaped (batch, heads, seqlen, head_dim)")
+    if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
+        raise ValueError("areno_causal_attention batch size mismatch")
+    if q.shape[1] != k.shape[1] or q.shape[1] != v.shape[1]:
+        raise ValueError("areno_causal_attention head count mismatch")
+    if q.shape[-1] != k.shape[-1] or q.shape[-1] != v.shape[-1]:
+        raise ValueError("areno_causal_attention head dim mismatch")
+    return _ArenoCausalAttention.apply(q, k, v, int(query_start), _window_left(window_left), _scale(q, softmax_scale))
+
+
+class _ArenoVarlenCausalAttention(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        window_left: int,
+        softmax_scale: float,
+    ) -> torch.Tensor:
+        out = _extension().areno_varlen_causal_attention_forward(
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            cu_seqlens.contiguous(),
+            int(window_left),
+            float(softmax_scale),
+        )
+        ctx.save_for_backward(q, k, v, out, cu_seqlens)
+        ctx.window_left = int(window_left)
+        ctx.softmax_scale = float(softmax_scale)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None, None]:
+        q, k, v, out, cu_seqlens = ctx.saved_tensors
+        dq, dk, dv = _extension().areno_varlen_causal_attention_backward(
+            grad_output.contiguous(),
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            out.contiguous(),
+            cu_seqlens.contiguous(),
+            ctx.window_left,
+            ctx.softmax_scale,
+        )
+        return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype), None, None, None
+
+
+@torch._dynamo.disable
+def areno_varlen_causal_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    window_left: int | None = None,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Apply packed causal attention to flat ``(tokens, heads, head_dim)`` tensors."""
+
+    if not (q.is_cuda and k.is_cuda and v.is_cuda and cu_seqlens.is_cuda):
+        raise RuntimeError("areno_varlen_causal_attention requires CUDA q, k, v, and cu_seqlens tensors")
+    if q.dim() != 3 or k.dim() != 3 or v.dim() != 3:
+        raise ValueError("areno_varlen_causal_attention expects q/k/v tensors shaped (tokens, heads, head_dim)")
+    if cu_seqlens.dim() != 1 or cu_seqlens.dtype != torch.int32:
+        raise ValueError("areno_varlen_causal_attention expects an int32 1D cu_seqlens tensor")
+    if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
+        raise ValueError("areno_varlen_causal_attention token count mismatch")
+    if k.shape[1] != v.shape[1] or q.shape[1] % k.shape[1] != 0:
+        raise ValueError("areno_varlen_causal_attention expects q heads to be divisible by kv heads")
+    if q.shape[2] != k.shape[2] or q.shape[2] != v.shape[2]:
+        raise ValueError("areno_varlen_causal_attention head dim mismatch")
+    return _ArenoVarlenCausalAttention.apply(q, k, v, cu_seqlens, _window_left(window_left), _scale(q, softmax_scale))
+
+
+class _ArenoPagedCausalAttentionDecode(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k_update: torch.Tensor,
+        v_update: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        window_left: int,
+        num_splits: int,
+        softmax_scale: float,
+    ) -> torch.Tensor:
+        out = _extension().areno_paged_causal_attention_decode_forward(
+            q.contiguous(),
+            k_update.contiguous(),
+            v_update.contiguous(),
+            k_cache.contiguous(),
+            v_cache.contiguous(),
+            block_table.contiguous(),
+            cache_seqlens.contiguous(),
+            int(window_left),
+            int(num_splits),
+            float(softmax_scale),
+        )
+        ctx.save_for_backward(q, k_cache, v_cache, block_table, cache_seqlens)
+        ctx.window_left = int(window_left)
+        ctx.num_splits = int(num_splits)
+        ctx.softmax_scale = float(softmax_scale)
+        return out
+
+    @staticmethod
+    def backward(
+        ctx, grad_output: torch.Tensor
+    ) -> tuple[torch.Tensor, None, None, torch.Tensor, torch.Tensor, None, None, None, None, None]:
+        q, k_cache, v_cache, block_table, cache_seqlens = ctx.saved_tensors
+        with torch.enable_grad():
+            q_ref = q.detach().float().requires_grad_(True)
+            k_ref = k_cache.detach().float().requires_grad_(True)
+            v_ref = v_cache.detach().float().requires_grad_(True)
+            out = _reference_paged_decode_attention(
+                q_ref,
+                k_ref,
+                v_ref,
+                block_table,
+                cache_seqlens,
+                ctx.window_left,
+                ctx.softmax_scale,
+            )
+            dq, dk, dv = torch.autograd.grad(out, (q_ref, k_ref, v_ref), grad_output.float())
+        return dq.to(q.dtype), None, None, dk.to(k_cache.dtype), dv.to(v_cache.dtype), None, None, None, None, None
+
+
+@torch._dynamo.disable
+def areno_paged_causal_attention_decode(
+    q: torch.Tensor,
+    k_update: torch.Tensor,
+    v_update: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    *,
+    window_left: int | None = None,
+    num_splits: int = 8,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Apply single-token paged-cache causal attention to ``(batch, heads, dim)`` Q."""
+
+    if not (
+        q.is_cuda
+        and k_update.is_cuda
+        and v_update.is_cuda
+        and k_cache.is_cuda
+        and v_cache.is_cuda
+        and block_table.is_cuda
+        and cache_seqlens.is_cuda
+    ):
+        raise RuntimeError("areno_paged_causal_attention_decode requires CUDA tensors")
+    if q.dim() != 3:
+        raise ValueError("areno_paged_causal_attention_decode expects q shaped (batch, heads, head_dim)")
+    if k_update.dim() != 3 or v_update.dim() != 3:
+        raise ValueError("areno_paged_causal_attention_decode expects k/v updates shaped (batch, kv_heads, head_dim)")
+    if k_cache.dim() != 4 or v_cache.dim() != 4:
+        raise ValueError("areno_paged_causal_attention_decode expects 4D paged cache tensors")
+    if block_table.dim() != 2 or cache_seqlens.dim() != 1:
+        raise ValueError("areno_paged_causal_attention_decode expects block_table 2D and cache_seqlens 1D")
+    if block_table.dtype != torch.int32 or cache_seqlens.dtype != torch.int32:
+        raise ValueError("areno_paged_causal_attention_decode expects int32 block_table and cache_seqlens")
+    return _ArenoPagedCausalAttentionDecode.apply(
+        q,
+        k_update,
+        v_update,
+        k_cache,
+        v_cache,
+        block_table,
+        cache_seqlens,
+        _window_left(window_left),
+        int(num_splits),
+        _scale(q, softmax_scale),
+    )

--- a/areno/accel/csrc/attention.cu
+++ b/areno/accel/csrc/attention.cu
@@ -1,0 +1,1006 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace {
+
+constexpr int kAttentionThreads = 256;
+constexpr int kAttentionTileN = 16;
+
+__device__ __forceinline__ int64_t find_sequence_id(const int32_t* __restrict__ cu_seqlens, int64_t num_seqs, int64_t token_idx) {
+  int64_t lo = 0;
+  int64_t hi = num_seqs;
+  while (lo + 1 < hi) {
+    const int64_t mid = (lo + hi) >> 1;
+    if (static_cast<int64_t>(cu_seqlens[mid]) <= token_idx) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+template <typename scalar_t>
+__global__ void causal_attention_forward_kernel(
+    const scalar_t* __restrict__ q,
+    const scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ v,
+    scalar_t* __restrict__ out,
+    int64_t batch,
+    int64_t heads,
+    int64_t q_len,
+    int64_t k_len,
+    int64_t head_dim,
+    int64_t query_start,
+    int64_t window_left,
+    float softmax_scale) {
+  extern __shared__ float shared[];
+  float* q_s = shared;
+  float* acc_s = q_s + head_dim;
+  float* partial_s = acc_s + head_dim;
+  float* k_tile = partial_s + blockDim.x;
+  float* v_tile = k_tile + kAttentionTileN * head_dim;
+
+  const int64_t row = blockIdx.x;
+  const int64_t b = row / (heads * q_len);
+  const int64_t rem = row - b * heads * q_len;
+  const int64_t h = rem / q_len;
+  const int64_t qi = rem - h * q_len;
+  const int64_t abs_q = query_start + qi;
+
+  const int64_t q_base = ((b * heads + h) * q_len + qi) * head_dim;
+  const int64_t k_base = (b * heads + h) * k_len * head_dim;
+  const int64_t v_base = (b * heads + h) * k_len * head_dim;
+  const int64_t out_base = q_base;
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    q_s[d] = static_cast<float>(q[q_base + d]);
+    acc_s[d] = 0.0f;
+  }
+  __syncthreads();
+
+  float m = -std::numeric_limits<float>::infinity();
+  float l = 0.0f;
+
+  for (int64_t tile_start = 0; tile_start < k_len; tile_start += kAttentionTileN) {
+    const int64_t remaining = k_len - tile_start;
+    const int64_t tile_len =
+        remaining < static_cast<int64_t>(kAttentionTileN) ? remaining : static_cast<int64_t>(kAttentionTileN);
+    const int64_t tile_elements = tile_len * head_dim;
+    for (int64_t idx = threadIdx.x; idx < tile_elements; idx += blockDim.x) {
+      const int64_t ki = tile_start + idx / head_dim;
+      const int64_t d = idx % head_dim;
+      k_tile[idx] = static_cast<float>(k[k_base + ki * head_dim + d]);
+      v_tile[idx] = static_cast<float>(v[v_base + ki * head_dim + d]);
+    }
+    __syncthreads();
+
+    for (int64_t tile_idx = 0; tile_idx < tile_len; ++tile_idx) {
+      const int64_t ki = tile_start + tile_idx;
+      const bool valid = ki <= abs_q && (window_left < 0 || ki >= abs_q - window_left);
+
+      float thread_dot = 0.0f;
+      for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        thread_dot += q_s[d] * k_tile[tile_idx * head_dim + d];
+      }
+      partial_s[threadIdx.x] = thread_dot;
+      __syncthreads();
+
+      for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+          partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+        }
+        __syncthreads();
+      }
+
+      if (threadIdx.x == 0) {
+        float alpha = 1.0f;
+        float beta = 0.0f;
+        if (valid) {
+          const float score = partial_s[0] * softmax_scale;
+          const float new_m = fmaxf(m, score);
+          alpha = l == 0.0f ? 0.0f : expf(m - new_m);
+          beta = expf(score - new_m);
+          l = l * alpha + beta;
+          m = new_m;
+        }
+        partial_s[0] = alpha;
+        partial_s[1] = beta;
+        partial_s[2] = l;
+      }
+      __syncthreads();
+
+      const float alpha = partial_s[0];
+      const float beta = partial_s[1];
+      for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        acc_s[d] = acc_s[d] * alpha + beta * v_tile[tile_idx * head_dim + d];
+      }
+      __syncthreads();
+    }
+  }
+
+  const float denom = partial_s[2];
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    out[out_base + d] = static_cast<scalar_t>(acc_s[d] / denom);
+  }
+}
+
+template <typename scalar_t>
+__global__ void varlen_causal_attention_forward_kernel(
+    const scalar_t* __restrict__ q,
+    const scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ v,
+    scalar_t* __restrict__ out,
+    const int32_t* __restrict__ cu_seqlens,
+    int64_t total_tokens,
+    int64_t num_seqs,
+    int64_t q_heads,
+    int64_t kv_heads,
+    int64_t head_dim,
+    int64_t window_left,
+    float softmax_scale) {
+  extern __shared__ float shared[];
+  float* q_s = shared;
+  float* acc_s = q_s + head_dim;
+  float* partial_s = acc_s + head_dim;
+  float* k_tile = partial_s + blockDim.x;
+  float* v_tile = k_tile + kAttentionTileN * head_dim;
+
+  const int64_t row = blockIdx.x;
+  const int64_t token_idx = row / q_heads;
+  const int64_t h = row - token_idx * q_heads;
+  const int64_t kv_group = q_heads / kv_heads;
+  const int64_t kv_h = h / kv_group;
+  const int64_t seq_id = find_sequence_id(cu_seqlens, num_seqs, token_idx);
+  const int64_t seq_start = static_cast<int64_t>(cu_seqlens[seq_id]);
+  const int64_t local_q = token_idx - seq_start;
+  const int64_t first_key = window_left >= 0 && local_q > window_left ? token_idx - window_left : seq_start;
+  const int64_t last_key = token_idx;
+
+  const int64_t q_base = (token_idx * q_heads + h) * head_dim;
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    q_s[d] = static_cast<float>(q[q_base + d]);
+    acc_s[d] = 0.0f;
+  }
+  __syncthreads();
+
+  float m = -std::numeric_limits<float>::infinity();
+  float l = 0.0f;
+
+  for (int64_t tile_start = first_key; tile_start <= last_key; tile_start += kAttentionTileN) {
+    const int64_t remaining = last_key - tile_start + 1;
+    const int64_t tile_len =
+        remaining < static_cast<int64_t>(kAttentionTileN) ? remaining : static_cast<int64_t>(kAttentionTileN);
+    const int64_t tile_elements = tile_len * head_dim;
+    for (int64_t idx = threadIdx.x; idx < tile_elements; idx += blockDim.x) {
+      const int64_t ki = tile_start + idx / head_dim;
+      const int64_t d = idx % head_dim;
+      const int64_t kv_offset = (ki * kv_heads + kv_h) * head_dim + d;
+      k_tile[idx] = static_cast<float>(k[kv_offset]);
+      v_tile[idx] = static_cast<float>(v[kv_offset]);
+    }
+    __syncthreads();
+
+    for (int64_t tile_idx = 0; tile_idx < tile_len; ++tile_idx) {
+      float thread_dot = 0.0f;
+      for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        thread_dot += q_s[d] * k_tile[tile_idx * head_dim + d];
+      }
+      partial_s[threadIdx.x] = thread_dot;
+      __syncthreads();
+
+      for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+          partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+        }
+        __syncthreads();
+      }
+
+      if (threadIdx.x == 0) {
+        const float score = partial_s[0] * softmax_scale;
+        const float new_m = fmaxf(m, score);
+        const float alpha = l == 0.0f ? 0.0f : expf(m - new_m);
+        const float beta = expf(score - new_m);
+        l = l * alpha + beta;
+        m = new_m;
+        partial_s[0] = alpha;
+        partial_s[1] = beta;
+        partial_s[2] = l;
+      }
+      __syncthreads();
+
+      const float alpha = partial_s[0];
+      const float beta = partial_s[1];
+      for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+        acc_s[d] = acc_s[d] * alpha + beta * v_tile[tile_idx * head_dim + d];
+      }
+      __syncthreads();
+    }
+  }
+
+  const float denom = partial_s[2];
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    out[q_base + d] = static_cast<scalar_t>(acc_s[d] / denom);
+  }
+}
+
+template <typename scalar_t>
+__global__ void causal_attention_backward_kernel(
+    const scalar_t* __restrict__ grad_out,
+    const scalar_t* __restrict__ q,
+    const scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ v,
+    const scalar_t* __restrict__ out,
+    float* __restrict__ grad_q,
+    float* __restrict__ grad_k,
+    float* __restrict__ grad_v,
+    int64_t batch,
+    int64_t heads,
+    int64_t q_len,
+    int64_t k_len,
+    int64_t head_dim,
+    int64_t query_start,
+    int64_t window_left,
+    float softmax_scale) {
+  extern __shared__ float shared[];
+  float* q_s = shared;
+  float* go_s = q_s + head_dim;
+  float* out_s = go_s + head_dim;
+  float* dq_s = out_s + head_dim;
+  float* partial_s = dq_s + head_dim;
+
+  const int64_t row = blockIdx.x;
+  const int64_t b = row / (heads * q_len);
+  const int64_t rem = row - b * heads * q_len;
+  const int64_t h = rem / q_len;
+  const int64_t qi = rem - h * q_len;
+  const int64_t abs_q = query_start + qi;
+
+  const int64_t q_base = ((b * heads + h) * q_len + qi) * head_dim;
+  const int64_t k_base = (b * heads + h) * k_len * head_dim;
+  const int64_t v_base = (b * heads + h) * k_len * head_dim;
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    q_s[d] = static_cast<float>(q[q_base + d]);
+    go_s[d] = static_cast<float>(grad_out[q_base + d]);
+    out_s[d] = static_cast<float>(out[q_base + d]);
+    dq_s[d] = 0.0f;
+  }
+  __syncthreads();
+
+  float max_score = -std::numeric_limits<float>::infinity();
+  for (int64_t ki = 0; ki < k_len; ++ki) {
+    if (ki > abs_q || (window_left >= 0 && ki < abs_q - window_left)) {
+      continue;
+    }
+    float thread_dot = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      thread_dot += q_s[d] * static_cast<float>(k[k_base + ki * head_dim + d]);
+    }
+    partial_s[threadIdx.x] = thread_dot;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+      max_score = fmaxf(max_score, partial_s[0] * softmax_scale);
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    partial_s[0] = max_score;
+  }
+  __syncthreads();
+  max_score = partial_s[0];
+  __syncthreads();
+
+  float denom = 0.0f;
+  for (int64_t ki = 0; ki < k_len; ++ki) {
+    if (ki > abs_q || (window_left >= 0 && ki < abs_q - window_left)) {
+      continue;
+    }
+    float thread_dot = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      thread_dot += q_s[d] * static_cast<float>(k[k_base + ki * head_dim + d]);
+    }
+    partial_s[threadIdx.x] = thread_dot;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+      denom += expf(partial_s[0] * softmax_scale - max_score);
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    partial_s[0] = denom;
+  }
+  __syncthreads();
+  denom = partial_s[0];
+  __syncthreads();
+
+  for (int64_t ki = 0; ki < k_len; ++ki) {
+    if (ki > abs_q || (window_left >= 0 && ki < abs_q - window_left)) {
+      continue;
+    }
+    float thread_qk = 0.0f;
+    float thread_go_v_minus_out = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      const float k_val = static_cast<float>(k[k_base + ki * head_dim + d]);
+      const float v_val = static_cast<float>(v[v_base + ki * head_dim + d]);
+      thread_qk += q_s[d] * k_val;
+      thread_go_v_minus_out += go_s[d] * (v_val - out_s[d]);
+    }
+    partial_s[threadIdx.x] = thread_qk;
+    partial_s[blockDim.x + threadIdx.x] = thread_go_v_minus_out;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+        partial_s[blockDim.x + threadIdx.x] += partial_s[blockDim.x + threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    const float p = expf(partial_s[0] * softmax_scale - max_score) / denom;
+    const float ds = p * partial_s[blockDim.x];
+    const float scaled_ds = ds * softmax_scale;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      const int64_t offset = k_base + ki * head_dim + d;
+      const float q_val = q_s[d];
+      const float k_val = static_cast<float>(k[offset]);
+      const float go_val = go_s[d];
+      dq_s[d] += scaled_ds * k_val;
+      atomicAdd(grad_k + offset, scaled_ds * q_val);
+      atomicAdd(grad_v + offset, p * go_val);
+    }
+    __syncthreads();
+  }
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    grad_q[q_base + d] = dq_s[d];
+  }
+}
+
+template <typename scalar_t>
+__global__ void varlen_causal_attention_backward_kernel(
+    const scalar_t* __restrict__ grad_out,
+    const scalar_t* __restrict__ q,
+    const scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ v,
+    const scalar_t* __restrict__ out,
+    const int32_t* __restrict__ cu_seqlens,
+    float* __restrict__ grad_q,
+    float* __restrict__ grad_k,
+    float* __restrict__ grad_v,
+    int64_t total_tokens,
+    int64_t num_seqs,
+    int64_t q_heads,
+    int64_t kv_heads,
+    int64_t head_dim,
+    int64_t window_left,
+    float softmax_scale) {
+  extern __shared__ float shared[];
+  float* q_s = shared;
+  float* go_s = q_s + head_dim;
+  float* out_s = go_s + head_dim;
+  float* dq_s = out_s + head_dim;
+  float* partial_s = dq_s + head_dim;
+
+  const int64_t row = blockIdx.x;
+  const int64_t token_idx = row / q_heads;
+  const int64_t h = row - token_idx * q_heads;
+  const int64_t kv_group = q_heads / kv_heads;
+  const int64_t kv_h = h / kv_group;
+  const int64_t seq_id = find_sequence_id(cu_seqlens, num_seqs, token_idx);
+  const int64_t seq_start = static_cast<int64_t>(cu_seqlens[seq_id]);
+  const int64_t local_q = token_idx - seq_start;
+  const int64_t first_key = window_left >= 0 && local_q > window_left ? token_idx - window_left : seq_start;
+  const int64_t last_key = token_idx;
+  const int64_t q_base = (token_idx * q_heads + h) * head_dim;
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    q_s[d] = static_cast<float>(q[q_base + d]);
+    go_s[d] = static_cast<float>(grad_out[q_base + d]);
+    out_s[d] = static_cast<float>(out[q_base + d]);
+    dq_s[d] = 0.0f;
+  }
+  __syncthreads();
+
+  float max_score = -std::numeric_limits<float>::infinity();
+  for (int64_t ki = first_key; ki <= last_key; ++ki) {
+    float thread_dot = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      thread_dot += q_s[d] * static_cast<float>(k[(ki * kv_heads + kv_h) * head_dim + d]);
+    }
+    partial_s[threadIdx.x] = thread_dot;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+      max_score = fmaxf(max_score, partial_s[0] * softmax_scale);
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    partial_s[0] = max_score;
+  }
+  __syncthreads();
+  max_score = partial_s[0];
+  __syncthreads();
+
+  float denom = 0.0f;
+  for (int64_t ki = first_key; ki <= last_key; ++ki) {
+    float thread_dot = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      thread_dot += q_s[d] * static_cast<float>(k[(ki * kv_heads + kv_h) * head_dim + d]);
+    }
+    partial_s[threadIdx.x] = thread_dot;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+      denom += expf(partial_s[0] * softmax_scale - max_score);
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    partial_s[0] = denom;
+  }
+  __syncthreads();
+  denom = partial_s[0];
+  __syncthreads();
+
+  for (int64_t ki = first_key; ki <= last_key; ++ki) {
+    float thread_qk = 0.0f;
+    float thread_go_v_minus_out = 0.0f;
+    const int64_t kv_base = (ki * kv_heads + kv_h) * head_dim;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      const float k_val = static_cast<float>(k[kv_base + d]);
+      const float v_val = static_cast<float>(v[kv_base + d]);
+      thread_qk += q_s[d] * k_val;
+      thread_go_v_minus_out += go_s[d] * (v_val - out_s[d]);
+    }
+    partial_s[threadIdx.x] = thread_qk;
+    partial_s[blockDim.x + threadIdx.x] = thread_go_v_minus_out;
+    __syncthreads();
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+        partial_s[blockDim.x + threadIdx.x] += partial_s[blockDim.x + threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    const float p = expf(partial_s[0] * softmax_scale - max_score) / denom;
+    const float ds = p * partial_s[blockDim.x];
+    const float scaled_ds = ds * softmax_scale;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      const float q_val = q_s[d];
+      const float k_val = static_cast<float>(k[kv_base + d]);
+      const float go_val = go_s[d];
+      dq_s[d] += scaled_ds * k_val;
+      atomicAdd(grad_k + kv_base + d, scaled_ds * q_val);
+      atomicAdd(grad_v + kv_base + d, p * go_val);
+    }
+    __syncthreads();
+  }
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    grad_q[q_base + d] = dq_s[d];
+  }
+}
+
+template <typename scalar_t>
+__global__ void paged_decode_update_kernel(
+    const scalar_t* __restrict__ k_update,
+    const scalar_t* __restrict__ v_update,
+    scalar_t* __restrict__ k_cache,
+    scalar_t* __restrict__ v_cache,
+    const int32_t* __restrict__ block_table,
+    const int32_t* __restrict__ cache_seqlens,
+    int64_t batch,
+    int64_t kv_heads,
+    int64_t block_size,
+    int64_t max_blocks,
+    int64_t head_dim) {
+  const int64_t row = blockIdx.x;
+  const int64_t b = row / kv_heads;
+  const int64_t kv_h = row - b * kv_heads;
+  const int64_t length = static_cast<int64_t>(cache_seqlens[b]) + 1;
+  const int64_t abs_q = length - 1;
+  const int64_t update_block_col = abs_q / block_size;
+  const int64_t update_block_offset = abs_q - update_block_col * block_size;
+  const int64_t update_block_id = static_cast<int64_t>(block_table[b * max_blocks + update_block_col]);
+  const int64_t update_cache_base = ((update_block_id * block_size + update_block_offset) * kv_heads + kv_h) * head_dim;
+  const int64_t update_base = (b * kv_heads + kv_h) * head_dim;
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    k_cache[update_cache_base + d] = k_update[update_base + d];
+    v_cache[update_cache_base + d] = v_update[update_base + d];
+  }
+}
+
+template <typename scalar_t>
+__global__ void paged_causal_attention_decode_split_kernel(
+    const scalar_t* __restrict__ q,
+    const scalar_t* __restrict__ k_cache,
+    const scalar_t* __restrict__ v_cache,
+    const int32_t* __restrict__ block_table,
+    const int32_t* __restrict__ cache_seqlens,
+    float* __restrict__ split_m,
+    float* __restrict__ split_l,
+    float* __restrict__ split_acc,
+    int64_t batch,
+    int64_t q_heads,
+    int64_t kv_heads,
+    int64_t block_size,
+    int64_t max_blocks,
+    int64_t head_dim,
+    int64_t window_left,
+    int64_t num_splits,
+    float softmax_scale) {
+  extern __shared__ float shared[];
+  float* q_s = shared;
+  float* acc_s = q_s + head_dim;
+  float* partial_s = acc_s + head_dim;
+
+  const int64_t row = blockIdx.x / num_splits;
+  const int64_t split = blockIdx.x - row * num_splits;
+  const int64_t b = row / q_heads;
+  const int64_t h = row - b * q_heads;
+  const int64_t kv_group = q_heads / kv_heads;
+  const int64_t kv_h = h / kv_group;
+  const int64_t q_base = (b * q_heads + h) * head_dim;
+  const int64_t length = static_cast<int64_t>(cache_seqlens[b]) + 1;
+  const int64_t abs_q = length - 1;
+  const int64_t window_start = abs_q - window_left;
+  const int64_t first_allowed = window_left >= 0 ? (window_start > 0 ? window_start : static_cast<int64_t>(0)) : static_cast<int64_t>(0);
+  const int64_t split_size = (length + num_splits - 1) / num_splits;
+  const int64_t split_start = split * split_size;
+  const int64_t split_end_raw = split_start + split_size;
+  const int64_t split_end = split_end_raw < length ? split_end_raw : length;
+  const int64_t start = split_start > first_allowed ? split_start : first_allowed;
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    q_s[d] = static_cast<float>(q[q_base + d]);
+    acc_s[d] = 0.0f;
+  }
+  __syncthreads();
+
+  float m = -std::numeric_limits<float>::infinity();
+  float l = 0.0f;
+
+  for (int64_t ki = start; ki < split_end; ++ki) {
+    const int64_t block_col = ki / block_size;
+    const int64_t block_offset = ki - block_col * block_size;
+    const int64_t block_id = static_cast<int64_t>(block_table[b * max_blocks + block_col]);
+    const int64_t cache_base = ((block_id * block_size + block_offset) * kv_heads + kv_h) * head_dim;
+
+    float thread_dot = 0.0f;
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      thread_dot += q_s[d] * static_cast<float>(k_cache[cache_base + d]);
+    }
+    partial_s[threadIdx.x] = thread_dot;
+    __syncthreads();
+
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      if (threadIdx.x < stride) {
+        partial_s[threadIdx.x] += partial_s[threadIdx.x + stride];
+      }
+      __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+      const float score = partial_s[0] * softmax_scale;
+      const float new_m = fmaxf(m, score);
+      const float alpha = l == 0.0f ? 0.0f : expf(m - new_m);
+      const float beta = expf(score - new_m);
+      l = l * alpha + beta;
+      m = new_m;
+      partial_s[0] = alpha;
+      partial_s[1] = beta;
+      partial_s[2] = l;
+    }
+    __syncthreads();
+
+    const float alpha = partial_s[0];
+    const float beta = partial_s[1];
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      acc_s[d] = acc_s[d] * alpha + beta * static_cast<float>(v_cache[cache_base + d]);
+    }
+    __syncthreads();
+  }
+
+  const int64_t split_base = (row * num_splits + split);
+  if (threadIdx.x == 0) {
+    split_m[split_base] = m;
+    split_l[split_base] = l;
+  }
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    split_acc[split_base * head_dim + d] = acc_s[d];
+  }
+}
+
+template <typename scalar_t>
+__global__ void paged_causal_attention_decode_reduce_kernel(
+    const float* __restrict__ split_m,
+    const float* __restrict__ split_l,
+    const float* __restrict__ split_acc,
+    scalar_t* __restrict__ out,
+    int64_t rows,
+    int64_t head_dim,
+    int64_t num_splits) {
+  extern __shared__ float shared[];
+  float* acc_s = shared;
+  float* state_s = acc_s + head_dim;
+
+  const int64_t row = blockIdx.x;
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    acc_s[d] = 0.0f;
+  }
+  __syncthreads();
+
+  float m = -std::numeric_limits<float>::infinity();
+  float l = 0.0f;
+  for (int64_t split = 0; split < num_splits; ++split) {
+    const int64_t split_base = row * num_splits + split;
+    const float part_l = split_l[split_base];
+    if (part_l == 0.0f) {
+      continue;
+    }
+    const float part_m = split_m[split_base];
+    const float new_m = fmaxf(m, part_m);
+    const float alpha = l == 0.0f ? 0.0f : expf(m - new_m);
+    const float beta = expf(part_m - new_m);
+    const float new_l = l * alpha + part_l * beta;
+    state_s[0] = alpha;
+    state_s[1] = beta;
+    __syncthreads();
+    for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      acc_s[d] = acc_s[d] * state_s[0] + split_acc[split_base * head_dim + d] * state_s[1];
+    }
+    __syncthreads();
+    m = new_m;
+    l = new_l;
+  }
+
+  for (int64_t d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    out[row * head_dim + d] = static_cast<scalar_t>(acc_s[d] / l);
+  }
+}
+
+}  // namespace
+
+torch::Tensor areno_causal_attention_forward_cuda(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    int64_t query_start,
+    int64_t window_left,
+    double softmax_scale) {
+  TORCH_CHECK(q.is_cuda(), "areno_causal_attention q must be CUDA");
+  TORCH_CHECK(k.is_cuda(), "areno_causal_attention k must be CUDA");
+  TORCH_CHECK(v.is_cuda(), "areno_causal_attention v must be CUDA");
+  TORCH_CHECK(q.is_contiguous(), "areno_causal_attention q must be contiguous");
+  TORCH_CHECK(k.is_contiguous(), "areno_causal_attention k must be contiguous");
+  TORCH_CHECK(v.is_contiguous(), "areno_causal_attention v must be contiguous");
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4, "areno_causal_attention expects 4D tensors");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(), "areno_causal_attention dtype mismatch");
+  TORCH_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0), "areno_causal_attention batch mismatch");
+  TORCH_CHECK(q.size(1) == k.size(1) && q.size(1) == v.size(1), "areno_causal_attention head mismatch");
+  TORCH_CHECK(q.size(3) == k.size(3) && q.size(3) == v.size(3), "areno_causal_attention head dim mismatch");
+  TORCH_CHECK(k.size(2) == v.size(2), "areno_causal_attention key/value length mismatch");
+  TORCH_CHECK(query_start >= 0, "areno_causal_attention query_start must be non-negative");
+  TORCH_CHECK(query_start + q.size(2) <= k.size(2), "areno_causal_attention query positions exceed key length");
+
+  const at::cuda::OptionalCUDAGuard guard(device_of(q));
+  auto out = torch::empty_like(q);
+  const int64_t rows = q.size(0) * q.size(1) * q.size(2);
+  const int64_t shared_floats = 2 * q.size(3) + kAttentionThreads + 2 * kAttentionTileN * q.size(3);
+  const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_causal_attention_forward", [&] {
+    causal_attention_forward_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        q.data_ptr<scalar_t>(),
+        k.data_ptr<scalar_t>(),
+        v.data_ptr<scalar_t>(),
+        out.data_ptr<scalar_t>(),
+        q.size(0),
+        q.size(1),
+        q.size(2),
+        k.size(2),
+        q.size(3),
+        query_start,
+        window_left,
+        static_cast<float>(softmax_scale));
+  });
+  return out;
+}
+
+std::vector<torch::Tensor> areno_causal_attention_backward_cuda(
+    torch::Tensor grad_out,
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor out,
+    int64_t query_start,
+    int64_t window_left,
+    double softmax_scale) {
+  TORCH_CHECK(grad_out.is_cuda(), "areno_causal_attention_backward grad_out must be CUDA");
+  TORCH_CHECK(q.is_cuda(), "areno_causal_attention_backward q must be CUDA");
+  TORCH_CHECK(k.is_cuda(), "areno_causal_attention_backward k must be CUDA");
+  TORCH_CHECK(v.is_cuda(), "areno_causal_attention_backward v must be CUDA");
+  TORCH_CHECK(out.is_cuda(), "areno_causal_attention_backward out must be CUDA");
+  TORCH_CHECK(grad_out.is_contiguous(), "areno_causal_attention_backward grad_out must be contiguous");
+  TORCH_CHECK(q.is_contiguous(), "areno_causal_attention_backward q must be contiguous");
+  TORCH_CHECK(k.is_contiguous(), "areno_causal_attention_backward k must be contiguous");
+  TORCH_CHECK(v.is_contiguous(), "areno_causal_attention_backward v must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "areno_causal_attention_backward out must be contiguous");
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4, "areno_causal_attention_backward expects 4D q/k/v");
+  TORCH_CHECK(grad_out.sizes() == q.sizes() && out.sizes() == q.sizes(), "areno_causal_attention_backward grad/out shape mismatch");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(), "areno_causal_attention_backward dtype mismatch");
+  TORCH_CHECK(grad_out.scalar_type() == q.scalar_type() && out.scalar_type() == q.scalar_type(), "areno_causal_attention_backward grad/out dtype mismatch");
+  TORCH_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0), "areno_causal_attention_backward batch mismatch");
+  TORCH_CHECK(q.size(1) == k.size(1) && q.size(1) == v.size(1), "areno_causal_attention_backward head mismatch");
+  TORCH_CHECK(q.size(3) == k.size(3) && q.size(3) == v.size(3), "areno_causal_attention_backward head dim mismatch");
+  TORCH_CHECK(k.size(2) == v.size(2), "areno_causal_attention_backward key/value length mismatch");
+  TORCH_CHECK(query_start >= 0, "areno_causal_attention_backward query_start must be non-negative");
+  TORCH_CHECK(query_start + q.size(2) <= k.size(2), "areno_causal_attention_backward query positions exceed key length");
+
+  const at::cuda::OptionalCUDAGuard guard(device_of(q));
+  auto grad_options = q.options().dtype(torch::kFloat32);
+  auto grad_q = torch::empty(q.sizes(), grad_options);
+  auto grad_k = torch::zeros(k.sizes(), grad_options);
+  auto grad_v = torch::zeros(v.sizes(), grad_options);
+  const int64_t rows = q.size(0) * q.size(1) * q.size(2);
+  const int64_t shared_floats = 4 * q.size(3) + 2 * kAttentionThreads;
+  const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_causal_attention_backward", [&] {
+    causal_attention_backward_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        grad_out.data_ptr<scalar_t>(),
+        q.data_ptr<scalar_t>(),
+        k.data_ptr<scalar_t>(),
+        v.data_ptr<scalar_t>(),
+        out.data_ptr<scalar_t>(),
+        grad_q.data_ptr<float>(),
+        grad_k.data_ptr<float>(),
+        grad_v.data_ptr<float>(),
+        q.size(0),
+        q.size(1),
+        q.size(2),
+        k.size(2),
+        q.size(3),
+        query_start,
+        window_left,
+        static_cast<float>(softmax_scale));
+  });
+  return {grad_q, grad_k, grad_v};
+}
+
+torch::Tensor areno_varlen_causal_attention_forward_cuda(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor cu_seqlens,
+    int64_t window_left,
+    double softmax_scale) {
+  TORCH_CHECK(q.is_cuda(), "areno_varlen_causal_attention q must be CUDA");
+  TORCH_CHECK(k.is_cuda(), "areno_varlen_causal_attention k must be CUDA");
+  TORCH_CHECK(v.is_cuda(), "areno_varlen_causal_attention v must be CUDA");
+  TORCH_CHECK(cu_seqlens.is_cuda(), "areno_varlen_causal_attention cu_seqlens must be CUDA");
+  TORCH_CHECK(q.is_contiguous(), "areno_varlen_causal_attention q must be contiguous");
+  TORCH_CHECK(k.is_contiguous(), "areno_varlen_causal_attention k must be contiguous");
+  TORCH_CHECK(v.is_contiguous(), "areno_varlen_causal_attention v must be contiguous");
+  TORCH_CHECK(cu_seqlens.is_contiguous(), "areno_varlen_causal_attention cu_seqlens must be contiguous");
+  TORCH_CHECK(q.dim() == 3 && k.dim() == 3 && v.dim() == 3, "areno_varlen_causal_attention expects 3D q/k/v");
+  TORCH_CHECK(cu_seqlens.dim() == 1, "areno_varlen_causal_attention cu_seqlens must be 1D");
+  TORCH_CHECK(cu_seqlens.scalar_type() == at::kInt, "areno_varlen_causal_attention cu_seqlens must be int32");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(), "areno_varlen_causal_attention dtype mismatch");
+  TORCH_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0), "areno_varlen_causal_attention token count mismatch");
+  TORCH_CHECK(k.size(1) == v.size(1), "areno_varlen_causal_attention key/value head mismatch");
+  TORCH_CHECK(q.size(1) % k.size(1) == 0, "areno_varlen_causal_attention q heads must be divisible by kv heads");
+  TORCH_CHECK(q.size(2) == k.size(2) && q.size(2) == v.size(2), "areno_varlen_causal_attention head dim mismatch");
+  TORCH_CHECK(cu_seqlens.size(0) >= 2, "areno_varlen_causal_attention cu_seqlens must contain at least one sequence");
+
+  const at::cuda::OptionalCUDAGuard guard(device_of(q));
+  auto out = torch::empty_like(q);
+  const int64_t rows = q.size(0) * q.size(1);
+  const int64_t shared_floats = 2 * q.size(2) + kAttentionThreads + 2 * kAttentionTileN * q.size(2);
+  const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_varlen_causal_attention_forward", [&] {
+    varlen_causal_attention_forward_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        q.data_ptr<scalar_t>(),
+        k.data_ptr<scalar_t>(),
+        v.data_ptr<scalar_t>(),
+        out.data_ptr<scalar_t>(),
+        cu_seqlens.data_ptr<int32_t>(),
+        q.size(0),
+        cu_seqlens.size(0) - 1,
+        q.size(1),
+        k.size(1),
+        q.size(2),
+        window_left,
+        static_cast<float>(softmax_scale));
+  });
+  return out;
+}
+
+std::vector<torch::Tensor> areno_varlen_causal_attention_backward_cuda(
+    torch::Tensor grad_out,
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor out,
+    torch::Tensor cu_seqlens,
+    int64_t window_left,
+    double softmax_scale) {
+  TORCH_CHECK(grad_out.is_cuda(), "areno_varlen_causal_attention_backward grad_out must be CUDA");
+  TORCH_CHECK(q.is_cuda(), "areno_varlen_causal_attention_backward q must be CUDA");
+  TORCH_CHECK(k.is_cuda(), "areno_varlen_causal_attention_backward k must be CUDA");
+  TORCH_CHECK(v.is_cuda(), "areno_varlen_causal_attention_backward v must be CUDA");
+  TORCH_CHECK(out.is_cuda(), "areno_varlen_causal_attention_backward out must be CUDA");
+  TORCH_CHECK(cu_seqlens.is_cuda(), "areno_varlen_causal_attention_backward cu_seqlens must be CUDA");
+  TORCH_CHECK(grad_out.is_contiguous(), "areno_varlen_causal_attention_backward grad_out must be contiguous");
+  TORCH_CHECK(q.is_contiguous(), "areno_varlen_causal_attention_backward q must be contiguous");
+  TORCH_CHECK(k.is_contiguous(), "areno_varlen_causal_attention_backward k must be contiguous");
+  TORCH_CHECK(v.is_contiguous(), "areno_varlen_causal_attention_backward v must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "areno_varlen_causal_attention_backward out must be contiguous");
+  TORCH_CHECK(cu_seqlens.is_contiguous(), "areno_varlen_causal_attention_backward cu_seqlens must be contiguous");
+  TORCH_CHECK(q.dim() == 3 && k.dim() == 3 && v.dim() == 3, "areno_varlen_causal_attention_backward expects 3D q/k/v");
+  TORCH_CHECK(cu_seqlens.dim() == 1, "areno_varlen_causal_attention_backward cu_seqlens must be 1D");
+  TORCH_CHECK(cu_seqlens.scalar_type() == at::kInt, "areno_varlen_causal_attention_backward cu_seqlens must be int32");
+  TORCH_CHECK(grad_out.sizes() == q.sizes() && out.sizes() == q.sizes(), "areno_varlen_causal_attention_backward grad/out shape mismatch");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(), "areno_varlen_causal_attention_backward dtype mismatch");
+  TORCH_CHECK(grad_out.scalar_type() == q.scalar_type() && out.scalar_type() == q.scalar_type(), "areno_varlen_causal_attention_backward grad/out dtype mismatch");
+  TORCH_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0), "areno_varlen_causal_attention_backward token count mismatch");
+  TORCH_CHECK(k.size(1) == v.size(1), "areno_varlen_causal_attention_backward key/value head mismatch");
+  TORCH_CHECK(q.size(1) % k.size(1) == 0, "areno_varlen_causal_attention_backward q heads must be divisible by kv heads");
+  TORCH_CHECK(q.size(2) == k.size(2) && q.size(2) == v.size(2), "areno_varlen_causal_attention_backward head dim mismatch");
+  TORCH_CHECK(cu_seqlens.size(0) >= 2, "areno_varlen_causal_attention_backward cu_seqlens must contain at least one sequence");
+
+  const at::cuda::OptionalCUDAGuard guard(device_of(q));
+  auto grad_options = q.options().dtype(torch::kFloat32);
+  auto grad_q = torch::empty(q.sizes(), grad_options);
+  auto grad_k = torch::zeros(k.sizes(), grad_options);
+  auto grad_v = torch::zeros(v.sizes(), grad_options);
+  const int64_t rows = q.size(0) * q.size(1);
+  const int64_t shared_floats = 4 * q.size(2) + 2 * kAttentionThreads;
+  const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_varlen_causal_attention_backward", [&] {
+    varlen_causal_attention_backward_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        grad_out.data_ptr<scalar_t>(),
+        q.data_ptr<scalar_t>(),
+        k.data_ptr<scalar_t>(),
+        v.data_ptr<scalar_t>(),
+        out.data_ptr<scalar_t>(),
+        cu_seqlens.data_ptr<int32_t>(),
+        grad_q.data_ptr<float>(),
+        grad_k.data_ptr<float>(),
+        grad_v.data_ptr<float>(),
+        q.size(0),
+        cu_seqlens.size(0) - 1,
+        q.size(1),
+        k.size(1),
+        q.size(2),
+        window_left,
+        static_cast<float>(softmax_scale));
+  });
+  return {grad_q, grad_k, grad_v};
+}
+
+torch::Tensor areno_paged_causal_attention_decode_forward_cuda(
+    torch::Tensor q,
+    torch::Tensor k_update,
+    torch::Tensor v_update,
+    torch::Tensor k_cache,
+    torch::Tensor v_cache,
+    torch::Tensor block_table,
+    torch::Tensor cache_seqlens,
+    int64_t window_left,
+    int64_t num_splits,
+    double softmax_scale) {
+  TORCH_CHECK(q.is_cuda(), "areno_paged_causal_attention_decode q must be CUDA");
+  TORCH_CHECK(k_update.is_cuda(), "areno_paged_causal_attention_decode k_update must be CUDA");
+  TORCH_CHECK(v_update.is_cuda(), "areno_paged_causal_attention_decode v_update must be CUDA");
+  TORCH_CHECK(k_cache.is_cuda(), "areno_paged_causal_attention_decode k_cache must be CUDA");
+  TORCH_CHECK(v_cache.is_cuda(), "areno_paged_causal_attention_decode v_cache must be CUDA");
+  TORCH_CHECK(block_table.is_cuda(), "areno_paged_causal_attention_decode block_table must be CUDA");
+  TORCH_CHECK(cache_seqlens.is_cuda(), "areno_paged_causal_attention_decode cache_seqlens must be CUDA");
+  TORCH_CHECK(q.is_contiguous(), "areno_paged_causal_attention_decode q must be contiguous");
+  TORCH_CHECK(k_update.is_contiguous(), "areno_paged_causal_attention_decode k_update must be contiguous");
+  TORCH_CHECK(v_update.is_contiguous(), "areno_paged_causal_attention_decode v_update must be contiguous");
+  TORCH_CHECK(k_cache.is_contiguous(), "areno_paged_causal_attention_decode k_cache must be contiguous");
+  TORCH_CHECK(v_cache.is_contiguous(), "areno_paged_causal_attention_decode v_cache must be contiguous");
+  TORCH_CHECK(block_table.is_contiguous(), "areno_paged_causal_attention_decode block_table must be contiguous");
+  TORCH_CHECK(cache_seqlens.is_contiguous(), "areno_paged_causal_attention_decode cache_seqlens must be contiguous");
+  TORCH_CHECK(q.dim() == 3, "areno_paged_causal_attention_decode q must be shaped (batch, heads, head_dim)");
+  TORCH_CHECK(k_update.dim() == 3 && v_update.dim() == 3, "areno_paged_causal_attention_decode updates must be 3D");
+  TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4, "areno_paged_causal_attention_decode cache tensors must be 4D");
+  TORCH_CHECK(block_table.dim() == 2, "areno_paged_causal_attention_decode block_table must be 2D");
+  TORCH_CHECK(cache_seqlens.dim() == 1, "areno_paged_causal_attention_decode cache_seqlens must be 1D");
+  TORCH_CHECK(q.scalar_type() == k_cache.scalar_type() && q.scalar_type() == v_cache.scalar_type(), "areno_paged_causal_attention_decode dtype mismatch");
+  TORCH_CHECK(k_update.scalar_type() == q.scalar_type() && v_update.scalar_type() == q.scalar_type(), "areno_paged_causal_attention_decode update dtype mismatch");
+  TORCH_CHECK(block_table.scalar_type() == at::kInt, "areno_paged_causal_attention_decode block_table must be int32");
+  TORCH_CHECK(cache_seqlens.scalar_type() == at::kInt, "areno_paged_causal_attention_decode cache_seqlens must be int32");
+  TORCH_CHECK(q.size(0) == block_table.size(0) && q.size(0) == cache_seqlens.size(0), "areno_paged_causal_attention_decode batch mismatch");
+  TORCH_CHECK(k_update.size(0) == q.size(0) && v_update.size(0) == q.size(0), "areno_paged_causal_attention_decode update batch mismatch");
+  TORCH_CHECK(k_cache.size(0) == v_cache.size(0) && k_cache.size(1) == v_cache.size(1), "areno_paged_causal_attention_decode cache block shape mismatch");
+  TORCH_CHECK(k_cache.size(2) == v_cache.size(2), "areno_paged_causal_attention_decode cache head mismatch");
+  TORCH_CHECK(k_update.size(1) == k_cache.size(2) && v_update.size(1) == v_cache.size(2), "areno_paged_causal_attention_decode update head mismatch");
+  TORCH_CHECK(q.size(2) == k_cache.size(3) && q.size(2) == v_cache.size(3), "areno_paged_causal_attention_decode head dim mismatch");
+  TORCH_CHECK(k_update.size(2) == k_cache.size(3) && v_update.size(2) == v_cache.size(3), "areno_paged_causal_attention_decode update head dim mismatch");
+  TORCH_CHECK(q.size(1) % k_cache.size(2) == 0, "areno_paged_causal_attention_decode q heads must be divisible by kv heads");
+  TORCH_CHECK(num_splits >= 1, "areno_paged_causal_attention_decode num_splits must be >= 1");
+
+  const at::cuda::OptionalCUDAGuard guard(device_of(q));
+  auto out = torch::empty_like(q);
+  const int64_t rows = q.size(0) * q.size(1);
+  const int64_t shared_floats = 2 * q.size(2) + kAttentionThreads;
+  const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
+  auto split_options = q.options().dtype(torch::kFloat32);
+  auto split_m = torch::empty({rows, num_splits}, split_options);
+  auto split_l = torch::empty({rows, num_splits}, split_options);
+  auto split_acc = torch::empty({rows, num_splits, q.size(2)}, split_options);
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_paged_causal_attention_decode_forward", [&] {
+    paged_decode_update_kernel<scalar_t><<<static_cast<int>(q.size(0) * k_cache.size(2)), kAttentionThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        k_update.data_ptr<scalar_t>(),
+        v_update.data_ptr<scalar_t>(),
+        k_cache.data_ptr<scalar_t>(),
+        v_cache.data_ptr<scalar_t>(),
+        block_table.data_ptr<int32_t>(),
+        cache_seqlens.data_ptr<int32_t>(),
+        q.size(0),
+        k_cache.size(2),
+        k_cache.size(1),
+        block_table.size(1),
+        q.size(2));
+    paged_causal_attention_decode_split_kernel<scalar_t><<<static_cast<int>(rows * num_splits), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        q.data_ptr<scalar_t>(),
+        k_cache.data_ptr<scalar_t>(),
+        v_cache.data_ptr<scalar_t>(),
+        block_table.data_ptr<int32_t>(),
+        cache_seqlens.data_ptr<int32_t>(),
+        split_m.data_ptr<float>(),
+        split_l.data_ptr<float>(),
+        split_acc.data_ptr<float>(),
+        q.size(0),
+        q.size(1),
+        k_cache.size(2),
+        k_cache.size(1),
+        block_table.size(1),
+        q.size(2),
+        window_left,
+        num_splits,
+        static_cast<float>(softmax_scale));
+    paged_causal_attention_decode_reduce_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
+        split_m.data_ptr<float>(),
+        split_l.data_ptr<float>(),
+        split_acc.data_ptr<float>(),
+        out.data_ptr<scalar_t>(),
+        rows,
+        q.size(2),
+        num_splits);
+  });
+  return out;
+}

--- a/areno/accel/csrc/attention.cu
+++ b/areno/accel/csrc/attention.cu
@@ -13,6 +13,16 @@ namespace {
 constexpr int kAttentionThreads = 256;
 constexpr int kAttentionTileN = 16;
 
+int64_t attention_tile_n(int64_t head_dim) {
+  if (head_dim <= 256) {
+    return 16;
+  }
+  if (head_dim <= 512) {
+    return 8;
+  }
+  return 4;
+}
+
 __device__ __forceinline__ int64_t find_sequence_id(const int32_t* __restrict__ cu_seqlens, int64_t num_seqs, int64_t token_idx) {
   int64_t lo = 0;
   int64_t hi = num_seqs;
@@ -38,6 +48,7 @@ __global__ void causal_attention_forward_kernel(
     int64_t q_len,
     int64_t k_len,
     int64_t head_dim,
+    int64_t tile_n,
     int64_t query_start,
     int64_t window_left,
     float softmax_scale) {
@@ -46,7 +57,7 @@ __global__ void causal_attention_forward_kernel(
   float* acc_s = q_s + head_dim;
   float* partial_s = acc_s + head_dim;
   float* k_tile = partial_s + blockDim.x;
-  float* v_tile = k_tile + kAttentionTileN * head_dim;
+  float* v_tile = k_tile + tile_n * head_dim;
 
   const int64_t row = blockIdx.x;
   const int64_t b = row / (heads * q_len);
@@ -69,10 +80,9 @@ __global__ void causal_attention_forward_kernel(
   float m = -std::numeric_limits<float>::infinity();
   float l = 0.0f;
 
-  for (int64_t tile_start = 0; tile_start < k_len; tile_start += kAttentionTileN) {
+  for (int64_t tile_start = 0; tile_start < k_len; tile_start += tile_n) {
     const int64_t remaining = k_len - tile_start;
-    const int64_t tile_len =
-        remaining < static_cast<int64_t>(kAttentionTileN) ? remaining : static_cast<int64_t>(kAttentionTileN);
+    const int64_t tile_len = remaining < tile_n ? remaining : tile_n;
     const int64_t tile_elements = tile_len * head_dim;
     for (int64_t idx = threadIdx.x; idx < tile_elements; idx += blockDim.x) {
       const int64_t ki = tile_start + idx / head_dim;
@@ -144,6 +154,7 @@ __global__ void varlen_causal_attention_forward_kernel(
     int64_t q_heads,
     int64_t kv_heads,
     int64_t head_dim,
+    int64_t tile_n,
     int64_t window_left,
     float softmax_scale) {
   extern __shared__ float shared[];
@@ -151,7 +162,7 @@ __global__ void varlen_causal_attention_forward_kernel(
   float* acc_s = q_s + head_dim;
   float* partial_s = acc_s + head_dim;
   float* k_tile = partial_s + blockDim.x;
-  float* v_tile = k_tile + kAttentionTileN * head_dim;
+  float* v_tile = k_tile + tile_n * head_dim;
 
   const int64_t row = blockIdx.x;
   const int64_t token_idx = row / q_heads;
@@ -174,10 +185,9 @@ __global__ void varlen_causal_attention_forward_kernel(
   float m = -std::numeric_limits<float>::infinity();
   float l = 0.0f;
 
-  for (int64_t tile_start = first_key; tile_start <= last_key; tile_start += kAttentionTileN) {
+  for (int64_t tile_start = first_key; tile_start <= last_key; tile_start += tile_n) {
     const int64_t remaining = last_key - tile_start + 1;
-    const int64_t tile_len =
-        remaining < static_cast<int64_t>(kAttentionTileN) ? remaining : static_cast<int64_t>(kAttentionTileN);
+    const int64_t tile_len = remaining < tile_n ? remaining : tile_n;
     const int64_t tile_elements = tile_len * head_dim;
     for (int64_t idx = threadIdx.x; idx < tile_elements; idx += blockDim.x) {
       const int64_t ki = tile_start + idx / head_dim;
@@ -718,7 +728,8 @@ torch::Tensor areno_causal_attention_forward_cuda(
   const at::cuda::OptionalCUDAGuard guard(device_of(q));
   auto out = torch::empty_like(q);
   const int64_t rows = q.size(0) * q.size(1) * q.size(2);
-  const int64_t shared_floats = 2 * q.size(3) + kAttentionThreads + 2 * kAttentionTileN * q.size(3);
+  const int64_t tile_n = attention_tile_n(q.size(3));
+  const int64_t shared_floats = 2 * q.size(3) + kAttentionThreads + 2 * tile_n * q.size(3);
   const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
   AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_causal_attention_forward", [&] {
     causal_attention_forward_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
@@ -731,6 +742,7 @@ torch::Tensor areno_causal_attention_forward_cuda(
         q.size(2),
         k.size(2),
         q.size(3),
+        tile_n,
         query_start,
         window_left,
         static_cast<float>(softmax_scale));
@@ -826,7 +838,8 @@ torch::Tensor areno_varlen_causal_attention_forward_cuda(
   const at::cuda::OptionalCUDAGuard guard(device_of(q));
   auto out = torch::empty_like(q);
   const int64_t rows = q.size(0) * q.size(1);
-  const int64_t shared_floats = 2 * q.size(2) + kAttentionThreads + 2 * kAttentionTileN * q.size(2);
+  const int64_t tile_n = attention_tile_n(q.size(2));
+  const int64_t shared_floats = 2 * q.size(2) + kAttentionThreads + 2 * tile_n * q.size(2);
   const size_t shared_bytes = static_cast<size_t>(shared_floats) * sizeof(float);
   AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, q.scalar_type(), "areno_varlen_causal_attention_forward", [&] {
     varlen_causal_attention_forward_kernel<scalar_t><<<static_cast<int>(rows), kAttentionThreads, shared_bytes, at::cuda::getCurrentCUDAStream()>>>(
@@ -840,6 +853,7 @@ torch::Tensor areno_varlen_causal_attention_forward_cuda(
         q.size(1),
         k.size(1),
         q.size(2),
+        tile_n,
         window_left,
         static_cast<float>(softmax_scale));
   });

--- a/areno/accel/csrc/extension.cpp
+++ b/areno/accel/csrc/extension.cpp
@@ -16,6 +16,49 @@ std::vector<torch::Tensor> areno_linear_backward_cuda(
     torch::Tensor input,
     torch::Tensor weight,
     bool use_bias);
+torch::Tensor areno_causal_attention_forward_cuda(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    int64_t query_start,
+    int64_t window_left,
+    double softmax_scale);
+std::vector<torch::Tensor> areno_causal_attention_backward_cuda(
+    torch::Tensor grad_out,
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor out,
+    int64_t query_start,
+    int64_t window_left,
+    double softmax_scale);
+torch::Tensor areno_varlen_causal_attention_forward_cuda(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor cu_seqlens,
+    int64_t window_left,
+    double softmax_scale);
+std::vector<torch::Tensor> areno_varlen_causal_attention_backward_cuda(
+    torch::Tensor grad_out,
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v,
+    torch::Tensor out,
+    torch::Tensor cu_seqlens,
+    int64_t window_left,
+    double softmax_scale);
+torch::Tensor areno_paged_causal_attention_decode_forward_cuda(
+    torch::Tensor q,
+    torch::Tensor k_update,
+    torch::Tensor v_update,
+    torch::Tensor k_cache,
+    torch::Tensor v_cache,
+    torch::Tensor block_table,
+    torch::Tensor cache_seqlens,
+    int64_t window_left,
+    int64_t num_splits,
+    double softmax_scale);
 torch::Tensor areno_grouped_linear_forward_cuda(
     torch::Tensor input,
     torch::Tensor weight,
@@ -134,6 +177,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("areno_d_softplus", &areno_d_softplus_cuda, "ARENO softplus backward");
   m.def("areno_linear_forward", &areno_linear_forward_cuda, "ARENO linear forward");
   m.def("areno_linear_backward", &areno_linear_backward_cuda, "ARENO linear backward");
+  m.def("areno_causal_attention_forward", &areno_causal_attention_forward_cuda, "ARENO causal attention forward");
+  m.def("areno_causal_attention_backward", &areno_causal_attention_backward_cuda, "ARENO causal attention backward");
+  m.def("areno_varlen_causal_attention_forward", &areno_varlen_causal_attention_forward_cuda, "ARENO varlen causal attention forward");
+  m.def("areno_varlen_causal_attention_backward", &areno_varlen_causal_attention_backward_cuda, "ARENO varlen causal attention backward");
+  m.def("areno_paged_causal_attention_decode_forward", &areno_paged_causal_attention_decode_forward_cuda, "ARENO paged causal attention decode forward");
   m.def("areno_grouped_linear_forward", &areno_grouped_linear_forward_cuda, "ARENO grouped linear forward");
   m.def("areno_grouped_linear_forward_counts", &areno_grouped_linear_forward_counts_cuda, "ARENO grouped linear forward with GPU counts");
   m.def("areno_grouped_linear_backward", &areno_grouped_linear_backward_cuda, "ARENO grouped linear backward");

--- a/areno/accel/ops.py
+++ b/areno/accel/ops.py
@@ -18,6 +18,11 @@ from typing import Any
 import torch
 
 from areno.accel.activations import areno_gelu_tanh_and_mul, areno_silu_and_mul
+from areno.accel.attention import (
+    areno_causal_attention,
+    areno_paged_causal_attention_decode,
+    areno_varlen_causal_attention,
+)
 from areno.accel.kernels.fused_moe import FusedMoeConfig
 from areno.accel.kernels.fused_moe import fused_experts as areno_fused_experts
 from areno.accel.kernels.fused_moe import is_available as fused_moe_is_available
@@ -76,6 +81,9 @@ __all__ = [
     "rms_norm_gate_fwd",
     "seg_la_fwd",
     "areno_gelu_tanh_and_mul",
+    "areno_causal_attention",
+    "areno_paged_causal_attention_decode",
+    "areno_varlen_causal_attention",
     "areno_silu_and_mul",
     "warn_once",
 ]

--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from areno.api.tokenizer import encode_generation_prompt
+from areno.api.tokenizer import encode_generation_prompt, normalize_token_ids
 
 
 def apply_chat_template(tokenizer, messages: list[dict[str, Any]]) -> list[int]:
     """Encode full chat messages, with a plain-text fallback for base tokenizers."""
 
     if getattr(tokenizer, "chat_template", None):
-        return tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False)
+        return normalize_token_ids(tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False))
     text = "\n".join(f"{item.get('role', 'user')}: {item.get('content', '')}" for item in messages)
-    return tokenizer.encode(text, add_special_tokens=True)
+    return normalize_token_ids(tokenizer.encode(text, add_special_tokens=True))
 
 
 def encode_prompt_value(tokenizer, prompt) -> list[int]:
@@ -21,7 +21,7 @@ def encode_prompt_value(tokenizer, prompt) -> list[int]:
 
     if isinstance(prompt, list):
         if getattr(tokenizer, "chat_template", None):
-            return tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True)
+            return normalize_token_ids(tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True))
         text = "\n".join(f"{item.get('role', 'user')}: {item.get('content', '')}" for item in prompt)
         return encode_generation_prompt(tokenizer, text)
     return encode_generation_prompt(tokenizer, prompt)
@@ -41,7 +41,7 @@ def response_to_tokens_and_mask(
 ) -> tuple[list[int], list[bool]]:
     """Append a response to pre-tokenized prompt ids and mask prompt tokens."""
 
-    response_ids = tokenizer.encode(response, add_special_tokens=False)
+    response_ids = normalize_token_ids(tokenizer.encode(response, add_special_tokens=False))
     if eos_token_id is not None and (not response_ids or response_ids[-1] != eos_token_id):
         response_ids.append(eos_token_id)
     return prompt_ids + response_ids, [True] * len(prompt_ids) + [False] * len(response_ids)
@@ -68,6 +68,6 @@ def first_value(record: dict[str, Any], keys: tuple[str, ...]):
 
     for key in keys:
         value = record.get(key)
-        if isinstance(value, (str, list)):
+        if isinstance(value, str | list):
             return value
     return None

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from typing import Any
 
+from areno.api.tokenizer import normalize_token_ids
 from areno.api.tool_call_parser import ToolCallParser
 
 
@@ -59,17 +60,17 @@ def messages_to_prompt_tokens(
         if tools:
             kwargs["tools"] = tools
         try:
-            return tokenizer.apply_chat_template(messages, **kwargs)
+            return normalize_token_ids(tokenizer.apply_chat_template(messages, **kwargs))
         except TypeError:
             if tools:
                 kwargs["tools"] = _normalize_tools_for_chat_template(tools)
                 try:
-                    return tokenizer.apply_chat_template(messages, **kwargs)
+                    return normalize_token_ids(tokenizer.apply_chat_template(messages, **kwargs))
                 except TypeError:
                     pass
             kwargs.pop("tools", None)
-            return tokenizer.apply_chat_template(messages, **kwargs)
-    return tokenizer.encode(messages_to_text(messages) or fallback_prompt)
+            return normalize_token_ids(tokenizer.apply_chat_template(messages, **kwargs))
+    return normalize_token_ids(tokenizer.encode(messages_to_text(messages) or fallback_prompt))
 
 
 def _normalize_tools_for_chat_template(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/areno/api/tokenizer.py
+++ b/areno/api/tokenizer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from areno.engine.data.tokenizer import load_tokenizer as load_tokenizer  # noqa: F401
 
@@ -45,12 +46,37 @@ def encode_generation_prompt(tokenizer, prompt: str) -> list[int]:
     """
 
     if _looks_chat_formatted(prompt) or not getattr(tokenizer, "chat_template", None):
-        return tokenizer.encode(prompt)
-    return tokenizer.apply_chat_template(
-        [{"role": "user", "content": prompt}],
-        tokenize=True,
-        add_generation_prompt=True,
+        return normalize_token_ids(tokenizer.encode(prompt))
+    return normalize_token_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )
     )
+
+
+def normalize_token_ids(value: Any) -> list[int]:
+    """Convert tokenizer outputs to a plain list of integer token ids."""
+
+    if hasattr(value, "ids"):
+        value = value.ids
+    if hasattr(value, "input_ids"):
+        value = value.input_ids
+    if isinstance(value, list | tuple):
+        if value and hasattr(value[0], "ids"):
+            if len(value) != 1:
+                raise TypeError("expected one tokenized prompt, got a batch of encodings")
+            return normalize_token_ids(value[0])
+        if value and isinstance(value[0], list | tuple):
+            if len(value) != 1:
+                raise TypeError("expected one tokenized prompt, got a batch of token id lists")
+            return normalize_token_ids(value[0])
+        try:
+            return [int(token_id) for token_id in value]
+        except TypeError as exc:
+            raise TypeError(f"expected token ids, got {type(value).__name__}") from exc
+    raise TypeError(f"expected token ids or tokenizer Encoding, got {type(value).__name__}")
 
 
 def _looks_chat_formatted(prompt: str) -> bool:

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -19,7 +19,7 @@ from areno.api.data import PromptBatch, PromptItem
 from areno.api.metrics import MetricsRecorder
 from areno.api.models import BackendType, RolloutResult, SamplingParams, TrainSequence
 from areno.api.roles import ModelRole
-from areno.api.tokenizer import encode_generation_prompt, eos_token_ids, load_tokenizer
+from areno.api.tokenizer import encode_generation_prompt, eos_token_ids, load_tokenizer, normalize_token_ids
 
 
 class Trainer:
@@ -268,7 +268,9 @@ class Trainer:
         if self._rollout_session_depth <= 0:
             raise RuntimeError("rollout_token_batch must be called inside `async with trainer.rollout_session(...)`")
         self._begin_step()
-        return self._backend.rollout_batch(self._ctx, prompt_tokens, n_samples, sampling_params)
+        return self._backend.rollout_batch(
+            self._ctx, _normalize_prompt_token_batch(prompt_tokens), n_samples, sampling_params
+        )
 
     async def rollout_token_batch_async(
         self,
@@ -284,7 +286,7 @@ class Trainer:
             )
         self._begin_step()
         rollout_async = getattr(self._backend, "rollout_batch_async")
-        return await rollout_async(self._ctx, prompt_tokens, n_samples, sampling_params)
+        return await rollout_async(self._ctx, _normalize_prompt_token_batch(prompt_tokens), n_samples, sampling_params)
 
     def rollout_session(
         self,
@@ -399,3 +401,7 @@ class Trainer:
 
         if self._metrics is not None:
             self._metrics.close()
+
+
+def _normalize_prompt_token_batch(prompt_tokens: list[list[int]]) -> list[list[int]]:
+    return [normalize_token_ids(row) for row in prompt_tokens]

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -50,10 +50,15 @@ class TrainerConfig:
     activation_checkpointing: bool = True
     keep_rollout_state: bool = True
     eager_decode: bool = False
+    attn_backend: str = "flash"
     metrics_log_dir: str | None = DEFAULT_METRICS_LOG_DIR
     agent_fn: str | None = None
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
+
+    def __post_init__(self) -> None:
+        if self.attn_backend not in {"flash", "native"}:
+            raise ValueError("attn_backend must be one of: flash, native")
 
     def optimizer_config(self) -> dict:
         """Build the optimizer dict consumed by the backend config."""
@@ -85,6 +90,7 @@ class TrainerConfig:
                 "activation_checkpointing": self.activation_checkpointing,
                 "keep_rollout_state": self.keep_rollout_state,
                 "eager_decode": self.eager_decode,
+                "attn_backend": self.attn_backend,
             },
         )
 
@@ -120,6 +126,7 @@ class RolloutTrainerConfig(TrainerConfig):
                 "activation_checkpointing": self.activation_checkpointing,
                 "keep_rollout_state": self.keep_rollout_state,
                 "eager_decode": self.eager_decode,
+                "attn_backend": self.attn_backend,
             },
         )
 

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -421,13 +421,16 @@ class PolicyOnlyTrainer:
         for prompt_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             for sample_idx, seq in enumerate(result.sequences):
                 self.logger.info(
-                    "epoch=%d step=%d prompt_idx=%d sample_idx=%d prompt=%r completion=%r tokens=%s",
+                    "epoch=%d step=%d prompt_idx=%d sample_idx=%d prompt=%r decoded_prompt=%r completion=%r "
+                    "prompt_tokens=%s response_tokens=%s",
                     epoch,
                     step,
                     prompt_idx,
                     sample_idx,
                     item.prompt,
+                    tokenizer.decode(item.input_tokens),
                     tokenizer.decode(seq.resp_tokens),
+                    item.input_tokens[:64],
                     seq.resp_tokens[:64],
                 )
                 logged += 1

--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -159,6 +159,7 @@ def create_app(
     default_max_tokens: int,
     decode_progress_interval_s: float,
     eager_decode: bool = False,
+    attn_backend: Literal["flash", "native"] = "flash",
 ) -> FastAPI:
     """Construct the FastAPI app: load tokenizer/engine, install routes and lifecycle hooks."""
     if world_size < 1:
@@ -175,7 +176,7 @@ def create_app(
         tp_size=tp_size,
         dp_size=world_size // tp_size,
         devices=list(range(world_size)),
-        runtime_config=RuntimeConfig(eager_decode=bool(eager_decode)),
+        runtime_config=RuntimeConfig(eager_decode=bool(eager_decode), attn_backend=attn_backend),
         loss_fn=_serve_loss_fn,
     )
     state = ServeState(
@@ -442,7 +443,7 @@ def _first_eos_token_id(tokenizer: Any) -> int | None:
     eos = getattr(tokenizer, "eos_token_id", None)
     if isinstance(eos, int):
         return eos
-    if isinstance(eos, (list, tuple)) and eos:
+    if isinstance(eos, list | tuple) and eos:
         return int(eos[0])
     return None
 
@@ -452,7 +453,7 @@ def _stop_token_ids(tokenizer: Any) -> tuple[int, ...]:
     eos = getattr(tokenizer, "eos_token_id", None)
     if isinstance(eos, int):
         return (eos,)
-    if isinstance(eos, (list, tuple)):
+    if isinstance(eos, list | tuple):
         return tuple(int(value) for value in eos)
     return ()
 
@@ -492,6 +493,13 @@ def _normalize_stop(stop: str | list[str] | None) -> list[str]:
     help="Worker decode progress log interval.",
 )
 @click.option("--eager-decode", is_flag=True, help="Run decode in eager mode instead of CUDA graph replay.")
+@click.option(
+    "--attn-backend",
+    type=click.Choice(["flash", "native"]),
+    default="flash",
+    show_default=True,
+    help="Attention backend. Use native for slower areno_accel attention compatibility/logprob diagnostics.",
+)
 def serve_command(
     model_path: str,
     tp_size: int,
@@ -502,6 +510,7 @@ def serve_command(
     default_max_tokens: int,
     decode_progress_interval_s: float,
     eager_decode: bool,
+    attn_backend: Literal["flash", "native"],
 ) -> None:
     """Click entry point: build the app and hand it to uvicorn."""
     import uvicorn
@@ -515,6 +524,7 @@ def serve_command(
         default_max_tokens=default_max_tokens,
         decode_progress_interval_s=decode_progress_interval_s,
         eager_decode=eager_decode,
+        attn_backend=attn_backend,
     )
     uvicorn.run(app, host=host, port=port)
 

--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -21,9 +22,14 @@ from areno.api.openai_chat import build_chat_completion_response, messages_to_pr
 from areno.api.tool_call_parser import ToolCallParser, get_tool_call_parser, infer_tool_call_parser_name
 from areno.cli.model_refs import resolve_model_ref
 from areno.engine import ArenoEngine
-from areno.engine.config import RuntimeConfig
+from areno.engine.config import (
+    RuntimeConfig,
+    flash_attention_unsupported_gpu_reason,
+    flash_attention_unsupported_model_reason,
+)
 from areno.engine.data import SamplingParams
 from areno.engine.data.tokenizer import load_tokenizer
+from areno.models.registry import config_from_hf
 
 
 def _serve_loss_fn(*_: Any) -> torch.Tensor:
@@ -170,6 +176,13 @@ def create_app(
         raise ValueError("world_size must be divisible by tp_size")
 
     tokenizer = load_tokenizer(model_path)
+    attn_backend, attn_warning = _resolve_serve_attn_backend(
+        model_path=model_path,
+        attn_backend=attn_backend,
+        world_size=world_size,
+    )
+    if attn_warning is not None:
+        warnings.warn(attn_warning, RuntimeWarning, stacklevel=2)
     parser_trainer = _ToolParserTrainerShim(model_path=model_path, tokenizer=tokenizer)
     engine = ArenoEngine.from_pretrained(
         model_path,
@@ -266,6 +279,41 @@ def create_app(
         return await _await_pending_response(state, raw_request, pending)
 
     return app
+
+
+def _resolve_serve_attn_backend(
+    *,
+    model_path: str,
+    attn_backend: Literal["flash", "native"],
+    world_size: int,
+) -> tuple[Literal["flash", "native"], str | None]:
+    """Apply flash-attn compatibility fallback before serve starts workers."""
+
+    if attn_backend != "flash":
+        return attn_backend, None
+    model_config = None
+    try:
+        model_config = config_from_hf(model_path)
+    except Exception:
+        # Engine startup still owns config loading errors. This preflight can
+        # still catch GPU-only fallback when model config is unavailable.
+        pass
+    reasons = [
+        reason
+        for reason in (
+            flash_attention_unsupported_gpu_reason(list(range(world_size))),
+            flash_attention_unsupported_model_reason(model_config) if model_config is not None else None,
+        )
+        if reason is not None
+    ]
+    if not reasons:
+        return "flash", None
+    reason = "; ".join(reasons)
+    warning = (
+        f"flash-attn does not support the detected serve runtime configuration ({reason}); "
+        "AReno will use attn_backend='native'. Native attention is a compatibility path and may be slower."
+    )
+    return "native", warning
 
 
 async def _run_request_task(app: FastAPI, item: PendingRequest) -> None:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -31,6 +31,11 @@ from areno.api.trainer_config import (
     TrainerConfig,
 )
 from areno.cli.model_refs import resolve_model_refs_for_config
+from areno.engine.config import (
+    ModelConfig,
+    flash_attention_unsupported_gpu_reason,
+    flash_attention_unsupported_model_reason,
+)
 
 
 def _trainer_config_from_options(**options) -> TrainerConfig:
@@ -112,11 +117,16 @@ def _require_positive_float(value: float, option_name: str) -> None:
 
 
 def _format_training_config_summary(
-    config: TrainerConfig, *, reward_ckpt: str | None = None, color: bool = False
+    config: TrainerConfig,
+    *,
+    reward_ckpt: str | None = None,
+    model_config: ModelConfig | None = None,
+    color: bool = False,
 ) -> str:
     """Return a concise user-facing summary of the resolved train config."""
 
     algorithm = get_algorithm(config.algo)
+    attn_backend, attn_warning = _resolved_attn_backend_for_summary(config, model_config=model_config)
     sections = [
         (
             "Algorithm",
@@ -146,6 +156,7 @@ def _format_training_config_summary(
                 ("world_size", str(config.world_size)),
                 ("tp_size", str(config.tp_size)),
                 ("dp_size", _resolved_dp_size_for_summary(config)),
+                ("attn_backend", attn_backend),
             ],
         ),
         ("Rollout", _rollout_summary_rows(config)),
@@ -176,6 +187,8 @@ def _format_training_config_summary(
         ),
     ]
     lines = [_style("AReno training config", fg="bright_white", bold=True, color=color)]
+    if attn_warning is not None:
+        lines.append(_style("WARNING", fg="yellow", bold=True, color=color) + f": {attn_warning}")
     for section, rows in sections:
         lines.extend(_format_summary_section(section, rows, color=color))
     if config.save_path is None:
@@ -186,8 +199,13 @@ def _format_training_config_summary(
     return "\n".join(lines)
 
 
-def _print_training_config_summary(config: TrainerConfig, *, reward_ckpt: str | None = None) -> None:
-    click.echo(_format_training_config_summary(config, reward_ckpt=reward_ckpt, color=True), color=True)
+def _print_training_config_summary(
+    config: TrainerConfig, *, reward_ckpt: str | None = None, model_config: ModelConfig | None = None
+) -> None:
+    click.echo(
+        _format_training_config_summary(config, reward_ckpt=reward_ckpt, model_config=model_config, color=True),
+        color=True,
+    )
 
 
 def _format_summary_section(section: str, rows: list[tuple[str, str]], *, color: bool) -> list[str]:
@@ -236,6 +254,41 @@ def _reward_ckpt_for_summary(config: TrainerConfig, reward_ckpt: str | None) -> 
     if isinstance(config, PPOTrainerConfig):
         return config.reward_ckpt
     return reward_ckpt
+
+
+def _resolved_attn_backend_for_summary(
+    config: TrainerConfig, *, model_config: ModelConfig | None = None
+) -> tuple[str, str | None]:
+    if config.attn_backend != "flash":
+        return config.attn_backend, None
+    reasons = [
+        reason
+        for reason in (
+            flash_attention_unsupported_gpu_reason(list(range(config.world_size))),
+            flash_attention_unsupported_model_reason(model_config) if model_config is not None else None,
+        )
+        if reason is not None
+    ]
+    if not reasons:
+        return config.attn_backend, None
+    reason = "; ".join(reasons)
+    backend = f"native (auto fallback from flash: {reason})"
+    warning = (
+        f"flash-attn does not support the detected runtime configuration ({reason}); "
+        "AReno will use attn_backend='native'. Native attention is a compatibility path and may be slower."
+    )
+    return backend, warning
+
+
+def _model_config_for_summary(config: TrainerConfig) -> ModelConfig | None:
+    if not Path(config.ckpt).exists():
+        return None
+    try:
+        from areno.models.registry import config_from_hf
+
+        return config_from_hf(config.ckpt)
+    except Exception:
+        return None
 
 
 def _callable_name(fn) -> str:
@@ -364,6 +417,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             activation_checkpointing=args.activation_checkpointing,
             keep_rollout_state=not args.drop_rollout_state,
             eager_decode=args.eager_decode,
+            attn_backend=args.attn_backend,
             metrics_log_dir=args.metrics_log_dir,
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
@@ -399,6 +453,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             activation_checkpointing=args.activation_checkpointing,
             keep_rollout_state=not args.drop_rollout_state,
             eager_decode=args.eager_decode,
+            attn_backend=args.attn_backend,
             metrics_log_dir=args.metrics_log_dir,
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
@@ -439,6 +494,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             activation_checkpointing=args.activation_checkpointing,
             keep_rollout_state=not args.drop_rollout_state,
             eager_decode=args.eager_decode,
+            attn_backend=args.attn_backend,
             gspo_clip_eps=args.gspo_clip_eps,
             grpo_clip_eps=args.grpo_clip_eps,
             metrics_log_dir=args.metrics_log_dir,
@@ -480,6 +536,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         activation_checkpointing=args.activation_checkpointing,
         keep_rollout_state=not args.drop_rollout_state,
         eager_decode=args.eager_decode,
+        attn_backend=args.attn_backend,
         gspo_clip_eps=args.gspo_clip_eps,
         grpo_clip_eps=args.grpo_clip_eps,
         metrics_log_dir=args.metrics_log_dir,
@@ -771,6 +828,13 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     help="Drop rollout state after each step to save GPU memory.",
 )
 @click.option("--eager-decode", is_flag=True, help="Disable decode CUDA graph and run rollout decode eagerly.")
+@click.option(
+    "--attn-backend",
+    type=click.Choice(["flash", "native"]),
+    default="flash",
+    show_default=True,
+    help="Attention backend. Use native for slower areno_accel attention consistency diagnostics.",
+)
 @click.option("--agent-fn", default=None, help="Python file defining async run_agent(ctx, batch) for agentic rollout.")
 @click.option(
     "--agent-timeout-s", type=float, default=300.0, show_default=True, help="Agentic rollout proxy request timeout."
@@ -805,7 +869,11 @@ def train_command(**options) -> None:
 
     trainer_config = _trainer_config_from_options(**options)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
-    _print_training_config_summary(trainer_config, reward_ckpt=options.get("reward_ckpt"))
+    _print_training_config_summary(
+        trainer_config,
+        reward_ckpt=options.get("reward_ckpt"),
+        model_config=_model_config_for_summary(trainer_config),
+    )
     run(trainer_config)
 
 

--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -9,11 +9,15 @@ groups consumed by the worker cluster.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import torch
+
+FLASH_ATTENTION_MIN_CUDA_CAPABILITY = (8, 0)
+FLASH_ATTENTION_MAX_QK_HEAD_DIM = 256
 
 
 @dataclass(slots=True)
@@ -37,12 +41,42 @@ class RuntimeConfig:
     """Runtime allocation config for rollout decode and CUDA graphs."""
 
     kv_block_size: int = 256
+    attn_backend: Literal["flash", "native"] = "flash"
     activation_checkpointing: bool = True
     keep_rollout_state: bool = True
     eager_decode: bool = False
     decode_graph_buckets: list[int] = field(
         default_factory=lambda: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 96, 128, 192, 256]
     )
+
+    def __post_init__(self) -> None:
+        if self.attn_backend not in {"flash", "native"}:
+            raise ValueError("runtime.attn_backend must be one of: flash, native")
+
+    def resolve_attn_backend(self, *, model: ModelConfig, devices: list[int]) -> None:
+        """Switch flash-attn unsupported hardware or model shapes to native attention."""
+
+        if self.attn_backend != "flash":
+            return
+        reasons = [
+            reason
+            for reason in (
+                flash_attention_unsupported_gpu_reason(devices),
+                flash_attention_unsupported_model_reason(model),
+            )
+            if reason is not None
+        ]
+        if not reasons:
+            return
+        reason = "; ".join(reasons)
+        warnings.warn(
+            f"flash-attn does not support the detected runtime configuration ({reason}); "
+            "falling back to attn_backend='native'. Native attention is a compatibility path "
+            "and may be slower than flash-attn on supported GPUs.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        self.attn_backend = "native"
 
 
 @dataclass(slots=True)
@@ -117,6 +151,7 @@ class ModelConfig:
     linear_value_head_dim: int = 128
     linear_num_key_heads: int = 16
     linear_num_value_heads: int = 16
+    attn_backend: Literal["flash", "native"] = "flash"
 
     def validate_tp(self, tp_size: int) -> None:
         """Validate tensor-parallel divisibility required by local kernels."""
@@ -196,6 +231,51 @@ class EngineConfig:
             raise ValueError("runtime.kv_block_size must be >= 1")
         if self.runtime.kv_block_size % 256 != 0:
             raise ValueError("runtime.kv_block_size must be a multiple of 256 for FlashAttention paged KV")
+        self.runtime.resolve_attn_backend(model=self.model, devices=self.devices)
+        self.model.attn_backend = self.runtime.attn_backend
+
+
+def flash_attention_unsupported_model_reason(model: ModelConfig) -> str | None:
+    """Return a user-facing reason when a model shape cannot run flash-attn."""
+
+    dims = [("qk head dim", model.head_dim)]
+    if model.swa_head_dim is not None:
+        dims.append(("swa qk head dim", model.swa_head_dim))
+    if model.qk_nope_head_dim or model.qk_rope_head_dim:
+        dims.append(("qk head dim", model.qk_nope_head_dim + model.qk_rope_head_dim))
+    unsupported = [
+        f"{name} {dim}" for name, dim in dims if dim is not None and int(dim) > FLASH_ATTENTION_MAX_QK_HEAD_DIM
+    ]
+    if not unsupported:
+        return None
+    return ", ".join(unsupported)
+
+
+def flash_attention_unsupported_gpu_reason(devices: list[int] | None = None) -> str | None:
+    """Return a user-facing reason when visible GPUs cannot run flash-attn."""
+
+    if not torch.cuda.is_available():
+        return None
+    device_count = torch.cuda.device_count()
+    if device_count <= 0:
+        return None
+    selected_devices = devices if devices is not None else list(range(device_count))
+    unsupported: list[str] = []
+    for device in selected_devices:
+        if device < 0 or device >= device_count:
+            continue
+        major, minor = torch.cuda.get_device_capability(device)
+        capability = (int(major), int(minor))
+        if capability >= FLASH_ATTENTION_MIN_CUDA_CAPABILITY:
+            continue
+        try:
+            name = torch.cuda.get_device_name(device)
+        except Exception:
+            name = f"cuda:{device}"
+        unsupported.append(f"{name} cc {major}.{minor}")
+    if not unsupported:
+        return None
+    return ", ".join(unsupported)
 
 
 def _parse_dtype(value: str | None) -> torch.dtype:

--- a/areno/engine/data/batch.py
+++ b/areno/engine/data/batch.py
@@ -56,6 +56,8 @@ def to_device(obj: Any, device: torch.device) -> Any:
     """Recursively move tensors inside Python containers to a device."""
 
     if isinstance(obj, torch.Tensor):
+        if obj.device == device:
+            return obj
         return obj.to(device, non_blocking=True)
     if isinstance(obj, dict):
         return {k: to_device(v, device) for k, v in obj.items()}

--- a/areno/engine/layers/attention.py
+++ b/areno/engine/layers/attention.py
@@ -40,6 +40,7 @@ class CausalSelfAttention(nn.Module):
         self.head_dim = config.head_dim
         self.num_heads = config.num_attention_heads
         self.num_kv_heads = config.num_key_value_heads
+        self.attn_backend = config.attn_backend
         # Local query head count after column-parallel sharding.
         self.local_heads = self.num_heads // ctx.world_size
         # Fused QKV column-parallel projection; ranks each own a contiguous
@@ -61,7 +62,7 @@ class CausalSelfAttention(nn.Module):
         # Optional per-head QK normalization (used by some recent models).
         self.q_norm = RMSNorm(config.head_dim, config.rms_norm_eps) if config.qk_norm else None
         self.k_norm = RMSNorm(config.head_dim, config.rms_norm_eps) if config.qk_norm else None
-        self.train_backend = build_train_attention_backend()
+        self.train_backend = build_train_attention_backend(self.attn_backend)
         # Inference backend and KV cache buffers are lazily attached: training
         # uses neither, and inference plumbs the cache in via set_kv_cache.
         self.infer_backend: FlashAttnInferBackend | None = None
@@ -117,7 +118,7 @@ class CausalSelfAttention(nn.Module):
         # Lazy backend init so the FlashAttention functions are only bound when
         # the layer actually serves an inference request.
         if self.infer_backend is None:
-            self.infer_backend = build_infer_attention_backend()
+            self.infer_backend = build_infer_attention_backend(self.attn_backend)
         out = self.infer_backend(q, k, v, self.k_cache, self.v_cache, infer_meta)
         out = out.contiguous().view(q.shape[0], q.shape[1], self.local_heads * self.head_dim)
         return self.o_proj(out)

--- a/areno/engine/layers/attention_backend/common.py
+++ b/areno/engine/layers/attention_backend/common.py
@@ -1,18 +1,21 @@
-"""Shared utilities for FlashAttention backends.
+"""Shared utilities for attention backends.
 
 Defines the `AttentionCall` value object, which packages a set of Q/K/V
 tensors together with the FlashAttention-shaped parameters (normalized
 window, optional softmax scale, padded V head dim) so train and infer paths
 present identical kernel arguments. Also exposes the small helpers used to
 pad value heads, expand grouped-query KV heads, and translate window-size
-conventions between FlashAttention and SDPA.
+conventions.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import torch
+
+AttnBackend = Literal["flash", "native"]
 
 
 @dataclass(frozen=True)
@@ -76,13 +79,6 @@ def flash_window_size(window_size: tuple[int, int] | None) -> tuple[int, int]:
     return window_size or (-1, -1)
 
 
-def sdpa_window_size(window_size: tuple[int, int]) -> tuple[int, int] | None:
-    """Convert FlashAttention's full-window sentinel back to SDPA semantics."""
-
-    # SDPA represents "no window" as None; flash-attn uses the (-1, -1) tuple.
-    return None if window_size == (-1, -1) else window_size
-
-
 def pad_last_dim(x: torch.Tensor, size: int) -> torch.Tensor:
     """Pad the value/cache head dim to the attention kernel head dim."""
 
@@ -98,10 +94,35 @@ def pad_last_dim(x: torch.Tensor, size: int) -> torch.Tensor:
 def expand_kv_heads(x: torch.Tensor, num_q_heads: int) -> torch.Tensor:
     """Repeat KV heads for grouped-query attention kernels."""
 
-    # SDPA fallback paths need physical KV head replication because they do
-    # not implement GQA natively; flash-attn handles GQA without expansion.
+    # Native attention paths need physical KV head replication because they
+    # operate after grouped-query heads have been expanded.
     num_kv_heads = x.shape[-2]
     if num_kv_heads == num_q_heads:
         return x
+    if num_q_heads < num_kv_heads or num_q_heads % num_kv_heads != 0:
+        raise ValueError(f"cannot expand {num_kv_heads} KV heads to {num_q_heads} query heads")
     repeat = num_q_heads // num_kv_heads
-    return x.repeat_interleave(repeat, dim=-2)
+    return (
+        x.unsqueeze(-2)
+        .expand(*x.shape[:-2], num_kv_heads, repeat, x.shape[-1])
+        .reshape(*x.shape[:-2], num_q_heads, x.shape[-1])
+        .contiguous()
+    )
+
+
+def use_native_attention(attn_backend: AttnBackend) -> bool:
+    """Return whether attention should bypass flash-attn and use native attention."""
+
+    return attn_backend == "native"
+
+
+def require_flash_attention_supported(call: AttentionCall, *, mode: str) -> None:
+    """Fail with an actionable message when flash-attn cannot handle the shape."""
+
+    if call.flash_supported:
+        return
+    raise RuntimeError(
+        f"flash attention does not support qk head dim {call.qk_head_dim} for {mode}. "
+        "Use --attn-backend native to run the native consistency attention backend instead; "
+        "this is slower and intended for compatibility or logprob diagnostics."
+    )

--- a/areno/engine/layers/attention_backend/infer.py
+++ b/areno/engine/layers/attention_backend/infer.py
@@ -11,21 +11,24 @@ The backend serves two distinct modes signalled by `InferMeta.mode`:
   block table, and `flash_attn_with_kvcache` reads the full history for
   each sequence directly from the paged cache.
 
-An SDPA fallback handles QK head dims that flash-attn does not support.
+The ``native`` backend selects the areno_accel native attention path that
+shares forward math with training attention for logprob diagnostics.
+Unsupported flash-attn shapes fail with an actionable message instead of
+silently falling back.
 """
 
 from __future__ import annotations
 
 import torch
-import torch.nn.functional as F
-from flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
 from torch import nn
 
+from areno.accel.attention import areno_paged_causal_attention_decode, areno_varlen_causal_attention
 from areno.engine.layers.attention_backend.common import (
+    AttnBackend,
     build_attention_call,
-    expand_kv_heads,
     pad_last_dim,
-    sdpa_window_size,
+    require_flash_attention_supported,
+    use_native_attention,
 )
 from areno.engine.runtime.metadata import InferMeta
 
@@ -38,12 +41,11 @@ class FlashAttnInferBackend(nn.Module):
     fused KV-cache attention path.
     """
 
-    def __init__(self):
+    def __init__(self, attn_backend: AttnBackend = "flash"):
         """Bind flash-attn entrypoints once for the module instance."""
 
         super().__init__()
-        self.flash_attn_varlen_func = flash_attn_varlen_func
-        self.flash_attn_with_kvcache = flash_attn_with_kvcache
+        self.attn_backend = attn_backend
 
     def forward(
         self,
@@ -70,17 +72,17 @@ class FlashAttnInferBackend(nn.Module):
             # Persist freshly computed K/V for the prompt into paged cache.
             if update_cache:
                 _store_prefill_cache(k_flat, v_flat, k_cache, v_cache, meta)
-            if not call.flash_supported:
-                # SDPA fallback when flash-attn cannot serve this head dim.
-                out = _sdpa_prefill(
+            if use_native_attention(self.attn_backend):
+                out = _native_prefill(
                     q_flat,
                     k_flat,
                     v_flat,
                     meta,
-                    sdpa_window_size(call.window_size),
+                    call.window_size,
                     call.softmax_scale,
                 )
                 return out.view(q.shape[0], q.shape[1], q.shape[2], call.value_dim)
+            require_flash_attention_supported(call, mode="prefill attention")
             # cu_seqlens tells flash-attn where each packed sequence ends so
             # causal attention does not bleed across sequence boundaries.
             out = _flash_attn_varlen_no_compile(
@@ -107,20 +109,21 @@ class FlashAttnInferBackend(nn.Module):
             # when combining those masked splits. Keep local decode on the
             # single-split kvcache kernel; full attention can keep the heuristic.
             num_splits = 1 if call.window_size != (-1, -1) else 0
-            if not call.flash_supported:
-                # SDPA decode fallback: write the new token then materialize
-                # the full key/value matrices from the paged cache.
-                if update_cache:
-                    _store_decode_cache(k_flat, v_flat, k_cache, v_cache, meta)
-                out = _sdpa_decode(
+            if use_native_attention(self.attn_backend):
+                if not update_cache:
+                    raise ValueError("native decode requires update_cache=True")
+                out = _native_decode(
                     q=q_flat,
+                    k_update=k_flat,
+                    v_update=pad_last_dim(v_flat, v_cache_dim),
                     k_cache=k_cache,
                     v_cache=v_cache,
                     meta=meta,
-                    window_size=sdpa_window_size(call.window_size),
+                    window_size=call.window_size,
                     softmax_scale=call.softmax_scale,
                 )
                 return out.view(q.shape[0], q.shape[1], q.shape[2], call.value_dim)
+            require_flash_attention_supported(call, mode="decode attention")
             # When value head dim < cache head dim we pad to match the cache
             # layout that was sized to the QK head dim at prefill time.
             v_update = (
@@ -150,15 +153,17 @@ class FlashAttnInferBackend(nn.Module):
         raise ValueError(f"unsupported inference mode: {meta.mode}")
 
 
-def build_infer_attention_backend() -> FlashAttnInferBackend:
+def build_infer_attention_backend(attn_backend: AttnBackend = "flash") -> FlashAttnInferBackend:
     """Build the default inference attention backend."""
 
-    return FlashAttnInferBackend()
+    return FlashAttnInferBackend(attn_backend=attn_backend)
 
 
 @torch._dynamo.disable
 def _flash_attn_varlen_no_compile(*args, **kwargs) -> torch.Tensor:
     """Dynamo-opaque wrapper so torch.compile does not specialize flash-attn."""
+
+    from flash_attn import flash_attn_varlen_func
 
     return flash_attn_varlen_func(*args, **kwargs)
 
@@ -167,94 +172,73 @@ def _flash_attn_varlen_no_compile(*args, **kwargs) -> torch.Tensor:
 def _flash_attn_with_kvcache_no_compile(*args, **kwargs) -> torch.Tensor:
     """Dynamo-opaque wrapper for the kvcache-aware flash-attn entrypoint."""
 
+    from flash_attn import flash_attn_with_kvcache
+
     return flash_attn_with_kvcache(*args, **kwargs)
 
 
+def _window_left(window_size: tuple[int, int]) -> int | None:
+    if window_size == (-1, -1):
+        return None
+    if window_size[1] != 0:
+        raise ValueError("native attention backend only supports causal right window 0")
+    return int(window_size[0])
+
+
 @torch._dynamo.disable
-def _sdpa_prefill(
+def _native_prefill(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
     meta: InferMeta,
-    window_size: tuple[int, int] | None,
+    window_size: tuple[int, int],
     softmax_scale: float | None,
 ) -> torch.Tensor:
-    """Per-sequence SDPA prefill fallback used for unsupported QK head dims."""
+    """Per-sequence native prefill path shared with training attention."""
 
     if meta.cu_seqlens is None:
         raise ValueError("prefill inference requires cu_seqlens")
-    outs = []
-    # Iterate packed sequences using their start/end offsets.
-    cu = meta.cu_seqlens.tolist()
-    for start, end in zip(cu[:-1], cu[1:], strict=True):
-        q_seq = q[start:end].transpose(0, 1).unsqueeze(0)
-        # SDPA does not understand GQA; replicate KV heads up to Q head count.
-        k_seq = expand_kv_heads(k[start:end], q.shape[1]).transpose(0, 1).unsqueeze(0)
-        v_seq = expand_kv_heads(v[start:end], q.shape[1]).transpose(0, 1).unsqueeze(0)
-        if window_size is None:
-            out = F.scaled_dot_product_attention(q_seq, k_seq, v_seq, is_causal=True, scale=softmax_scale)
-        else:
-            # Build a banded causal mask covering only positions inside the
-            # sliding window when one is requested.
-            seqlen = end - start
-            rows = torch.arange(seqlen, device=q.device).view(seqlen, 1)
-            cols = torch.arange(seqlen, device=q.device).view(1, seqlen)
-            mask = cols <= rows
-            if window_size[0] >= 0:
-                mask = mask & (cols >= rows - int(window_size[0]))
-            out = F.scaled_dot_product_attention(
-                q_seq,
-                k_seq,
-                v_seq,
-                attn_mask=mask.view(1, 1, seqlen, seqlen),
-                scale=softmax_scale,
-            )
-        outs.append(out.squeeze(0).transpose(0, 1))
-    return torch.cat(outs, dim=0)
+    return areno_varlen_causal_attention(
+        q,
+        k,
+        v,
+        meta.cu_seqlens,
+        window_left=_window_left(window_size),
+        softmax_scale=softmax_scale,
+    )
 
 
-def _sdpa_decode(
+def _native_decode(
     q: torch.Tensor,
+    k_update: torch.Tensor,
+    v_update: torch.Tensor,
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
     meta: InferMeta,
-    window_size: tuple[int, int] | None,
+    window_size: tuple[int, int],
     softmax_scale: float | None,
 ) -> torch.Tensor:
-    """SDPA-based single-token decode fallback over the paged KV cache."""
+    """Native single-token decode path over the paged KV cache."""
 
     if meta.cache_seqlens is None or meta.block_table is None:
         raise ValueError("decode inference requires cache_seqlens and block_table")
     out_dtype = q.dtype
-    # Materialize each sequence's K/V history by gathering the paged blocks
-    # listed in its block_table (block_size becomes the second axis).
-    k = k_cache[meta.block_table.long()].flatten(1, 2).float()
-    v = v_cache[meta.block_table.long()].flatten(1, 2).float()
-    q = q.float()
-    q_heads = q.shape[1]
-    kv_heads = k.shape[2]
-    # Reshape Q into (batch, kv_heads, groups, head_dim) to match GQA layout.
-    groups = q_heads // kv_heads
-    q = q.view(q.shape[0], kv_heads, groups, q.shape[-1])
-    scale = softmax_scale if softmax_scale is not None else q.shape[-1] ** -0.5
-    # Mask out positions beyond each sequence's current length (and outside
-    # the sliding window when one was requested).
-    positions = torch.arange(k.shape[1], device=q.device).view(1, 1, 1, -1)
-    total_lens = (meta.cache_seqlens + 1).view(-1, 1, 1, 1)
-    mask = positions < total_lens
-    if window_size is not None and window_size[0] >= 0:
-        start = (total_lens - int(window_size[0]) - 1).clamp_min(0)
-        mask = mask & (positions >= start)
-    kv_mask = mask.view(mask.shape[0], mask.shape[-1], 1, 1)
-    k = k.masked_fill(~kv_mask, 0.0)
-    v = v.masked_fill(~kv_mask, 0.0)
-    k_t = k.permute(0, 2, 3, 1)
-    scores = torch.matmul(q, k_t) * scale
-    scores = scores.masked_fill(~mask, torch.finfo(scores.dtype).min)
-    probs = torch.softmax(scores, dim=-1)
-    v_t = v.permute(0, 2, 1, 3)
-    out = torch.matmul(probs, v_t)
-    return out.reshape(out.shape[0], q_heads, out.shape[-1]).to(dtype=out_dtype)
+    if meta.cache_seqlens.dtype != torch.int32:
+        raise ValueError("native decode requires int32 cache_seqlens")
+    if meta.block_table.dtype != torch.int32:
+        raise ValueError("native decode requires int32 block_table")
+    return areno_paged_causal_attention_decode(
+        q.contiguous(),
+        k_update.contiguous(),
+        v_update.contiguous(),
+        k_cache.contiguous(),
+        v_cache.contiguous(),
+        meta.block_table.contiguous(),
+        meta.cache_seqlens.contiguous(),
+        window_left=_window_left(window_size),
+        num_splits=8,
+        softmax_scale=softmax_scale,
+    ).to(dtype=out_dtype)
 
 
 def _store_prefill_cache(

--- a/areno/engine/layers/attention_backend/train.py
+++ b/areno/engine/layers/attention_backend/train.py
@@ -9,21 +9,34 @@ Supports two activation layouts:
   `flash_attn_varlen_func` so packed batches without padding can be
   trained efficiently.
 
-When flash-attn cannot serve the QK head dim (>256) the backend falls back
-to a manual SDPA path that supports both layouts and sliding windows.
+The ``native`` backend keeps rollout prefill/decode on native kernels while
+training uses PyTorch's SDPA math backend to avoid the slow native backward
+diagnostic kernel.
+Unsupported flash-attn shapes fail with an actionable message instead of
+silently falling back.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import torch
 import torch.nn.functional as F
-from flash_attn import flash_attn_func, flash_attn_varlen_func
 from torch import nn
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from areno.engine.layers.attention_backend.common import build_attention_call, expand_kv_heads, sdpa_window_size
+from areno.engine.layers.attention_backend.common import (
+    AttnBackend,
+    build_attention_call,
+    expand_kv_heads,
+    require_flash_attention_supported,
+    use_native_attention,
+)
 from areno.engine.runtime.metadata import TrainMeta
+
+_SDPA_MATH_QUERY_CHUNK = 512
 
 
 class TrainAttentionBackend(nn.Module, ABC):
@@ -45,10 +58,9 @@ class TrainAttentionBackend(nn.Module, ABC):
 class FlashAttnTrainAttentionBackend(TrainAttentionBackend):
     """FlashAttention backend shared by padded and varlen packed training."""
 
-    def __init__(self):
+    def __init__(self, attn_backend: AttnBackend = "flash"):
         super().__init__()
-        self.flash_attn_func = flash_attn_func
-        self.flash_attn_varlen_func = flash_attn_varlen_func
+        self.attn_backend = attn_backend
 
     def forward(
         self,
@@ -60,9 +72,10 @@ class FlashAttnTrainAttentionBackend(TrainAttentionBackend):
         softmax_scale: float | None = None,
     ) -> torch.Tensor:
         call = build_attention_call(q, k, v, window_size, softmax_scale)
-        if not call.flash_supported:
-            # Unsupported QK head dim: drop to SDPA fallback (slower).
-            return _sdpa_train(q, k, v, meta, sdpa_window_size(call.window_size), call.softmax_scale)
+        if use_native_attention(self.attn_backend):
+            out = _native_train(call.q, call.k, call.v, meta, call.window_size, call.softmax_scale)
+            return call.trim_value_dim(out)
+        require_flash_attention_supported(call, mode="training attention")
         if meta is not None and meta.cu_seqlens is not None:
             # Varlen packed path: tensors must be flattened to (T, H, D) so
             # cu_seqlens can carve out the per-sequence boundaries.
@@ -104,15 +117,17 @@ class FlashAttnTrainAttentionBackend(TrainAttentionBackend):
         return call.trim_value_dim(out)
 
 
-def build_train_attention_backend() -> TrainAttentionBackend:
+def build_train_attention_backend(attn_backend: AttnBackend = "flash") -> TrainAttentionBackend:
     """Build the default FlashAttention training backend."""
 
-    return FlashAttnTrainAttentionBackend()
+    return FlashAttnTrainAttentionBackend(attn_backend=attn_backend)
 
 
 @torch._dynamo.disable
 def _flash_attn_train_no_compile(*args, **kwargs) -> torch.Tensor:
     """Dynamo-opaque wrapper for the dense flash-attn training kernel."""
+
+    from flash_attn import flash_attn_func
 
     return flash_attn_func(*args, **kwargs)
 
@@ -121,85 +136,139 @@ def _flash_attn_train_no_compile(*args, **kwargs) -> torch.Tensor:
 def _flash_attn_varlen_train_no_compile(*args, **kwargs) -> torch.Tensor:
     """Dynamo-opaque wrapper for the packed varlen flash-attn training kernel."""
 
+    from flash_attn import flash_attn_varlen_func
+
     return flash_attn_varlen_func(*args, **kwargs)
 
 
 @torch._dynamo.disable
-def _sdpa_train(
+def _native_train(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
     meta: TrainMeta | None,
-    window_size: tuple[int, int] | None,
+    window_size: tuple[int, int],
     softmax_scale: float | None,
 ) -> torch.Tensor:
-    """Training fallback for QK head dimensions unsupported by flash-attn."""
+    """Training path for attn_backend=native using PyTorch SDPA math."""
 
+    if meta is not None and meta.sequence_parallel:
+        raise RuntimeError(
+            "native attention backend training does not support sequence parallelism with SDPA math yet. "
+            "Disable sequence parallelism for logprob diagnostics or use --attn-backend flash."
+        )
     if meta is not None and meta.cu_seqlens is not None:
-        # Packed-layout SDPA: iterate sequences and concatenate the outputs.
-        outs = []
-        cu = meta.cu_seqlens.tolist()
+        cu = meta.cu_seqlens.detach().cpu().tolist()
         q_flat = q.reshape(-1, q.shape[-2], q.shape[-1])
         k_flat = k.reshape(-1, k.shape[-2], k.shape[-1])
         v_flat = v.reshape(-1, v.shape[-2], v.shape[-1])
-        for start, end in zip(cu[:-1], cu[1:], strict=True):
-            outs.append(
-                _sdpa_sequence(q_flat[start:end], k_flat[start:end], v_flat[start:end], window_size, softmax_scale)
-            )
+        outs = [
+            _sdpa_math_sequence(q_flat[start:end], k_flat[start:end], v_flat[start:end], window_size, softmax_scale)
+            for start, end in zip(cu[:-1], cu[1:], strict=True)
+            if end > start
+        ]
         return torch.cat(outs, dim=0).view(q.shape)
-    # Padded SDPA: expand KV heads for GQA and reshape to (B, H, S, D).
     k = expand_kv_heads(k, q.shape[-2])
     v = expand_kv_heads(v, q.shape[-2])
-    q_seq = q.transpose(1, 2)
-    k_seq = k.transpose(1, 2)
-    v_seq = v.transpose(1, 2)
-    if window_size is None:
-        return F.scaled_dot_product_attention(q_seq, k_seq, v_seq, is_causal=True, scale=softmax_scale).transpose(1, 2)
-    # Build a banded causal mask covering only positions inside the window.
-    seqlen = q.shape[1]
-    rows = torch.arange(seqlen, device=q.device).view(seqlen, 1)
-    cols = torch.arange(seqlen, device=q.device).view(1, seqlen)
-    mask = cols <= rows
-    if window_size[0] >= 0:
-        mask = mask & (cols >= rows - int(window_size[0]))
-    return F.scaled_dot_product_attention(
-        q_seq,
-        k_seq,
-        v_seq,
-        attn_mask=mask.view(1, 1, seqlen, seqlen),
-        scale=softmax_scale,
-    ).transpose(1, 2)
+    return _sdpa_math_padded(q, k, v, window_size, softmax_scale)
 
 
-def _sdpa_sequence(
+@contextmanager
+def _sdpa_math_kernel() -> Iterator[None]:
+    with sdpa_kernel(SDPBackend.MATH):
+        yield
+
+
+def _sdpa_math_padded(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    window_size: tuple[int, int] | None,
+    window_size: tuple[int, int],
     softmax_scale: float | None,
 ) -> torch.Tensor:
-    """SDPA over a single varlen-packed sequence slice."""
+    q_seq = q.transpose(1, 2)
+    k_seq = k.transpose(1, 2)
+    v_seq = v.transpose(1, 2)
+    if q.shape[1] > _SDPA_MATH_QUERY_CHUNK:
+        return _sdpa_math_chunked(q_seq, k_seq, v_seq, window_size, softmax_scale).transpose(1, 2)
+    with _sdpa_math_kernel():
+        if window_size == (-1, -1):
+            out = F.scaled_dot_product_attention(q_seq, k_seq, v_seq, is_causal=True, scale=softmax_scale)
+        else:
+            out = F.scaled_dot_product_attention(
+                q_seq,
+                k_seq,
+                v_seq,
+                attn_mask=_causal_window_mask(q.shape[1], k.shape[1], window_size, q.device, 0),
+                scale=softmax_scale,
+            )
+    return out.transpose(1, 2)
 
-    # Expand KV heads to match Q heads (SDPA has no GQA support).
-    k = expand_kv_heads(k, q.shape[1])
-    v = expand_kv_heads(v, q.shape[1])
+
+def _sdpa_math_sequence(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    window_size: tuple[int, int],
+    softmax_scale: float | None,
+) -> torch.Tensor:
+    k = expand_kv_heads(k, q.shape[-2])
+    v = expand_kv_heads(v, q.shape[-2])
     q_seq = q.transpose(0, 1).unsqueeze(0)
     k_seq = k.transpose(0, 1).unsqueeze(0)
     v_seq = v.transpose(0, 1).unsqueeze(0)
-    if window_size is None:
-        out = F.scaled_dot_product_attention(q_seq, k_seq, v_seq, is_causal=True, scale=softmax_scale)
-    else:
-        seqlen = q.shape[0]
-        rows = torch.arange(seqlen, device=q.device).view(seqlen, 1)
-        cols = torch.arange(seqlen, device=q.device).view(1, seqlen)
-        mask = cols <= rows
-        if window_size[0] >= 0:
-            mask = mask & (cols >= rows - int(window_size[0]))
-        out = F.scaled_dot_product_attention(
-            q_seq,
-            k_seq,
-            v_seq,
-            attn_mask=mask.view(1, 1, seqlen, seqlen),
-            scale=softmax_scale,
-        )
+    if q.shape[0] > _SDPA_MATH_QUERY_CHUNK:
+        return _sdpa_math_chunked(q_seq, k_seq, v_seq, window_size, softmax_scale).squeeze(0).transpose(0, 1)
+    with _sdpa_math_kernel():
+        if window_size == (-1, -1):
+            out = F.scaled_dot_product_attention(q_seq, k_seq, v_seq, is_causal=True, scale=softmax_scale)
+        else:
+            out = F.scaled_dot_product_attention(
+                q_seq,
+                k_seq,
+                v_seq,
+                attn_mask=_causal_window_mask(q.shape[0], k.shape[0], window_size, q.device, 0),
+                scale=softmax_scale,
+            )
     return out.squeeze(0).transpose(0, 1)
+
+
+def _sdpa_math_chunked(
+    q_seq: torch.Tensor,
+    k_seq: torch.Tensor,
+    v_seq: torch.Tensor,
+    window_size: tuple[int, int],
+    softmax_scale: float | None,
+) -> torch.Tensor:
+    chunks = []
+    seqlen = q_seq.shape[-2]
+    with _sdpa_math_kernel():
+        for start in range(0, seqlen, _SDPA_MATH_QUERY_CHUNK):
+            end = min(start + _SDPA_MATH_QUERY_CHUNK, seqlen)
+            chunks.append(
+                F.scaled_dot_product_attention(
+                    q_seq[:, :, start:end],
+                    k_seq,
+                    v_seq,
+                    attn_mask=_causal_window_mask(end - start, k_seq.shape[-2], window_size, q_seq.device, start),
+                    scale=softmax_scale,
+                )
+            )
+    return torch.cat(chunks, dim=-2)
+
+
+def _causal_window_mask(
+    q_len: int,
+    k_len: int,
+    window_size: tuple[int, int],
+    device: torch.device,
+    query_start: int,
+) -> torch.Tensor:
+    if window_size != (-1, -1) and window_size[1] != 0:
+        raise ValueError("SDPA math training only supports causal right window 0")
+    rows = torch.arange(query_start, query_start + q_len, device=device).view(q_len, 1)
+    cols = torch.arange(k_len, device=device).view(1, k_len)
+    mask = cols <= rows
+    if window_size[0] >= 0:
+        mask = mask & (cols >= rows - int(window_size[0]))
+    return mask.view(1, 1, q_len, k_len)

--- a/areno/engine/runtime/logprobs.py
+++ b/areno/engine/runtime/logprobs.py
@@ -54,28 +54,21 @@ def packed_next_token_logprobs(
     # of the next token, then run the same TP kernel over those.
     flat_tokens = tokens.reshape(-1)
     cu_seqlens = cu_seqlens.to(device=tokens.device, dtype=torch.long)
-    action_count = int((cu_seqlens[1:] - cu_seqlens[:-1] - 1).clamp(min=0).sum().item())
+    # Training packs every row with at least one token, so the number of
+    # next-token action sites is total_tokens minus one tail token per row.
+    # Keep this as shape arithmetic to avoid a GPU sync from `.item()`.
+    action_count = max(flat_tokens.numel() - (cu_seqlens.numel() - 1), 0)
     selected = torch.empty(action_count, device=logits_shard.device, dtype=torch.float32)
     if action_count == 0:
         return selected
 
-    positions = torch.empty(action_count, device=tokens.device, dtype=torch.long)
-    labels = torch.empty(action_count, device=tokens.device, dtype=torch.long)
-    offset = 0
-    for seq_idx in range(cu_seqlens.numel() - 1):
-        start = int(cu_seqlens[seq_idx].item())
-        end = int(cu_seqlens[seq_idx + 1].item())
-        length = end - start
-        if length <= 1:
-            continue
-        count = length - 1
-        slc = slice(offset, offset + count)
-        # `positions[k]` is the index inside the packed sequence whose logits
-        # predict `labels[k]`. We drop the last position of each row because
-        # it has no next-token target.
-        positions[slc] = torch.arange(start, end - 1, device=tokens.device)
-        labels[slc] = flat_tokens[start + 1 : end]
-        offset += count
+    # `positions[k]` is the packed index whose logits predict `labels[k]`.
+    # Drop each sequence tail because it has no next-token target.
+    positions = torch.arange(flat_tokens.numel(), device=tokens.device)
+    keep = torch.ones(flat_tokens.numel(), device=tokens.device, dtype=torch.bool)
+    keep[cu_seqlens[1:] - 1] = False
+    positions = positions[keep]
+    labels = flat_tokens[positions + 1]
 
     for start in range(0, action_count, chunk_size):
         end = min(start + chunk_size, action_count)

--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -67,8 +67,8 @@ class TrainingManager:
             worker._prepare_for_train()
         worker.model.train()
         data_pack_obj = data_pack_shards[ctx.dp_rank]
-        data_pack = to_device(data_pack_obj, worker.device)
-        data_pack = _pack_train_data(data_pack)
+        data_pack = _pack_train_data(data_pack_obj)
+        data_pack = to_device(data_pack, worker.device)
         data_pack["_sequence_parallel_enabled"] = worker.config.model.sequence_parallel
         data_pack["_activation_checkpointing_enabled"] = worker.config.runtime.activation_checkpointing
         tokens = data_pack["input_ids"].long()

--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -608,7 +608,7 @@ def _grouped_weight(module: nn.Module, expert_id: int) -> torch.Tensor:
     weights = getattr(module, "weight", None)
     if isinstance(weights, torch.Tensor) and weights.dim() == 3:
         return weights[expert_id]
-    if isinstance(weights, (list, tuple, nn.ParameterList)):
+    if isinstance(weights, list | tuple | nn.ParameterList):
         return weights[expert_id]
     raise AttributeError(f"cannot find grouped expert weight for expert {expert_id}")
 
@@ -693,7 +693,8 @@ class BailingSoftmaxAttention(nn.Module):
             1.0,
             is_neox_style=False,
         )
-        self.train_backend = build_train_attention_backend()
+        self.attn_backend = config.attn_backend
+        self.train_backend = build_train_attention_backend(self.attn_backend)
         self.infer_backend: FlashAttnInferBackend | None = None
         # KV cache slots populated by the runtime at engine setup.
         self.k_cache = torch.tensor([])
@@ -712,7 +713,7 @@ class BailingSoftmaxAttention(nn.Module):
             # Lazily build the inference backend so weight-only training paths
             # don't pay the cost.
             if self.infer_backend is None:
-                self.infer_backend = build_infer_attention_backend()
+                self.infer_backend = build_infer_attention_backend(self.attn_backend)
             out = self.infer_backend(q, k, v, self.k_cache, self.v_cache, infer_meta)
         else:
             out = self.train_backend(q, k, v, train_meta)

--- a/areno/models/gemma4/model.py
+++ b/areno/models/gemma4/model.py
@@ -350,6 +350,7 @@ class Gemma4Attention(nn.Module):
             else None
         )
         self.softmax_scale = config.attention_softmax_scale
+        self.attn_backend = config.attn_backend
         # Rotary frequency base and partial-rotary fraction may differ per
         # layer_type (full vs sliding may use different long-context settings).
         theta = _rope_theta(config, layer_type)
@@ -360,7 +361,7 @@ class Gemma4Attention(nn.Module):
             theta,
             partial,
         )
-        self.train_backend = build_train_attention_backend()
+        self.train_backend = build_train_attention_backend(self.attn_backend)
         self.infer_backend: FlashAttnInferBackend | None = None
         # KV cache slots are lazily bound; numel==0 means "not yet allocated".
         self.k_cache = torch.tensor([])
@@ -422,7 +423,7 @@ class Gemma4Attention(nn.Module):
             raise RuntimeError("inference requires per-layer KV cache tensors")
         if self.infer_backend is None:
             # Lazily instantiate once we know what we are running against.
-            self.infer_backend = build_infer_attention_backend()
+            self.infer_backend = build_infer_attention_backend(self.attn_backend)
         out = self.infer_backend(
             q,
             k,

--- a/areno/models/minicpmv46/model.py
+++ b/areno/models/minicpmv46/model.py
@@ -105,7 +105,8 @@ class MiniCPMFullAttention(nn.Module):
             config.partial_rotary_factor,
             is_neox_style=True,
         )
-        self.train_backend = build_train_attention_backend()
+        self.attn_backend = config.attn_backend
+        self.train_backend = build_train_attention_backend(self.attn_backend)
         self.infer_backend: FlashAttnInferBackend | None = None
         self.k_cache = torch.tensor([])
         self.v_cache = torch.tensor([])
@@ -146,7 +147,7 @@ class MiniCPMFullAttention(nn.Module):
         if self.infer_backend is None:
             # Lazy-build the flash-attn inference backend the first time we
             # serve a request.
-            self.infer_backend = build_infer_attention_backend()
+            self.infer_backend = build_infer_attention_backend(self.attn_backend)
         return self.infer_backend(q, k, v, self.k_cache, self.v_cache, infer_meta)
 
     def set_kv_cache(self, k_cache: torch.Tensor, v_cache: torch.Tensor) -> None:

--- a/areno/models/qwen3_5/model.py
+++ b/areno/models/qwen3_5/model.py
@@ -126,7 +126,8 @@ class Qwen35FullAttention(nn.Module):
             config.partial_rotary_factor,
             is_neox_style=True,
         )
-        self.train_backend = build_train_attention_backend()
+        self.attn_backend = config.attn_backend
+        self.train_backend = build_train_attention_backend(self.attn_backend)
         self.infer_backend: FlashAttnInferBackend | None = None
         self.k_cache = torch.tensor([])
         self.v_cache = torch.tensor([])
@@ -173,7 +174,7 @@ class Qwen35FullAttention(nn.Module):
         if self.k_cache.numel() == 0 or self.v_cache.numel() == 0:
             raise RuntimeError("Qwen3.5 full attention inference requires KV cache")
         if self.infer_backend is None:
-            self.infer_backend = build_infer_attention_backend()
+            self.infer_backend = build_infer_attention_backend(self.attn_backend)
         return self.infer_backend(q, k, v, self.k_cache, self.v_cache, infer_meta)
 
     def set_kv_cache(self, k_cache: torch.Tensor, v_cache: torch.Tensor) -> None:

--- a/docs/cli/inference.rst
+++ b/docs/cli/inference.rst
@@ -52,6 +52,13 @@ Options:
 ``--eager-decode``
    Disable decode CUDA graph and run rollout decode eagerly.
 
+``--attn-backend [flash|native]``
+   Attention backend. Default: ``flash``. Use ``native`` to run without
+   ``flash-attn`` on the areno_accel native compatibility path. AReno
+   automatically falls back to ``native`` on flash-attn-unsupported GPUs such
+   as Tesla T4 and prints a warning. ``native`` is slower than ``flash`` on
+   supported GPUs.
+
 ``world-size`` must be divisible by ``tp-size``.
 
 Examples

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -167,6 +167,13 @@ Runtime memory and speed
 ``--eager-decode``
    Disable decode CUDA graph and run rollout decode eagerly.
 
+``--attn-backend [flash|native]``
+   Attention backend. Default: ``flash``. Use ``native`` to run without
+   ``flash-attn`` on the areno_accel native compatibility path. AReno
+   automatically falls back to ``native`` on flash-attn-unsupported GPUs such
+   as Tesla T4 and prints a warning. ``native`` is slower than ``flash`` on
+   supported GPUs.
+
 Training rollouts run inside a rollout session. The session owns actor
 onload/offload, rollout cache state, CUDA graph state, and cleanup between
 rollout and train phases. Direct prompt rollout and agentic rollout both use

--- a/docs/getting-started/build.rst
+++ b/docs/getting-started/build.rst
@@ -47,19 +47,23 @@ the repository root:
 .. code-block:: bash
 
    pip install psutil
-   pip install flash-attn flash-linear-attention
+   pip install flash-linear-attention
    pip install -e . --no-build-isolation
 
 .. note::
 
    ``--no-build-isolation`` uses the packages already installed in your
    environment. Install ``psutil`` first because PyTorch's CUDA extension
-   builder imports it while sizing parallel compile jobs. ``flash-attn``,
-   CUDA, and PyTorch must be ABI compatible. The editable install builds the
-   ``areno_accel`` CUDA extension used by local kernels.
-   Install ``flash-attn`` before AReno so the local build can reuse the
-   already-installed package. If building ``flash-attn`` from source is too
-   slow for your environment, install a pre-built wheel from the
+   builder imports it while sizing parallel compile jobs. CUDA and PyTorch
+   must be ABI compatible. The editable install builds the ``areno_accel``
+   CUDA extension used by local kernels.
+   Install ``flash-attn`` before AReno only if you use the default
+   ``--attn-backend flash`` high-throughput path. ``flash-attn`` is optional
+   when running with ``--attn-backend native``; AReno automatically falls back
+   to native attention on flash-attn-unsupported GPUs such as Tesla T4 and
+   warns that native attention is a slower compatibility path. If building
+   ``flash-attn`` from source is too slow for your environment, install a
+   pre-built wheel from the
    `flash-attention releases <https://github.com/Dao-AILab/flash-attention/releases>`_
    that matches your Python, PyTorch, CUDA, and platform.
    When ``TORCH_CUDA_ARCH_LIST`` is not set, AReno targets the visible GPU

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,8 +34,13 @@ Install in an existing CUDA + PyTorch environment:
 .. code-block:: bash
 
    pip install psutil
-   pip install flash-attn flash-linear-attention
+   pip install flash-linear-attention
    pip install -e . --no-build-isolation
+
+Install ``flash-attn`` as an optional extra only when using the default
+``--attn-backend flash`` path. ``flash-attn`` is not required for
+``--attn-backend native`` or for GPUs such as Tesla T4 where AReno falls back
+to native attention.
 
 Check whether the environment is ready:
 

--- a/docs/sdk/trainer.rst
+++ b/docs/sdk/trainer.rst
@@ -397,6 +397,11 @@ Data classes
    :param dict | None optimizer: Advanced optimizer config passed to the
       engine.
    :param dict | None runtime: Advanced runtime config passed to the engine.
+      Set ``runtime={"attn_backend": "native"}`` to run without
+      ``flash-attn`` on the areno_accel native compatibility path. AReno also
+      falls back to native attention on flash-attn-unsupported GPUs such as
+      Tesla T4 and prints a warning. The default is ``"flash"`` for normal
+      high-throughput training on supported GPUs.
    :param int max_running_prompts: Concurrent rollout prompt limit.
    :param float decode_progress_interval_s: Worker decode progress log
       interval. Logs report per-DP scheduled decode throughput for the current

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers = [
 ]
 dependencies = [
   "torch>=2.6",
-  "flash-attn>=2.7",
   "flash-linear-attention>=0.2",
   "safetensors>=0.4",
   "transformers>=4.56",
@@ -51,6 +50,11 @@ dependencies = [
   "click>=8.1",
   "tqdm>=4.66",
   "uvicorn>=0.27",
+]
+
+[project.optional-dependencies]
+flash = [
+  "flash-attn>=2.7",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ def _cuda_extensions():
             sources=[
                 "areno/accel/csrc/extension.cpp",
                 "areno/accel/csrc/activation.cu",
+                "areno/accel/csrc/attention.cu",
                 "areno/accel/csrc/conv.cu",
                 "areno/accel/csrc/embedding.cu",
                 "areno/accel/csrc/linear.cu",

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -13,8 +14,22 @@ from click.testing import CliRunner
 from areno.api.data import PromptBatch, PromptItem
 from areno.api.trainer_config import RolloutTrainerConfig, TrainerConfig
 from areno.cli import train as train_cli
-from areno.engine.config import EngineConfig, ModelConfig, RuntimeConfig, _parse_dtype
+from areno.engine.config import (
+    EngineConfig,
+    ModelConfig,
+    RuntimeConfig,
+    _parse_dtype,
+    flash_attention_unsupported_gpu_reason,
+    flash_attention_unsupported_model_reason,
+)
 from areno.engine.data import to_cpu, to_device
+from areno.engine.layers.attention_backend.common import (
+    build_attention_call,
+    expand_kv_heads,
+    require_flash_attention_supported,
+)
+from areno.engine.layers.attention_backend.infer import _native_prefill
+from areno.engine.runtime.metadata import InferMeta
 
 
 class ConfigAndDataTest(unittest.TestCase):
@@ -78,6 +93,152 @@ class ConfigAndDataTest(unittest.TestCase):
 
         self.assertEqual(cfg.dp_size, 2)
 
+    def test_runtime_config_attn_backend_propagates_to_model_config(self):
+        """The runtime attention backend should reach model layer construction."""
+        model = ModelConfig(num_attention_heads=4, num_key_value_heads=4, intermediate_size=16, vocab_size=32)
+
+        EngineConfig(model=model, tp_size=1, devices=[0], runtime=RuntimeConfig(attn_backend="native"))
+
+        self.assertEqual(model.attn_backend, "native")
+
+    def test_runtime_config_falls_back_to_native_on_turing_gpu(self):
+        """Turing GPUs like T4 should use native attention instead of flash-attn."""
+        model = ModelConfig(num_attention_heads=4, num_key_value_heads=4, intermediate_size=16, vocab_size=32)
+        runtime = RuntimeConfig(attn_backend="flash")
+
+        with (
+            patch("areno.engine.config.torch.cuda.is_available", return_value=True),
+            patch("areno.engine.config.torch.cuda.device_count", return_value=1),
+            patch("areno.engine.config.torch.cuda.get_device_capability", return_value=(7, 5)),
+            patch("areno.engine.config.torch.cuda.get_device_name", return_value="Tesla T4"),
+            self.assertWarnsRegex(RuntimeWarning, "falling back to attn_backend='native'.*slower"),
+        ):
+            cfg = EngineConfig(model=model, tp_size=1, devices=[0], runtime=runtime)
+
+        self.assertEqual(cfg.runtime.attn_backend, "native")
+        self.assertEqual(model.attn_backend, "native")
+
+    def test_flash_attention_supported_gpu_keeps_flash_backend(self):
+        """Ampere and newer GPUs should keep the explicit flash attention backend."""
+        model = ModelConfig(num_attention_heads=4, num_key_value_heads=4, intermediate_size=16, vocab_size=32)
+        runtime = RuntimeConfig(attn_backend="flash")
+
+        with (
+            patch("areno.engine.config.torch.cuda.is_available", return_value=True),
+            patch("areno.engine.config.torch.cuda.device_count", return_value=1),
+            patch("areno.engine.config.torch.cuda.get_device_capability", return_value=(8, 0)),
+        ):
+            cfg = EngineConfig(model=model, tp_size=1, devices=[0], runtime=runtime)
+
+        self.assertEqual(cfg.runtime.attn_backend, "flash")
+        self.assertEqual(model.attn_backend, "flash")
+
+    def test_runtime_config_falls_back_to_native_on_large_qk_head_dim(self):
+        """Gemma-style qk head dim 512 should use native attention instead of flash-attn."""
+        model = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            head_dim=512,
+        )
+        runtime = RuntimeConfig(attn_backend="flash")
+
+        with self.assertWarnsRegex(RuntimeWarning, "qk head dim 512.*attn_backend='native'"):
+            cfg = EngineConfig(model=model, tp_size=1, devices=[0], runtime=runtime)
+
+        self.assertEqual(cfg.runtime.attn_backend, "native")
+        self.assertEqual(model.attn_backend, "native")
+
+    def test_flash_attention_unsupported_model_reason_names_large_head_dim(self):
+        """The compatibility warning should identify unsupported model dimensions."""
+        model = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            head_dim=512,
+        )
+
+        self.assertEqual(flash_attention_unsupported_model_reason(model), "qk head dim 512")
+
+    def test_flash_attention_unsupported_gpu_reason_names_t4(self):
+        """The compatibility warning should identify unsupported visible GPUs."""
+        with (
+            patch("areno.engine.config.torch.cuda.is_available", return_value=True),
+            patch("areno.engine.config.torch.cuda.device_count", return_value=1),
+            patch("areno.engine.config.torch.cuda.get_device_capability", return_value=(7, 5)),
+            patch("areno.engine.config.torch.cuda.get_device_name", return_value="Tesla T4"),
+        ):
+            reason = flash_attention_unsupported_gpu_reason([0])
+
+        self.assertEqual(reason, "Tesla T4 cc 7.5")
+
+    def test_runtime_config_rejects_unknown_attn_backend(self):
+        """Invalid attention backend names should fail before worker startup."""
+        with self.assertRaisesRegex(ValueError, "attn_backend"):
+            RuntimeConfig(attn_backend="bogus")
+
+    def test_flash_attention_unsupported_shape_points_to_torch_backend(self):
+        """Unsupported flash-attn shapes should not silently fall back to SDPA."""
+        call = build_attention_call(
+            torch.empty(1, 1, 1, 257),
+            torch.empty(1, 1, 1, 257),
+            torch.empty(1, 1, 1, 257),
+            window_size=None,
+            softmax_scale=None,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "--attn-backend native.*slower"):
+            require_flash_attention_supported(call, mode="test attention")
+
+    def test_expand_kv_heads_uses_head_axis_for_varlen_layout(self):
+        """Native varlen paths pass tensors as [tokens, heads, dim]."""
+        kv = torch.arange(3 * 2 * 4).view(3, 2, 4)
+
+        expanded = expand_kv_heads(kv, 8)
+
+        self.assertEqual(tuple(expanded.shape), (3, 8, 4))
+        self.assertTrue(torch.equal(expanded[:, 0], kv[:, 0]))
+        self.assertTrue(torch.equal(expanded[:, 3], kv[:, 0]))
+        self.assertTrue(torch.equal(expanded[:, 4], kv[:, 1]))
+        self.assertTrue(torch.equal(expanded[:, 7], kv[:, 1]))
+
+    def test_native_prefill_uses_varlen_gqa_without_expanding_kv_heads(self):
+        """Gemma native prefill should leave GQA expansion to the varlen kernel."""
+        q = torch.zeros(3, 8, 4)
+        k = torch.zeros(3, 2, 4)
+        v = torch.zeros(3, 2, 4)
+        meta = InferMeta(mode="prefill", cu_seqlens=torch.tensor([0, 3], dtype=torch.int32), max_seqlen=3)
+        captured = {}
+
+        def fake_varlen(q_arg, k_arg, v_arg, cu_arg, *, window_left, softmax_scale):
+            captured["q_shape"] = tuple(q_arg.shape)
+            captured["k_shape"] = tuple(k_arg.shape)
+            captured["v_shape"] = tuple(v_arg.shape)
+            captured["cu"] = cu_arg.tolist()
+            captured["window_left"] = window_left
+            captured["softmax_scale"] = softmax_scale
+            return q_arg
+
+        with patch("areno.engine.layers.attention_backend.infer.areno_varlen_causal_attention", fake_varlen):
+            out = _native_prefill(q, k, v, meta, (-1, -1), None)
+
+        self.assertIs(out, q)
+        self.assertEqual(captured["q_shape"], (3, 8, 4))
+        self.assertEqual(captured["k_shape"], (3, 2, 4))
+        self.assertEqual(captured["v_shape"], (3, 2, 4))
+        self.assertEqual(captured["cu"], [0, 3])
+
+    def test_native_attention_backend_does_not_require_flash_attn_import(self):
+        """Native train/infer backends should construct without flash-attn installed."""
+        from areno.engine.layers.attention_backend.infer import build_infer_attention_backend
+        from areno.engine.layers.attention_backend.train import build_train_attention_backend
+
+        with patch.dict(sys.modules, {"flash_attn": None}):
+            build_train_attention_backend("native")
+            build_infer_attention_backend("native")
+
     def test_rollout_config_defaults_max_running_prompts_to_flat_batch(self):
         """Rollout concurrency defaults to batch_size * n_samples, not per-DP."""
         cfg = RolloutTrainerConfig(
@@ -121,6 +282,15 @@ class ConfigAndDataTest(unittest.TestCase):
         cfg = train_cli._trainer_config_from_args(args)
 
         self.assertFalse(cfg.keep_rollout_state)
+
+    def test_train_cli_attn_backend_reaches_backend_runtime_config(self):
+        """The train CLI attention backend flag should pass through SDK config."""
+        args = _train_args(algo="sft", attn_backend="native")
+
+        cfg = train_cli._trainer_config_from_args(args)
+
+        self.assertEqual(cfg.attn_backend, "native")
+        self.assertEqual(cfg.areno_config().runtime["attn_backend"], "native")
 
     def test_to_device_and_to_cpu_walk_nested_containers(self):
         """Device helpers should preserve nested container structure."""
@@ -371,6 +541,7 @@ def _train_args(**overrides):
         activation_checkpointing=True,
         drop_rollout_state=False,
         eager_decode=False,
+        attn_backend="flash",
         metrics_log_dir=None,
         agent_fn=None,
         agent_timeout_s=300.0,

--- a/tests/test_serve_cli_cpu.py
+++ b/tests/test_serve_cli_cpu.py
@@ -29,9 +29,11 @@ def test_create_app_passes_eager_decode_runtime_config(monkeypatch):
         default_max_tokens=16,
         decode_progress_interval_s=0.0,
         eager_decode=True,
+        attn_backend="native",
     )
 
     assert captured["runtime_config"].eager_decode is True
+    assert captured["runtime_config"].attn_backend == "native"
 
 
 def test_chat_completion_request_defaults_match_sampling_params():

--- a/tests/test_serve_cli_cpu.py
+++ b/tests/test_serve_cli_cpu.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from areno.api.tool_call_parser import QwenToolCallParser
 from areno.cli import serve as serve_mod
+from areno.engine.config import ModelConfig
 
 
 def test_create_app_passes_eager_decode_runtime_config(monkeypatch):
@@ -33,6 +36,44 @@ def test_create_app_passes_eager_decode_runtime_config(monkeypatch):
     )
 
     assert captured["runtime_config"].eager_decode is True
+    assert captured["runtime_config"].attn_backend == "native"
+
+
+def test_create_app_falls_back_to_native_for_flash_unsupported_model(monkeypatch):
+    captured = {}
+
+    class FakeEngine:
+        config = SimpleNamespace(model=SimpleNamespace(max_position_embeddings=1024))
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            del args
+            captured["runtime_config"] = kwargs["runtime_config"]
+            return cls()
+
+    model_config = ModelConfig(
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=16,
+        vocab_size=32,
+        head_dim=512,
+    )
+    monkeypatch.setattr(serve_mod, "load_tokenizer", lambda model_path: SimpleNamespace(eos_token_id=1))
+    monkeypatch.setattr(serve_mod, "ArenoEngine", FakeEngine)
+    monkeypatch.setattr(serve_mod, "config_from_hf", lambda model_path: model_config)
+    monkeypatch.setattr(serve_mod, "flash_attention_unsupported_gpu_reason", lambda devices: None)
+
+    with pytest.warns(RuntimeWarning, match="qk head dim 512.*attn_backend='native'.*slower"):
+        serve_mod.create_app(
+            model_path="model",
+            tp_size=1,
+            world_size=1,
+            max_running_prompts=4,
+            default_max_tokens=16,
+            decode_progress_interval_s=0.0,
+            attn_backend="flash",
+        )
+
     assert captured["runtime_config"].attn_backend == "native"
 
 

--- a/tests/test_tokenizer_api_cpu.py
+++ b/tests/test_tokenizer_api_cpu.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from areno.api.config import ArenoConfig, coerce_backend_config, resolve_backend_type
 from areno.api.models import BackendType, SamplingParams, TrainSequence
 from areno.api.rewards import load_reward_fn
-from areno.api.tokenizer import _looks_chat_formatted, encode_generation_prompt, eos_token_ids
+from areno.api.tokenizer import _looks_chat_formatted, encode_generation_prompt, eos_token_ids, normalize_token_ids
 
 
 class FakeTokenizer:
@@ -59,6 +59,14 @@ class TokenizerApiTest(unittest.TestCase):
         self.assertEqual(len(tokenizer.templated), 1)
         self.assertEqual(tokenizer.encoded, ["<start_of_turn>user\nhello"])
         self.assertTrue(_looks_chat_formatted("<|im_start|>user"))
+
+    def test_normalize_token_ids_accepts_tokenizer_encoding_outputs(self):
+        """Fast tokenizer Encoding and BatchEncoding-like outputs should become ids."""
+        encoding = SimpleNamespace(ids=[1, 2, 3])
+        batch_encoding = SimpleNamespace(input_ids=[4, 5, 6])
+
+        self.assertEqual(normalize_token_ids(encoding), [1, 2, 3])
+        self.assertEqual(normalize_token_ids(batch_encoding), [4, 5, 6])
 
     def test_sampling_params_defaults_are_backend_agnostic(self):
         """Public sampling defaults are part of the backend API contract."""

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -114,13 +114,17 @@ def test_train_config_validates_ppo_positive_fields(field, value, message):
 
 
 def test_train_config_builds_sft_shape_without_rollout_or_role_fields():
-    cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None, min_lr=0.0))
+    cfg = _trainer_config_from_options(
+        **_options(algo="sft", reward_fn_path=None, reward_ckpt=None, min_lr=0.0, attn_backend="native")
+    )
 
     assert type(cfg) is TrainerConfig
     assert cfg.algo == "sft"
     assert cfg.ckpt == "actor"
     assert cfg.dataset_path == "dataset"
     assert cfg.optimizer_min_lr == 0.0
+    assert cfg.attn_backend == "native"
+    assert cfg.areno_config().runtime["attn_backend"] == "native"
     assert cfg.batch_size == 2
     assert cfg.mini_bs == 1
     assert not hasattr(cfg, "n_samples")
@@ -257,12 +261,28 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "dataset_path    dataset" in summary
     assert "reward_fn       none" in summary
     assert "reward_ckpt     reward-model" in summary
-    assert "dp_size     4" in summary
+    assert "dp_size       4" in summary
+    assert "attn_backend  flash" in summary
     assert "max_running_prompts  12" in summary
     assert "sampling             greedy=no, temperature=0.7, top_k=20, top_p=0.9" in summary
     assert "optimizer                    lr=2e-06, min_lr=0.0, decay=cosine/100" in summary
     assert "metrics_log_dir  /tmp/metrics" in summary
     assert "WARNING: no checkpoint output path configured (--save-path)" in summary
+
+
+def test_training_config_summary_warns_about_native_attention_fallback(monkeypatch):
+    cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None, world_size=1))
+    monkeypatch.setattr(
+        train_cli,
+        "flash_attention_unsupported_gpu_reason",
+        lambda devices: "Tesla T4 cc 7.5",
+    )
+
+    summary = _format_training_config_summary(cfg)
+
+    assert summary.startswith("AReno training config\nWARNING: flash-attn does not support")
+    assert "AReno will use attn_backend='native'" in summary
+    assert "attn_backend  native (auto fallback from flash: Tesla T4 cc 7.5)" in summary
 
 
 def test_training_config_summary_can_colorize_output():
@@ -313,8 +333,8 @@ def test_training_config_summary_handles_invalid_tp_size_defensively():
 
     summary = _format_training_config_summary(cfg)
 
-    assert "tp_size     0" in summary
-    assert "dp_size     n/a" in summary
+    assert "tp_size       0" in summary
+    assert "dp_size       n/a" in summary
 
 
 def test_training_config_summary_section_handles_empty_rows():
@@ -358,7 +378,7 @@ def test_train_command_prints_summary_before_run(monkeypatch):
     assert result.exit_code == 0, result.output
     output = unstyle(result.output)
     assert output.startswith("AReno training config\n")
-    assert "dp_size     2" in output
+    assert "dp_size       2" in output
     assert "save_path        out" in output
     assert "WARNING: no checkpoint output path configured" not in output
     assert events == [("run", "sft")]
@@ -399,6 +419,7 @@ def _options(**overrides):
         activation_checkpointing=True,
         drop_rollout_state=False,
         eager_decode=False,
+        attn_backend="flash",
         metrics_log_dir=None,
         agent_fn=None,
         agent_timeout_s=300.0,

--- a/tests/test_trainer_api_cpu.py
+++ b/tests/test_trainer_api_cpu.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import unittest
+from types import SimpleNamespace
 
 import areno.api.trainer as trainer_mod
 from areno import Trainer
@@ -121,7 +122,7 @@ class TrainerPromptBatchTest(unittest.TestCase):
 
         async def run_rollout():
             async with trainer.rollout_session(sampling_params=SamplingParams(), proxy=False):
-                return trainer.rollout_token_batch([[1, 2], [3]], 4, SamplingParams())
+                return trainer.rollout_token_batch([SimpleNamespace(ids=[1, 2]), [3]], 4, SamplingParams())
 
         result = asyncio.run(run_rollout())
 


### PR DESCRIPTION
## Summary
- add `attn_backend="native"` train/serve/SDK plumbing backed by areno_accel native attention
- automatically fall back from flash to native attention on flash-attn-unsupported GPUs such as Tesla T4, with warning in runtime config and training summary
- make `flash-attn` optional for native attention while keeping `flash-linear-attention` required
- normalize tokenizer `Encoding`/`BatchEncoding` outputs before rollout so tokenized prompts remain compatible

Closes #30

## Tests
- `ruff check areno/cli/train.py areno/engine/config.py areno/api/tokenizer.py areno/api/data_utils.py areno/api/openai_chat.py areno/api/trainer.py tests/test_config_data_cpu.py tests/test_train_cli_config_cpu.py tests/test_tokenizer_api_cpu.py tests/test_trainer_api_cpu.py areno/engine/layers/attention_backend/train.py areno/engine/layers/attention_backend/infer.py`
- `ruff format --check areno/cli/train.py areno/engine/config.py areno/api/tokenizer.py areno/api/data_utils.py areno/api/openai_chat.py areno/api/trainer.py tests/test_config_data_cpu.py tests/test_train_cli_config_cpu.py tests/test_tokenizer_api_cpu.py tests/test_trainer_api_cpu.py areno/engine/layers/attention_backend/train.py areno/engine/layers/attention_backend/infer.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_data_cpu.py tests/test_train_cli_config_cpu.py tests/test_tokenizer_api_cpu.py tests/test_trainer_api_cpu.py tests/test_serve_cli_cpu.py -q`
- `ARENO_BUILD_EXT=0 python -m build --sdist --no-isolation --outdir /tmp/areno-build-check`