### PR TITLE
chore(release): define v0.0.2 release hygiene

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Git tag to publish, for example 0.0.1"
+        description: "Git tag to publish, for example v0.0.2"
         required: true
         type: string
 
@@ -32,9 +32,12 @@ jobs:
           import os
           import re
 
+          # Tags use a leading `v` (e.g. v0.0.2). The PEP 440 package version
+          # written into pyproject.toml/sdist strips that prefix (-> 0.0.2),
+          # so the git tag and the distribution version stay in lockstep.
           tag = os.environ["RELEASE_TAG"]
-          if not re.fullmatch(r"[0-9]+(?:\.[0-9]+)*(?:[a-zA-Z0-9_.!+-]*)?", tag):
-              raise SystemExit(f"invalid release tag/version: {tag!r}")
+          if not re.fullmatch(r"v[0-9]+(?:\.[0-9]+)*(?:[a-zA-Z0-9_.!+-]*)?", tag):
+              raise SystemExit(f"invalid release tag (expected leading 'v', e.g. v0.0.2): {tag!r}")
           PY
           if ! git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"; then
             echo "::error::tag ${RELEASE_TAG} does not exist on origin"
@@ -46,7 +49,7 @@ jobs:
             exit 1
           fi
           git checkout --detach "${tag_commit}"
-          echo "RELEASE_VERSION=${RELEASE_TAG}" >> "${GITHUB_ENV}"
+          echo "RELEASE_VERSION=${RELEASE_TAG#v}" >> "${GITHUB_ENV}"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,77 @@
+# Releasing AReno
+
+This is the release-hygiene checklist for cutting a tagged AReno release
+(for example `v0.0.2`). It exists so that package metadata, git tags, the
+GitHub milestone, and the docs do not drift apart.
+
+## Conventions
+
+| Concern | Convention |
+| --- | --- |
+| Git tag format | `vMAJOR.MINOR.PATCH`, e.g. `v0.0.2`. The leading `v` is required; the publish workflow rejects a tag without it. Pre-release suffixes are allowed (`v1.2.0rc1`). |
+| Package version | PEP 440, without the `v`, e.g. `0.0.2`. `pyproject.toml` carries this string, and the publish workflow derives it from the tag by stripping the leading `v` (`v0.0.2` -> `0.0.2`). |
+| `pyproject.toml` `version` | Kept in sync with the release being cut. The publish workflow also rewrites it from the tag at build time, so the tag is the ultimate source of truth, but the committed value should still match the latest release. |
+| GitHub milestone | `vMAJOR.MINOR.PATCH`, matching the tag (e.g. milestone `v0.0.2` <-> tag `v0.0.2`). |
+| Release artifacts | Source distribution (sdist) only. No wheels are built or published — the CUDA extension is compiled at install time on the user's machine. |
+| Release notes | Written from the closed issues in the matching GitHub milestone. There is no committed `CHANGELOG.md`; the milestone is the source of truth. |
+
+## Pre-release checklist
+
+1. **All milestone issues closed.** Every issue in the `vX.Y.Z` milestone is
+   closed (or explicitly moved to a later milestone).
+2. **Version string matches.** `pyproject.toml` `version = "X.Y.Z"` equals the
+   release you are about to tag (without the `v`).
+3. **CI is green on `main`.** The required checks pass on the commit you will
+   tag:
+   - `cpu_unit_tests` (`pytest tests/ -k cpu`)
+   - `pre-commit`
+   - `pr-style`
+4. **Docs build cleanly** and do not reference a stale version.
+5. **Release notes drafted** from the milestone's closed issues (see below).
+
+## Cutting the release
+
+1. Ensure `main` is at the commit you want to release and CI is green.
+2. Confirm `pyproject.toml` `version` is `X.Y.Z`.
+3. Tag the release commit and push the tag:
+
+   ```bash
+   git tag vX.Y.Z <commit>
+   git push origin vX.Y.Z
+   ```
+
+   The tag must be reachable from `origin/main` — the publish workflow refuses
+   tags that are not ancestors of `main`.
+4. Run the **Publish PyPI sdist** workflow (`workflow_dispatch`) with the tag
+   input set to `vX.Y.Z`. The workflow:
+   - validates the tag format (leading `v` required);
+   - checks out the tagged commit and confirms it is reachable from `main`;
+   - rewrites `pyproject.toml` `version` to `X.Y.Z` (the `v` stripped);
+   - builds an sdist only (asserts no wheel is produced);
+   - runs `twine check` and uploads to PyPI.
+5. Publish the GitHub release for `vX.Y.Z` with notes generated from the
+   milestone (below), then close the milestone.
+
+## Release notes from the milestone
+
+Notes are written from the closed issues in the matching milestone. To list
+them:
+
+```bash
+gh issue list --milestone vX.Y.Z --state closed \
+  --json number,title,labels \
+  --jq '.[] | "- \(.title) (#\(.number))"'
+```
+
+Group the resulting lines by label (e.g. `kind/feature`, `kind/fix`,
+`kind/cleanup`) into the release body.
+
+## Notes
+
+- The committed `pyproject.toml` version and the publish-time rewrite are
+  intentionally redundant: the rewrite guarantees the published artifact always
+  matches the tag, while the committed value keeps local installs and source
+  inspection honest.
+- Wheels are deliberately not shipped. AReno builds a CUDA extension at install
+  time, so a prebuilt wheel would be environment-specific; the sdist lets each
+  user build against their own CUDA/PyTorch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "areno"
-version = "0.1.0"
+version = "0.0.2"
 description = "An easy-to-use, fast toolkit to scale up RL post-training on a single node."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Closes #13. The GitHub milestone is `v0.0.2`, but `pyproject.toml` said `version = "0.1.0"` and the existing tag is `v0.0.1` while the publish workflow rejected a leading `v` — three conflicting version conventions. This defines and documents the release hygiene so package metadata, tags, milestone, and docs stay in lockstep.

