### PR TITLE
ci(docs): publish static docs to gh-pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,54 @@
+name: Publish docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "examples/agentic/duelgrid/images/**"
+      - ".github/workflows/publish-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build Sphinx docs and publish static site
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r docs/requirements.txt
+
+      - name: Build docs
+        run: |
+          rm -rf dist/docs
+          python -m sphinx -W --keep-going -b html docs dist/docs
+          touch dist/docs/.nojekyll
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: dist/docs
+          force_orphan: true
+          enable_jekyll: false
+          commit_message: "docs: publish static site"


### PR DESCRIPTION
## Summary
- add a docs publishing workflow for GitHub Pages
- build Sphinx docs into dist/docs with warnings treated as errors
- publish only compiled static files to a clean orphan gh-pages branch


Closes #101