### PR TITLE
fix(attention): clean native fallback diagnostics

### DIFF
--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -246,16 +246,11 @@ def flash_attention_unsupported_model_reason(model: ModelConfig) -> str | None:
         dims.append(("swa qk head dim", model.swa_head_dim))
     if model.qk_nope_head_dim or model.qk_rope_head_dim:
         dims.append(("qk head dim", model.qk_nope_head_dim + model.qk_rope_head_dim))
-    unsupported = []
-    seen: set[str] = set()
-    for name, dim in dims:
-        if dim is None or int(dim) <= FLASH_ATTENTION_MAX_QK_HEAD_DIM:
-            continue
-        reason = f"{name} {dim}"
-        if reason in seen:
-            continue
-        seen.add(reason)
-        unsupported.append(reason)
+    unsupported = list(
+        dict.fromkeys(
+            f"{name} {dim}" for name, dim in dims if dim is not None and int(dim) > FLASH_ATTENTION_MAX_QK_HEAD_DIM
+        )
+    )
     if not unsupported:
         return None
     return ", ".join(unsupported)

--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -16,6 +16,9 @@ from typing import Any, Literal
 
 import torch
 
+# AReno's flash path uses flash-attn features beyond the Turing-compatible
+# forward kernels, including paged KV/cache and training paths, so require
+# Ampere+ even though flash-attn 2.x has partial sm75 forward support.
 FLASH_ATTENTION_MIN_CUDA_CAPABILITY = (8, 0)
 FLASH_ATTENTION_MAX_QK_HEAD_DIM = 256
 
@@ -243,9 +246,16 @@ def flash_attention_unsupported_model_reason(model: ModelConfig) -> str | None:
         dims.append(("swa qk head dim", model.swa_head_dim))
     if model.qk_nope_head_dim or model.qk_rope_head_dim:
         dims.append(("qk head dim", model.qk_nope_head_dim + model.qk_rope_head_dim))
-    unsupported = [
-        f"{name} {dim}" for name, dim in dims if dim is not None and int(dim) > FLASH_ATTENTION_MAX_QK_HEAD_DIM
-    ]
+    unsupported = []
+    seen: set[str] = set()
+    for name, dim in dims:
+        if dim is None or int(dim) <= FLASH_ATTENTION_MAX_QK_HEAD_DIM:
+            continue
+        reason = f"{name} {dim}"
+        if reason in seen:
+            continue
+        seen.add(reason)
+        unsupported.append(reason)
     if not unsupported:
         return None
     return ", ".join(unsupported)

--- a/areno/engine/layers/attention_backend/common.py
+++ b/areno/engine/layers/attention_backend/common.py
@@ -1,11 +1,10 @@
 """Shared utilities for attention backends.
 
 Defines the `AttentionCall` value object, which packages a set of Q/K/V
-tensors together with the FlashAttention-shaped parameters (normalized
-window, optional softmax scale, padded V head dim) so train and infer paths
-present identical kernel arguments. Also exposes the small helpers used to
-pad value heads, expand grouped-query KV heads, and translate window-size
-conventions.
+tensors together with the attention-call parameters (normalized window,
+optional softmax scale, padded V head dim) so train, prefill, and native
+fallback paths can share one shape contract. Also exposes the small helpers
+used to pad value heads and expand grouped-query KV heads.
 """
 
 from __future__ import annotations

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -162,6 +162,20 @@ class ConfigAndDataTest(unittest.TestCase):
 
         self.assertEqual(flash_attention_unsupported_model_reason(model), "qk head dim 512")
 
+    def test_flash_attention_unsupported_model_reason_dedupes_qk_head_dim(self):
+        """Split QK dims should not duplicate a matching base head-dim reason."""
+        model = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            head_dim=512,
+            qk_nope_head_dim=384,
+            qk_rope_head_dim=128,
+        )
+
+        self.assertEqual(flash_attention_unsupported_model_reason(model), "qk head dim 512")
+
     def test_flash_attention_unsupported_gpu_reason_names_t4(self):
         """The compatibility warning should identify unsupported visible GPUs."""
         with (


### PR DESCRIPTION
## Summary
- document why AReno keeps flash-attn CUDA capability at sm80+
- dedupe duplicate qk head-dim fallback reasons when split QK dims match head_dim
- refresh the shared attention backend docstring to remove stale SDPA conversion wording

## Tests
- env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_data_cpu.py -q
- ruff check areno/engine/config.py areno/engine/layers/attention_backend/common.py tests/test_config_data_cpu.py

Closes #84