### PR TITLE
fix(sft): require dataset loader normalization

### DIFF
--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 import areno.api
-from areno.api.data_utils import apply_chat_template, prompt_response_to_tokens_and_mask
+from areno.api.data_utils import prompt_response_to_tokens_and_mask
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
@@ -131,7 +131,7 @@ class SFTTrainer:
 
 
 def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int, max_new_tokens: int):
-    """Normalize common SFT schemas into the backend training row format.
+    """Normalize one loader-produced SFT row into backend training format.
 
     `prompt_mask=True` means "do not train this source token"; the backend loss
     is next-token aligned, so the loss function later uses positions after the
@@ -141,20 +141,16 @@ def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int,
 
     record = dict(record)
     eos_token_id = tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 0
-    if isinstance(record.get("messages"), list):
-        # Chat rows train only assistant turns.
-        tokens, prompt_mask = _messages_to_tokens_and_mask(record["messages"], tokenizer)
-    elif "prompt" in record and "response" in record:
-        # Prompt/response style rows train on the response suffix.
-        tokens, prompt_mask = prompt_response_to_tokens_and_mask(
-            record["prompt"], record["response"], tokenizer, eos_token_id
+    if "prompt" not in record or "response" not in record:
+        raise ValueError(
+            "SFT dataset loader must return rows with `prompt` and `response`; "
+            "normalize raw dataset fields in --dataset-loader-fn"
         )
-    elif isinstance(record.get("text"), str):
-        # Plain text rows train on every token after the first context token.
-        tokens = tokenizer.encode(record["text"], add_special_tokens=True)
-        prompt_mask = [True] + [False] * max(0, len(tokens) - 1)
-    else:
-        raise ValueError("SFT dataset row must contain `messages`, `prompt`/`response`, or `text`")
+    prompt = str(record["prompt"])
+    response = str(record["response"])
+    if not response:
+        return None
+    tokens, prompt_mask = prompt_response_to_tokens_and_mask(prompt, response, tokenizer, eos_token_id)
 
     if len(tokens) < 2:
         return None
@@ -171,29 +167,6 @@ def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int,
         advantages=zeros,
         eos_token_id=eos_token_id,
     )
-
-
-def _messages_to_tokens_and_mask(messages: list[dict[str, Any]], tokenizer) -> tuple[list[int], list[bool]]:
-    # Chat SFT should only optimize assistant turns. We apply the chat template
-    # incrementally and mark the token delta introduced by each assistant
-    # message as target tokens; user/system/tool deltas remain prompt-masked.
-    tokens: list[int] = []
-    prompt_mask: list[bool] = []
-    previous: list[int] = []
-    for end in range(1, len(messages) + 1):
-        current = apply_chat_template(tokenizer, messages[:end])
-        delta = current[len(previous) :] if current[: len(previous)] == previous else current
-        is_target = str(messages[end - 1].get("role", "")).lower() == "assistant"
-        tokens.extend(delta)
-        prompt_mask.extend([not is_target] * len(delta))
-        previous = current
-    if not getattr(tokenizer, "chat_template", None) and messages:
-        is_last_assistant = str(messages[-1].get("role", "")).lower() == "assistant"
-        eos_token_id = getattr(tokenizer, "eos_token_id", None)
-        if is_last_assistant and eos_token_id is not None:
-            tokens.append(eos_token_id)
-            prompt_mask.append(False)
-    return tokens, prompt_mask
 
 
 __all__ = ["SFTTrainer"]

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -146,6 +146,8 @@ def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int,
             "SFT dataset loader must return rows with `prompt` and `response`; "
             "normalize raw dataset fields in --dataset-loader-fn"
         )
+    if record["prompt"] is None or record["response"] is None:
+        return None
     prompt = str(record["prompt"])
     response = str(record["response"])
     if not response:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -170,6 +170,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if args.dataset_path is None:
         raise click.UsageError("--dataset-path is required")
     algorithm = _algorithm_for_cli(args.algo)
+    if algorithm.name == "sft" and args.dataset_loader_fn is None:
+        raise click.UsageError("--dataset-loader-fn is required for --algo sft")
     if algorithm.requires_rollout and args.reward_fn_path is None and args.reward_ckpt is None:
         raise click.UsageError("--reward-fn-path or --reward-ckpt is required")
     if args.save_interval <= 0:

