### PR TITLE
feat(cli): tune rollout training params

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,30 @@ areno train \
 
 For models whose tokenizer chat template supports a thinking-mode switch, add `--disable-thinking` to pass `enable_thinking=False` during training prompt rendering. Tokenizers that do not support this argument automatically use their normal chat-template path.
 
+For rollout-based algorithms, add `--tune-params` when you want AReno to probe
+rollout and train memory before the real run and fill conservative values for
+`--max-running-prompts`, `--batch-size`, and `--mini-bs`:
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path gsm8k:main \
+  --dataset-loader-fn examples/math/dataset_loader.py \
+  --reward-fn-path examples/math/math_verify_reward.py \
+  --algo gspo \
+  --tp-size 1 \
+  --world-size 1 \
+  --n-samples 8 \
+  --tune-params \
+  --mem-frac 0.9 \
+  --tune-max-samples 256
+```
+
+The tuner uses dummy-loaded model weights and synthetic token rows, respects
+the configured sequence limits and tensor-parallel size, and enables
+`--drop-rollout-state` for the tuned run. See `docs/cli/training.rst` for the
+full tuning rules.
+
 For Agentic RL, add `--agent-fn` to supply an agent function. The agent calls the local OpenAI-compatible endpoint, including `tools` and `tool_choice` when needed, and returns explicit `AgentTrajectoryTurn` objects. AReno converts those turns into trainable assistant outputs and masks tool results by default:
 
 ```bash

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -131,6 +131,14 @@ class ArenoBackend(Backend):
             raise RuntimeError("ArenoBackend is not initialized")
         return self._engine
 
+    def close(self) -> None:
+        """Stop backend worker processes and release engine resources."""
+
+        engine = self._engine
+        self._engine = None
+        if engine is not None:
+            engine.close()
+
     def initialize(self, ctx: Context):
         _prefer_repo_areno()
         from areno import ArenoEngine, OptimizerConfig, RuntimeConfig
@@ -246,6 +254,23 @@ class ArenoBackend(Backend):
 
         del ctx
         return int(self._require_engine().config.model.max_position_embeddings)
+
+    def probe_rollout_cache(
+        self,
+        ctx: Context,
+        *,
+        max_new_tokens: int,
+        max_running_prompts: int,
+        max_prompt_len: int,
+    ) -> float:
+        """Allocate rollout cache and capture decode graphs without generating."""
+
+        del ctx
+        return self._require_engine().probe_rollout_cache(
+            max_new_tokens=max_new_tokens,
+            max_running_prompts=max_running_prompts,
+            max_prompt_len=max_prompt_len,
+        )
 
     def end_rollout_session(self, ctx: Context) -> None:
         """Finalize rollout-only state before scoring or training."""

--- a/areno/api/backend/base.py
+++ b/areno/api/backend/base.py
@@ -64,6 +64,11 @@ class Backend(ABC):
 
         pass
 
