### PR TITLE
fix(sft): keep fallback chat deltas stable

### DIFF
--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -13,7 +13,7 @@ def apply_chat_template(tokenizer, messages: list[dict[str, Any]]) -> list[int]:
     if getattr(tokenizer, "chat_template", None):
         return normalize_token_ids(tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False))
     text = "\n".join(f"{item.get('role', 'user')}: {item.get('content', '')}" for item in messages)
-    return normalize_token_ids(tokenizer.encode(text, add_special_tokens=True))
+    return normalize_token_ids(tokenizer.encode(text, add_special_tokens=False))
 
 
 def encode_prompt_value(tokenizer, prompt) -> list[int]:

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -175,6 +175,12 @@ def _messages_to_tokens_and_mask(messages: list[dict[str, Any]], tokenizer) -> t
         tokens.extend(delta)
         prompt_mask.extend([not is_target] * len(delta))
         previous = current
+    if not getattr(tokenizer, "chat_template", None) and messages:
+        is_last_assistant = str(messages[-1].get("role", "")).lower() == "assistant"
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if is_last_assistant and eos_token_id is not None:
+            tokens.append(eos_token_id)
+            prompt_mask.append(False)
     return tokens, prompt_mask
 
 

--- a/tests/test_trainer_dataset_utils_cpu.py
+++ b/tests/test_trainer_dataset_utils_cpu.py
@@ -26,6 +26,16 @@ class FakeTextTokenizer:
         return ids
 
 
+class EosAddingFallbackTokenizer(FakeTextTokenizer):
+    """Tokenizer double whose fallback encode adds EOS for special-token calls."""
+
+    def encode(self, text, add_special_tokens=False):
+        ids = super().encode(text, add_special_tokens=False)
+        if add_special_tokens:
+            ids.append(self.eos_token_id)
+        return ids
+
+
 class FakeSFTBackend:
     """Backend double that records whether SFT attempted to train."""
 
@@ -95,6 +105,24 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         seq = sft_mod._record_to_train_sequence({"text": "a"}, tokenizer, max_seq_len=16)
 
         self.assertIsNone(seq)
+
+    def test_sft_fallback_chat_template_keeps_assistant_delta_scoped(self):
+        """Fallback chat rendering should not let EOS suffixes over-mark history."""
+        tokenizer = EosAddingFallbackTokenizer()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        tokens, prompt_mask = sft_mod._messages_to_tokens_and_mask(messages, tokenizer)
+        final_rendering = data_utils.apply_chat_template(tokenizer, messages)
+        prompt_rendering = data_utils.apply_chat_template(tokenizer, messages[:1])
+
+        self.assertEqual(tokens, final_rendering)
+        self.assertEqual(len(tokens), len(prompt_mask))
+        self.assertNotIn(tokenizer.eos_token_id, tokens)
+        self.assertEqual(prompt_mask[: len(prompt_rendering)], [True] * len(prompt_rendering))
+        self.assertEqual(prompt_mask[len(prompt_rendering) :], [False] * (len(final_rendering) - len(prompt_rendering)))
 
     def test_sft_fit_raises_when_all_rows_are_filtered(self):
         """SFT should fail loudly instead of finishing with zero train steps."""

--- a/tests/test_trainer_dataset_utils_cpu.py
+++ b/tests/test_trainer_dataset_utils_cpu.py
@@ -118,11 +118,15 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         final_rendering = data_utils.apply_chat_template(tokenizer, messages)
         prompt_rendering = data_utils.apply_chat_template(tokenizer, messages[:1])
 
-        self.assertEqual(tokens, final_rendering)
+        self.assertEqual(tokens, final_rendering + [tokenizer.eos_token_id])
         self.assertEqual(len(tokens), len(prompt_mask))
-        self.assertNotIn(tokenizer.eos_token_id, tokens)
+        self.assertEqual(tokens[-1], tokenizer.eos_token_id)
+        self.assertFalse(prompt_mask[-1])
         self.assertEqual(prompt_mask[: len(prompt_rendering)], [True] * len(prompt_rendering))
-        self.assertEqual(prompt_mask[len(prompt_rendering) :], [False] * (len(final_rendering) - len(prompt_rendering)))
+        self.assertEqual(
+            prompt_mask[len(prompt_rendering) :],
+            [False] * (len(final_rendering) - len(prompt_rendering) + 1),
+        )
 
     def test_sft_fit_raises_when_all_rows_are_filtered(self):
         """SFT should fail loudly instead of finishing with zero train steps."""


### PR DESCRIPTION
## Summary
- make fallback chat rendering prefix-stable by avoiding per-prefix special suffixes
- add an EOS-adding fallback tokenizer regression test
- verify assistant-turn targets stay scoped to the new assistant delta

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_trainer_dataset_utils_cpu.py -q

Closes #76