--- a/docs/cli/dataset_loaders.rst
+++ b/docs/cli/dataset_loaders.rst
@@ -1,0 +1,65 @@
+Dataset loaders
+===============
+
+``--dataset-loader-fn`` points to a Python function that normalizes raw dataset
+rows before the trainer sees them. The function shape is the same across
+examples:
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object):
+       dataset = default_loader(dataset_path)
+       ...
+       return normalized_rows
+
+``default_loader`` understands the same ``--dataset-path`` values as the CLI:
+JSON/JSONL, Parquet, CSV/TSV, Arrow, ``datasets.save_to_disk(...)`` directories,
+and Hugging Face dataset references. Loaders should keep tokenization out of the
+dataset layer; trainers own tokenizer-specific rendering and token limits.
+
+SFT
+---
+
+SFT always requires ``--dataset-loader-fn``. The loader must return rows with
+``prompt`` and ``response`` keys:
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> list[dict]:
+       rows = default_loader(dataset_path)
+       records = []
+       for row in rows:
+           record = dict(row)
+           records.append(
+               {
+                   "prompt": f"Instruction: {record['instruction']}\nAnswer:",
+                   "response": str(record["answer"]),
+               }
+           )
+       return records
+
+For a concrete example, use ``--dataset-path yahma/alpaca-cleaned`` with
+``examples/sft/alpaca/dataset_loader.py``.
+
+DPO
+---
+
+DPO loaders should return ``prompt``, ``chosen``, and ``rejected``. ``prompt``
+is the shared context, ``chosen`` is the preferred answer, and ``rejected`` is
+the lower-ranked answer.
+
+Prompt-based RL
+---------------
+
+GSPO, GRPO, and PPO prompt datasets should return ``prompt``. Reward functions
+may require additional fields such as ``solutions`` or task metadata, so loaders
+usually preserve those fields while adding the canonical prompt. The math loader
+in ``examples/math/dataset_loader.py`` follows this pattern.
+
+Agentic RL
+----------
+
+Agentic loaders also return ``prompt`` plus task metadata consumed by
+``run_agent.py`` and ``reward.py``. Examples include
+``examples/agentic/coding/dataset_loader.py`` and
+``examples/agentic/shopping/dataset_loader.py``.

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -56,7 +56,9 @@ Dataset references use ``repo/name``, ``repo/name:config``, or
    ``file.py:function``.
 
 Use ``--dataset-loader-fn`` when the raw dataset does not already match the
-trainer schema. Without a loader, Areno passes dataset rows through unchanged.
+trainer schema. Without a loader, Areno passes dataset rows through unchanged,
+except for SFT where a loader is required. See :doc:`dataset_loaders` for the
+per-algorithm loader contracts.
 
 ``--algo TEXT``
    Training algorithm registered in ``areno.api``. Default: ``gspo``.
@@ -332,6 +334,24 @@ GSPO math training
      --batch-size 2 \
      --n-samples 2 \
      --mini-bs 1
+
+SFT instruction tuning
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path yahma/alpaca-cleaned \
+     --dataset-loader-fn examples/sft/alpaca/dataset_loader.py \
+     --algo sft \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 2 \
+     --mini-bs 1
+
+SFT loaders must normalize raw rows to ``prompt`` and ``response`` dictionaries.
+The trainer performs tokenization and trains on the response suffix.
 
 DPO preference training
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,7 @@ What areno owns
    :caption: Reference
 
    cli/training
+   cli/dataset_loaders
    cli/inference
    cli/diagnostics
    sdk/trainer

--- a/examples/sft/alpaca/README.md
+++ b/examples/sft/alpaca/README.md
@@ -1,0 +1,31 @@
+# Alpaca SFT Example
+
+This example shows the required SFT dataset-loader contract using Alpaca-style
+rows with `instruction`, optional `input`, and `output` fields.
+
+Recommended public dataset:
+
+```text
+yahma/alpaca-cleaned
+```
+
+The loader normalizes raw rows to the SFT trainer schema:
+
+- `prompt`: source text used as context
+- `response`: supervised target suffix
+
+Run SFT with the recommended Hugging Face dataset:
+
+```bash
+areno train \
+  --algo sft \
+  --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path yahma/alpaca-cleaned \
+  --dataset-loader-fn examples/sft/alpaca/dataset_loader.py \
+  --tp-size 1 \
+  --world-size 1 \
+  --batch-size 2 \
+  --mini-bs 1 \
+  --max-prompt-tokens 128 \
+  --max-new-tokens 64
+```

