### PR TITLE
fix: improve setup guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,6 +72,50 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: install-mode
+    attributes:
+      label: Install mode
+      description: How did you install AReno?
+      options:
+        - sdist / pip install areno
+        - wheel
+        - editable source / pip install -e .
+        - Docker
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build-ext
+    attributes:
+      label: Was ARENO_BUILD_EXT=0 used?
+      description: This skips the runtime CUDA extension and is only valid for docs/metadata installs.
+      options:
+        - "No"
+        - "Yes"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: areno-env
+    attributes:
+      label: areno env --json
+      description: Paste the full output of `areno env --json`.
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: areno-check
+    attributes:
+      label: areno check
+      description: Paste the full output of `areno check`.
+      render: shell
+    validations:
+      required: false
+
   - type: textarea
     id: context
     attributes:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ AReno's mission is to make LLM RL **accessible** for a broad community of resear
 > instructions. DGX Spark and other Grace/Blackwell systems work, but install an
 > `aarch64` PyTorch build first.
 
+**Compatibility matrix:**
+
+| Environment | Status | Notes |
+| --- | --- | --- |
+| Linux x86_64 + NVIDIA GPU | Supported | Primary training/serving target. Use CUDA-enabled PyTorch >= 2.6 and build `areno_accel`. |
+| Linux aarch64 / Grace-Blackwell | Supported | Install a matching `aarch64` CUDA PyTorch build first; build from source with `--no-build-isolation`. |
+| Windows WSL2 + NVIDIA GPU | Supported | Follow the Linux install path inside WSL2. Native Windows is not supported. |
+| macOS Apple Silicon | Metadata/docs only | Use `ARENO_BUILD_EXT=0` for docs or packaging checks. Training/serving is not supported. |
+| CPU-only environments | Metadata/docs/tests only | CPU-only PyTorch can run lightweight docs/tests, but cannot train or serve AReno models. |
+
 **To install:**
 
 ```bash
@@ -57,10 +67,14 @@ pip install areno --no-build-isolation
 `--no-build-isolation` is required so that pip uses your existing CUDA-enabled PyTorch instead of installing a CPU-only torch in an isolated build environment.
 Because build isolation is disabled, build-time helpers are not installed automatically; `psutil` must already be present because PyTorch's CUDA extension builder imports it while sizing parallel compile jobs.
 
-After installation, run `areno check` for an actionable readiness check. Use
-`areno env --json` when opening an issue so maintainers can see the Python,
-CUDA, PyTorch, GPU, and extension state without guessing from low-level build
-errors.
+**Post-install readiness check:**
+
+```bash
+areno check
+areno env --json  # attach this to setup/support reports
+```
+
+`areno check` fails fast with next steps for common setup problems such as missing or CPU-only PyTorch, unsupported PyTorch versions, missing `CUDA_HOME`/`nvcc`, missing build-time dependencies, unsupported platforms, or a skipped `areno_accel` build. Use `areno env --json` when opening an issue so maintainers can see the Python, CUDA, PyTorch, GPU, and extension state without guessing from low-level build errors.
 
 **From source** (recommended if you want the examples or plan to contribute):
 

--- a/areno/accel/_extension.py
+++ b/areno/accel/_extension.py
@@ -11,6 +11,7 @@ kernel. There is no pure-Python fallback: if the extension was not built the
 from __future__ import annotations
 
 import importlib
+import os
 from types import ModuleType
 
 # Cached reference to the compiled extension; populated on first call.
@@ -21,5 +22,20 @@ def extension() -> ModuleType:
     """Return the compiled C++/CUDA extension module, importing it lazily."""
     global _EXT
     if _EXT is None:
-        _EXT = importlib.import_module("areno.accel._areno_accel")
+        try:
+            _EXT = importlib.import_module("areno.accel._areno_accel")
+        except ModuleNotFoundError as exc:
+            build_ext = os.environ.get("ARENO_BUILD_EXT")
+            build_hint = (
+                " The current environment has ARENO_BUILD_EXT=0, which intentionally skips compiling the extension."
+                if build_ext is not None and build_ext.lower() in {"0", "false", "no", "off"}
+                else ""
+            )
+            raise RuntimeError(
+                "AReno runtime setup failed: the compiled `areno_accel` extension is not installed."
+                f"{build_hint}\n"
+                "Why: training and serving require AReno's CUDA extension at runtime.\n"
+                "Next steps: reinstall with CUDA enabled, for example `pip install -e . --no-build-isolation`, "
+                "then run `areno check`."
+            ) from exc
     return _EXT

--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -96,6 +96,9 @@ def collect_env() -> dict[str, Any]:
             "flash_linear_attention": _dependency_info("flash-linear-attention", "fla"),
             "areno_accel": _dependency_info(None, "areno.accel._areno_accel"),
         },
+        "install": {
+            "build_ext_disabled": _build_ext_disabled(),
+        },
         "env": {name: os.environ.get(name) for name in _ENV_VARS},
         "paths": {
             "metrics_log_dir": "/tmp/areno/tfevent",
@@ -195,6 +198,16 @@ def run_checks(report: dict[str, Any]) -> list[CheckResult]:
 
     accel = report["dependencies"]["areno_accel"]
     accel_imported = bool(accel["imported"])
+    build_ext_disabled = bool(report.get("install", {}).get("build_ext_disabled"))
+    if build_ext_disabled and not accel_imported:
+        results.append(
+            CheckResult(
+                "FAIL",
+                "ARENO_BUILD_EXT",
+                "ARENO_BUILD_EXT=0 skipped the runtime CUDA extension",
+                "Reinstall without ARENO_BUILD_EXT=0 before training or serving: pip install -e . --no-build-isolation",
+            )
+        )
     cuda_home = report["cuda"]["cuda_home"]
     results.append(_cuda_toolkit_result("CUDA_HOME", cuda_home or "not set", bool(cuda_home), accel_imported))
     nvcc = report["cuda"]["nvcc"]
@@ -363,6 +376,11 @@ def _package_version(name: str | None) -> str | None:
         return None
 
 
+def _build_ext_disabled() -> bool:
+    value = os.environ.get("ARENO_BUILD_EXT")
+    return value is not None and value.lower() in {"0", "false", "no", "off"}
+
+
 def _cuda_home() -> str | None:
     for name in ("CUDA_HOME", "CUDA_PATH"):
         value = os.environ.get(name)
@@ -458,6 +476,9 @@ def _print_env_report(report: dict[str, Any]) -> None:
         click.echo(f"    {name}: {status} (version={version})")
         if dep["error"]:
             click.echo(f"      {dep['error']}")
+    install = report.get("install", {})
+    click.echo("  Install:")
+    click.echo(f"    ARENO_BUILD_EXT disabled: {install.get('build_ext_disabled', False)}")
     click.echo("  Environment variables:")
     for name, value in report["env"].items():
         click.echo(f"    {name}={value if value is not None else '<unset>'}")

--- a/docs/getting-started/build.rst
+++ b/docs/getting-started/build.rst
@@ -5,6 +5,31 @@ This page covers the setup paths used by contributors and local operators:
 Docker images, editable installs, source/wheel distributions, and local
 installation.
 
+Compatibility matrix
+--------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Environment
+     - Status
+     - Notes
+   * - Linux x86_64 + NVIDIA GPU
+     - Supported
+     - Primary training/serving target. Use CUDA-enabled PyTorch >= 2.6 and build ``areno_accel``.
+   * - Linux aarch64 / Grace-Blackwell
+     - Supported
+     - Install a matching ``aarch64`` CUDA PyTorch build first, then build AReno with ``--no-build-isolation``.
+   * - Windows WSL2 + NVIDIA GPU
+     - Supported
+     - Follow the Linux install path inside WSL2. Native Windows is not supported.
+   * - macOS Apple Silicon
+     - Metadata/docs only
+     - Use ``ARENO_BUILD_EXT=0`` for docs or packaging checks. Training/serving is not supported.
+   * - CPU-only environments
+     - Metadata/docs/tests only
+     - CPU-only PyTorch can run lightweight docs/tests, but cannot train or serve AReno models.
+
 Docker
 ------
 
@@ -73,3 +98,24 @@ the repository root:
 
    For iterative CUDA work, configure ``ccache`` with ``CC="ccache gcc"`` and
    ``CXX="ccache g++"`` before rebuilding.
+
+Post-install checklist
+----------------------
+
+Run the readiness check after every fresh install:
+
+.. code-block:: bash
+
+   areno check
+
+For setup reports, also collect a machine-readable environment bundle:
+
+.. code-block:: bash
+
+   areno env --json
+
+``areno check`` reports common build-time and runtime setup problems with next
+steps: missing or CPU-only PyTorch, unsupported PyTorch versions, missing
+``CUDA_HOME`` or ``nvcc``, missing build-time dependencies such as ``psutil``,
+unsupported platforms, and ``ARENO_BUILD_EXT=0`` installs that try to train or
+serve without the compiled ``areno_accel`` extension.

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import os
+import platform
+import shutil
 import sys
 import warnings
 
 from setuptools import setup
 
 _METADATA_COMMANDS = {"egg_info", "dist_info", "sdist"}
+_MIN_TORCH_VERSION = (2, 6)
 
 
 def _metadata_only_command() -> bool:
@@ -19,23 +22,35 @@ def _cuda_extensions():
     mode = os.environ.get("ARENO_BUILD_EXT", "1").lower()
     if mode in {"0", "false", "no", "off"}:
         return [], {}
+    _check_supported_build_platform()
+    torch = _require_torch()
+    _check_torch_version(torch)
+    _check_cuda_torch(torch)
     try:
         import psutil  # noqa: F401
     except ImportError as exc:
         raise RuntimeError(
-            "building areno.accel requires psutil to be installed before running "
-            "`pip install ... --no-build-isolation`. PyTorch's CUDA extension "
-            "builder imports psutil to size parallel compile jobs, and build "
-            "isolation is disabled so pip will not install build-time dependencies "
-            "for you. Fix: run `pip install psutil` in this environment, then "
-            "retry the AReno install."
+            "AReno build-time setup failed: missing dependency `psutil`.\n"
+            "Why: AReno builds CUDA extensions with `--no-build-isolation`, and PyTorch's CUDA extension builder "
+            "imports psutil while sizing parallel compile jobs.\n"
+            "Next steps: run `pip install psutil`, then retry `pip install -e . --no-build-isolation`."
         ) from exc
     _set_default_cuda_arch_list()
     from torch.utils.cpp_extension import CUDA_HOME, BuildExtension, CUDAExtension
 
     if CUDA_HOME is None:
         raise RuntimeError(
-            "building areno.accel requires CUDA_HOME; set ARENO_BUILD_EXT=0 to build docs/metadata without CUDA"
+            "AReno build-time setup failed: CUDA_HOME is not set.\n"
+            "Why: building areno.accel requires the CUDA toolkit, not just a PyTorch CUDA wheel.\n"
+            "Next steps: install the CUDA toolkit and export CUDA_HOME=/usr/local/cuda, or set "
+            "ARENO_BUILD_EXT=0 only for docs/metadata installs that will not train or serve."
+        )
+    nvcc = shutil.which("nvcc") or shutil.which(str(os.path.join(CUDA_HOME, "bin", "nvcc")))
+    if nvcc is None:
+        raise RuntimeError(
+            "AReno build-time setup failed: nvcc was not found.\n"
+            "Why: building areno.accel requires CUDA's compiler in PATH or under CUDA_HOME/bin.\n"
+            "Next steps: add CUDA's bin directory to PATH (`export PATH=$CUDA_HOME/bin:$PATH`) and retry."
         )
     return [
         CUDAExtension(
@@ -58,6 +73,53 @@ def _cuda_extensions():
             },
         )
     ], {"build_ext": BuildExtension}
+
+
+def _check_supported_build_platform() -> None:
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Linux" and machine in {"x86_64", "amd64", "aarch64", "arm64"}:
+        return
+    raise RuntimeError(
+        f"AReno runtime install is not supported on this platform: {system} {platform.machine()}.\n"
+        "Why: AReno training/serving requires Linux with NVIDIA CUDA.\n"
+        "Next steps: use Linux x86_64/aarch64 with an NVIDIA GPU, Windows WSL2, or set ARENO_BUILD_EXT=0 "
+        "for docs/metadata-only installs on unsupported platforms."
+    )
+
+
+def _require_torch():
+    try:
+        import torch
+    except ImportError as exc:
+        raise RuntimeError(
+            "AReno build-time setup failed: PyTorch is not installed.\n"
+            "Why: areno.accel is compiled with PyTorch's CUDA extension tooling.\n"
+            "Next steps: install CUDA-enabled PyTorch >= 2.6 first, then retry with `--no-build-isolation`."
+        ) from exc
+    return torch
+
+
+def _check_torch_version(torch) -> None:
+    version = getattr(torch, "__version__", "")
+    if _version_at_least(version, _MIN_TORCH_VERSION):
+        return
+    raise RuntimeError(
+        f"AReno build-time setup failed: unsupported PyTorch version {version or '<unknown>'}.\n"
+        "Why: AReno requires PyTorch >= 2.6 for its local runtime and CUDA extension ABI.\n"
+        "Next steps: upgrade to CUDA-enabled PyTorch >= 2.6, then retry the AReno install."
+    )
+
+
+def _check_cuda_torch(torch) -> None:
+    cuda_build = getattr(getattr(torch, "version", None), "cuda", None)
+    if cuda_build:
+        return
+    raise RuntimeError(
+        "AReno build-time setup failed: this PyTorch install is CPU-only.\n"
+        "Why: AReno training/serving requires a CUDA-enabled PyTorch build and NVIDIA CUDA extensions.\n"
+        "Next steps: install a CUDA-enabled PyTorch wheel matching your CUDA toolkit, then retry."
+    )
 
 
 def _set_default_cuda_arch_list() -> None:
@@ -89,6 +151,24 @@ def _set_default_cuda_arch_list() -> None:
         RuntimeWarning,
         stacklevel=2,
     )
+
+
+def _version_at_least(version: str | None, minimum: tuple[int, int]) -> bool:
+    if not version:
+        return False
+    parts: list[int] = []
+    for piece in version.split("+", 1)[0].split("."):
+        digits = ""
+        for char in piece:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    while len(parts) < len(minimum):
+        parts.append(0)
+    return tuple(parts[: len(minimum)]) >= minimum
 
 
 ext_modules, cmdclass = _cuda_extensions()

--- a/tests/test_cli_diagnostics_cpu.py
+++ b/tests/test_cli_diagnostics_cpu.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from areno.accel import _extension
 from areno.cli import diagnostics
 from areno.cli.main import main
 
@@ -59,6 +60,7 @@ def _ready_report(tmp_path: str) -> dict:
                 "error": None,
             },
         },
+        "install": {"build_ext_disabled": False},
         "env": {"CUDA_HOME": "/usr/local/cuda", "MAX_JOBS": "8"},
         "paths": {"metrics_log_dir": tmp_path, "hf_cache": tmp_path},
     }
@@ -118,6 +120,20 @@ class CliDiagnosticsTest(unittest.TestCase):
         self.assertIn("not required for runtime", result.output)
         self.assertIn("OK   nvcc", result.output)
 
+    def test_check_reports_build_ext_disabled_runtime_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["install"]["build_ext_disabled"] = True
+            report["dependencies"]["areno_accel"]["imported"] = False
+            report["dependencies"]["areno_accel"]["error"] = "ModuleNotFoundError: missing extension"
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = CliRunner().invoke(diagnostics.check_command)
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("FAIL ARENO_BUILD_EXT", result.output)
+        self.assertIn("ARENO_BUILD_EXT=0 skipped the runtime CUDA extension", result.output)
+        self.assertIn("Reinstall without ARENO_BUILD_EXT=0", result.output)
+
     def test_writable_path_check_warns_for_missing_parent(self):
         result = diagnostics._writable_path_check("cache", "/definitely/missing/areno/path")
 
@@ -156,6 +172,18 @@ class CliDiagnosticsTest(unittest.TestCase):
             info = diagnostics._nvidia_smi_driver_info()
 
         self.assertEqual(info["error"], "nvidia-smi returned empty output")
+
+    def test_runtime_extension_missing_error_is_actionable(self):
+        _extension._EXT = None
+        with (
+            patch.dict("os.environ", {"ARENO_BUILD_EXT": "0"}),
+            patch.object(_extension.importlib, "import_module", side_effect=ModuleNotFoundError("missing")),
+            self.assertRaises(RuntimeError) as exc,
+        ):
+            _extension.extension()
+        message = str(exc.exception)
+        self.assertIn("ARENO_BUILD_EXT=0", message)
+        self.assertIn("pip install -e . --no-build-isolation", message)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup_guardrails_cpu.py
+++ b/tests/test_setup_guardrails_cpu.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import runpy
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_setup_module() -> dict:
+    setup_path = Path(__file__).resolve().parents[1] / "setup.py"
+    with (
+        patch.object(sys, "argv", ["setup.py", "egg_info"]),
+        patch("setuptools.setup"),
+    ):
+        return runpy.run_path(str(setup_path))
+
+
+class SetupGuardrailsTest(unittest.TestCase):
+    def test_missing_torch_error_is_actionable(self):
+        setup_mod = _load_setup_module()
+
+        with (
+            patch.dict(sys.modules, {"torch": None}),
+            self.assertRaises(RuntimeError) as exc,
+        ):
+            setup_mod["_require_torch"]()
+        message = str(exc.exception)
+        self.assertIn("PyTorch is not installed", message)
+        self.assertIn("CUDA-enabled PyTorch", message)
+
+    def test_cpu_only_torch_error_is_actionable(self):
+        setup_mod = _load_setup_module()
+        fake_torch = types.SimpleNamespace(version=types.SimpleNamespace(cuda=None))
+
+        with self.assertRaises(RuntimeError) as exc:
+            setup_mod["_check_cuda_torch"](fake_torch)
+        message = str(exc.exception)
+        self.assertIn("CPU-only", message)
+        self.assertIn("CUDA-enabled PyTorch", message)
+
+    def test_unsupported_platform_error_mentions_metadata_install(self):
+        setup_mod = _load_setup_module()
+
+        with (
+            patch.object(setup_mod["platform"], "system", return_value="Darwin"),
+            patch.object(setup_mod["platform"], "machine", return_value="arm64"),
+            self.assertRaises(RuntimeError) as exc,
+        ):
+            setup_mod["_check_supported_build_platform"]()
+        message = str(exc.exception)
+        self.assertIn("not supported", message)
+        self.assertIn("ARENO_BUILD_EXT=0", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- improve build-time setup failures for missing torch, CPU-only torch, old torch, missing CUDA_HOME/nvcc, missing psutil, and unsupported runtime platforms
- make runtime `areno_accel` import failures actionable, including the `ARENO_BUILD_EXT=0` case
- extend `areno env/check` with install-state reporting and checks for skipped extension builds
- add README/docs compatibility matrix and post-install readiness checklist
- update the bug report template to collect install mode, `ARENO_BUILD_EXT=0`, `areno env --json`, and `areno check`

Closes #5

## Tests

- `ruff check setup.py areno/accel/_extension.py areno/cli/diagnostics.py tests/test_cli_diagnostics_cpu.py tests/test_setup_guardrails_cpu.py`
- `ruff format --check setup.py areno/accel/_extension.py areno/cli/diagnostics.py tests/test_cli_diagnostics_cpu.py tests/test_setup_guardrails_cpu.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_cli_diagnostics_cpu.py tests/test_setup_guardrails_cpu.py -q`
- issue template YAML parse check

## Sample `areno env` output

Captured locally with `PYTHONPATH=. python -m areno.cli.main env` because the console script was not installed in this dev env:

```bash
AReno environment
  AReno: 0.1.0
  Python: 3.12.11 (/Users/sule/miniconda/envs/share/bin/python)
  Platform: macOS-26.2-x86_64-i386-64bit [x86_64]
  PyTorch: 2.3.0.dev20240311
  PyTorch CUDA build: none
  CUDA runtime: unavailable
  torch.cuda.is_available: False
  CUDA_HOME: not set
  nvcc: not found
  nvidia-smi: not found
    nvidia-smi not found
  GPUs:
    none visible
  Dependencies:
    flash_attn: missing (version=unknown)
      ModuleNotFoundError: No module named 'flash_attn'
    flash_linear_attention: missing (version=unknown)
      ModuleNotFoundError: No module named 'fla'
    areno_accel: missing (version=unknown)
      ModuleNotFoundError: No module named 'areno.accel._areno_accel'
  Install:
    ARENO_BUILD_EXT disabled: False
  Environment variables:
    CUDA_HOME=<unset>
    CUDA_PATH=<unset>
    CUDA_VISIBLE_DEVICES=<unset>
    MAX_JOBS=<unset>
    TORCH_CUDA_ARCH_LIST=<unset>
    ARENO_BUILD_EXT=<unset>
    HF_HOME=<unset>
    HF_HUB_CACHE=<unset>
