### PR TITLE
feat(cli): add chat template thinking toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ areno train \
 
 `--ckpt` and `--dataset-path` accept either local paths or Hugging Face repo IDs. Switch algorithms by changing `--algo` (e.g. `--algo grpo`, `--algo sft`).
 
+For models whose tokenizer chat template supports a thinking-mode switch, add `--disable-thinking` to pass `enable_thinking=False` during training prompt rendering. Tokenizers that do not support this argument automatically use their normal chat-template path.
+
 For Agentic RL, add `--agent-fn` to supply an agent function. The agent calls the local OpenAI-compatible endpoint, including `tools` and `tool_choice` when needed, and returns explicit `AgentTrajectoryTurn` objects. AReno converts those turns into trainable assistant outputs and masks tool results by default:
 
 ```bash
@@ -344,6 +346,8 @@ areno serve \
 ```
 
 Point any OpenAI client at `http://localhost:8000/v1/chat/completions` to start generating. For the full list of serving options, run `areno serve --help`.
+
+Use `--disable-thinking` with `areno serve` to pass `enable_thinking=False` to compatible tokenizer chat templates for request rendering.
 
 ## Development
 

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -34,6 +34,7 @@ from areno.api.openai_chat import (
     normalize_messages,
 )
 from areno.api.rewards import RewardEvent, RewardRecord
+from areno.api.tokenizer import apply_chat_template_with_options
 from areno.api.tool_call_parser import get_tool_call_parser, infer_tool_call_parser_name
 
 if TYPE_CHECKING:
@@ -790,7 +791,8 @@ def _render_messages_for_display(tokenizer, messages: list[dict[str, Any]]) -> s
 
     if getattr(tokenizer, "chat_template", None):
         try:
-            rendered = tokenizer.apply_chat_template(
+            rendered = apply_chat_template_with_options(
+                tokenizer,
                 messages,
                 tokenize=False,
                 add_generation_prompt=False,

--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from areno.api.tokenizer import encode_generation_prompt, normalize_token_ids
+from areno.api.tokenizer import apply_chat_template_with_options, encode_generation_prompt, normalize_token_ids
 
 
 def apply_chat_template(tokenizer, messages: list[dict[str, Any]]) -> list[int]:
     """Encode full chat messages, with a plain-text fallback for base tokenizers."""
 
     if getattr(tokenizer, "chat_template", None):
-        return normalize_token_ids(tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False))
+        return normalize_token_ids(
+            apply_chat_template_with_options(tokenizer, messages, tokenize=True, add_generation_prompt=False)
+        )
     text = "\n".join(f"{item.get('role', 'user')}: {item.get('content', '')}" for item in messages)
     return normalize_token_ids(tokenizer.encode(text, add_special_tokens=False))
 
@@ -21,7 +23,9 @@ def encode_prompt_value(tokenizer, prompt) -> list[int]:
 
     if isinstance(prompt, list):
         if getattr(tokenizer, "chat_template", None):
-            return normalize_token_ids(tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True))
+            return normalize_token_ids(
+                apply_chat_template_with_options(tokenizer, prompt, tokenize=True, add_generation_prompt=True)
+            )
         text = "\n".join(f"{item.get('role', 'user')}: {item.get('content', '')}" for item in prompt)
         return encode_generation_prompt(tokenizer, text)
     return encode_generation_prompt(tokenizer, prompt)

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from typing import Any
 
-from areno.api.tokenizer import normalize_token_ids
+from areno.api.tokenizer import apply_chat_template_with_options, normalize_token_ids
 from areno.api.tool_call_parser import ToolCallParser
 
 
