### PR TITLE
fix(sft): weight loss by global target tokens

### DIFF
--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -27,6 +27,7 @@ import torch
 from areno.api.backend.base import Backend, register_backend
 from areno.api.config import ArenoConfig
 from areno.api.context import Context
+from areno.api.loss_fns.sft import sft_loss_fn
 from areno.api.models import BackendType, RolloutResult, RolloutSequence, SamplingParams, TrainSequence
 from areno.api.roles import ModelRole
 
@@ -323,10 +324,19 @@ class ArenoBackend(Backend):
         # pack and the loss function is stamped onto each pack so the engine's
         # forward worker can call it without having to know about the loss API.
         packs = []
+        sft_target_counts = []
         for start in range(0, len(batch_data), mini_bs):
-            pack = _make_train_pack(batch_data[start : start + mini_bs])
+            seqs = batch_data[start : start + mini_bs]
+            pack = _make_train_pack(seqs)
             pack["_loss_fn"] = loss_fn
             packs.append(pack)
+            sft_target_counts.append(_sft_target_token_count(seqs))
+        if _is_sft_loss_fn(loss_fn):
+            _annotate_sft_token_mean_packs(
+                packs,
+                sft_target_counts,
+                gradient_accumulation_steps=gradient_accumulation_steps,
+            )
         stats_list = engine.step(packs, gradient_accumulation_steps=gradient_accumulation_steps)
         train_time_s = time.perf_counter() - train_start
         # `first_policy_metrics` keeps the per-step rollout/policy diagnostics
@@ -470,6 +480,47 @@ def _make_train_pack(seqs: list[TrainSequence]) -> dict[str, torch.Tensor]:
     if ref_logprobs is not None:
         pack["ref_logprobs"] = ref_logprobs
     return pack
+
+
+def _is_sft_loss_fn(loss_fn: Callable) -> bool:
+    """Return true for the built-in SFT loss, including simple partial wrappers."""
+
+    return loss_fn is sft_loss_fn or getattr(loss_fn, "func", None) is sft_loss_fn
+
+
+def _annotate_sft_token_mean_packs(
+    packs: list[dict],
+    target_counts: list[int],
+    *,
+    gradient_accumulation_steps: int | None,
+) -> None:
+    """Attach per-accumulation-group token normalizers for global token-mean SFT."""
+
+    if not packs:
+        return
+    accumulation_steps = len(packs) if gradient_accumulation_steps is None else max(int(gradient_accumulation_steps), 1)
+    for group_start in range(0, len(packs), accumulation_steps):
+        group_end = min(group_start + accumulation_steps, len(packs))
+        group_total = max(sum(target_counts[group_start:group_end]), 1)
+        group_size = group_end - group_start
+        for pack in packs[group_start:group_end]:
+            pack["_sft_total_target_tokens"] = group_total
+            pack["_sft_grad_scale"] = group_size
+
+
+def _sft_target_token_count(seqs: list[TrainSequence]) -> int:
+    """Count target tokens using the same next-token masks as packed training."""
+
+    count = 0
+    for seq in seqs:
+        length = min(len(seq.tokens), len(seq.prompt_mask))
+        for idx in range(1, length):
+            is_target = not bool(seq.prompt_mask[idx])
+            if seq.loss_mask:
+                is_target = is_target and idx < len(seq.loss_mask) and bool(seq.loss_mask[idx])
+            if is_target:
+                count += 1
+    return count
 
 
 def _pad_token_id(ctx: Context) -> int:

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -324,14 +324,16 @@ class ArenoBackend(Backend):
         # pack and the loss function is stamped onto each pack so the engine's
         # forward worker can call it without having to know about the loss API.
         packs = []
-        sft_target_counts = []
+        is_sft = _is_sft_loss_fn(loss_fn)
+        sft_target_counts = [] if is_sft else None
         for start in range(0, len(batch_data), mini_bs):
             seqs = batch_data[start : start + mini_bs]
             pack = _make_train_pack(seqs)
             pack["_loss_fn"] = loss_fn
             packs.append(pack)