```

## Sample `areno check` output

Captured locally with `PYTHONPATH=. python -m areno.cli.main check`; this machine is intentionally not a supported CUDA runtime:

```bash
AReno check: not ready

OK   Python >= 3.10
     found 3.12.11
FAIL Supported platform
     Darwin x86_64
OK   PyTorch import
     2.3.0.dev20240311
FAIL PyTorch >= 2.6
     2.3.0.dev20240311
FAIL PyTorch CUDA build
     torch.version.cuda=None
FAIL torch.cuda.is_available()
     visible_gpus=0
FAIL NVIDIA GPU visibility
     no GPUs reported by torch
WARN flash_attn import
     ModuleNotFoundError: No module named 'flash_attn'
WARN flash_linear_attention import
     ModuleNotFoundError: No module named 'fla'
WARN CUDA_HOME
     not set
WARN nvcc
     not found
FAIL areno_accel import
     ModuleNotFoundError: No module named 'areno.accel._areno_accel'
OK   metrics_log_dir writable
     /tmp/areno/tfevent
WARN hf_cache writable
     /Users/sule/.cache/huggingface/hub

Next:
  Run AReno on Linux with an NVIDIA CUDA GPU. On Windows, use WSL2.
  Install PyTorch 2.6 or newer with CUDA support.
  Install a CUDA-enabled PyTorch build; CPU-only torch cannot run AReno.
  Check NVIDIA driver installation, CUDA_VISIBLE_DEVICES, and PyTorch CUDA compatibility.
  Make at least one NVIDIA GPU visible to the process.
  Install flash-attn before installing AReno.
  Install flash-linear-attention before installing AReno.
  export CUDA_HOME=/usr/local/cuda
  Add CUDA's bin directory to PATH, for example: export PATH=$CUDA_HOME/bin:$PATH
  Reinstall AReno from source with CUDA enabled: pip install -e . --no-build-isolation
  Create the directory or choose a writable path: mkdir -p /Users/sule/.cache/huggingface/hub
```