--- a/examples/sft/alpaca/dataset_loader.py
+++ b/examples/sft/alpaca/dataset_loader.py
@@ -1,0 +1,19 @@
+"""Dataset loader for Alpaca-style SFT rows."""
+
+from __future__ import annotations
+
+
+def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> list[dict]:
+    """Normalize Alpaca instruction/input/output rows to SFT prompt/response."""
+
+    records = []
+    for row in default_loader(dataset_path):
+        record = dict(row)
+        instruction = str(record["instruction"]).strip()
+        input_text = str(record.get("input") or "").strip()
+        prompt = f"Instruction: {instruction}\n"
+        if input_text:
+            prompt += f"Input: {input_text}\n"
+        prompt += "Response:"
+        records.append({"prompt": prompt, "response": str(record["output"])})
+    return records

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -603,6 +603,8 @@ def _train_args(**overrides):
         critic_warmup_steps=20,
     )
     defaults.update(overrides)
+    if defaults["algo"] == "sft" and "dataset_loader_fn" not in overrides:
+        defaults["dataset_loader_fn"] = "examples/sft/alpaca/dataset_loader.py"
     return SimpleNamespace(**defaults)
 
 

--- a/tests/test_sft_example_cpu.py
+++ b/tests/test_sft_example_cpu.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "sft" / "alpaca"
+
+
+def _load_dataset_loader():
+    path = EXAMPLE_DIR / "dataset_loader.py"
+    spec = importlib.util.spec_from_file_location("sft_alpaca_dataset_loader_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_alpaca_sft_loader_returns_prompt_response_rows():
+    loader = _load_dataset_loader()
+    raw = [
+        {
+            "instruction": "Convert text to uppercase.",
+            "input": "hello",
+            "output": "Use `hello.upper()`.",
+        }
+    ]
+
+    records = loader.load_training_dataset("unused", default_loader=lambda _: raw)
+
+    assert records == [
+        {
+            "prompt": "Instruction: Convert text to uppercase.\nInput: hello\nResponse:",
+            "response": "Use `hello.upper()`.",
+        }
+    ]

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -25,6 +25,11 @@ def test_train_config_requires_dataset_path():
         _trainer_config_from_options(**_options(dataset_path=None, algo="sft"))
 
 
+def test_train_config_requires_dataset_loader_for_sft():
+    with pytest.raises(UsageError, match="--dataset-loader-fn is required for --algo sft"):
+        _trainer_config_from_options(**_options(algo="sft", dataset_loader_fn=None))
+
+
 def test_train_config_requires_reward_source_for_rollout_algorithms():
     with pytest.raises(UsageError, match="--reward-fn-path or --reward-ckpt is required"):
         _trainer_config_from_options(**_options(algo="gspo", reward_fn_path=None, reward_ckpt=None))
@@ -380,6 +385,8 @@ def test_train_command_prints_summary_before_run(monkeypatch):
             "actor",
             "--dataset-path",
             "dataset",
+            "--dataset-loader-fn",
+            "examples/sft/alpaca/dataset_loader.py",
             "--world-size",
             "2",
             "--tp-size",
@@ -517,4 +524,6 @@ def _options(**overrides):
         critic_warmup_steps=20,
     )
     defaults.update(overrides)
+    if defaults["algo"] == "sft" and "dataset_loader_fn" not in overrides:
+        defaults["dataset_loader_fn"] = "examples/sft/alpaca/dataset_loader.py"
     return defaults

--- a/tests/test_trainer_dataset_utils_cpu.py
+++ b/tests/test_trainer_dataset_utils_cpu.py
@@ -26,16 +26,6 @@ class FakeTextTokenizer:
         return ids
 
 
-class EosAddingFallbackTokenizer(FakeTextTokenizer):
-    """Tokenizer double whose fallback encode adds EOS for special-token calls."""
-
-    def encode(self, text, add_special_tokens=False):
-        ids = super().encode(text, add_special_tokens=False)
-        if add_special_tokens:
-            ids.append(self.eos_token_id)
-        return ids
-
-
 class FakeSFTBackend:
     """Backend double that records whether SFT attempted to train."""
 
@@ -79,7 +69,7 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
     """Dataset helper tests convert rows to TrainSequence without backend init."""
 
     def test_sft_prompt_response_row_masks_only_response_suffix(self):