-            sft_target_counts.append(_sft_target_token_count(seqs))
-        if _is_sft_loss_fn(loss_fn):
+            if is_sft:
+                sft_target_counts.append(_sft_target_token_count(seqs))
+        if is_sft:
             _annotate_sft_token_mean_packs(
                 packs,
                 sft_target_counts,
@@ -515,9 +517,9 @@ def _sft_target_token_count(seqs: list[TrainSequence]) -> int:
     for seq in seqs:
         length = min(len(seq.tokens), len(seq.prompt_mask))
         for idx in range(1, length):
-            is_target = not bool(seq.prompt_mask[idx])
+            is_target = not seq.prompt_mask[idx]
             if seq.loss_mask:
-                is_target = is_target and idx < len(seq.loss_mask) and bool(seq.loss_mask[idx])
+                is_target = is_target and idx < len(seq.loss_mask) and seq.loss_mask[idx]
             if is_target:
                 count += 1
     return count

--- a/areno/api/loss_fns/sft.py
+++ b/areno/api/loss_fns/sft.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import torch
+
 
 def sft_loss_fn(data_pack, logprobs):
     """Negative log-likelihood on non-prompt target tokens.
@@ -16,22 +18,38 @@ def sft_loss_fn(data_pack, logprobs):
         # packed_response_mask already excludes prompt and padding positions.
         response_mask = data_pack["packed_response_mask"].to(device=logprobs.device).bool()
         valid_count = response_mask.sum().clamp_min(1)
+        logprob_sum = logprobs[response_mask].sum()
         # SFT is plain negative log-likelihood averaged over target tokens.
-        loss = -(logprobs[response_mask].sum() / valid_count)
+        loss = _sft_token_mean_loss(data_pack, logprob_sum, valid_count, logprobs)
         return loss, {
             "sft_loss": loss.detach(),
             "sft_target_tokens": valid_count.detach(),
-            "sft_logprob_mean": (logprobs[response_mask].sum() / valid_count).detach(),
+            "sft_logprob_mean": (-loss).detach(),
         }
 
     # Padded layout: position t predicts token t+1, so prompt_mask[:, 1:]
     # aligns with the returned next-token logprobs tensor.
     response_mask = (~data_pack["prompt_mask"][:, 1:]).to(device=logprobs.device, dtype=logprobs.dtype)
     valid_count = response_mask.sum().clamp_min(1.0)
+    logprob_sum = (logprobs * response_mask).sum()
     # Prompt and right-padding positions have zero weight in the loss.
-    loss = -((logprobs * response_mask).sum() / valid_count)
+    loss = _sft_token_mean_loss(data_pack, logprob_sum, valid_count, logprobs)
     return loss, {
         "sft_loss": loss.detach(),
         "sft_target_tokens": valid_count.detach(),
-        "sft_logprob_mean": ((logprobs * response_mask).sum() / valid_count).detach(),
+        "sft_logprob_mean": (-loss).detach(),
     }
+
+
+def _sft_token_mean_loss(data_pack, logprob_sum, valid_count, logprobs):
+    """Return local token mean, or global accumulation-group token mean when annotated."""
+
+    total_target_tokens = data_pack.get("_sft_total_target_tokens")
+    if total_target_tokens is None:
+        return -(logprob_sum / valid_count.to(dtype=logprobs.dtype))
+    denominator = torch.as_tensor(total_target_tokens, device=logprobs.device, dtype=logprobs.dtype).clamp_min(1)
+    grad_scale = torch.as_tensor(data_pack.get("_sft_grad_scale", 1), device=logprobs.device, dtype=logprobs.dtype)
+    # TrainingManager divides every microbatch loss by grad_scale before
+    # backward. Multiplying here makes the summed accumulation-group gradient
+    # equal to -sum(logprobs) / total_target_tokens.
+    return -(logprob_sum / denominator) * grad_scale

--- a/tests/test_more_losses_cpu.py
+++ b/tests/test_more_losses_cpu.py
@@ -36,6 +36,48 @@ class SftLossTest(unittest.TestCase):
         self.assertEqual(float(stats["sft_target_tokens"]), 2.0)
         self.assertEqual(float(logprobs.grad[0]), 0.0)
 
+    def test_sft_accumulation_uses_global_token_mean_when_annotated(self):
+        """SFT accumulation should weight microbatches by target-token count."""
+        short_logprobs = torch.tensor([-1.0], requires_grad=True)
+        long_logprobs = torch.tensor([-3.0, -3.0, -3.0], requires_grad=True)
+
+        short_loss, _ = sft_loss_fn({"packed_response_mask": torch.tensor([True])}, short_logprobs)
+        long_loss, _ = sft_loss_fn({"packed_response_mask": torch.tensor([True, True, True])}, long_logprobs)
+        microbatch_mean = (short_loss + long_loss) / 2
+
+        annotated_short_loss, _ = sft_loss_fn(
+            {
+                "packed_response_mask": torch.tensor([True]),
+                "_sft_total_target_tokens": 4,
+                "_sft_grad_scale": 2,
+            },
+            short_logprobs,
+        )
+        annotated_long_loss, _ = sft_loss_fn(
+            {
+                "packed_response_mask": torch.tensor([True, True, True]),
+                "_sft_total_target_tokens": 4,
+                "_sft_grad_scale": 2,
+            },
+            long_logprobs,
+        )
+        global_token_mean = (annotated_short_loss + annotated_long_loss) / 2
+
+        self.assertAlmostEqual(float(microbatch_mean.detach()), 2.0, places=6)
+        self.assertAlmostEqual(float(global_token_mean.detach()), 2.5, places=6)
+
+    def test_sft_backend_annotations_group_target_tokens(self):
+        """Backend SFT annotations describe one optimizer-step accumulation group."""
+        from areno.api.backend.areno.backend import _annotate_sft_token_mean_packs
+
+        packs = [{}, {}]
+        _annotate_sft_token_mean_packs(packs, [1, 3], gradient_accumulation_steps=None)
+
+        self.assertEqual(packs[0]["_sft_total_target_tokens"], 4)
+        self.assertEqual(packs[1]["_sft_total_target_tokens"], 4)
+        self.assertEqual(packs[0]["_sft_grad_scale"], 2)
+        self.assertEqual(packs[1]["_sft_grad_scale"], 2)
+
 
 class DpoLossTest(unittest.TestCase):
     """DPO tests validate pair ordering and packed sequence aggregation."""


### PR DESCRIPTION
## Summary

- Annotate built-in SFT microbatches with per-accumulation-group target-token totals.
- Scale SFT microbatch loss so TrainingManager's existing grad_scale division yields a global target-token mean gradient.
- Keep non-SFT losses and unannotated SFT loss behavior unchanged.

## Tests

- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_more_losses_cpu.py tests/test_trainer_dataset_utils_cpu.py tests/test_config_data_cpu.py -q

Fixes https://github.com/inclusionAI/AReno/issues/75