+    def close(self) -> None:
+        """Release backend-owned resources."""
+
+        return None
+
     @abstractmethod
     def rollout_batch(
         self,
@@ -125,6 +130,19 @@ class Backend(ABC):
 
         del ctx
         return None
+
+    def probe_rollout_cache(
+        self,
+        ctx: Context,
+        *,
+        max_new_tokens: int,
+        max_running_prompts: int,
+        max_prompt_len: int,
+    ) -> float:
+        """Optionally allocate rollout cache/graphs without decoding."""
+
+        del ctx, max_new_tokens, max_running_prompts, max_prompt_len
+        raise NotImplementedError(f"{type(self).__name__} does not support rollout cache probing")
 
     def end_rollout_session(self, ctx: Context) -> None:
         """Finalize rollout state before scoring or training."""

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -154,6 +154,18 @@ class Trainer:
             raise RuntimeError("Trainer is not initialized")
         return self._backend.model_context_len(self._ctx)
 
+    def probe_rollout_cache(self, *, max_new_tokens: int, max_running_prompts: int, max_prompt_len: int) -> float:
+        """Allocate rollout KV cache/decode graphs without running rollout decode."""
+
+        if self._backend is None or self._ctx is None:
+            raise RuntimeError("Trainer is not initialized")
+        return self._backend.probe_rollout_cache(
+            self._ctx,
+            max_new_tokens=max_new_tokens,
+            max_running_prompts=max_running_prompts,
+            max_prompt_len=max_prompt_len,
+        )
+
     def end_rollout_session(self) -> None:
         """Finalize backend rollout state when a rollout group completes."""
 
@@ -397,10 +409,16 @@ class Trainer:
         return self._backend.save_checkpoint(self._ctx, path)
 
     def close(self) -> None:
-        """Release local resources such as metric writers."""
+        """Release backend workers and local resources such as metric writers."""
 
-        if self._metrics is not None:
-            self._metrics.close()
+        try:
+            if self._backend is not None:
+                self._backend.close()
+        finally:
+            self._backend = None
+            self._initialized = False
+            if self._metrics is not None:
+                self._metrics.close()
 
 
 def _normalize_prompt_token_batch(prompt_tokens: list[list[int]]) -> list[list[int]]:

--- a/areno/cli/auto_tune.py
+++ b/areno/cli/auto_tune.py
@@ -76,7 +76,9 @@ def auto_tune_config(
     if not isinstance(config, RolloutTrainerConfig):
         raise ValueError("--tune-params currently tunes rollout-based trainers only")
     probe = probe_fn or probe_candidate_with_dummy_run
-    rollout_candidates = _rollout_candidates(config, auto_max_samples=auto_max_samples)
+    rollout_candidates = (
+        [] if config.max_running_prompts is not None else _rollout_candidates(config, auto_max_samples=auto_max_samples)
+    )
     logger.info(
         "auto tune start mem_frac=%.3f auto_max_samples=%d world_size=%d rollout_candidates=%d",
         mem_frac,
@@ -84,21 +86,27 @@ def auto_tune_config(
         config.world_size,
         len(rollout_candidates),
     )
-    rollout_result = _first_under_target_desc(
-        config,
-        rollout_candidates,
-        mem_frac=mem_frac,
-        probe=probe,
-        stage="rollout",
-    )
-    measurements = list(rollout_result.measurements)
-    logger.info(
-        "auto tune rollout selected %s",
-        _format_measurement(rollout_result.measurement),
-    )
+    if config.max_running_prompts is not None:
+        rollout_candidate = _template_candidate_from_user_rollout(config)
+        measurements = []
+        logger.info("auto tune rollout skipped user_max_running_prompts=%d", config.max_running_prompts)
+    else:
+        rollout_result = _first_under_target_desc(
+            config,
+            rollout_candidates,
+            mem_frac=mem_frac,
+            probe=probe,
+            stage="rollout",
+        )
+        measurements = list(rollout_result.measurements)
+        rollout_candidate = rollout_result.measurement.candidate
+        logger.info(
+            "auto tune rollout selected %s",
+            _format_measurement(rollout_result.measurement),
+        )
     train_result = _best_train_mini_bs(
         config,
-        rollout_result.measurement.candidate,
+        rollout_candidate,
         auto_max_samples=auto_max_samples,
         mem_frac=mem_frac,
         probe=probe,
@@ -235,6 +243,11 @@ def _default_template_candidate(config: RolloutTrainerConfig) -> AutoTuneCandida
         adam_8bit=bool(config.adam_8bit),
         keep_rollout_state=False,
     )
+
+
+def _template_candidate_from_user_rollout(config: RolloutTrainerConfig) -> AutoTuneCandidate:
+    template = _default_template_candidate(config)
+    return replace(template, max_running_prompts=int(config.max_running_prompts or 1))
 
 
 def _first_under_target_desc(

--- a/areno/cli/auto_tune.py
+++ b/areno/cli/auto_tune.py
@@ -72,9 +72,9 @@ def auto_tune_config(
     if not 0 < float(mem_frac) <= 1:
         raise ValueError("--mem-frac must be in (0, 1]")
     if int(auto_max_samples) < 1:
-        raise ValueError("--auto-max-samples must be >= 1")
+        raise ValueError("--tune-max-samples must be >= 1")
     if not isinstance(config, RolloutTrainerConfig):
-        raise ValueError("--auto currently tunes rollout-based trainers only")
+        raise ValueError("--tune-params currently tunes rollout-based trainers only")
     probe = probe_fn or probe_candidate_with_dummy_run
     rollout_candidates = _rollout_candidates(config, auto_max_samples=auto_max_samples)
     logger.info(
@@ -406,8 +406,8 @@ def _run_dummy_probe(config: TrainerConfig, candidate: AutoTuneCandidate, *, sta
         metrics_log_dir=None,
     )
     _reset_cuda_peak_stats(devices)
-    trainer.init()
     try:
+        trainer.init()
         tokenizer = trainer.get_tokenizer()
         prompt_len, response_len = _dummy_token_budgets(
             max_prompt_tokens=probe_config.max_prompt_tokens,
@@ -538,6 +538,8 @@ def _dummy_train_rows(
 
 def _eos_token_id(tokenizer) -> int:
     token_id = getattr(tokenizer, "eos_token_id", None)
+    if isinstance(token_id, list | tuple):
+        return int(token_id[0]) if token_id else 0
     return int(token_id) if token_id is not None else 0
 
 
@@ -545,12 +547,12 @@ def _probe_devices(world_size: int) -> list[int]:
     import torch
 
     if not torch.cuda.is_available():
-        raise RuntimeError("--auto requires CUDA so it can measure GPU memory")
+        raise RuntimeError("--tune-params requires CUDA so it can measure GPU memory")
     visible = int(torch.cuda.device_count())
     required = int(world_size)
     if required > visible:
         raise RuntimeError(
-            f"--auto requires --world-size <= visible CUDA devices; got world_size={required}, visible_cuda_devices={visible}"
+            f"--tune-params requires --world-size <= visible CUDA devices; got world_size={required}, visible_cuda_devices={visible}"
         )
     return list(range(required))
 

--- a/areno/cli/auto_tune.py
+++ b/areno/cli/auto_tune.py
@@ -615,6 +615,15 @@ def _is_oom_error(message: str) -> bool:
             "worker exited without reporting result" in lowered
             and ("exitcode -9" in lowered or "during op.train" in lowered or "during op.probe_rollout_cache" in lowered)
         )
+        or (
+            "failed during op.probe_rollout_cache" in lowered
+            and (
+                "nccl" in lowered
+                or "device error" in lowered
+                or "external library call failed" in lowered
+                or "system call" in lowered
+            )
+        )
     )
 
 

--- a/areno/cli/auto_tune.py
+++ b/areno/cli/auto_tune.py
@@ -1,0 +1,629 @@
+"""Automatic train/rollout parameter selection for ``areno train``.
+
+The tuner intentionally probes the real AReno backend with dummy-loaded
+weights and synthetic token rows. That keeps the estimate close to the
+selected model architecture and TP/DP layout without requiring a real dataset
+or writing checkpoints during the search.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from typing import TypeVar
+
+from areno.api.trainer_config import RolloutTrainerConfig, TrainerConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class AutoTuneCandidate:
+    tp_size: int
+    batch_size: int
+    n_samples: int
+    mini_bs: int
+    max_running_prompts: int
+    adam_8bit: bool
+    keep_rollout_state: bool
+
+    @property
+    def train_rows(self) -> int:
+        return self.batch_size * self.n_samples
+
+
+@dataclass(frozen=True, slots=True)
+class AutoTuneMeasurement:
+    candidate: AutoTuneCandidate
+    peak_mem_frac: float
+    ok: bool
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AutoTuneResult:
+    config: TrainerConfig
+    measurement: AutoTuneMeasurement | None
+    measurements: tuple[AutoTuneMeasurement, ...]
+
+
+ProbeFn = Callable[[TrainerConfig, AutoTuneCandidate, str], AutoTuneMeasurement]
+T = TypeVar("T")
+
+
+def auto_tune_config(
+    config: TrainerConfig,
+    *,
+    mem_frac: float = 0.9,
+    auto_max_samples: int = 256,
+    probe_fn: ProbeFn | None = None,
+) -> AutoTuneResult:
+    """Return a copy of ``config`` with safe train/rollout knobs filled in.
+
+    The search probes large candidates first and falls back to smaller points
+    until it finds one whose observed peak memory fraction is below
+    ``mem_frac``. Rollout tunes concurrency. Train derives batch size from the
+    selected rollout concurrency and only tunes mini-batch size.
+    """
+
+    if not 0 < float(mem_frac) <= 1:
+        raise ValueError("--mem-frac must be in (0, 1]")
+    if int(auto_max_samples) < 1:
+        raise ValueError("--auto-max-samples must be >= 1")
+    if not isinstance(config, RolloutTrainerConfig):
+        raise ValueError("--auto currently tunes rollout-based trainers only")
+    probe = probe_fn or probe_candidate_with_dummy_run
+    rollout_candidates = _rollout_candidates(config, auto_max_samples=auto_max_samples)
+    logger.info(
+        "auto tune start mem_frac=%.3f auto_max_samples=%d world_size=%d rollout_candidates=%d",
+        mem_frac,
+        auto_max_samples,
+        config.world_size,
+        len(rollout_candidates),
+    )
+    rollout_result = _first_under_target_desc(
+        config,
+        rollout_candidates,
+        mem_frac=mem_frac,
+        probe=probe,
+        stage="rollout",
+    )
+    measurements = list(rollout_result.measurements)
+    logger.info(
+        "auto tune rollout selected %s",
+        _format_measurement(rollout_result.measurement),
+    )
+    train_result = _best_train_mini_bs(
+        config,
+        rollout_result.measurement.candidate,
+        auto_max_samples=auto_max_samples,
+        mem_frac=mem_frac,
+        probe=probe,
+    )
+    measurements.extend(train_result.measurements)
+    train_best = train_result.measurement.candidate
+    tuned = replace(
+        config,
+        tp_size=train_best.tp_size,
+        batch_size=train_best.batch_size,
+        n_samples=train_best.n_samples,
+        mini_bs=train_best.mini_bs,
+        max_running_prompts=train_best.max_running_prompts,
+        keep_rollout_state=train_best.keep_rollout_state,
+    )
+    logger.info("auto tune selected %s", _format_measurement(train_result.measurement))
+    return AutoTuneResult(config=tuned, measurement=train_result.measurement, measurements=tuple(measurements))
+
+
+def enumerate_candidates(config: RolloutTrainerConfig, *, auto_max_samples: int = 256) -> list[AutoTuneCandidate]:
+    """Generate a compact, monotonic-ish search space around common RL knobs."""
+
+    rollout_candidates = _rollout_candidates(config, auto_max_samples=auto_max_samples)
+    train_candidates = [
+        candidate
+        for template in rollout_candidates
+        for candidate in _train_candidates(config, template, auto_max_samples=auto_max_samples)
+    ]
+    return sorted(
+        {candidate: None for candidate in [*rollout_candidates, *train_candidates]}.keys(), key=_candidate_key
+    )
+
+
+def enumerate_candidate_groups(
+    config: RolloutTrainerConfig, *, auto_max_samples: int = 256
+) -> list[list[AutoTuneCandidate]]:
+    """Group rollout candidates for auto-tune inspection."""
+
+    return [_rollout_candidates(config, auto_max_samples=auto_max_samples)]
+
+
+def _rollout_candidates(
+    config: RolloutTrainerConfig,
+    template: AutoTuneCandidate | None = None,
+    *,
+    auto_max_samples: int = 256,
+) -> list[AutoTuneCandidate]:
+    """Return up to 16 sparse candidates over rollout concurrency."""
+
+    tp_size = int(config.tp_size)
+    if template is None:
+        template = _default_template_candidate(config)
+    batch_size = template.batch_size
+    n_samples = template.n_samples
+    rows = max(int(batch_size) * int(n_samples), 1)
+    max_running_prompts = max(int(auto_max_samples), 1)
+    running_prompt_values = _powers_of_two_up_to(max_running_prompts)
+    candidates = []
+    for max_running_prompts in running_prompt_values:
+        candidates.append(
+            AutoTuneCandidate(
+                tp_size=tp_size,
+                batch_size=batch_size,
+                n_samples=n_samples,
+                mini_bs=min(template.mini_bs, rows),
+                max_running_prompts=max_running_prompts,
+                adam_8bit=bool(config.adam_8bit),
+                keep_rollout_state=template.keep_rollout_state,
+            )
+        )
+    selected = _sparse_select(sorted(set(candidates), key=_rollout_candidate_key), 16)
+    return list(reversed(selected))
+
+
+def _train_candidates(
+    config: RolloutTrainerConfig,
+    template: AutoTuneCandidate,
+    *,
+    auto_max_samples: int = 256,
+) -> list[AutoTuneCandidate]:
+    """Return sparse train-memory candidates over batch and mini-batch size."""
+
+    n_samples = max(int(config.n_samples), 1)
+    max_batch = max(1, min(int(config.batch_size), max(int(auto_max_samples), 1) // n_samples))
+    max_mini_bs = max(int(config.mini_bs), 1)
+    candidates = []
+    for batch_size in _powers_of_two_up_to(max_batch):
+        rows = batch_size * n_samples
+        for mini_bs in _mini_bs_values(max_mini_bs, rows):
+            candidates.append(
+                AutoTuneCandidate(
+                    tp_size=template.tp_size,
+                    batch_size=batch_size,
+                    n_samples=n_samples,
+                    mini_bs=mini_bs,
+                    max_running_prompts=template.max_running_prompts,
+                    adam_8bit=bool(config.adam_8bit),
+                    keep_rollout_state=False,
+                )
+            )
+    return sorted(_sparse_select(sorted(set(candidates), key=_train_candidate_key), 32), key=_train_candidate_key)
+
+
+def _train_template_from_rollout(
+    config: RolloutTrainerConfig,
+    template: AutoTuneCandidate,
+    *,
+    auto_max_samples: int = 256,
+) -> AutoTuneCandidate:
+    """Derive a fixed train batch size from the selected rollout concurrency."""
+
+    n_samples = max(int(config.n_samples), 1)
+    max_rows = max(1, min(int(auto_max_samples), int(template.max_running_prompts)))
+    batch_size = max(1, _floor_power_of_two(max_rows // n_samples))
+    rows = batch_size * n_samples
+    return AutoTuneCandidate(
+        tp_size=template.tp_size,
+        batch_size=batch_size,
+        n_samples=n_samples,
+        mini_bs=min(max(int(config.mini_bs), 1), rows),
+        max_running_prompts=template.max_running_prompts,
+        adam_8bit=bool(config.adam_8bit),
+        keep_rollout_state=False,
+    )
+
+
+def _default_template_candidate(config: RolloutTrainerConfig) -> AutoTuneCandidate:
+    return AutoTuneCandidate(
+        tp_size=int(config.tp_size),
+        batch_size=_floor_power_of_two(max(int(config.batch_size), 1)),
+        n_samples=max(int(config.n_samples), 1),
+        mini_bs=1,
+        max_running_prompts=1,
+        adam_8bit=bool(config.adam_8bit),
+        keep_rollout_state=False,
+    )
+
+
+def _first_under_target_desc(
+    config: TrainerConfig,
+    candidates: list[AutoTuneCandidate],
+    *,
+    mem_frac: float,
+    probe: ProbeFn,
+    stage: str,
+) -> AutoTuneResult:
+    measurements: list[AutoTuneMeasurement] = []
+    logger.info("auto tune %s stage start candidates=%d direction=desc", stage, len(candidates))
+    for index, candidate in enumerate(candidates, start=1):
+        logger.info(
+            "auto tune %s probe start index=%d/%d %s",
+            stage,
+            index,
+            len(candidates),
+            _format_candidate(candidate),
+        )
+        measurement = probe(config, candidate, stage)
+        measurements.append(measurement)
+        _log_measurement(measurement)
+        if measurement.ok and measurement.peak_mem_frac <= mem_frac:
+            logger.info("auto tune %s stage first fit %s", stage, _format_measurement(measurement))
+            return AutoTuneResult(config=config, measurement=measurement, measurements=tuple(measurements))
+        logger.info("auto tune %s probe rejected target %.3f with %s", stage, mem_frac, _format_candidate(candidate))
+    raise RuntimeError(
+        f"auto tune {stage} stage could not find a candidate under mem_frac={mem_frac}; "
+        f"first error: {measurements[0].error if measurements else 'no candidates'}"
+    )
+
+
+def _best_train_mini_bs(
+    config: RolloutTrainerConfig,
+    rollout: AutoTuneCandidate,
+    *,
+    auto_max_samples: int,
+    mem_frac: float,
+    probe: ProbeFn,
+) -> AutoTuneResult:
+    measurements: list[AutoTuneMeasurement] = []
+    template = _train_template_from_rollout(config, rollout, auto_max_samples=auto_max_samples)
+    mini_values = list(reversed(_mini_bs_values(max(int(config.mini_bs), 1), template.train_rows)))
+    logger.info(
+        "auto tune train stage start fixed_batch_size=%d train_rows=%d mini_bs_candidates=%d direction=desc",
+        template.batch_size,
+        template.train_rows,
+        len(mini_values),
+    )
+    for mini_index, mini_bs in enumerate(mini_values, start=1):
+        candidate = replace(template, mini_bs=mini_bs)
+        logger.info(
+            "auto tune train probe start mini_bs index=%d/%d %s",
+            mini_index,
+            len(mini_values),
+            _format_candidate(candidate),
+        )
+        measurement = probe(config, candidate, "train")
+        measurements.append(measurement)
+        _log_measurement(measurement)
+        if measurement.ok and measurement.peak_mem_frac <= mem_frac:
+            logger.info(
+                "auto tune train stage first fit %.3f with %s",
+                mem_frac,
+                _format_candidate(candidate),
+            )
+            return AutoTuneResult(config=config, measurement=measurement, measurements=tuple(measurements))
+        logger.info("auto tune train probe rejected target %.3f with %s", mem_frac, _format_candidate(candidate))
+    raise RuntimeError(
+        f"auto tune train stage could not find a candidate under mem_frac={mem_frac}; "
+        f"first error: {measurements[0].error if measurements else 'no candidates'}"
+    )
+
+
+def _log_measurement(measurement: AutoTuneMeasurement) -> None:
+    logger.info("auto tune probe result %s", _format_measurement(measurement))
+
+
+def _format_measurement(measurement: AutoTuneMeasurement) -> str:
+    suffix = f" error={measurement.error}" if measurement.error else ""
+    return f"{_format_candidate(measurement.candidate)} ok={measurement.ok} peak_mem_frac={measurement.peak_mem_frac:.4f}{suffix}"
+
+
+def _format_candidate(candidate: AutoTuneCandidate) -> str:
+    return (
+        f"tp_size={candidate.tp_size} batch_size={candidate.batch_size} n_samples={candidate.n_samples} "
+        f"mini_bs={candidate.mini_bs} max_running_prompts={candidate.max_running_prompts} "
+        f"adam_8bit={candidate.adam_8bit} keep_rollout_state={candidate.keep_rollout_state}"
+    )
+
+
+def _candidate_key(item: AutoTuneCandidate) -> tuple:
+    return (
+        item.max_running_prompts,
+        item.train_rows,
+        item.mini_bs,
+        item.batch_size,
+        item.n_samples,
+        -item.tp_size,
+        not item.adam_8bit,
+        item.keep_rollout_state,
+    )
+
+
+def _rollout_candidate_key(item: AutoTuneCandidate) -> tuple:
+    return (
+        -item.tp_size,
+        item.max_running_prompts,
+        item.train_rows,
+        item.batch_size,
+        item.n_samples,
+        item.mini_bs,
+        item.keep_rollout_state,
+    )
+
+
+def _train_candidate_key(item: AutoTuneCandidate) -> tuple:
+    return (
+        item.tp_size,
+        item.mini_bs,
+        not item.adam_8bit,
+        item.keep_rollout_state,
+        item.max_running_prompts,
+        item.train_rows,
+    )
+
+
+def probe_candidate_with_dummy_run(
+    config: TrainerConfig, candidate: AutoTuneCandidate, stage: str
+) -> AutoTuneMeasurement:
+    """Measure one candidate with dummy weights/data on the configured GPUs."""
+
+    try:
+        peak = _run_dummy_probe(config, candidate, stage=stage)
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=peak, ok=True)
+    except (RuntimeError, ValueError) as exc:
+        message = str(exc)
+        if _is_oom_error(message) or _is_tp_compat_error(message):
+            return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=1.0, ok=False, error=message)
+        raise
+
+
+def _run_dummy_probe(config: TrainerConfig, candidate: AutoTuneCandidate, *, stage: str) -> float:
+    import torch
+
+    import areno.api
+    from areno.api.models import BackendType
+
+    probe_config = copy.deepcopy(config)
+    probe_config.batch_size = candidate.batch_size
+    probe_config.n_samples = candidate.n_samples
+    probe_config.mini_bs = candidate.mini_bs
+    probe_config.max_running_prompts = candidate.max_running_prompts
+    probe_config.tp_size = candidate.tp_size
+    probe_config.adam_8bit = candidate.adam_8bit
+    probe_config.keep_rollout_state = candidate.keep_rollout_state
+    custom_config = probe_config.areno_config()
+    custom_config.dummy_load = True
+    custom_config.max_running_prompts = candidate.max_running_prompts
+    devices = _probe_devices(probe_config.world_size)
+    custom_config.devices = devices
+
+    trainer = areno.api.Trainer(
+        probe_config.world_size,
+        probe_config.ckpt,
+        backend_type=BackendType.Areno,
+        custom_config=custom_config,
+        metrics_log_dir=None,
+    )
+    _reset_cuda_peak_stats(devices)
+    trainer.init()
+    try:
+        tokenizer = trainer.get_tokenizer()
+        prompt_len, response_len = _dummy_token_budgets(
+            max_prompt_tokens=probe_config.max_prompt_tokens,
+            max_new_tokens=probe_config.max_new_tokens,
+            max_context_len=probe_config.max_context_len,
+        )
+        prompt_tokens = _dummy_prompt_tokens(tokenizer, prompt_len)
+        response_tokens = _dummy_response_tokens(
+            tokenizer,
+            response_len=response_len,
+        )
+        if stage == "rollout":
+            peak = trainer.probe_rollout_cache(
+                max_new_tokens=len(response_tokens),
+                max_running_prompts=candidate.max_running_prompts,
+                max_prompt_len=len(prompt_tokens),
+            )
+            for device in devices:
+                torch.cuda.synchronize(device)
+            return float(peak)
+        trainer.begin_rollout_session()
+        try:
+            trainer.probe_rollout_cache(
+                max_new_tokens=len(response_tokens),
+                max_running_prompts=candidate.max_running_prompts,
+                max_prompt_len=len(prompt_tokens),
+            )
+        finally:
+            with suppress(Exception):
+                trainer.end_rollout_session()
+        train_rows = _dummy_train_rows(
+            prompt_tokens=prompt_tokens,
+            eos_token_id=_eos_token_id(tokenizer),
+            target_rows=candidate.train_rows,
+            response_tokens=response_tokens,
+        )
+        train_stats = trainer.train(train_rows, _dummy_policy_loss, mini_bs=candidate.mini_bs)
+        for device in devices:
+            torch.cuda.synchronize(device)
+        worker_peak = float(train_stats.get("auto_tune_worker_peak_mem_frac", 0.0))
+        return worker_peak if worker_peak > 0.0 else _peak_cuda_memory_fraction(devices)
+    finally:
+        with suppress(Exception):
+            trainer.close()
+        torch.cuda.empty_cache()
+
+
+def _dummy_token_budgets(
+    *,
+    max_prompt_tokens: int,
+    max_new_tokens: int,
+    max_context_len: int | None,
+) -> tuple[int, int]:
+    if max_context_len is None:
+        return max(1, int(max_prompt_tokens)), max(1, int(max_new_tokens))
+
+    total_len = max(2, int(max_context_len))
+    prompt_len = min(max(1, int(max_prompt_tokens)), total_len - 1)
+    return prompt_len, total_len - prompt_len
+
+
+def _dummy_prompt_tokens(tokenizer, max_prompt_tokens: int) -> list[int]:
+    encoded = tokenizer.encode("AReno auto tune prompt.", add_special_tokens=False)
+    if not encoded:
+        encoded = [_eos_token_id(tokenizer)]
+    width = max(1, int(max_prompt_tokens))
+    return _repeat_to_width([int(token) for token in encoded], width)
+
+
+def _dummy_response_tokens(
+    tokenizer,
+    *,
+    response_len: int,
+) -> list[int]:
+    encoded = tokenizer.encode("AReno auto tune response.", add_special_tokens=False)
+    if not encoded:
+        encoded = [_eos_token_id(tokenizer)]
+    return _repeat_to_width([int(token) for token in encoded], max(1, int(response_len)))
+
+
+def _repeat_to_width(tokens: list[int], width: int) -> list[int]:
+    if width <= len(tokens):
+        return tokens[:width]
+    repeats = (width + len(tokens) - 1) // len(tokens)
+    return (tokens * repeats)[:width]
+
+
+def _dummy_policy_loss(pack: dict, logprobs):
+    from areno.api.loss_fns.layout import response_layout
+
+    layout = response_layout(pack, logprobs, need_advantages=True)
+    advantages = layout.advantages
+    if advantages is None:
+        raise ValueError("auto tune dummy loss requires advantages")
+    response_mask = layout.response_mask.to(dtype=logprobs.dtype)
+    target = (advantages.abs() * response_mask).sum().clamp_min(1.0)
+    loss = -(logprobs * advantages * response_mask).sum() / target
+    return loss, {"auto_tune_dummy_loss": loss.detach()}
+
+
+def _dummy_train_rows(
+    *,
+    prompt_tokens: list[int],
+    response_tokens: list[int],
+    eos_token_id: int,
+    target_rows: int,
+):
+    from areno.api.models import TrainSequence
+
+    rows = []
+    tokens = [*prompt_tokens, *response_tokens]
+    prompt_mask = [True] * len(prompt_tokens) + [False] * len(response_tokens)
+    logprobs = [0.0] * len(tokens)
+    advantages = [0.0] * len(prompt_tokens) + [1.0] * len(response_tokens)
+    while len(rows) < target_rows:
+        rows.append(
+            TrainSequence(
+                tokens=list(tokens),
+                prompt_mask=list(prompt_mask),
+                logprobs=list(logprobs),
+                advantages=list(advantages),
+                reward=1.0,
+                eos_token_id=eos_token_id,
+            )
+        )
+    return rows
+
+
+def _eos_token_id(tokenizer) -> int:
+    token_id = getattr(tokenizer, "eos_token_id", None)
+    return int(token_id) if token_id is not None else 0
+
+
+def _probe_devices(world_size: int) -> list[int]:
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("--auto requires CUDA so it can measure GPU memory")
+    visible = int(torch.cuda.device_count())
+    required = int(world_size)
+    if required > visible:
+        raise RuntimeError(
+            f"--auto requires --world-size <= visible CUDA devices; got world_size={required}, visible_cuda_devices={visible}"
+        )
+    return list(range(required))
+
+
+def _reset_cuda_peak_stats(devices: list[int]) -> None:
+    import torch
+
+    for device in devices:
+        device_idx = int(device)
+        torch.cuda.set_device(device_idx)
+        torch.empty((), device=f"cuda:{device_idx}")
+        torch.cuda.synchronize(device_idx)
+        torch.cuda.reset_peak_memory_stats(device_idx)
+
+
+def _peak_cuda_memory_fraction(devices: list[int]) -> float:
+    import torch
+
+    fractions = []
+    for device in devices:
+        device_idx = int(device)
+        total = torch.cuda.get_device_properties(device_idx).total_memory
+        peak = torch.cuda.max_memory_allocated(device_idx)
+        fractions.append(float(peak) / float(total))
+    return max(fractions) if fractions else 0.0
+
+
+def _powers_of_two_up_to(value: int) -> list[int]:
+    out = []
+    current = 1
+    while current <= value:
+        out.append(current)
+        current *= 2
+    return out or [1]
+
+
+def _floor_power_of_two(value: int) -> int:
+    return _powers_of_two_up_to(max(int(value), 1))[-1]
+
+
+def _sparse_select(items: list[T], limit: int) -> list[T]:
+    if len(items) <= limit:
+        return items
+    if limit <= 1:
+        return [items[-1]]
+    last = len(items) - 1
+    indices = sorted({round(index * last / (limit - 1)) for index in range(limit)})
+    return [items[index] for index in indices]
+
+
+def _mini_bs_values(max_mini_bs: int, rows: int) -> list[int]:
+    limit = min(max_mini_bs, rows)
+    return [value for value in (1, 2, 4, 8, 16) if value <= limit] or [1]
+
+
+def _is_oom_error(message: str) -> bool:
+    lowered = message.lower()
+    return (
+        "out of memory" in lowered
+        or "cuda error: out of memory" in lowered
+        or (
+            "worker exited without reporting result" in lowered
+            and ("exitcode -9" in lowered or "during op.train" in lowered or "during op.probe_rollout_cache" in lowered)
+        )
+    )
+
+
+def _is_tp_compat_error(message: str) -> bool:
+    lowered = message.lower()
+    return (
+        "tp_size" in lowered
+        or "divisible by tp" in lowered
+        or "divisible by tp_size" in lowered
+        or ("head" in lowered and "divisible" in lowered)
+        or ("kv" in lowered and "divisible" in lowered)
+    )

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -173,11 +173,14 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if args.dataset_path is None:
         raise click.UsageError("--dataset-path is required")
     algorithm = _algorithm_for_cli(args.algo)
-    if args.tune_params and not algorithm.requires_rollout:
+    tune_params = bool(getattr(args, "tune_params", False))
+    mem_frac = float(getattr(args, "mem_frac", 0.9))
+    tune_max_samples = int(getattr(args, "tune_max_samples", 256))
+    if tune_params and not algorithm.requires_rollout:
         raise click.UsageError("--tune-params currently supports rollout-based algorithms")
-    if args.mem_frac <= 0 or args.mem_frac > 1:
+    if mem_frac <= 0 or mem_frac > 1:
         raise click.UsageError("--mem-frac must be in (0, 1]")
-    if args.tune_max_samples <= 0:
+    if tune_max_samples <= 0:
         raise click.UsageError("--tune-max-samples must be positive")
     if algorithm.requires_rollout and args.reward_fn_path is None and args.reward_ckpt is None:
         raise click.UsageError("--reward-fn-path or --reward-ckpt is required")

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -56,6 +56,9 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "ckpt",
             "dataset_path",
             "dataset_loader_fn",
+            "tune_params",
+            "mem_frac",
+            "tune_max_samples",
             "epochs",
             "world_size",
             "tp_size",
@@ -170,6 +173,12 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if args.dataset_path is None:
         raise click.UsageError("--dataset-path is required")
     algorithm = _algorithm_for_cli(args.algo)
+    if args.tune_params and not algorithm.requires_rollout:
+        raise click.UsageError("--tune-params currently supports rollout-based algorithms")
+    if args.mem_frac <= 0 or args.mem_frac > 1:
+        raise click.UsageError("--mem-frac must be in (0, 1]")
+    if args.tune_max_samples <= 0:
+        raise click.UsageError("--tune-max-samples must be positive")
     if algorithm.requires_rollout and args.reward_fn_path is None and args.reward_ckpt is None:
         raise click.UsageError("--reward-fn-path or --reward-ckpt is required")
     if args.save_interval <= 0:
@@ -331,6 +340,23 @@ def _print_training_config_summary(
 ) -> None:
     click.echo(
         _format_training_config_summary(config, reward_ckpt=reward_ckpt, model_config=model_config, color=True),
+        color=True,
+    )
+
+
+def _print_auto_tune_summary(result) -> None:
+    measurement = result.measurement
+    if measurement is None:
+        return
+    candidate = measurement.candidate
+    click.echo(
+        _style("AReno parameter tune selected", fg="bright_green", bold=True, color=True)
+        + (
+            f": tp_size={candidate.tp_size}, batch_size={candidate.batch_size}, n_samples={candidate.n_samples}, "
+            f"mini_bs={candidate.mini_bs}, max_running_prompts={candidate.max_running_prompts}, "
+            f"adam_8bit={candidate.adam_8bit}, drop_rollout_state={not candidate.keep_rollout_state}, "
+            f"peak_mem_frac={measurement.peak_mem_frac:.4f}"
+        ),
         color=True,
     )
 
@@ -915,6 +941,27 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--metrics-log-dir", default=DEFAULT_METRICS_LOG_DIR, show_default=True, help="TensorBoard metrics log directory."
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
+@click.option(
+    "--tune-params",
+    "tune_params",
+    is_flag=True,
+    help="Tune rollout/train memory parameters with dummy probes before training.",
+)
+@click.option(
+    "--mem-frac",
+    type=float,
+    default=0.9,
+    show_default=True,
+    help="Target maximum GPU memory fraction for --tune-params probing.",
+)
+@click.option(
+    "--tune-max-samples",
+    "tune_max_samples",
+    type=int,
+    default=256,
+    show_default=True,
+    help="Maximum sampled rollout/train rows considered by --tune-params probing.",
+)
 @click.option("--tp-size", type=int, default=4, show_default=True, help="Tensor parallel size for the backend.")
 @click.option("--world-size", type=int, default=8, show_default=True, help="Total device count for the backend.")
 @click.option("--batch-size", type=int, default=32, show_default=True, help="Prompt/pair batch size.")
@@ -1022,6 +1069,16 @@ def train_command(**options) -> None:
 
     trainer_config = _trainer_config_from_options(**options)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    if options.get("tune_params"):
+        from areno.cli.auto_tune import auto_tune_config
+
+        result = auto_tune_config(
+            trainer_config,
+            mem_frac=options["mem_frac"],
+            auto_max_samples=options["tune_max_samples"],
+        )
+        trainer_config = result.config
+        _print_auto_tune_summary(result)
     _print_training_config_summary(
         trainer_config,
         reward_ckpt=options.get("reward_ckpt"),

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -33,6 +33,7 @@ from areno.engine.protocol import (
     EnsureRolesPayload,
     Op,
     RoleSpecPayload,
+    RolloutCacheProbePayload,
     RolloutPayload,
     SaveCheckpointPayload,
     ScorePayload,
@@ -318,6 +319,37 @@ class ArenoEngine:
             )
         # Fast path for single-chunk inputs; otherwise concat per-chunk outputs.
         return outputs[0] if len(outputs) == 1 else _merge_rollouts(outputs)
+
+    def probe_rollout_cache(
+        self,
+        *,
+        max_new_tokens: int,
+        max_running_prompts: int,
+        max_prompt_len: int,
+    ) -> float:
+        """Allocate rollout KV cache and capture decode graphs without decoding."""
+
+        if max_running_prompts < 1:
+            raise ValueError("max_running_prompts must be >= 1")
+        if max_prompt_len < 1:
+            raise ValueError("max_prompt_len must be >= 1")
+        if max_new_tokens < 1:
+            raise ValueError("max_new_tokens must be >= 1")
+        dp_size = int(self.config.dp_size)
+        local_max_running = max(ceil_div(int(max_running_prompts), dp_size), 1)
+        max_cache_len = int(max_prompt_len) + int(max_new_tokens)
+        max_blocks_per_seq = ceil_div(max_cache_len, self.config.runtime.kv_block_size)
+        results = self.cluster.call(
+            Op.PROBE_ROLLOUT_CACHE,
+            RolloutCacheProbePayload(
+                max_running_seqs=local_max_running,
+                max_cache_len=max_cache_len,
+                max_blocks_per_seq=max_blocks_per_seq,
+                num_blocks=local_max_running * max_blocks_per_seq,
+                block_size=self.config.runtime.kv_block_size,
+            ),
+        )
+        return max(float(result or 0.0) for result in results) if results else 0.0
 
     async def generate_rollout_async(
         self,

--- a/areno/engine/modeling.py
+++ b/areno/engine/modeling.py
@@ -27,7 +27,10 @@ def build_model_on_device(config: EngineConfig, device: torch.device) -> torch.n
     try:
         torch.set_default_dtype(config.model.dtype)
         with torch.device(device), skip_torch_init(enabled=config.model_path is not None and not config.dummy_load):
-            return build_model(config.model)
+            model = build_model(config.model)
+        if config.dummy_load:
+            _zero_model_parameters(model)
+        return model
     finally:
         torch.set_default_dtype(old_dtype)
 
@@ -61,6 +64,14 @@ def _noop_init(tensor: torch.Tensor, *_args, **_kwargs) -> torch.Tensor:
     """Replacement for `torch.nn.init.*` that returns the tensor unchanged."""
 
     return tensor
+
+
+def _zero_model_parameters(model: torch.nn.Module) -> None:
+    """Initialize dummy-loaded models deterministically with finite zeros."""
+
+    with torch.no_grad():
+        for param in model.parameters():
+            param.zero_()
 
 
 def unwrap_model(model: torch.nn.Module) -> torch.nn.Module:

--- a/areno/engine/protocol.py
+++ b/areno/engine/protocol.py
@@ -33,6 +33,7 @@ class Op(Enum):
 
     TRAIN = auto()
     INFER_ROLLOUT = auto()
+    PROBE_ROLLOUT_CACHE = auto()
     ENSURE_ROLES = auto()
     SCORE_LOGPROBS = auto()
     SCORE_VALUES = auto()
@@ -85,6 +86,17 @@ class RolloutPayload:
     decode_progress_interval_s: float = 0.0
     cancel_flags: torch.Tensor | None = None
     cancel_indices_by_dp: list[list[int]] | None = None
+
+
+@dataclass(slots=True)
+class RolloutCacheProbePayload:
+    """Typed payload for Op.PROBE_ROLLOUT_CACHE."""
+
+    max_running_seqs: int
+    max_cache_len: int
+    max_blocks_per_seq: int
+    num_blocks: int
+    block_size: int
 
 
 @dataclass(slots=True)
@@ -536,7 +548,13 @@ def _worker_entry(
         for failed_request_id in request_ids:
             result_q.put((rank, WorkerResult(ok=False, error=error, request_id=failed_request_id)))
     finally:
-        destroy_process_group()
+        try:
+            destroy_process_group()
+        except Exception:
+            # CUDA OOM can leave NCCL in an error state. Worker teardown should
+            # not emit a second traceback or keep the coordinator from reaping
+            # the failed process.
+            pass
 
 
 def _close_queue(q: mp.Queue) -> None:

--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -68,6 +68,11 @@ class TrainingManager:
         worker.model.train()
         data_pack_obj = data_pack_shards[ctx.dp_rank]
         data_pack = _pack_train_data(data_pack_obj)
+        pack_loss_fn = data_pack.get("_loss_fn")
+        auto_tune_probe = callable(pack_loss_fn) and getattr(pack_loss_fn, "__name__", "") == "_dummy_policy_loss"
+        if auto_tune_probe and worker.device.type == "cuda":
+            torch.cuda.synchronize(worker.device)
+            torch.cuda.reset_peak_memory_stats(worker.device)
         data_pack = to_device(data_pack, worker.device)
         data_pack["_sequence_parallel_enabled"] = worker.config.model.sequence_parallel
         data_pack["_activation_checkpointing_enabled"] = worker.config.runtime.activation_checkpointing
@@ -109,6 +114,13 @@ class TrainingManager:
         else:
             current_lr = worker.optimizer.lr
         if ctx.is_rank0:
+            if auto_tune_probe and worker.device.type == "cuda":
+                torch.cuda.synchronize(worker.device)
+                total = torch.cuda.get_device_properties(worker.device).total_memory
+                peak = torch.cuda.max_memory_allocated(worker.device)
+                if metrics is None:
+                    metrics = {}
+                metrics["auto_tune_worker_peak_mem_frac"] = float(peak) / float(total)
             return {
                 "loss": float(loss.detach().cpu()),
                 "stepped": stepped,

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -23,10 +23,17 @@ import torch.distributed as dist
 from areno.engine.config import EngineConfig
 from areno.engine.data import RolloutOutput
 from areno.engine.data.sampling import _truncate_generated
-from areno.engine.inference import InferenceManager
+from areno.engine.inference import InferCacheSpec, InferenceManager
 from areno.engine.modeling import build_model_on_device, build_optimizer, param_grad
 from areno.engine.parallel.context import get_tp_context
-from areno.engine.protocol import Command, Op, RolloutPayload, SaveCheckpointPayload, WorkerResult
+from areno.engine.protocol import (
+    Command,
+    Op,
+    RolloutCacheProbePayload,
+    RolloutPayload,
+    SaveCheckpointPayload,
+    WorkerResult,
+)
 from areno.engine.roles import RoleManager, WorkerRole
 from areno.engine.runtime.common import pad_rollout_rows
 from areno.engine.runtime.decode_graph import DecodeGraph
@@ -93,6 +100,8 @@ class ArenoWorker:
             return self.ensure_roles(cmd.payload)
         if cmd.op is Op.INFER_ROLLOUT:
             return self.infer_rollout(cmd.payload)
+        if cmd.op is Op.PROBE_ROLLOUT_CACHE:
+            return self.probe_rollout_cache(cmd.payload)
         if cmd.op is Op.ROLLOUT_SESSION_BEGIN:
             return self.rollout_session_begin(cmd.payload)
         if cmd.op is Op.ROLLOUT_SESSION_SYNC:
@@ -124,6 +133,28 @@ class ArenoWorker:
             finished_callback=finished_callback,
             refill_callback=refill_callback,
         )
+
+    def probe_rollout_cache(self, payload: RolloutCacheProbePayload) -> float:
+        """Allocate rollout KV cache and capture decode graphs without decoding."""
+
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+            torch.cuda.reset_peak_memory_stats(self.device)
+        self.inference._init_infer_cache(
+            InferCacheSpec(
+                max_running_seqs=int(payload.max_running_seqs),
+                max_cache_len=int(payload.max_cache_len),
+                num_blocks=int(payload.num_blocks),
+                block_size=int(payload.block_size),
+                max_blocks_per_seq=int(payload.max_blocks_per_seq),
+            )
+        )
+        if self.device.type != "cuda":
+            return 0.0
+        torch.cuda.synchronize(self.device)
+        total = torch.cuda.get_device_properties(self.device).total_memory
+        peak = torch.cuda.max_memory_allocated(self.device)
+        return float(peak) / float(total)
 
     def run_rollout_command(self, command: Command) -> list[tuple[int | None, RolloutOutput | None]]:
         """Run one rollout command and continuously refill from queued requests."""

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -183,6 +183,63 @@ Reward files should expose:
 ``--reward-ckpt TEXT``
    Optional PPO reward model checkpoint path or Hugging Face repo ID.
 
+Parameter tuning
+~~~~~~~~~~~~~~~~
+
+``--tune-params``
+   Probe rollout and training memory before starting the real run, then fill
+   safe values for ``--max-running-prompts``, ``--batch-size`` and
+   ``--mini-bs``. This is intended for rollout-based algorithms such as GSPO,
+   GRPO and PPO, including agentic rollouts where the right concurrency is
+   hard to estimate by hand.
+
+The tuner uses dummy-loaded model weights and synthetic token rows, so it
+measures the selected model architecture, ``--world-size``/``--tp-size``,
+sequence lengths, CUDA graph setup, optimizer state, and train microbatch
+memory without consuming a real dataset row or writing checkpoints. It keeps
+the user-provided ``--tp-size``, ``--n-samples``, ``--adam-8bit``, sequence
+limits, model path, algorithm, and backend settings.
+
+Search is deliberately conservative:
+
+* rollout candidates are tried from larger to smaller
+  ``--max-running-prompts`` values;
+* training uses the rollout-selected concurrency to derive a batch size, then
+  tries larger to smaller ``--mini-bs`` values;
+* ``--drop-rollout-state`` is enabled for the tuned run so rollout memory does
+  not remain resident during the training probe or optimizer step.
+
+``--mem-frac FLOAT``
+   Target maximum GPU memory fraction for tuning. Default: ``0.9``. Lower this
+   when sharing a node or when the real reward/agent path has additional GPU
+   users.
+
+``--tune-max-samples INTEGER``
+   Upper bound for sampled rollout/train rows considered during tuning.
+   Default: ``256``. The rollout search does not try
+   ``--max-running-prompts`` above this value, and the derived train batch size
+   is capped by ``tune-max-samples / n-samples``.
+
+Example:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt /path/to/Qwen3.5-4B \
+     --dataset-path examples/agentic/coding/dataset.jsonl \
+     --dataset-loader-fn examples/agentic/coding/dataset_loader.py \
+     --reward-fn-path examples/agentic/coding/reward.py \
+     --agent-fn examples/agentic/coding/run_agent.py \
+     --algo gspo \
+     --world-size 8 \
+     --tp-size 4 \
+     --n-samples 8 \
+     --max-new-tokens 2048 \
+     --max-context-len 32768 \
+     --tune-params \
+     --mem-frac 0.9 \
+     --tune-max-samples 256
+
 Train
 ~~~~~
 

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -204,6 +204,8 @@ Search is deliberately conservative:
 
 * rollout candidates are tried from larger to smaller
   ``--max-running-prompts`` values;
+* if ``--max-running-prompts`` is explicitly provided, rollout probing is
+  skipped and that concurrency is used directly for training-parameter tuning;
 * training uses the rollout-selected concurrency to derive a batch size, then
   tries larger to smaller ``--mini-bs`` values;
 * ``--drop-rollout-state`` is enabled for the tuned run so rollout memory does

--- a/examples/agentic/coding/README.md
+++ b/examples/agentic/coding/README.md
@@ -76,6 +76,33 @@ areno train \
   --max-new-tokens 256
 ```
 
+For larger local checkpoints or higher concurrency, let AReno tune the rollout
+and train memory knobs before the real run:
+
+```bash
+areno train \
+  --ckpt /path/to/Qwen3.5-4B \
+  --dataset-path examples/agentic/coding/dataset.jsonl \
+  --dataset-loader-fn examples/agentic/coding/dataset_loader.py \
+  --reward-fn-path examples/agentic/coding/reward.py \
+  --agent-fn examples/agentic/coding/run_agent.py \
+  --algo gspo \
+  --tp-size 4 \
+  --world-size 8 \
+  --n-samples 8 \
+  --max-new-tokens 2048 \
+  --max-context-len 32768 \
+  --tune-params \
+  --mem-frac 0.9 \
+  --tune-max-samples 256
+```
+
+`--tune-params` keeps the user-provided tensor parallel size and sample count,
+then probes dummy rollout/train rows to choose conservative values for
+`--max-running-prompts`, `--batch-size`, and `--mini-bs`. This is useful for
+coding rollouts because agent turns, command output, and full trajectory
+contexts can vary substantially across samples.
+
 The reward is `1.0` when the trajectory applies a patch, runs every required
 test command successfully, and submits `solved`. It gives partial credit for
 passing tests without a final solved submission and negative reward for failed

--- a/examples/agentic/coding/agent_loop.py
+++ b/examples/agentic/coding/agent_loop.py
@@ -191,22 +191,98 @@ async def run_agentic_coding_loop(ctx, batch) -> AgentTrajectory:
     )
     client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
 
-    async def run_one(item):
-        # Training tasks are materialized into a disposable repo so model
-        # patches/tests cannot affect the source checkout running AReno.
-        workspace = CodingWorkspace.from_task(item.record)
-        try:
-            _, turns = await run_single_task(client=client, item=item, workspace=workspace, model="policy")
-            return turns
-        finally:
-            workspace.close()
-
+    # Materialize workspaces before the first model turn. Doing this inside
+    # each per-task loop staggers the first HTTP requests and prevents the
+    # rollout proxy from seeing a full batch.
+    workspaces = await asyncio.gather(*(asyncio.to_thread(CodingWorkspace.from_task, item.record) for item in items))
     try:
-        grouped = await asyncio.gather(*(run_one(item) for item in items))
-        return AgentTrajectory(turns=[turn for turns in grouped for turn in turns])
+        turns = await _run_training_tasks_by_turn(client=client, items=items, workspaces=workspaces, model="policy")
+        return AgentTrajectory(turns=turns)
     finally:
+        for workspace in workspaces:
+            workspace.close()
         await client.close()
         await http_client.aclose()
+
+
+async def _run_training_tasks_by_turn(
+    *,
+    client: Any,
+    items: list[Any],
+    workspaces: list[CodingWorkspace],
+    model: str,
+) -> list[AgentTrajectoryTurn]:
+    """Run coding tasks in lockstep turns so rollout requests batch together."""
+
+    states = [
+        {
+            "item": item,
+            "workspace": workspace,
+            "messages": initial_messages(workspace.task),
+            "turn_limit": int(workspace.task.get("max_turns") or 8),
+            "done": False,
+        }
+        for item, workspace in zip(items, workspaces, strict=True)
+    ]
+    turns: list[AgentTrajectoryTurn] = []
+    for turn_idx in range(max((int(state["turn_limit"]) for state in states), default=0)):
+        active = [state for state in states if not state["done"] and turn_idx < int(state["turn_limit"])]
+        if not active:
+            break
+        responses = await asyncio.gather(
+            *(
+                client.chat.completions.create(
+                    model=model,
+                    messages=state["messages"],
+                    tools=TOOLS,
+                    tool_choice="auto",
+                    stream=False,
+                )
+                for state in active
+            )
+        )
+        tool_tasks = []
+        tool_states = []
+        tool_calls = []
+        for state, response in zip(active, responses, strict=True):
+            turns.append(
+                AgentTrajectoryTurn(
+                    item=state["item"], messages=list(state["messages"]), response=response, tools=TOOLS
+                )
+            )
+            assistant_message = _assistant_message_from_response(response)
+            state["messages"].append(assistant_message)
+            call = _first_tool_call(assistant_message)
+            if call is None:
+                state["messages"].append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "Your previous response did not include a tool call. Continue the agent loop by "
+                            "outputting exactly one tool call in the next assistant response: use an available "
+                            "inspect/read/search/edit/test tool, or call submit if the task is solved or blocked."
+                        ),
+                    }
+                )
+                continue
+            tool_tasks.append(asyncio.to_thread(_execute_tool_call, state["workspace"], call))
+            tool_states.append(state)
+            tool_calls.append(call)
+        if not tool_tasks:
+            continue
+        tool_results = await asyncio.gather(*tool_tasks)
+        for state, call, result in zip(tool_states, tool_calls, tool_results, strict=True):
+            state["messages"].append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call["id"],
+                    "name": call["function"]["name"],
+                    "content": json.dumps(result, ensure_ascii=False, sort_keys=True),
+                }
+            )
+            if call["function"]["name"] == "submit":
+                state["done"] = True
+    return turns
 
 
 async def run_single_task(

--- a/examples/agentic/coding/agent_loop.py
+++ b/examples/agentic/coding/agent_loop.py
@@ -280,7 +280,7 @@ async def run_conversation_turns(
                 }
             )
             continue
-        result = _execute_tool_call(workspace, call)
+        result = await asyncio.to_thread(_execute_tool_call, workspace, call)
         tool_message = {
             "role": "tool",
             "tool_call_id": call["id"],

--- a/examples/agentic/shopping/dataset_loader.py
+++ b/examples/agentic/shopping/dataset_loader.py
@@ -8,6 +8,38 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from game import make_prompt  # noqa: E402
 
+_TASK_DEFAULTS = {
+    "rain commute": {
+        "categories": ["jacket", "bottle"],
+        "required_features_by_category": {
+            "jacket": ["waterproof", "packable"],
+            "bottle": ["insulated", "leakproof"],
+        },
+    },
+    "trail day": {
+        "categories": ["shoes", "bottle"],
+        "required_features_by_category": {
+            "shoes": ["trail", "water-resistant"],
+            "bottle": ["collapsible", "lightweight"],
+        },
+    },
+    "cold city": {
+        "categories": ["jacket", "shoes"],
+        "required_features_by_category": {
+            "jacket": ["windproof", "warm"],
+            "shoes": ["casual", "water-resistant"],
+        },
+    },
+    "full travel": {
+        "categories": ["jacket", "shoes", "bottle"],
+        "required_features_by_category": {
+            "jacket": ["waterproof", "packable"],
+            "shoes": ["casual", "water-resistant"],
+            "bottle": ["collapsible", "lightweight"],
+        },
+    },
+}
+
 
 def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> list[dict]:
     """Normalize JSONL shopping rows into prompt-bearing records."""
@@ -16,10 +48,23 @@ def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> 
     records = []
     for row in rows:
         record = dict(row)
-        record["categories"] = list(record["categories"])
-        record["required_features_by_category"] = {
-            category: list(features) for category, features in record["required_features_by_category"].items()
-        }
+        defaults = _TASK_DEFAULTS.get(str(record.get("kit_name", "")), {})
+        categories = record.get("categories") or defaults.get("categories") or []
+        record["categories"] = [str(category) for category in categories]
+        raw_required = (
+            record.get("required_features_by_category") or defaults.get("required_features_by_category") or {}
+        )
+        record["required_features_by_category"] = _normalize_required_features(raw_required, record["categories"])
         record["prompt"] = make_prompt(record)
         records.append(record)
     return records
+
+
+def _normalize_required_features(raw_required: object, categories: list[str]) -> dict[str, list[str]]:
+    if not isinstance(raw_required, dict):
+        raw_required = {}
+    normalized = {}
+    for category in categories:
+        features = raw_required.get(category) or []
+        normalized[category] = [str(feature) for feature in features]
+    return normalized

--- a/tests/test_agentic_shopping_example_cpu.py
+++ b/tests/test_agentic_shopping_example_cpu.py
@@ -67,6 +67,26 @@ def test_shopping_loader_and_reward_import_from_file_path_without_sys_path():
     assert reward.reward_fn(SimpleNamespace(source_record=source, tool_calls=[])) == -1.0
 
 
+def test_shopping_loader_fills_missing_required_features_from_kit_name():
+    loader = _load_module_without_sys_path("dataset_loader")
+    source = {
+        "id": 1,
+        "kit_name": "rain commute",
+        "categories": None,
+        "budget": 140,
+        "required_features_by_category": None,
+    }
+
+    records = loader.load_training_dataset("unused", default_loader=lambda _: [source])
+
+    assert records[0]["categories"] == ["jacket", "bottle"]
+    assert records[0]["required_features_by_category"] == {
+        "jacket": ["waterproof", "packable"],
+        "bottle": ["insulated", "leakproof"],
+    }
+    assert "jacket: waterproof, packable" in records[0]["prompt"]
+
+
 def test_shopping_tools_filter_inspect_and_check_catalog():
     game = _load_module("game")
 

--- a/tests/test_auto_tune_cpu.py
+++ b/tests/test_auto_tune_cpu.py
@@ -15,6 +15,7 @@ from areno.cli.auto_tune import (
     _dummy_response_tokens,
     _dummy_token_budgets,
     _dummy_train_rows,
+    _eos_token_id,
     _is_oom_error,
     _peak_cuda_memory_fraction,
     _probe_devices,
@@ -387,7 +388,7 @@ def test_auto_tune_rejects_non_rollout_configs() -> None:
     try:
         auto_tune_config(config, probe_fn=lambda _config, candidate, stage: AutoTuneMeasurement(candidate, 0.1, True))
     except ValueError as exc:
-        assert "--auto currently tunes rollout-based trainers only" in str(exc)
+        assert "--tune-params currently tunes rollout-based trainers only" in str(exc)
     else:
         raise AssertionError("expected ValueError")
 
@@ -671,6 +672,52 @@ def test_train_dummy_probe_preserves_original_oom_when_cleanup_fails(monkeypatch
         "close",
         "empty_cache",
     ]
+
+
+def test_dummy_probe_closes_trainer_when_init_fails(monkeypatch) -> None:
+    import areno.api
+
+    calls = []
+
+    class FakeTrainer:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def init(self):
+            calls.append("init")
+            raise RuntimeError("CUDA out of memory during init")
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(areno.api, "Trainer", FakeTrainer)
+    monkeypatch.setattr(auto_tune, "_probe_devices", lambda world_size: [0])
+    monkeypatch.setattr(auto_tune, "_reset_cuda_peak_stats", lambda devices: calls.append(("reset", devices)))
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: calls.append("empty_cache"))
+
+    config = PolicyTrainerConfig(algo="gspo", ckpt="actor", dataset_path="dataset")
+    candidate = AutoTuneCandidate(
+        tp_size=1,
+        batch_size=1,
+        n_samples=4,
+        mini_bs=1,
+        max_running_prompts=4,
+        adam_8bit=False,
+        keep_rollout_state=False,
+    )
+
+    measurement = auto_tune.probe_candidate_with_dummy_run(config, candidate, "rollout")
+
+    assert measurement.ok is False
+    assert measurement.error is not None
+    assert "CUDA out of memory during init" in measurement.error
+    assert calls == [("reset", [0]), "init", "close", "empty_cache"]
+
+
+def test_eos_token_id_accepts_sequence_values() -> None:
+    assert _eos_token_id(SimpleNamespace(eos_token_id=[128001, 128009])) == 128001
+    assert _eos_token_id(SimpleNamespace(eos_token_id=(2, 3))) == 2
+    assert _eos_token_id(SimpleNamespace(eos_token_id=[])) == 0
 
 
 def test_dummy_policy_loss_aligns_next_token_logprobs_with_response_advantages() -> None:

--- a/tests/test_auto_tune_cpu.py
+++ b/tests/test_auto_tune_cpu.py
@@ -319,6 +319,30 @@ def test_auto_tune_logs_progress(monkeypatch) -> None:
     assert "auto tune selected" in text
 
 
+def test_auto_tune_skips_rollout_probe_when_max_running_prompts_is_explicit() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=8,
+        n_samples=8,
+        mini_bs=8,
+        max_running_prompts=64,
+    )
+    stages = []
+
+    def fake_probe(_config, candidate, stage):
+        stages.append(stage)
+        assert candidate.max_running_prompts == 64
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=0.1, ok=True)
+
+    result = auto_tune_config(config, mem_frac=0.9, probe_fn=fake_probe)
+
+    assert stages == ["train"]
+    assert result.config.max_running_prompts == 64
+    assert result.config.batch_size == 8
+
+
 def test_auto_tune_does_not_change_user_tp_size() -> None:
     config = PolicyTrainerConfig(
         algo="gspo",

--- a/tests/test_auto_tune_cpu.py
+++ b/tests/test_auto_tune_cpu.py
@@ -371,6 +371,16 @@ def test_auto_tune_treats_probe_worker_sigkill_as_oom() -> None:
     assert _is_oom_error(message)
 
 
+def test_auto_tune_treats_rollout_probe_nccl_resource_error_as_oom() -> None:
+    message = (
+        "rank 1 failed during Op.PROBE_ROLLOUT_CACHE:\n"
+        "torch.distributed.DistBackendError: NCCL error in NCCLUtils.hpp, unhandled system error. "
+        "ncclSystemError: System call or external library call failed or device error."
+    )
+
+    assert _is_oom_error(message)
+
+
 def test_auto_tune_rejects_non_rollout_configs() -> None:
     config = TrainerConfig(algo="sft", ckpt="actor", dataset_path="dataset")
 

--- a/tests/test_auto_tune_cpu.py
+++ b/tests/test_auto_tune_cpu.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import areno.cli.auto_tune as auto_tune
+from areno.api.trainer_config import PolicyTrainerConfig, TrainerConfig
+from areno.cli.auto_tune import (
+    AutoTuneCandidate,
+    AutoTuneMeasurement,
+    _dummy_policy_loss,
+    _dummy_prompt_tokens,
+    _dummy_response_tokens,
+    _dummy_token_budgets,
+    _dummy_train_rows,
+    _is_oom_error,
+    _peak_cuda_memory_fraction,
+    _probe_devices,
+    _reset_cuda_peak_stats,
+    _rollout_candidates,
+    _run_dummy_probe,
+    _train_candidates,
+    auto_tune_config,
+    enumerate_candidates,
+)
+from areno.engine.api import ArenoEngine
+from areno.engine.modeling import _zero_model_parameters
+from areno.engine.protocol import Op
+
+
+def test_enumerate_candidates_grows_rollout_and_train_knobs() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=4,
+        n_samples=4,
+        mini_bs=4,
+    )
+
+    candidates = enumerate_candidates(config)
+
+    assert candidates[0] == AutoTuneCandidate(
+        tp_size=4,
+        batch_size=1,
+        n_samples=4,
+        mini_bs=1,
+        max_running_prompts=1,
+        adam_8bit=False,
+        keep_rollout_state=False,
+    )
+    assert any(candidate.max_running_prompts == 16 for candidate in candidates)
+    assert len(_rollout_candidates(config)) <= 16
+    assert candidates == sorted(
+        candidates,
+        key=lambda item: (
+            item.max_running_prompts,
+            item.train_rows,
+            item.mini_bs,
+            item.batch_size,
+            item.n_samples,
+            -item.tp_size,
+            not item.adam_8bit,
+            item.keep_rollout_state,
+        ),
+    )
+
+
+def test_enumerate_candidates_limits_policy_samples_and_mini_bs_values() -> None:
+    config = PolicyTrainerConfig(
+        algo="grpo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=4,
+        n_samples=8,
+        mini_bs=16,
+    )
+
+    candidates = enumerate_candidates(config)
+
+    assert {candidate.n_samples for candidate in candidates} == {8}
+    assert {candidate.mini_bs for candidate in candidates} <= {1, 2, 4, 8, 16}
+    assert all(candidate.mini_bs <= candidate.batch_size * candidate.n_samples for candidate in candidates)
+    assert all(not candidate.keep_rollout_state for candidate in candidates)
+    assert {candidate.adam_8bit for candidate in candidates} == {False}
+    assert len(_rollout_candidates(config)) <= 16
+    assert all(len(_train_candidates(config, rollout)) <= 32 for rollout in _rollout_candidates(config))
+
+
+def test_enumerate_candidates_uses_user_tp_and_power_of_two_numeric_values() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        world_size=12,
+        tp_size=3,
+        batch_size=6,
+        n_samples=8,
+        mini_bs=12,
+    )
+
+    candidates = enumerate_candidates(config)
+
+    assert {candidate.tp_size for candidate in candidates} == {3}
+    assert {candidate.batch_size for candidate in candidates} <= {1, 2, 4}
+    assert {candidate.n_samples for candidate in candidates} == {8}
+    assert {candidate.mini_bs for candidate in candidates} <= {1, 2, 4, 8}
+    assert all(candidate.max_running_prompts & (candidate.max_running_prompts - 1) == 0 for candidate in candidates)
+
+
+def test_train_candidates_use_rollout_tp_and_vary_batch_and_mini_batch() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        world_size=8,
+        batch_size=4,
+        n_samples=7,
+        mini_bs=16,
+    )
+    rollout = AutoTuneCandidate(
+        tp_size=4,
+        batch_size=4,
+        n_samples=7,
+        mini_bs=1,
+        max_running_prompts=8,
+        adam_8bit=False,
+        keep_rollout_state=False,
+    )
+
+    candidates = _train_candidates(config, rollout)
+
+    assert {candidate.max_running_prompts for candidate in candidates} == {8}
+    assert {candidate.n_samples for candidate in candidates} == {7}
+    assert {candidate.tp_size for candidate in candidates} == {4}
+    assert {candidate.batch_size for candidate in candidates} <= {1, 2, 4}
+    assert {candidate.mini_bs for candidate in candidates} <= {1, 2, 4, 8, 16}
+
+
+def test_auto_max_samples_caps_rollout_prompts_and_train_batch_size() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        world_size=8,
+        tp_size=4,
+        batch_size=64,
+        n_samples=8,
+        mini_bs=16,
+    )
+
+    rollout_candidates = _rollout_candidates(config, auto_max_samples=32)
+    train_candidates = [
+        candidate
+        for rollout in rollout_candidates
+        for candidate in _train_candidates(config, rollout, auto_max_samples=32)
+    ]
+
+    assert max(candidate.max_running_prompts for candidate in rollout_candidates) == 32
+    assert max(candidate.batch_size for candidate in train_candidates) == 4
+    assert all(candidate.batch_size * candidate.n_samples <= 32 for candidate in train_candidates)
+
+
+def test_rollout_candidates_vary_running_prompts_with_fixed_tp() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        world_size=8,
+        tp_size=4,
+        batch_size=8,
+        n_samples=8,
+        mini_bs=4,
+    )
+
+    candidates = _rollout_candidates(config)
+
+    assert {candidate.tp_size for candidate in candidates} == {4}
+    assert candidates == sorted(
+        candidates,
+        key=lambda item: (
+            item.max_running_prompts,
+            item.train_rows,
+            item.batch_size,
+            item.n_samples,
+            item.mini_bs,
+            item.keep_rollout_state,
+        ),
+        reverse=True,
+    )
+
+
+def test_auto_tune_selects_largest_candidate_under_memory_fraction() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=4,
+        n_samples=4,
+        mini_bs=4,
+    )
+
+    def fake_probe(_config, candidate, stage):
+        peak = 0.1 + candidate.max_running_prompts * 0.05
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=peak, ok=peak < 0.95)
+
+    result = auto_tune_config(config, mem_frac=0.5, probe_fn=fake_probe)
+
+    assert isinstance(result.config, PolicyTrainerConfig)
+    assert result.config.resolved_max_running_prompts() == 8
+    assert result.config.n_samples == 4
+    assert result.config.batch_size in {1, 2, 4}
+    assert result.config.keep_rollout_state is False
+    assert result.measurement is not None
+    assert result.measurement.peak_mem_frac <= 0.5
+
+
+def test_auto_tune_probes_sparse_rollout_and_train_candidates() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=8,
+        n_samples=8,
+        mini_bs=16,
+    )
+    probed = []
+
+    def fake_probe(_config, candidate, stage):
+        probed.append(candidate)
+        peak = 0.2 if candidate.max_running_prompts <= 32 else 0.95
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=peak, ok=True)
+
+    result = auto_tune_config(config, mem_frac=0.9, probe_fn=fake_probe)
+
+    assert len(_rollout_candidates(config)) <= 16
+    assert all(len(_train_candidates(config, rollout)) <= 32 for rollout in _rollout_candidates(config))
+    assert len(probed) <= 11
+    assert result.config.max_running_prompts == 32
+    assert result.config.batch_size == 4
+
+
+def test_auto_tune_train_tunes_mini_bs_after_fixed_rollout_batch() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=8,
+        n_samples=8,
+        mini_bs=16,
+    )
+    train_probes = []
+
+    def fake_probe(_config, candidate, stage):
+        if stage == "rollout":
+            return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=0.1, ok=True)
+        train_probes.append(candidate)
+        if candidate.mini_bs > 2:
+            return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=1.0, ok=False, error="oom")
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=0.2, ok=True)
+
+    result = auto_tune_config(config, mem_frac=0.9, auto_max_samples=64, probe_fn=fake_probe)
+
+    assert result.config.batch_size == 8
+    assert result.config.mini_bs == 2
+    assert [candidate.mini_bs for candidate in train_probes] == [16, 8, 4, 2]
+    assert {candidate.batch_size for candidate in train_probes} == {8}
+
+
+def test_auto_tune_preserves_user_adam_8bit_choice() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=4,
+        n_samples=8,
+        mini_bs=4,
+        adam_8bit=True,
+    )
+
+    def fake_probe(_config, candidate, stage):
+        del stage
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=0.1, ok=True)
+
+    result = auto_tune_config(config, mem_frac=0.9, probe_fn=fake_probe)
+
+    assert result.config.adam_8bit is True
+    assert {measurement.candidate.adam_8bit for measurement in result.measurements} == {True}
+
+
+def test_auto_tune_logs_progress(monkeypatch) -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        batch_size=2,
+        n_samples=8,
+        mini_bs=2,
+    )
+
+    def fake_probe(_config, candidate, stage):
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=0.1, ok=True)
+
+    messages = []
+    monkeypatch.setattr(auto_tune.logger, "info", lambda message, *args: messages.append(message % args))
+
+    auto_tune_config(config, mem_frac=0.5, probe_fn=fake_probe)
+
+    text = "\n".join(messages)
+    assert "auto tune start" in text
+    assert "auto tune rollout stage start" in text
+    assert "auto tune train stage start" in text
+    assert text.index("auto tune rollout stage start") < text.index("auto tune train stage start")
+    assert "probe start" in text
+    assert "auto tune probe result" in text
+    assert "auto tune selected" in text
+
+
+def test_auto_tune_does_not_change_user_tp_size() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        world_size=8,
+        tp_size=4,
+        batch_size=1,
+        n_samples=1,
+        mini_bs=1,
+    )
+
+    def fake_probe(_config, candidate, stage):
+        return AutoTuneMeasurement(candidate=candidate, peak_mem_frac=0.4, ok=True)
+
+    result = auto_tune_config(config, mem_frac=0.9, probe_fn=fake_probe)
+
+    assert result.config.tp_size == 4
+    assert result.measurement is not None
+    assert {measurement.candidate.tp_size for measurement in result.measurements} == {4}
+
+
+def test_auto_tune_surfaces_user_tp_compatibility_errors() -> None:
+    config = PolicyTrainerConfig(
+        algo="gspo",
+        ckpt="actor",
+        dataset_path="dataset",
+        world_size=8,
+        tp_size=8,
+        batch_size=4,
+        n_samples=8,
+        mini_bs=4,
+    )
+
+    def fake_probe(_config, candidate, stage):
+        del stage
+        return AutoTuneMeasurement(
+            candidate=candidate,
+            peak_mem_frac=1.0,
+            ok=False,
+            error="num_key_value_heads must be divisible by tp_size",
+        )
+
+    with pytest.raises(RuntimeError, match="num_key_value_heads must be divisible by tp_size"):
+        auto_tune_config(config, mem_frac=0.9, probe_fn=fake_probe)
+
+
+def test_auto_tune_treats_probe_worker_sigkill_as_oom() -> None:
+    message = "worker exited without reporting result during Op.TRAIN: rank 0 pid 13907 exitcode -9"
+
+    assert _is_oom_error(message)
+
+
+def test_auto_tune_rejects_non_rollout_configs() -> None:
+    config = TrainerConfig(algo="sft", ckpt="actor", dataset_path="dataset")
+
+    try:
+        auto_tune_config(config, probe_fn=lambda _config, candidate, stage: AutoTuneMeasurement(candidate, 0.1, True))
+    except ValueError as exc:
+        assert "--auto currently tunes rollout-based trainers only" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_zero_model_parameters_makes_dummy_load_deterministic() -> None:
+    model = torch.nn.Sequential(torch.nn.Linear(3, 4), torch.nn.LayerNorm(4))
+    for param in model.parameters():
+        param.data.normal_()
+
+    _zero_model_parameters(model)
+
+    for param in model.parameters():
+        assert torch.count_nonzero(param).item() == 0
+
+
+def test_probe_devices_uses_world_size_visible_cuda_devices(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 4)
+
+    assert _probe_devices(2) == [0, 1]
+
+
+def test_probe_devices_fails_when_world_size_exceeds_visible_cuda_devices(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 4)
+
+    try:
+        _probe_devices(8)
+    except RuntimeError as exc:
+        assert "world_size=8" in str(exc)
+        assert "visible_cuda_devices=4" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_reset_cuda_peak_stats_initializes_each_device_by_index(monkeypatch) -> None:
+    calls = []
+
+    monkeypatch.setattr(torch.cuda, "set_device", lambda device: calls.append(("set", device)))
+    monkeypatch.setattr(torch, "empty", lambda *args, **kwargs: calls.append(("empty", args, kwargs)))
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda device: calls.append(("sync", device)))
+    monkeypatch.setattr(torch.cuda, "reset_peak_memory_stats", lambda device: calls.append(("reset", device)))
+
+    _reset_cuda_peak_stats([0, 1])
+
+    assert calls == [
+        ("set", 0),
+        ("empty", ((),), {"device": "cuda:0"}),
+        ("sync", 0),
+        ("reset", 0),
+        ("set", 1),
+        ("empty", ((),), {"device": "cuda:1"}),
+        ("sync", 1),
+        ("reset", 1),
+    ]
+
+
+def test_peak_cuda_memory_fraction_uses_device_indices(monkeypatch) -> None:
+    class Props:
+        total_memory = 100
+
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda device: Props())
+    monkeypatch.setattr(torch.cuda, "max_memory_allocated", lambda device: {0: 40, 1: 80}[device])
+
+    assert _peak_cuda_memory_fraction([0, 1]) == 0.8
+
+
+class _TinyTokenizer:
+    eos_token_id = 0
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del text, add_special_tokens
+        return [11, 12, 13]
+
+
+def test_dummy_probe_rows_respect_prompt_response_and_context_lengths() -> None:
+    tokenizer = _TinyTokenizer()
+    prompt_len, response_len = _dummy_token_budgets(max_prompt_tokens=7, max_new_tokens=9, max_context_len=12)
+    prompt = _dummy_prompt_tokens(tokenizer, max_prompt_tokens=prompt_len)
+    response = _dummy_response_tokens(tokenizer, response_len=response_len)
+    rows = _dummy_train_rows(prompt_tokens=prompt, response_tokens=response, eos_token_id=0, target_rows=2)
+
+    assert len(prompt) == 7
+    assert len(response) == 5
+    assert len(rows) == 2
+    assert all(len(row.tokens) == 12 for row in rows)
+    assert all(row.prompt_mask == [True] * 7 + [False] * 5 for row in rows)
+
+
+def test_dummy_probe_uses_context_len_when_context_is_set() -> None:
+    tokenizer = _TinyTokenizer()
+
+    prompt_len, response_len = _dummy_token_budgets(max_prompt_tokens=7, max_new_tokens=6, max_context_len=100)
+    prompt = _dummy_prompt_tokens(tokenizer, max_prompt_tokens=prompt_len)
+    response = _dummy_response_tokens(tokenizer, response_len=response_len)
+
+    assert len(prompt) == 7
+    assert len(response) == 93
+    assert len(prompt) + len(response) == 100
+
+
+def test_dummy_probe_uses_prompt_plus_new_tokens_without_context() -> None:
+    prompt_len, response_len = _dummy_token_budgets(max_prompt_tokens=7, max_new_tokens=6, max_context_len=None)
+
+    assert prompt_len == 7
+    assert response_len == 6
+
+
+def test_rollout_dummy_probe_skips_train(monkeypatch) -> None:
+    import areno.api
+
+    calls = []
+
+    class FakeTrainer:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def init(self):
+            calls.append("init")
+
+        def get_tokenizer(self):
+            return _TinyTokenizer()
+
+        def probe_rollout_cache(self, **kwargs):
+            calls.append(("probe_rollout_cache", kwargs))
+            return 0.25
+
+        def train(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("rollout auto tune probe must not run train")
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(areno.api, "Trainer", FakeTrainer)
+    monkeypatch.setattr(auto_tune, "_probe_devices", lambda world_size: [0])
+    monkeypatch.setattr(auto_tune, "_reset_cuda_peak_stats", lambda devices: calls.append(("reset", devices)))
+    monkeypatch.setattr(auto_tune, "_peak_cuda_memory_fraction", lambda devices: 0.0)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda device: calls.append(("sync", device)))
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: calls.append("empty_cache"))
+
+    config = PolicyTrainerConfig(algo="gspo", ckpt="actor", dataset_path="dataset")
+    candidate = AutoTuneCandidate(
+        tp_size=1,
+        batch_size=1,
+        n_samples=4,
+        mini_bs=1,
+        max_running_prompts=4,
+        adam_8bit=True,
+        keep_rollout_state=False,
+    )
+
+    peak = _run_dummy_probe(config, candidate, stage="rollout")
+
+    assert peak == 0.25
+    assert any(call[0] == "probe_rollout_cache" for call in calls if isinstance(call, tuple))
+    assert "close" in calls
+
+
+def test_train_dummy_probe_drops_rollout_state_before_train(monkeypatch) -> None:
+    import areno.api
+
+    calls = []
+
+    class FakeTrainer:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def init(self):
+            calls.append("init")
+
+        def get_tokenizer(self):
+            return _TinyTokenizer()
+
+        def begin_rollout_session(self):
+            calls.append("begin_rollout_session")
+
+        def probe_rollout_cache(self, **kwargs):
+            calls.append(("probe_rollout_cache", kwargs))
+            return 0.5
+
+        def end_rollout_session(self):
+            calls.append("end_rollout_session")
+
+        def train(self, *args, **kwargs):
+            calls.append("train")
+            return {"auto_tune_worker_peak_mem_frac": 0.42}
+
+        def close(self):
+            calls.append("close")
+
+    monkeypatch.setattr(areno.api, "Trainer", FakeTrainer)
+    monkeypatch.setattr(auto_tune, "_probe_devices", lambda world_size: [0])
+    monkeypatch.setattr(auto_tune, "_reset_cuda_peak_stats", lambda devices: calls.append(("reset", devices)))
+    monkeypatch.setattr(auto_tune, "_peak_cuda_memory_fraction", lambda devices: 0.0)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda device: calls.append(("sync", device)))
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: calls.append("empty_cache"))
+
+    config = PolicyTrainerConfig(algo="gspo", ckpt="actor", dataset_path="dataset")
+    candidate = AutoTuneCandidate(
+        tp_size=1,
+        batch_size=1,
+        n_samples=4,
+        mini_bs=1,
+        max_running_prompts=4,
+        adam_8bit=False,
+        keep_rollout_state=False,
+    )
+
+    peak = _run_dummy_probe(config, candidate, stage="train")
+
+    assert peak == 0.42
+    assert calls.index("begin_rollout_session") < calls.index("end_rollout_session") < calls.index("train")
+    assert "close" in calls
+
+
+def test_train_dummy_probe_preserves_original_oom_when_cleanup_fails(monkeypatch) -> None:
+    import areno.api
+
+    calls = []
+
+    class FakeTrainer:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def init(self):
+            calls.append("init")
+
+        def get_tokenizer(self):
+            return _TinyTokenizer()
+
+        def begin_rollout_session(self):
+            calls.append("begin_rollout_session")
+
+        def probe_rollout_cache(self, **kwargs):
+            calls.append(("probe_rollout_cache", kwargs))
+            return 0.5
+
+        def end_rollout_session(self):
+            calls.append("end_rollout_session")
+            raise RuntimeError("worker exited without reporting result during Op.ROLLOUT_SESSION_END")
+
+        def train(self, *args, **kwargs):
+            del args, kwargs
+            calls.append("train")
+            raise RuntimeError("CUDA out of memory while probing train")
+
+        def close(self):
+            calls.append("close")
+            raise RuntimeError("worker exited during close")
+
+    monkeypatch.setattr(areno.api, "Trainer", FakeTrainer)
+    monkeypatch.setattr(auto_tune, "_probe_devices", lambda world_size: [0])
+    monkeypatch.setattr(auto_tune, "_reset_cuda_peak_stats", lambda devices: calls.append(("reset", devices)))
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: calls.append("empty_cache"))
+
+    config = PolicyTrainerConfig(algo="gspo", ckpt="actor", dataset_path="dataset")
+    candidate = AutoTuneCandidate(
+        tp_size=1,
+        batch_size=1,
+        n_samples=4,
+        mini_bs=1,
+        max_running_prompts=4,
+        adam_8bit=False,
+        keep_rollout_state=False,
+    )
+
+    measurement = auto_tune.probe_candidate_with_dummy_run(config, candidate, "train")
+
+    assert measurement.ok is False
+    assert measurement.error is not None
+    assert "CUDA out of memory" in measurement.error
+    assert "ROLLOUT_SESSION_END" not in measurement.error
+    assert calls == [
+        ("reset", [0]),
+        "init",
+        "begin_rollout_session",
+        ("probe_rollout_cache", {"max_new_tokens": 3071, "max_running_prompts": 4, "max_prompt_len": 1024}),
+        "end_rollout_session",
+        "train",
+        "close",
+        "empty_cache",
+    ]
+
+
+def test_dummy_policy_loss_aligns_next_token_logprobs_with_response_advantages() -> None:
+    pack = {
+        "prompt_mask": torch.tensor([[True, True, False, False]]),
+        "advantages": torch.tensor([[0.0, 0.0, 1.0, 1.0]]),
+    }
+    logprobs = torch.tensor([[0.1, 0.2, 0.3]], requires_grad=True)
+
+    loss, stats = _dummy_policy_loss(pack, logprobs)
+
+    assert torch.isclose(loss, torch.tensor(-0.25))
+    assert "auto_tune_dummy_loss" in stats
+    loss.backward()
+    assert logprobs.grad is not None
+
+
+def test_engine_rollout_cache_probe_sizes_payload_without_decoding() -> None:
+    calls = []
+
+    class FakeCluster:
+        def call(self, op, payload):
+            calls.append((op, payload))
+            return [0.2, 0.4]
+
+    engine = object.__new__(ArenoEngine)
+    engine.config = SimpleNamespace(dp_size=2, runtime=SimpleNamespace(kv_block_size=16))
+    engine.cluster = FakeCluster()
+
+    peak = engine.probe_rollout_cache(max_new_tokens=20, max_running_prompts=5, max_prompt_len=33)
+
+    assert len(calls) == 1
+    op, payload = calls[0]
+    assert op is Op.PROBE_ROLLOUT_CACHE
+    assert payload.max_running_seqs == 3
+    assert payload.max_cache_len == 53
+    assert payload.max_blocks_per_seq == 4
+    assert payload.num_blocks == 12
+    assert peak == 0.4

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 from click import UsageError, unstyle
 from click.testing import CliRunner
@@ -71,6 +73,21 @@ def test_train_config_requires_world_size_divisible_by_tp_size():
 def test_train_config_validates_common_positive_fields(field, value, message):
     with pytest.raises(UsageError, match=message):
         _trainer_config_from_options(**_options(algo="gspo", **{field: value}))
+
+
+def test_train_config_validates_tune_params_for_rollout_algorithms():
+    with pytest.raises(UsageError, match="--tune-params currently supports rollout-based algorithms"):
+        _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None, tune_params=True))
+
+
+def test_train_config_validates_mem_frac():
+    with pytest.raises(UsageError, match=r"--mem-frac must be in \(0, 1\]"):
+        _trainer_config_from_options(**_options(algo="gspo", mem_frac=1.2))
+
+
+def test_train_config_validates_tune_max_samples():
+    with pytest.raises(UsageError, match="--tune-max-samples must be positive"):
+        _trainer_config_from_options(**_options(algo="gspo", tune_max_samples=0))
 
 
 def test_train_config_validates_grpo_clip_eps_only_for_grpo():
@@ -398,6 +415,83 @@ def test_train_command_prints_summary_before_run(monkeypatch):
     assert events == [("run", "sft")]
 
 
+def test_train_command_tunes_params_before_summary_and_run(monkeypatch):
+    from areno.cli.auto_tune import AutoTuneCandidate, AutoTuneMeasurement, AutoTuneResult
+
+    events = []
+
+    def fake_auto_tune(config, *, mem_frac, auto_max_samples):
+        events.append(("tune", config.batch_size, config.n_samples, config.mini_bs, mem_frac, auto_max_samples))
+        tuned = replace(
+            config,
+            tp_size=2,
+            batch_size=1,
+            n_samples=4,
+            mini_bs=2,
+            max_running_prompts=4,
+            adam_8bit=True,
+            keep_rollout_state=False,
+        )
+        return AutoTuneResult(
+            config=tuned,
+            measurement=AutoTuneMeasurement(
+                candidate=AutoTuneCandidate(
+                    tp_size=2,
+                    batch_size=1,
+                    n_samples=4,
+                    mini_bs=2,
+                    max_running_prompts=4,
+                    adam_8bit=True,
+                    keep_rollout_state=False,
+                ),
+                peak_mem_frac=0.81,
+                ok=True,
+            ),
+            measurements=(),
+        )
+
+    def fake_run(config):
+        events.append(
+            ("run", config.batch_size, config.n_samples, config.mini_bs, config.resolved_max_running_prompts())
+        )
+
+    monkeypatch.setattr("areno.cli.auto_tune.auto_tune_config", fake_auto_tune)
+    monkeypatch.setattr(train_cli, "run", fake_run)
+
+    result = CliRunner().invoke(
+        train_cli.train_command,
+        [
+            "--algo",
+            "gspo",
+            "--ckpt",
+            "actor",
+            "--dataset-path",
+            "dataset",
+            "--reward-ckpt",
+            "reward-model",
+            "--world-size",
+            "2",
+            "--tp-size",
+            "1",
+            "--tune-params",
+            "--mem-frac",
+            "0.82",
+            "--tune-max-samples",
+            "64",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output)
+    assert "AReno parameter tune selected: tp_size=2, batch_size=1, n_samples=4, mini_bs=2" in output
+    assert "adam_8bit=True, drop_rollout_state=True" in output
+    assert "tp_size       2" in output
+    assert "batch_size           1" in output
+    assert "n_samples            4" in output
+    assert "max_running_prompts  4" in output
+    assert events == [("tune", 32, 8, 16, 0.82, 64), ("run", 1, 4, 2, 4)]
+
+
 EXPECTED_HELP_SECTIONS = [
     "Basic:",
     "Rollout:",
@@ -465,6 +559,9 @@ def _options(**overrides):
         reward_fn_path=None,
         save_path="save",
         save_interval=10,
+        tune_params=False,
+        mem_frac=0.9,
+        tune_max_samples=256,
         epochs=2,
         tp_size=1,
         world_size=1,

--- a/tests/test_trainer_api_cpu.py
+++ b/tests/test_trainer_api_cpu.py
@@ -32,6 +32,26 @@ class TrainerPromptBatchTest(unittest.TestCase):
     def test_top_level_trainer_export_matches_api_trainer(self):
         self.assertIs(Trainer, ApiTrainer)
 
+    def test_close_releases_backend(self):
+        trainer = Trainer(world_size=1, model_path="unused")
+
+        class BackendStub:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        backend = BackendStub()
+        trainer._backend = backend
+        trainer._initialized = True
+
+        trainer.close()
+
+        self.assertTrue(backend.closed)
+        self.assertIsNone(trainer._backend)
+        self.assertFalse(trainer._initialized)
+
     def test_load_prompt_batches_skips_long_prompts_and_keeps_records(self):
         """Overlong prompts should be skipped without dropping record metadata."""
         trainer = Trainer(world_size=1, model_path="unused")


### PR DESCRIPTION
## Summary

- add explicit `areno train --tune-params` parameter tuning for rollout-based trainers
- tune rollout concurrency from high to low, then derive train batch size from rollout capacity
- tune train `mini_bs` from high to low under the configured memory fraction
- rename the ambiguous `--auto` CLI entry point to explicit tuning flags

## Usage

```bash
areno train \
  --algo gspo \
  --ckpt /path/to/model \
  --dataset-path ./dataset.jsonl \
  --reward-fn-path ./reward.py \
  --tp-size 4 \
  --world-size 8 \
  --tune-params \
  --mem-frac 0.9 \
  --tune-max-samples 256
```

## Tests

- `ruff format areno/cli/auto_tune.py areno/cli/train.py tests/test_auto_tune_cpu.py tests/test_train_cli_config_cpu.py`
- `ruff check areno/cli/auto_tune.py areno/cli/train.py tests/test_auto_tune_cpu.py tests/test_train_cli_config_cpu.py`
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_auto_tune_cpu.py tests/test_train_cli_config_cpu.py tests/test_trainer_api_cpu.py -q`

Closes #113
