### PR TITLE
test: protect lazy public API imports

### DIFF
--- a/tests/test_import_boundaries_cpu.py
+++ b/tests/test_import_boundaries_cpu.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 import textwrap
@@ -12,7 +11,6 @@ def test_public_api_imports_do_not_load_engine_heavy_modules():
     script = textwrap.dedent(
         """
         import importlib
-        import json
         import sys
 
         for module_name in [
@@ -30,21 +28,12 @@ def test_public_api_imports_do_not_load_engine_heavy_modules():
             "areno.engine.inference",
             "areno.engine.worker",
         ]
-        print(json.dumps({name: name in sys.modules for name in heavy_modules}, sort_keys=True))
+        for name in heavy_modules:
+            assert name not in sys.modules, f"{name} was unexpectedly loaded"
         """
     )
 
-    result = subprocess.run(
+    subprocess.run(
         [sys.executable, "-c", script],
         check=True,
-        capture_output=True,
-        text=True,
     )
-
-    imported = json.loads(result.stdout.strip().splitlines()[-1])
-    assert imported == {
-        "areno.api.backend.areno": False,
-        "areno.engine.api": False,
-        "areno.engine.inference": False,
-        "areno.engine.worker": False,
-    }

--- a/tests/test_import_boundaries_cpu.py
+++ b/tests/test_import_boundaries_cpu.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+
+def test_public_api_imports_do_not_load_engine_heavy_modules():
+    """Public API imports stay on the lazy side of the engine/backend boundary."""
+
+    script = textwrap.dedent(
+        """
+        import importlib
+        import json
+        import sys
+
+        for module_name in [
+            "areno",
+            "areno.api",
+            "areno.api.trainer",
+            "areno.api.backend",
+            "areno.api.backend.base",
+        ]:
+            importlib.import_module(module_name)
+
+        heavy_modules = [
+            "areno.api.backend.areno",
+            "areno.engine.api",
+            "areno.engine.inference",
+            "areno.engine.worker",
+        ]
+        print(json.dumps({name: name in sys.modules for name in heavy_modules}, sort_keys=True))
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    imported = json.loads(result.stdout.strip().splitlines()[-1])
+    assert imported == {
+        "areno.api.backend.areno": False,
+        "areno.engine.api": False,
+        "areno.engine.inference": False,
+        "areno.engine.worker": False,
+    }


### PR DESCRIPTION
## Summary
- Add a subprocess CPU regression test for public API import boundaries.
- Assert importing areno, areno.api, areno.api.trainer, and backend seam modules does not load engine-heavy modules.
- Keep assertions focused on heavy modules instead of brittle full sys.modules state.

## Tests
- env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_import_boundaries_cpu.py tests/test_trainer_api_cpu.py -q
- ruff check tests/test_import_boundaries_cpu.py

Closes #65