### PR TITLE
fix(agentic): penalize unspent DuelGrid energy

### DIFF
--- a/examples/agentic/duelgrid/README.md
+++ b/examples/agentic/duelgrid/README.md
@@ -66,7 +66,9 @@ For tool-call mode, the function name is always `choose_action`; `MOVE`,
 Energy costs are `MOVE=1`, `ATTACK=1`, `RANGED_ATTACK=2`, `SHIELD=1`,
 `PICKUP=0`, and `WAIT=0`; energy refreshes to that player's current max energy
 at the end of the turn. Picking up `E` increases max energy for future turns and
-refills to the new max.
+refills to the new max. The reward function subtracts a small penalty for each
+point of unspent turn energy, so one-action turns are discouraged when useful
+energy remains.
 
 Rewards are computed by the rule engine, so the same generated states can be
 used for supervised warmup, rollout collection, or GSPO/RLVR training.

--- a/examples/agentic/duelgrid/game.py
+++ b/examples/agentic/duelgrid/game.py
@@ -36,6 +36,7 @@ ACTION_COSTS = {
     "PICKUP": 0,
     "WAIT": 0,
 }
+UNSPENT_ENERGY_PENALTY = 0.05
 
 DEFAULT_MAP = (
     "###########",
@@ -143,6 +144,7 @@ def format_prompt(state: State) -> str:
         "Goal:\nDefeat player U.\n\n"
         "Rules:\n"
         "- Choose a sequence of legal action objects from the Legal actions list.\n"
+        "- Use all useful A energy each turn; unspent energy is penalized.\n"
         "- You may use multiple actions in one turn until A energy is spent.\n"
         "- Energy costs: MOVE 1, ATTACK 1, RANGED_ATTACK 2, SHIELD 1, PICKUP 0, WAIT 0.\n"
         "- If using tool calls, the function name is choose_action; action names are arguments, not tool names.\n"
@@ -330,6 +332,9 @@ def step_turn(
         applied.append({"action": "WAIT"})
         if info.get("illegal"):
             return current, total_reward, done, {"illegal": True, "applied_actions": []}
+    energy_budget = _player(state, actor).energy
+    unspent_energy = max(0, energy_budget - spent_energy)
+    total_reward -= UNSPENT_ENERGY_PENALTY * unspent_energy
     refreshed = _end_turn(current, actor, state.turn)
     return (
         refreshed,
@@ -338,7 +343,8 @@ def step_turn(
         {
             "illegal": False,
             "spent_energy": spent_energy,
-            "energy_budget": _player(state, actor).energy,
+            "energy_budget": energy_budget,
+            "unspent_energy": unspent_energy,
             "applied_actions": applied,
         },
     )

--- a/examples/agentic/duelgrid/run_agent.py
+++ b/examples/agentic/duelgrid/run_agent.py
@@ -14,7 +14,8 @@ SYSTEM_PROMPT = (
     "You are an expert DuelGrid player controlling A. "
     "Choose one or more legal actions by calling the choose_action tool. "
     "The tool name is always choose_action; never use MOVE, ATTACK, or another action as the tool name. "
-    "Copy legal action objects from the prompt into the actions array until energy is spent."
+    "Copy legal action objects from the prompt into the actions array until energy is spent. "
+    "Unspent energy is penalized."
 )
 
 CHOOSE_ACTION_TOOL = {

--- a/examples/agentic/duelgrid/web_ui.py
+++ b/examples/agentic/duelgrid/web_ui.py
@@ -38,7 +38,8 @@ SYSTEM_PROMPT = (
     "You are an expert DuelGrid player controlling A. "
     "Choose one or more legal actions by calling the choose_action tool. "
     "The tool name is always choose_action; never use MOVE, ATTACK, or another action as the tool name. "
-    "Copy legal action objects from the prompt into the actions array until energy is spent."
+    "Copy legal action objects from the prompt into the actions array until energy is spent. "
+    "Unspent energy is penalized."
 )
 
 CHOOSE_ACTION_TOOL = {


### PR DESCRIPTION
## Summary
- add a small DuelGrid reward penalty for unspent agent energy
- update DuelGrid agent/UI prompt text to mention spending available energy
- document the reward-shaping behavior in the DuelGrid README

## Tests
- Not run; small DuelGrid reward/docs change only.

Closes #99