@@ -60,16 +60,16 @@ def messages_to_prompt_tokens(
         if tools:
             kwargs["tools"] = tools
         try:
-            return normalize_token_ids(tokenizer.apply_chat_template(messages, **kwargs))
+            return normalize_token_ids(apply_chat_template_with_options(tokenizer, messages, **kwargs))
         except TypeError:
             if tools:
                 kwargs["tools"] = _normalize_tools_for_chat_template(tools)
                 try:
-                    return normalize_token_ids(tokenizer.apply_chat_template(messages, **kwargs))
+                    return normalize_token_ids(apply_chat_template_with_options(tokenizer, messages, **kwargs))
                 except TypeError:
                     pass
             kwargs.pop("tools", None)
-            return normalize_token_ids(tokenizer.apply_chat_template(messages, **kwargs))
+            return normalize_token_ids(apply_chat_template_with_options(tokenizer, messages, **kwargs))
     return normalize_token_ids(tokenizer.encode(messages_to_text(messages) or fallback_prompt))
 
 

--- a/areno/api/tokenizer.py
+++ b/areno/api/tokenizer.py
@@ -14,6 +14,38 @@ from typing import Any
 
 from areno.engine.data.tokenizer import load_tokenizer as load_tokenizer  # noqa: F401
 
+_CHAT_TEMPLATE_ENABLE_THINKING_ATTR = "_areno_chat_template_enable_thinking"
+
+
+def configure_chat_template_enable_thinking(tokenizer, enable_thinking: bool | None) -> None:
+    """Store the optional chat-template thinking switch on a tokenizer.
+
+    ``None`` keeps the tokenizer default.  A boolean is passed to
+    ``apply_chat_template`` calls when the tokenizer/template supports it.
+    """
+
+    if enable_thinking is None:
+        if hasattr(tokenizer, _CHAT_TEMPLATE_ENABLE_THINKING_ATTR):
+            delattr(tokenizer, _CHAT_TEMPLATE_ENABLE_THINKING_ATTR)
+        return
+    setattr(tokenizer, _CHAT_TEMPLATE_ENABLE_THINKING_ATTR, bool(enable_thinking))
+
+
+def apply_chat_template_with_options(tokenizer, messages, **kwargs):
+    """Apply a tokenizer chat template with AReno-level optional kwargs."""
+
+    kwargs = dict(kwargs)
+    enable_thinking = getattr(tokenizer, _CHAT_TEMPLATE_ENABLE_THINKING_ATTR, None)
+    if enable_thinking is not None:
+        kwargs["enable_thinking"] = bool(enable_thinking)
+    try:
+        return tokenizer.apply_chat_template(messages, **kwargs)
+    except TypeError:
+        if "enable_thinking" not in kwargs:
+            raise
+        kwargs.pop("enable_thinking", None)
+        return tokenizer.apply_chat_template(messages, **kwargs)
+
 
 def eos_token_ids(model_path: str | Path, tokenizer) -> tuple[int, ...]:
     """Collect EOS ids from tokenizer and HF config.
@@ -48,7 +80,8 @@ def encode_generation_prompt(tokenizer, prompt: str) -> list[int]:
     if _looks_chat_formatted(prompt) or not getattr(tokenizer, "chat_template", None):
         return normalize_token_ids(tokenizer.encode(prompt))
     return normalize_token_ids(
-        tokenizer.apply_chat_template(
+        apply_chat_template_with_options(
+            tokenizer,
             [{"role": "user", "content": prompt}],
             tokenize=True,
             add_generation_prompt=True,

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -55,6 +55,7 @@ class TrainerConfig:
     agent_fn: str | None = None
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
+    chat_template_enable_thinking: bool | None = None
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -21,6 +21,7 @@ from typing import Any
 import areno.api
 from areno.api.data_utils import apply_chat_template, encode_prompt_value, response_to_tokens_and_mask
 from areno.api.roles import ModelRole
+from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
 class DPOTrainer:
@@ -62,6 +63,7 @@ class DPOTrainer:
 
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
+        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
         step = 0
         max_seq_len = self.config.max_prompt_tokens + self.config.max_new_tokens
         for epoch in range(self.config.epochs):

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -63,7 +63,7 @@ class DPOTrainer:
 
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
-        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
+        configure_chat_template_enable_thinking(tokenizer, getattr(self.config, "chat_template_enable_thinking", None))
         step = 0
         max_seq_len = self.config.max_prompt_tokens + self.config.max_new_tokens
         for epoch in range(self.config.epochs):

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -53,7 +53,7 @@ class PolicyOnlyTrainer:
         import areno.api
 
         tokenizer = self.areno.get_tokenizer()
-        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
+        configure_chat_template_enable_thinking(tokenizer, getattr(self.config, "chat_template_enable_thinking", None))
         sampling_params = areno.api.SamplingParams(
             greedy=self.config.greedy,
             temperature=self.config.temperature,

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import numpy as np
 
+from areno.api.tokenizer import configure_chat_template_enable_thinking
+
 
 class PolicyOnlyTrainer:
     """Rollout-reward-train loop for policy-only RL algorithms.
@@ -51,6 +53,7 @@ class PolicyOnlyTrainer:
         import areno.api
 
         tokenizer = self.areno.get_tokenizer()
+        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
         sampling_params = areno.api.SamplingParams(
             greedy=self.config.greedy,
             temperature=self.config.temperature,

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import areno.api
 from areno.api.data_utils import apply_chat_template, prompt_response_to_tokens_and_mask
+from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
 class SFTTrainer:
@@ -51,6 +52,7 @@ class SFTTrainer:
 
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
+        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
         step = 0
         for epoch in range(self.config.epochs):
             self.logger.info("epoch=%d stage=epoch_start", epoch)

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -52,7 +52,7 @@ class SFTTrainer:
 
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
-        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
+        configure_chat_template_enable_thinking(tokenizer, getattr(self.config, "chat_template_enable_thinking", None))
         step = 0
         for epoch in range(self.config.epochs):
             self.logger.info("epoch=%d stage=epoch_start", epoch)

--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from areno.api.openai_chat import build_chat_completion_response, messages_to_prompt_tokens
+from areno.api.tokenizer import configure_chat_template_enable_thinking
 from areno.api.tool_call_parser import ToolCallParser, get_tool_call_parser, infer_tool_call_parser_name
 from areno.cli.model_refs import resolve_model_ref
 from areno.engine import ArenoEngine
@@ -166,6 +167,7 @@ def create_app(
     decode_progress_interval_s: float,
     eager_decode: bool = False,
     attn_backend: Literal["flash", "native"] = "flash",
+    chat_template_enable_thinking: bool | None = None,
 ) -> FastAPI:
     """Construct the FastAPI app: load tokenizer/engine, install routes and lifecycle hooks."""
     if world_size < 1:
@@ -176,6 +178,7 @@ def create_app(
         raise ValueError("world_size must be divisible by tp_size")
 
     tokenizer = load_tokenizer(model_path)
+    configure_chat_template_enable_thinking(tokenizer, chat_template_enable_thinking)
     attn_backend, attn_warning = _resolve_serve_attn_backend(
         model_path=model_path,
         attn_backend=attn_backend,
@@ -548,6 +551,11 @@ def _normalize_stop(stop: str | list[str] | None) -> list[str]:
     show_default=True,
     help="Attention backend. Use native for slower areno_accel attention compatibility/logprob diagnostics.",
 )
+@click.option(
+    "--disable-thinking",
+    is_flag=True,
+    help="Pass enable_thinking=False to tokenizer chat templates when supported.",
+)
 def serve_command(
     model_path: str,
     tp_size: int,
@@ -559,6 +567,7 @@ def serve_command(
     decode_progress_interval_s: float,
     eager_decode: bool,
     attn_backend: Literal["flash", "native"],
+    disable_thinking: bool,
 ) -> None:
     """Click entry point: build the app and hand it to uvicorn."""
     import uvicorn
@@ -573,6 +582,7 @@ def serve_command(
         decode_progress_interval_s=decode_progress_interval_s,
         eager_decode=eager_decode,
         attn_backend=attn_backend,
+        chat_template_enable_thinking=False if disable_thinking else None,
     )
     uvicorn.run(app, host=host, port=port)
 

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -76,6 +76,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "eager_decode",
             "drop_rollout_state",
             "attn_backend",
+            "disable_thinking",
             "agent_fn",
             "agent_timeout_s",
             "train_tool_results",
@@ -276,6 +277,10 @@ def _format_training_config_summary(
                 ("tp_size", str(config.tp_size)),
                 ("dp_size", _resolved_dp_size_for_summary(config)),
                 ("attn_backend", attn_backend),
+                (
+                    "thinking",
+                    _format_optional(config.chat_template_enable_thinking, default="tokenizer default"),
+                ),
             ],
         ),
         ("Rollout", _rollout_summary_rows(config)),
@@ -508,6 +513,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     # Each algorithm gets the narrowest config dataclass it needs; offline
     # trainers do not receive rollout/reward/GSPO fields by construction.
     algorithm = get_algorithm(args.algo)
+    chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
         return DPOTrainerConfig(
             algo=algorithm.name,
@@ -541,6 +547,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            chat_template_enable_thinking=chat_template_enable_thinking,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
         )
@@ -577,6 +584,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            chat_template_enable_thinking=chat_template_enable_thinking,
         )
     if algorithm.name != "ppo":
         return PolicyTrainerConfig(
@@ -620,6 +628,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            chat_template_enable_thinking=chat_template_enable_thinking,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -676,6 +685,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_fn=args.agent_fn,
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
+        chat_template_enable_thinking=chat_template_enable_thinking,
     )
 
 
@@ -955,6 +965,11 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     default="flash",
     show_default=True,
     help="Attention backend. Use native for slower areno_accel attention consistency diagnostics.",
+)
+@click.option(
+    "--disable-thinking",
+    is_flag=True,
+    help="Pass enable_thinking=False to tokenizer chat templates when supported.",
 )
 @click.option("--agent-fn", default=None, help="Python file defining async run_agent(ctx, batch) for agentic rollout.")
 @click.option(

--- a/docs/cli/inference.rst
+++ b/docs/cli/inference.rst
@@ -59,6 +59,13 @@ Options:
    as Tesla T4 and prints a warning. ``native`` is slower than ``flash`` on
    supported GPUs.
 
+``--disable-thinking``
+   Pass ``enable_thinking=False`` to tokenizer chat templates when supported.
+   Use this when serving a model whose chat template supports a thinking-mode
+   switch and you want normal responses without reasoning spans. Tokenizers
+   that do not accept ``enable_thinking`` automatically fall back to their
+   normal chat-template call.
+
 ``world-size`` must be divisible by ``tp-size``.
 
 Examples
@@ -157,6 +164,7 @@ Request fields
    * - ``tool_choice``
      - ``str | dict | None``
      - Optional tool-choice directive, including a forced function name.
+
 ``ChatMessage`` fields:
 
 ``role``

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -123,6 +123,13 @@ signal.
    as Tesla T4 and prints a warning. ``native`` is slower than ``flash`` on
    supported GPUs.
 
+``--disable-thinking``
+   Pass ``enable_thinking=False`` to tokenizer chat templates when supported.
+   This is useful for models whose tokenizer template exposes an explicit
+   thinking-mode switch, such as some reasoning/chat checkpoints. Tokenizers
+   that do not accept ``enable_thinking`` automatically fall back to their
+   normal chat-template call.
+
 Training rollouts run inside a rollout session. The session owns actor
 onload/offload, rollout cache state, CUDA graph state, and cleanup between
 rollout and train phases. Direct prompt rollout and agentic rollout both use

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -578,6 +578,7 @@ def _train_args(**overrides):
         drop_rollout_state=False,
         eager_decode=False,
         attn_backend="flash",
+        disable_thinking=False,
         metrics_log_dir=None,
         agent_fn=None,
         agent_timeout_s=300.0,

--- a/tests/test_serve_cli_cpu.py
+++ b/tests/test_serve_cli_cpu.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from areno.api.tokenizer import configure_chat_template_enable_thinking
 from areno.api.tool_call_parser import QwenToolCallParser
 from areno.cli import serve as serve_mod
 from areno.engine.config import ModelConfig
@@ -37,6 +38,36 @@ def test_create_app_passes_eager_decode_runtime_config(monkeypatch):
 
     assert captured["runtime_config"].eager_decode is True
     assert captured["runtime_config"].attn_backend == "native"
+
+
+def test_create_app_can_disable_chat_template_thinking(monkeypatch):
+    class FakeEngine:
+        config = SimpleNamespace(model=SimpleNamespace(max_position_embeddings=1024))
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            del args, kwargs
+            return cls()
+
+    tokenizer = _ToolAwareTokenizer()
+    monkeypatch.setattr(serve_mod, "load_tokenizer", lambda model_path: tokenizer)
+    monkeypatch.setattr(serve_mod, "ArenoEngine", FakeEngine)
+
+    app = serve_mod.create_app(
+        model_path="model",
+        tp_size=1,
+        world_size=1,
+        max_running_prompts=4,
+        default_max_tokens=16,
+        decode_progress_interval_s=0.0,
+        attn_backend="native",
+        chat_template_enable_thinking=False,
+    )
+
+    assert serve_mod._encode_messages(
+        app.state.areno_serve.tokenizer, [serve_mod.ChatMessage(role="user", content="hi")]
+    )
+    assert tokenizer.calls[0][1]["enable_thinking"] is False
 
 
 def test_create_app_falls_back_to_native_for_flash_unsupported_model(monkeypatch):
@@ -138,11 +169,19 @@ def test_serve_chat_template_receives_tools_and_tool_messages():
     tools = [{"type": "function", "function": {"name": "choose_move"}}]
 
     assert serve_mod._encode_messages(tokenizer, messages, tools=tools) == [3]
-    rendered_messages, rendered_tools = tokenizer.calls[0]
-    assert rendered_tools == tools
+    rendered_messages, rendered_kwargs = tokenizer.calls[0]
+    assert rendered_kwargs["tools"] == tools
     assert rendered_messages[1]["content"] == ""
     assert rendered_messages[1]["tool_calls"][0]["function"]["name"] == "choose_move"
     assert rendered_messages[2]["tool_call_id"] == "call-1"
+
+
+def test_serve_chat_template_can_disable_thinking():
+    tokenizer = _ToolAwareTokenizer()
+    configure_chat_template_enable_thinking(tokenizer, False)
+
+    assert serve_mod._encode_messages(tokenizer, [serve_mod.ChatMessage(role="user", content="hello")]) == [1]
+    assert tokenizer.calls[0][1]["enable_thinking"] is False
 
 
 class _TokenTokenizer:
@@ -161,5 +200,5 @@ class _ToolAwareTokenizer:
         self.calls = []
 
     def apply_chat_template(self, messages, **kwargs):
-        self.calls.append((messages, kwargs.get("tools")))
+        self.calls.append((messages, dict(kwargs)))
         return [len(messages)]

--- a/tests/test_tokenizer_api_cpu.py
+++ b/tests/test_tokenizer_api_cpu.py
@@ -9,7 +9,13 @@ from types import SimpleNamespace
 from areno.api.config import ArenoConfig, coerce_backend_config, resolve_backend_type
 from areno.api.models import BackendType, SamplingParams, TrainSequence
 from areno.api.rewards import load_reward_fn
-from areno.api.tokenizer import _looks_chat_formatted, encode_generation_prompt, eos_token_ids, normalize_token_ids
+from areno.api.tokenizer import (
+    _looks_chat_formatted,
+    configure_chat_template_enable_thinking,
+    encode_generation_prompt,
+    eos_token_ids,
+    normalize_token_ids,
+)
 
 
 class FakeTokenizer:
@@ -28,6 +34,12 @@ class FakeTokenizer:
 
     def apply_chat_template(self, messages, tokenize, add_generation_prompt):
         self.templated.append((messages, tokenize, add_generation_prompt))
+        return [7, 8, 9]
+
+
+class ThinkingTokenizer(FakeTokenizer):
+    def apply_chat_template(self, messages, tokenize, add_generation_prompt, enable_thinking=None):
+        self.templated.append((messages, tokenize, add_generation_prompt, enable_thinking))
         return [7, 8, 9]
 
 
@@ -59,6 +71,24 @@ class TokenizerApiTest(unittest.TestCase):
         self.assertEqual(len(tokenizer.templated), 1)
         self.assertEqual(tokenizer.encoded, ["<start_of_turn>user\nhello"])
         self.assertTrue(_looks_chat_formatted("<|im_start|>user"))
+
+    def test_encode_generation_prompt_can_disable_chat_template_thinking(self):
+        tokenizer = ThinkingTokenizer()
+        configure_chat_template_enable_thinking(tokenizer, False)
+
+        templated = encode_generation_prompt(tokenizer, "plain prompt")
+
+        self.assertEqual(templated, [7, 8, 9])
+        self.assertEqual(tokenizer.templated[0][3], False)
+
+    def test_encode_generation_prompt_falls_back_when_thinking_kwarg_is_unsupported(self):
+        tokenizer = FakeTokenizer()
+        configure_chat_template_enable_thinking(tokenizer, False)
+
+        templated = encode_generation_prompt(tokenizer, "plain prompt")
+
+        self.assertEqual(templated, [7, 8, 9])
+        self.assertEqual(len(tokenizer.templated), 1)
 
     def test_normalize_token_ids_accepts_tokenizer_encoding_outputs(self):
         """Fast tokenizer Encoding and BatchEncoding-like outputs should become ids."""

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -133,6 +133,16 @@ def test_train_config_builds_sft_shape_without_rollout_or_role_fields():
     assert not hasattr(cfg, "ref_ckpt")
 
 
+def test_train_config_disable_thinking_sets_chat_template_option():
+    default_cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None))
+    disabled_cfg = _trainer_config_from_options(
+        **_options(algo="sft", reward_fn_path=None, reward_ckpt=None, disable_thinking=True)
+    )
+
+    assert default_cfg.chat_template_enable_thinking is None
+    assert disabled_cfg.chat_template_enable_thinking is False
+
+
 def test_train_config_builds_dpo_shape_and_ref_ckpt():
     cfg = _trainer_config_from_options(
         **_options(algo="dpo", reward_fn_path=None, reward_ckpt=None, ref_ckpt="reference", dpo_beta=0.25)
@@ -479,6 +489,7 @@ def _options(**overrides):
         drop_rollout_state=False,
         eager_decode=False,
         attn_backend="flash",
+        disable_thinking=False,
         metrics_log_dir=None,
         agent_fn=None,
         agent_timeout_s=300.0,


### PR DESCRIPTION
## Summary

- Add `--disable-thinking` to `areno train` and `areno serve`.
- Route chat-template rendering through a shared tokenizer helper that passes `enable_thinking=False` only when requested.
- Preserve default tokenizer behavior and fall back cleanly for tokenizers that do not support `enable_thinking`.
- Document the option in README and CLI docs.

## Tests

- `uvx ruff check areno/api/tokenizer.py areno/api/data_utils.py areno/api/openai_chat.py areno/api/agentic.py areno/api/trainer_config.py areno/api/trainers/sft.py areno/api/trainers/dpo.py areno/api/trainers/policy_only.py areno/cli/train.py areno/cli/serve.py tests/test_tokenizer_api_cpu.py tests/test_serve_cli_cpu.py tests/test_train_cli_config_cpu.py tests/test_config_data_cpu.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_tokenizer_api_cpu.py tests/test_train_cli_config_cpu.py tests/test_config_data_cpu.py tests/test_serve_cli_cpu.py -q`
- `python -m sphinx -b html docs /tmp/areno-docs-chat-template-thinking`

Closes #97