### PR TITLE
fix(sft): enforce prompt and response budgets

### DIFF
--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -154,9 +154,11 @@ def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int,
     else:
         raise ValueError("SFT dataset row must contain `messages`, `prompt`/`response`, or `text`")
 
-    prompt_tokens = sum(1 for item in prompt_mask if item)
-    response_tokens = sum(1 for item in prompt_mask[1:] if not item)
-    if len(tokens) < 2 or prompt_tokens > max_prompt_tokens or response_tokens > max_new_tokens or response_tokens == 0:
+    if len(tokens) < 2:
+        return None
+    prompt_tokens = prompt_mask.count(True)
+    response_tokens = prompt_mask[1:].count(False)
+    if prompt_tokens > max_prompt_tokens or response_tokens > max_new_tokens or response_tokens == 0:
         return None
     zeros = [0.0] * len(tokens)
     # Dummy rollout fields keep the backend packer shared with RL trainers.

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -52,12 +52,13 @@ class SFTTrainer:
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
         step = 0
-        # Reuse the existing prompt/new-token limits as a single teacher-forced
-        # sequence budget for offline examples.
-        max_seq_len = self.config.max_prompt_tokens + self.config.max_new_tokens
         for epoch in range(self.config.epochs):
             self.logger.info("epoch=%d stage=epoch_start", epoch)
-            for train_batch in self._iter_train_batches(tokenizer, max_seq_len=max_seq_len):
+            for train_batch in self._iter_train_batches(
+                tokenizer,
+                max_prompt_tokens=self.config.max_prompt_tokens,
+                max_new_tokens=self.config.max_new_tokens,
+            ):
                 if not train_batch:
                     continue
                 self.logger.info(
@@ -82,17 +83,22 @@ class SFTTrainer:
                 step += 1
             self.logger.info("epoch=%d stage=epoch_end", epoch)
 
-    def _iter_train_batches(self, tokenizer, *, max_seq_len: int):
+    def _iter_train_batches(self, tokenizer, *, max_prompt_tokens: int, max_new_tokens: int):
         # Dataset rows are converted lazily so large HF datasets do not need an
         # up-front tokenized copy. Rows that are empty, all-prompt, or exceed
-        # the configured max sequence length are dropped.
+        # the configured prompt or supervised-response budgets are dropped.
         batch = []
         skipped = 0
         accepted = 0
         total_rows = len(self.dataset)
         for index in range(total_rows):
             # Normalize each supported row schema into one TrainSequence.
-            seq = _record_to_train_sequence(self.dataset[index], tokenizer, max_seq_len=max_seq_len)
+            seq = _record_to_train_sequence(
+                self.dataset[index],
+                tokenizer,
+                max_prompt_tokens=max_prompt_tokens,
+                max_new_tokens=max_new_tokens,
+            )
             if seq is None:
                 skipped += 1
                 continue
@@ -106,8 +112,8 @@ class SFTTrainer:
         if accepted == 0:
             raise ValueError(
                 "SFT dataset produced no valid training rows after filtering: "
-                f"scanned {total_rows} row(s), skipped {skipped} as empty, overlong, or all-prompt examples. "
-                "Check dataset quality and sequence length limits."
+                f"scanned {total_rows} row(s), skipped {skipped} as empty, over-budget, or all-prompt examples. "
+                "Check dataset quality, --max-prompt-tokens, and --max-new-tokens."
             )
         if batch:
             yield batch
@@ -122,7 +128,7 @@ class SFTTrainer:
         self.logger.info("epoch=%d step=%d stage=save_checkpoint_end path=%s", epoch, step, saved_path)
 
 
-def _record_to_train_sequence(record: Any, tokenizer, *, max_seq_len: int):
+def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int, max_new_tokens: int):
     """Normalize common SFT schemas into the backend training row format.
 
     `prompt_mask=True` means "do not train this source token"; the backend loss
@@ -148,7 +154,9 @@ def _record_to_train_sequence(record: Any, tokenizer, *, max_seq_len: int):
     else:
         raise ValueError("SFT dataset row must contain `messages`, `prompt`/`response`, or `text`")
 
-    if len(tokens) < 2 or len(tokens) > max_seq_len or not any(not item for item in prompt_mask[1:]):
+    prompt_tokens = sum(1 for item in prompt_mask if item)
+    response_tokens = sum(1 for item in prompt_mask[1:] if not item)
+    if len(tokens) < 2 or prompt_tokens > max_prompt_tokens or response_tokens > max_new_tokens or response_tokens == 0:
         return None
     zeros = [0.0] * len(tokens)
     # Dummy rollout fields keep the backend packer shared with RL trainers.

--- a/tests/test_trainer_dataset_utils_cpu.py
+++ b/tests/test_trainer_dataset_utils_cpu.py
@@ -72,7 +72,9 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         """Prompt/response SFT rows should train on response tokens plus EOS."""
         tokenizer = FakeTextTokenizer()
 
-        seq = sft_mod._record_to_train_sequence({"prompt": "q", "response": "a"}, tokenizer, max_seq_len=16)
+        seq = sft_mod._record_to_train_sequence(
+            {"prompt": "q", "response": "a"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16
+        )
 
         self.assertIsNotNone(seq)
         self.assertEqual(seq.eos_token_id, 99)
@@ -84,7 +86,7 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         """Plain text SFT rows use the first token as context and train the rest."""
         tokenizer = FakeTextTokenizer()
 
-        seq = sft_mod._record_to_train_sequence({"text": "abc"}, tokenizer, max_seq_len=16)
+        seq = sft_mod._record_to_train_sequence({"text": "abc"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16)
 
         self.assertEqual(seq.prompt_mask, [True, False, False])
 
@@ -92,9 +94,36 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         """Rows that cannot produce a next-token target should be filtered out."""
         tokenizer = FakeTextTokenizer()
 
-        seq = sft_mod._record_to_train_sequence({"text": "a"}, tokenizer, max_seq_len=16)
+        seq = sft_mod._record_to_train_sequence({"text": "a"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16)
 
         self.assertIsNone(seq)
+
+    def test_sft_enforces_prompt_and_response_budgets_independently(self):
+        """SFT should reject over-budget prompts and responses separately."""
+        tokenizer = FakeTextTokenizer()
+
+        too_long_prompt = sft_mod._record_to_train_sequence(
+            {"prompt": "abc", "response": "d"},
+            tokenizer,
+            max_prompt_tokens=2,
+            max_new_tokens=10,
+        )
+        too_long_response = sft_mod._record_to_train_sequence(
+            {"prompt": "q", "response": "abc"},
+            tokenizer,
+            max_prompt_tokens=10,
+            max_new_tokens=3,
+        )
+        exact_budget = sft_mod._record_to_train_sequence(
+            {"prompt": "ab", "response": "cd"},
+            tokenizer,
+            max_prompt_tokens=2,
+            max_new_tokens=3,
+        )
+
+        self.assertIsNone(too_long_prompt)
+        self.assertIsNone(too_long_response)
+        self.assertIsNotNone(exact_budget)
 
     def test_sft_fit_raises_when_all_rows_are_filtered(self):
         """SFT should fail loudly instead of finishing with zero train steps."""


### PR DESCRIPTION
## Summary
- enforce SFT prompt and supervised-response token budgets independently
- keep CLI semantics aligned with --max-prompt-tokens and --max-new-tokens
- add CPU coverage for over-budget prompts, over-budget responses, and exact-budget rows

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_trainer_dataset_utils_cpu.py -q

Closes #77