### PR TITLE
fix(api): parse nested Gemma tool-call arguments

### DIFF
--- a/areno/api/tool_call_parser.py
+++ b/areno/api/tool_call_parser.py
@@ -385,21 +385,29 @@ def _find_matching_brace(text: str) -> int:
 
 def _parse_gemma4_args(args_text: str) -> dict[str, Any]:
     result: dict[str, Any] = {}
-    for part in re.split(r",\s*", args_text.strip()):
+    for part in _split_gemma4_top_level(args_text.strip()):
         if ":" not in part:
             continue
-        key, value = part.split(":", 1)
-        result[key.strip()] = _parse_gemma4_value(value.strip())
+        key, value = _split_gemma4_key_value(part)
+        if key:
+            result[key] = _parse_gemma4_value(value)
     return result
 
 
 def _parse_gemma4_value(value: str) -> Any:
+    value = value.strip()
     if value.startswith('<|"|>') and value.endswith('<|"|>'):
         return value[len('<|"|>') : -len('<|"|>')]
+    if value.startswith("{") and value.endswith("}"):
+        return _parse_gemma4_args(value[1:-1])
+    if value.startswith("[") and value.endswith("]"):
+        return [_parse_gemma4_value(item) for item in _split_gemma4_top_level(value[1:-1])]
     if value == "true":
         return True
     if value == "false":
         return False
+    if value == "null":
+        return None
     try:
         return int(value)
     except ValueError:
@@ -408,6 +416,48 @@ def _parse_gemma4_value(value: str) -> Any:
         return float(value)
     except ValueError:
         return value
+
+
+def _split_gemma4_key_value(part: str) -> tuple[str, str]:
+    key, value = part.split(":", 1)
+    return _strip_gemma4_key(key), value.strip()
+
+
+def _strip_gemma4_key(key: str) -> str:
+    key = key.strip()
+    if key.startswith('<|"|>') and key.endswith('<|"|>'):
+        return key[len('<|"|>') : -len('<|"|>')]
+    return key.strip("\"'")
+
+
+def _split_gemma4_top_level(text: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    i = 0
+    while i < len(text):
+        if text.startswith('<|"|>', i):
+            i += len('<|"|>')
+            end = text.find('<|"|>', i)
+            if end == -1:
+                break
+            i = end + len('<|"|>')
+            continue
+        char = text[i]
+        if char in "[{":
+            depth += 1
+        elif char in "]}":
+            depth = max(0, depth - 1)
+        elif char == "," and depth == 0:
+            part = text[start:i].strip()
+            if part:
+                parts.append(part)
+            start = i + 1
+        i += 1
+    tail = text[start:].strip()
+    if tail:
+        parts.append(tail)
+    return parts
 
 
 def _parse_minicpm_param_value(value: str) -> Any:

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -842,6 +842,45 @@ def test_gemma4_tool_call_parser_supports_chat_completions_tools():
     assert '"direction":"left"' in parsed.tool_calls[0]["function"]["arguments"]
 
 
+def test_gemma4_tool_call_parser_supports_nested_action_arrays():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "choose_action",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "action": {"type": "string"},
+                                    "direction": {"type": "string"},
+                                },
+                            },
+                        }
+                    },
+                },
+            },
+        }
+    ]
+
+    parsed = Gemma4ToolCallParser().parse(
+        '<|tool_call>call:choose_action{actions:[{action:<|"|>MOVE<|"|>,direction:<|"|>UP<|"|>},'
+        '{action:<|"|>ATTACK<|"|>,direction:<|"|>UP<|"|>}]}<tool_call|>',
+        tools,
+        "required",
+    )
+
+    assert len(parsed.tool_calls) == 1
+    assert (
+        parsed.tool_calls[0]["function"]["arguments"]
+        == '{"actions":[{"action":"MOVE","direction":"UP"},{"action":"ATTACK","direction":"UP"}]}'
+    )
+
+
 def test_minicpm_tool_call_parser_supports_xml_function_calls():
     tools = [
         {


### PR DESCRIPTION
## Summary
- parse Gemma tool-call arguments with top-level-aware splitting
- recursively decode nested object and array values emitted in Gemma native tool-call syntax
- add a regression test for nested `actions` arrays

## Verification
- `python -m py_compile areno/api/tool_call_parser.py`
- direct no-torch parser check for nested Gemma action arrays
- `git diff --check`

Note: `tests/test_agentic_cpu.py` cannot be collected in this local shell because this Python environment is missing `torch`.

Closes #35