### PR TITLE
fix(attn): pad native prefill values

### DIFF
--- a/areno/engine/layers/attention_backend/infer.py
+++ b/areno/engine/layers/attention_backend/infer.py
@@ -74,8 +74,8 @@ class FlashAttnInferBackend(nn.Module):
                 _store_prefill_cache(k_flat, v_flat, k_cache, v_cache, meta)
             if use_native_attention(self.attn_backend):
                 out = _native_prefill(
-                    q_flat,
-                    k_flat,
+                    call.q,
+                    call.k,
                     call.v,
                     meta,
                     call.window_size,

--- a/areno/engine/layers/attention_backend/infer.py
+++ b/areno/engine/layers/attention_backend/infer.py
@@ -76,11 +76,12 @@ class FlashAttnInferBackend(nn.Module):
                 out = _native_prefill(
                     q_flat,
                     k_flat,
-                    v_flat,
+                    call.v,
                     meta,
                     call.window_size,
                     call.softmax_scale,
                 )
+                out = call.trim_value_dim(out)
                 return out.view(q.shape[0], q.shape[1], q.shape[2], call.value_dim)
             require_flash_attention_supported(call, mode="prefill attention")
             # cu_seqlens tells flash-attn where each packed sequence ends so

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -28,7 +28,7 @@ from areno.engine.layers.attention_backend.common import (
     expand_kv_heads,
     require_flash_attention_supported,
 )
-from areno.engine.layers.attention_backend.infer import _native_prefill
+from areno.engine.layers.attention_backend.infer import FlashAttnInferBackend, _native_prefill
 from areno.engine.runtime.metadata import InferMeta
 
 
@@ -229,6 +229,42 @@ class ConfigAndDataTest(unittest.TestCase):
         self.assertEqual(captured["k_shape"], (3, 2, 4))
         self.assertEqual(captured["v_shape"], (3, 2, 4))
         self.assertEqual(captured["cu"], [0, 3])
+
+    def test_native_prefill_pads_value_dim_and_trims_output(self):
+        """Native prefill should match flash/decode behavior when V dim is smaller than QK."""
+        backend = FlashAttnInferBackend("native")
+        q = torch.zeros(1, 2, 2, 6)
+        k = torch.zeros(1, 2, 2, 6)
+        v = torch.zeros(1, 2, 2, 4)
+        k_cache = torch.zeros(1, 2, 2, 6)
+        v_cache = torch.zeros(1, 2, 2, 6)
+        meta = InferMeta(
+            mode="prefill",
+            cu_seqlens=torch.tensor([0, 2], dtype=torch.int32),
+            max_seqlen=2,
+            block_table=torch.zeros(1, 1, dtype=torch.int32),
+        )
+        captured = {}
+
+        def fake_native_prefill(q_arg, k_arg, v_arg, meta_arg, window_size, softmax_scale):
+            captured["q_shape"] = tuple(q_arg.shape)
+            captured["k_shape"] = tuple(k_arg.shape)
+            captured["v_shape"] = tuple(v_arg.shape)
+            captured["value_tail"] = v_arg[..., 4:].clone()
+            captured["meta"] = meta_arg
+            captured["window_size"] = window_size
+            captured["softmax_scale"] = softmax_scale
+            return torch.ones_like(v_arg)
+
+        with patch("areno.engine.layers.attention_backend.infer._native_prefill", fake_native_prefill):
+            out = backend(q, k, v, k_cache, v_cache, meta, update_cache=False)
+
+        self.assertEqual(captured["q_shape"], (2, 2, 6))
+        self.assertEqual(captured["k_shape"], (2, 2, 6))
+        self.assertEqual(captured["v_shape"], (2, 2, 6))
+        self.assertTrue(torch.equal(captured["value_tail"], torch.zeros(2, 2, 2)))
+        self.assertIs(captured["meta"], meta)
+        self.assertEqual(tuple(out.shape), (1, 2, 2, 4))
 
     def test_native_attention_backend_does_not_require_flash_attn_import(self):
         """Native train/infer backends should construct without flash-attn installed."""


### PR DESCRIPTION
## Summary
- pad native prefill V through build_attention_call, matching flash prefill and native decode
- trim native prefill output back to the original value head dimension
- add CPU coverage for value_dim smaller than qk_head_dim

## Target model note
Bailing MLA can use separate qk and V head dimensions via qk_nope_head_dim/qk_rope_head_dim and v_head_dim. Other current softmax attention model paths keep Q/K/V head dims equal; Qwen3.5 GatedDeltaNet has separate key/value dims but uses the linear attention path, not this native softmax prefill kernel.

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_config_data_cpu.py -q

Closes #82