## Changes

- **`pyproject.toml`**: `version` `0.1.0` → `0.0.2` to match the milestone and the release being cut.
- **`.github/workflows/publish-pypi.yml`**:
  - Require a leading `v` in the release tag (e.g. `v0.0.2`), consistent with the existing `v0.0.1` tag. The regex now rejects a bare `0.0.2`.
  - Derive the PEP 440 package version by stripping the `v` (`${RELEASE_TAG#v}` → `0.0.2`), so the git tag and the published distribution version stay in lockstep (a `v`-prefixed string is not a valid PEP 440 version and PyPI would reject it).
  - Update the input description example to `v0.0.2`.
- **`RELEASE.md`** (new): the release-hygiene checklist — tag format, version string, sdist-only artifacts, milestone-driven release notes, and the required CI gate. Filename follows the vLLM/TRL convention (`RELEASE.md`).

## Decisions (resolved with the maintainer)

| Question | Decision |
| --- | --- |
| Tag format | Leading `v` (e.g. `v0.0.2`), consistent with `v0.0.1` |
| `pyproject.toml` version | Tracks the release (`0.0.2`); workflow still rewrites it from the tag at build |
| Release notes source | The matching GitHub milestone's closed issues (no committed `CHANGELOG.md`) |
| Artifacts | sdist-only (CUDA ext builds at install time; no wheels) |

## Acceptance criteria (#13)

- [x] Project has a clear checklist for cutting v0.0.2 (`RELEASE.md`)
- [x] Version/milestone/tag naming is unambiguous (`v0.0.2` tag → `0.0.2` version → `v0.0.2` milestone)
- [x] Release notes can be generated from the milestone issues (documented `gh issue list --milestone` recipe)
- [x] Existing PyPI publish workflow expectations documented (sdist-only, tag-driven version)

## Validation

- `pyproject.toml` parses; `version = 0.0.2`.
- `publish-pypi.yml` is valid YAML; simulated `v0.0.2` tag → rewritten version `0.0.2` (PEP 440 valid). Bare `0.0.2` and `v` alone are correctly rejected.
- `pytest tests/test_cli_diagnostics_cpu.py` → 11 passed (the `0.1.0` there is mock fixture data, not a package-version assertion).
- Pre-existing collection errors in the local checkout (`safetensors`/`fastapi` not installed) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