-        """Prompt/response SFT rows should train on response tokens plus EOS."""
+        """SFT loader rows should train on response tokens plus EOS."""
         tokenizer = FakeTextTokenizer()
 
         seq = sft_mod._record_to_train_sequence(
@@ -92,19 +82,20 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         self.assertEqual(seq.prompt_mask.count(True), 1)
         self.assertTrue(any(not item for item in seq.prompt_mask[1:]))
 
-    def test_sft_text_row_trains_after_first_context_token(self):
-        """Plain text SFT rows use the first token as context and train the rest."""
+    def test_sft_rejects_raw_rows_that_loader_did_not_normalize(self):
+        """SFT requires the dataset loader to emit prompt/response rows."""
         tokenizer = FakeTextTokenizer()
 
-        seq = sft_mod._record_to_train_sequence({"text": "abc"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16)
-
-        self.assertEqual(seq.prompt_mask, [True, False, False])
+        with self.assertRaisesRegex(ValueError, "dataset loader must return rows"):
+            sft_mod._record_to_train_sequence({"text": "abc"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16)
 
     def test_sft_drops_rows_without_target_tokens(self):
         """Rows that cannot produce a next-token target should be filtered out."""
         tokenizer = FakeTextTokenizer()
 
-        seq = sft_mod._record_to_train_sequence({"text": "a"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16)
+        seq = sft_mod._record_to_train_sequence(
+            {"prompt": "a", "response": ""}, tokenizer, max_prompt_tokens=16, max_new_tokens=16
+        )
 
         self.assertIsNone(seq)
 
@@ -135,35 +126,13 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
         self.assertIsNone(too_long_response)
         self.assertIsNotNone(exact_budget)
 
-    def test_sft_fallback_chat_template_keeps_assistant_delta_scoped(self):
-        """Fallback chat rendering should not let EOS suffixes over-mark history."""
-        tokenizer = EosAddingFallbackTokenizer()
-        messages = [
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "ok"},
-        ]
-
-        tokens, prompt_mask = sft_mod._messages_to_tokens_and_mask(messages, tokenizer)
-        final_rendering = data_utils.apply_chat_template(tokenizer, messages)
-        prompt_rendering = data_utils.apply_chat_template(tokenizer, messages[:1])
-
-        self.assertEqual(tokens, final_rendering + [tokenizer.eos_token_id])
-        self.assertEqual(len(tokens), len(prompt_mask))
-        self.assertEqual(tokens[-1], tokenizer.eos_token_id)
-        self.assertFalse(prompt_mask[-1])
-        self.assertEqual(prompt_mask[: len(prompt_rendering)], [True] * len(prompt_rendering))
-        self.assertEqual(
-            prompt_mask[len(prompt_rendering) :],
-            [False] * (len(final_rendering) - len(prompt_rendering) + 1),
-        )
-
     def test_sft_fit_raises_when_all_rows_are_filtered(self):
         """SFT should fail loudly instead of finishing with zero train steps."""
         backend = FakeSFTBackend()
         trainer = sft_mod.SFTTrainer(
             _sft_config(),
             instance=backend,
-            dataset=[{"text": ""}, {"text": "a"}],
+            dataset=[{"prompt": "q", "response": ""}, {"prompt": "q", "response": ""}],
             reward_fn=None,
             loss_fn=lambda _pack, _logprobs: None,
         )

--- a/tests/test_trainer_dataset_utils_cpu.py
+++ b/tests/test_trainer_dataset_utils_cpu.py
@@ -99,6 +99,20 @@ class TrainerDatasetUtilityTest(unittest.TestCase):
 
         self.assertIsNone(seq)
 
+    def test_sft_drops_rows_with_none_prompt_or_response(self):
+        """None values should not be converted to the literal token string."""
+        tokenizer = FakeTextTokenizer()
+
+        none_prompt = sft_mod._record_to_train_sequence(
+            {"prompt": None, "response": "answer"}, tokenizer, max_prompt_tokens=16, max_new_tokens=16
+        )
+        none_response = sft_mod._record_to_train_sequence(
+            {"prompt": "question", "response": None}, tokenizer, max_prompt_tokens=16, max_new_tokens=16
+        )
+
+        self.assertIsNone(none_prompt)
+        self.assertIsNone(none_response)
+
     def test_sft_enforces_prompt_and_response_budgets_independently(self):
         """SFT should reject over-budget prompts and responses separately."""
         tokenizer = FakeTextTokenizer()


### PR DESCRIPTION
## Summary
- require --dataset-loader-fn for SFT training so raw dataset schemas are normalized outside the trainer
- make SFT consume loader-produced prompt/response rows only
- add an Alpaca SFT loader example for yahma/alpaca-cleaned and document per-algorithm dataset loader contracts

## Tests
- env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_trainer_dataset_utils_cpu.py tests/test_train_cli_config_cpu.py tests/test_config_data_cpu.py tests/test_sft_example_cpu.py -q
- ruff check areno/api/trainers/sft.py areno/cli/train.py examples/sft/alpaca/dataset_loader.py tests/test_trainer_dataset_utils_cpu.py tests/test_train_cli_config_cpu.py tests/test_config_data_cpu.py tests/test_sft_example_cpu.py
- make -C docs html

Closes #115