### PR TITLE
docs: add Docker setup check path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PIP_NO_CACHE_DIR=1 \
 RUN python -m pip install --index-url "${PIP_INDEX_URL}" --upgrade pip setuptools wheel packaging ninja
 
 RUN python -m pip install --index-url "${PIP_INDEX_URL}" \
+        "psutil" \
         "transformers==${TRANSFORMERS_VERSION}" \
         "datasets>=3.3.0" \
         "einops" \

--- a/README.md
+++ b/README.md
@@ -87,6 +87,33 @@ pip install flash-linear-attention
 pip install -e . --no-build-isolation
 ```
 
+**Docker setup escape hatch** (recommended when you want to verify AReno before debugging local build state):
+
+```bash
+docker build -t areno .
+docker run --gpus all --rm -it areno areno check
+```
+
+If you need local project files, model files, or a Hugging Face cache inside the container:
+
+```bash
+docker run --gpus all --rm -it \
+  -v $PWD:/workspace \
+  -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+  areno \
+  areno check
+```
+
+Host checklist before blaming AReno setup:
+
+```bash
+nvidia-smi
+docker run --gpus all --rm nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
+docker run --gpus all --rm areno areno check
+```
+
+Docker gives you a known-good Python/PyTorch/CUDA user-space install path and reuses the same `areno check` diagnostic flow. It does not replace host requirements: the host still needs a working NVIDIA driver, NVIDIA Container Toolkit support for `--gpus all`, and a driver new enough for the container CUDA runtime. Docker also does not solve model downloads, Hugging Face tokens, cache paths, network access, disk space, or multi-node networking; those remain user environment concerns.
+
 **Tips:**
 
 - Install `ninja` (`pip install ninja`) before building so CUDA kernels compile in parallel.

--- a/docs/getting-started/build.rst
+++ b/docs/getting-started/build.rst
@@ -33,14 +33,44 @@ Compatibility matrix
 Docker
 ------
 
-Build the CUDA runtime image from the repository root:
+Docker is the setup escape hatch when you want to verify AReno before
+debugging local Python, PyTorch, or CUDA build state. Build the CUDA runtime
+image from the repository root, then run the same readiness check used by local
+installs:
 
 .. code-block:: bash
 
    docker build -t areno .
+   docker run --gpus all --rm -it areno areno check
 
 Use ``--build-arg PIP_INDEX_URL=...`` if your environment requires a package
 mirror.
+
+If you need local project files, model files, or a Hugging Face cache inside
+the container, mount them explicitly:
+
+.. code-block:: bash
+
+   docker run --gpus all --rm -it \
+     -v $PWD:/workspace \
+     -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+     areno \
+     areno check
+
+Host checklist:
+
+.. code-block:: bash
+
+   nvidia-smi
+   docker run --gpus all --rm nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
+   docker run --gpus all --rm areno areno check
+
+Docker gives you a known-good Python/PyTorch/CUDA user-space environment. It
+does not fix host-side requirements: the host still needs a working NVIDIA
+driver, NVIDIA Container Toolkit support for ``--gpus all``, and a driver new
+enough for the container CUDA runtime. Model downloads, Hugging Face tokens,
+cache paths, network access, disk space, and multi-node or custom networking
+remain user environment concerns and are outside the first Docker setup path.
 
 Python distributions
 --------------------


### PR DESCRIPTION
## Background
Local CUDA/PyTorch/toolchain setup can fail before users know whether AReno itself works. Docker should provide a known-good setup escape hatch that still ends in the standard diagnostic flow.

## Changes
- Document a Docker build and run path that ends with `areno check`.
- Add host GPU/container checklist commands, including `nvidia-smi` and NVIDIA Container Toolkit validation.
- Explain what Docker does and does not solve: host driver, `--gpus all`, CUDA driver compatibility, model downloads, Hugging Face tokens, cache paths, network, disk, and multi-node networking.
- Add `psutil` to the Dockerfile build-time dependency list for the no-build-isolation install path.

## Validation
- `git diff --check`
- Docker build/run not executed locally because Docker is not installed in this environment.

Related to https://github.com/inclusionAI/AReno/issues/6