### PR TITLE
fix(runtime): assert packed logprob length invariant

### DIFF
--- a/areno/engine/runtime/logprobs.py
+++ b/areno/engine/runtime/logprobs.py
@@ -54,6 +54,8 @@ def packed_next_token_logprobs(
     # of the next token, then run the same TP kernel over those.
     flat_tokens = tokens.reshape(-1)
     cu_seqlens = cu_seqlens.to(device=tokens.device, dtype=torch.long)
+    if cu_seqlens.numel() > 1 and bool(torch.any(cu_seqlens[1:] <= cu_seqlens[:-1])):
+        raise ValueError("packed_next_token_logprobs requires strictly increasing cu_seqlens")
     # Training packs every row with at least one token, so the number of
     # next-token action sites is total_tokens minus one tail token per row.
     # Keep this as shape arithmetic to avoid a GPU sync from `.item()`.

--- a/areno/engine/runtime/train_step.py
+++ b/areno/engine/runtime/train_step.py
@@ -102,8 +102,9 @@ def _pack_train_data(data_pack: dict[str, Any]) -> dict[str, Any]:
     if int(lengths.numel()) != batch:
         return data_pack
 
-    # Token-axis bookkeeping. `cu_seqlens[i+1]` is the prefix sum of valid
-    # tokens up to row i, matching the FlashAttention varlen contract.
+    # Token-axis bookkeeping. Clamp to at least one token per row so
+    # `cu_seqlens` is strictly increasing; packed_next_token_logprobs relies on
+    # that invariant when vectorizing sequence-tail masking.
     lengths = lengths.to(device=input_ids.device, dtype=torch.long).clamp(min=1, max=input_ids.shape[1])
     total_tokens = int(lengths.sum().item())
     packed_ids = torch.empty(total_tokens, device=input_ids.device, dtype=input_ids.dtype)

--- a/tests/test_logprobs_cpu.py
+++ b/tests/test_logprobs_cpu.py
@@ -80,6 +80,15 @@ class LogprobTest(unittest.TestCase):
 
         self.assertTrue(torch.allclose(actual, expected, atol=1e-6))
 
+    def test_packed_next_token_logprobs_rejects_zero_length_segments(self):
+        """Packed scoring depends on strictly positive segment lengths."""
+        logits = torch.randn(1, 3, 4)
+        tokens = torch.tensor([0, 1, 2])
+        cu_seqlens = torch.tensor([0, 2, 2, 3])
+
+        with self.assertRaisesRegex(ValueError, "strictly increasing cu_seqlens"):
+            logprob_ops.packed_next_token_logprobs(logits, tokens, cu_seqlens)
+
     def test_empty_vocab_logprob_path_returns_empty_tensor(self):
         """Empty microbatches should return an empty tensor instead of failing."""
         logits = torch.empty(0, 3)


### PR DESCRIPTION
## Summary
- add a cheap invariant check that packed_next_token_logprobs receives strictly increasing cu_seqlens
- document the _pack_train_data clamp that establishes the no-zero-length-segment invariant
- add a CPU regression test for zero-length packed segments

## Tests
- env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_logprobs_cpu.py -q
- ruff check areno/engine/runtime/logprobs.py areno/engine/runtime/train_step.py tests/test_logprobs_cpu.py

Closes #83