### PR TITLE
ci: add Modal math training smoke workflows

### DIFF
--- a/.github/workflows/modal_math_algorithms.yml
+++ b/.github/workflows/modal_math_algorithms.yml
@@ -1,0 +1,53 @@
+name: Modal Math Algorithms
+
+on:
+  schedule:
+    - cron: "17 19 * * *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "AReno branch to checkout inside the Modal image."
+        required: false
+        default: main
+      ckpt:
+        description: "Checkpoint path or Hugging Face repo ID."
+        required: false
+        default: Qwen/Qwen3.5-0.8B
+      github_environment:
+        description: "GitHub Environment that stores Modal secrets."
+        required: false
+        default: modal
+
+permissions:
+  contents: read
+
+concurrency:
+  group: modal-math-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  math:
+    name: math / ${{ matrix.algo }}
+    strategy:
+      fail-fast: false
+      matrix:
+        algo: [gspo, ppo]
+    uses: ./.github/workflows/modal_train.yml
+    with:
+      branch: ${{ inputs.branch || 'main' }}
+      ckpt: ${{ inputs.ckpt || 'Qwen/Qwen3.5-0.8B' }}
+      algo: ${{ matrix.algo }}
+      dataset_path: gsm8k:main
+      dataset_loader_fn: examples/math/dataset_loader.py
+      reward_fn_path: examples/math/math_verify_reward.py
+      tp_size: "1"
+      world_size: "1"
+      batch_size: "2"
+      n_samples: "8"
+      mini_bs: "1"
+      max_running_prompts: "16"
+      max_new_tokens: "1024"
+      epochs: "1"
+      max_steps: "5"
+      github_environment: ${{ inputs.github_environment || 'modal' }}
+    secrets: inherit

--- a/.github/workflows/modal_train.yml
+++ b/.github/workflows/modal_train.yml
@@ -1,0 +1,307 @@
+name: Modal Train
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "AReno branch to checkout inside the Modal image."
+        required: false
+        type: string
+        default: main
+      ckpt:
+        description: "Checkpoint path or Hugging Face repo ID."
+        required: false
+        type: string
+        default: Qwen/Qwen3.5-0.8B
+      algo:
+        description: "AReno algorithm name."
+        required: false
+        type: string
+        default: gspo
+      dataset_path:
+        description: "Dataset path passed to areno train."
+        required: false
+        type: string
+        default: gsm8k:main
+      dataset_loader_fn:
+        description: "Dataset loader path/function. Leave empty to omit."
+        required: false
+        type: string
+        default: examples/math/dataset_loader.py
+      reward_fn_path:
+        description: "Reward function path. Leave empty to omit."
+        required: false
+        type: string
+        default: examples/math/math_verify_reward.py
+      agent_fn:
+        description: "Optional agent function path. Leave empty to omit."
+        required: false
+        type: string
+        default: ""
+      tp_size:
+        description: "Tensor parallel size."
+        required: false
+        type: string
+        default: "1"
+      world_size:
+        description: "World size."
+        required: false
+        type: string
+        default: "1"
+      batch_size:
+        description: "Prompt batch size."
+        required: false
+        type: string
+        default: "2"
+      n_samples:
+        description: "Rollout samples per prompt."
+        required: false
+        type: string
+        default: "8"
+      mini_bs:
+        description: "Training microbatch size."
+        required: false
+        type: string
+        default: "1"
+      max_running_prompts:
+        description: "Max concurrent rollout prompts."
+        required: false
+        type: string
+        default: "16"
+      max_prompt_tokens:
+        description: "Optional max prompt tokens. Leave empty to omit."
+        required: false
+        type: string
+        default: ""
+      max_new_tokens:
+        description: "Max generated tokens."
+        required: false
+        type: string
+        default: "1024"
+      max_context_len:
+        description: "Optional total context limit. Leave empty to omit."
+        required: false
+        type: string
+        default: ""
+      epochs:
+        description: "Epoch count."
+        required: false
+        type: string
+        default: "1"
+      max_steps:
+        description: "Trainer step cap."
+        required: false
+        type: string
+        default: "5"
+      extra_train_args:
+        description: "Extra areno train args, shell-split by the launcher."
+        required: false
+        type: string
+        default: ""
+      keep_rollout_state:
+        description: "Set true to avoid adding --drop-rollout-state."
+        required: false
+        type: boolean
+        default: false
+      github_environment:
+        description: "GitHub Environment that stores Modal secrets."
+        required: false
+        type: string
+        default: modal
+    secrets:
+      MODAL_TOKEN_ID:
+        required: true
+      MODAL_TOKEN_SECRET:
+        required: true
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "AReno branch to checkout inside the Modal image."
+        required: false
+        default: main
+      ckpt:
+        description: "Checkpoint path or Hugging Face repo ID."
+        required: false
+        default: Qwen/Qwen3.5-0.8B
+      algo:
+        description: "AReno algorithm name."
+        required: false
+        default: gspo
+      dataset_path:
+        description: "Dataset path passed to areno train."
+        required: false
+        default: gsm8k:main
+      dataset_loader_fn:
+        description: "Dataset loader path/function. Leave empty to omit."
+        required: false
+        default: examples/math/dataset_loader.py
+      reward_fn_path:
+        description: "Reward function path. Leave empty to omit."
+        required: false
+        default: examples/math/math_verify_reward.py
+      agent_fn:
+        description: "Optional agent function path. Leave empty to omit."
+        required: false
+        default: ""
+      tp_size:
+        description: "Tensor parallel size."
+        required: false
+        default: "1"
+      world_size:
+        description: "World size."
+        required: false
+        default: "1"
+      batch_size:
+        description: "Prompt batch size."
+        required: false
+        default: "2"
+      n_samples:
+        description: "Rollout samples per prompt."
+        required: false
+        default: "8"
+      mini_bs:
+        description: "Training microbatch size."
+        required: false
+        default: "1"
+      max_running_prompts:
+        description: "Max concurrent rollout prompts."
+        required: false
+        default: "16"
+      max_prompt_tokens:
+        description: "Optional max prompt tokens. Leave empty to omit."
+        required: false
+        default: ""
+      max_new_tokens:
+        description: "Max generated tokens."
+        required: false
+        default: "1024"
+      max_context_len:
+        description: "Optional total context limit. Leave empty to omit."
+        required: false
+        default: ""
+      epochs:
+        description: "Epoch count."
+        required: false
+        default: "1"
+      max_steps:
+        description: "Trainer step cap."
+        required: false
+        default: "5"
+      extra_train_args:
+        description: "Extra areno train args, shell-split by the launcher."
+        required: false
+        default: ""
+      keep_rollout_state:
+        description: "Set true to avoid adding --drop-rollout-state."
+        required: false
+        type: boolean
+        default: false
+      github_environment:
+        description: "GitHub Environment that stores Modal secrets."
+        required: false
+        default: modal
+
+permissions:
+  contents: read
+
+concurrency:
+  group: modal-train-${{ github.workflow }}-${{ github.ref }}-${{ inputs.algo || 'gspo' }}
+  cancel-in-progress: false
+
+jobs:
+  train:
+    name: modal / ${{ inputs.algo || 'gspo' }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.github_environment || 'modal' }}
+    timeout-minutes: 45
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      ARENO_MODAL_BRANCH: ${{ inputs.branch || 'main' }}
+      ARENO_MODAL_CKPT: ${{ inputs.ckpt || 'Qwen/Qwen3.5-0.8B' }}
+      ARENO_MODAL_ALGO: ${{ inputs.algo || 'gspo' }}
+      ARENO_MODAL_DATASET_PATH: ${{ inputs.dataset_path || 'gsm8k:main' }}
+      ARENO_MODAL_DATASET_LOADER_FN: ${{ inputs.dataset_loader_fn || 'examples/math/dataset_loader.py' }}
+      ARENO_MODAL_REWARD_FN_PATH: ${{ inputs.reward_fn_path || 'examples/math/math_verify_reward.py' }}
+      ARENO_MODAL_AGENT_FN: ${{ inputs.agent_fn || '' }}
+      ARENO_MODAL_TP_SIZE: ${{ inputs.tp_size || '1' }}
+      ARENO_MODAL_WORLD_SIZE: ${{ inputs.world_size || '1' }}
+      ARENO_MODAL_BATCH_SIZE: ${{ inputs.batch_size || '2' }}
+      ARENO_MODAL_N_SAMPLES: ${{ inputs.n_samples || '8' }}
+      ARENO_MODAL_MINI_BS: ${{ inputs.mini_bs || '1' }}
+      ARENO_MODAL_MAX_RUNNING_PROMPTS: ${{ inputs.max_running_prompts || '16' }}
+      ARENO_MODAL_MAX_PROMPT_TOKENS: ${{ inputs.max_prompt_tokens || '' }}
+      ARENO_MODAL_MAX_NEW_TOKENS: ${{ inputs.max_new_tokens || '1024' }}
+      ARENO_MODAL_MAX_CONTEXT_LEN: ${{ inputs.max_context_len || '' }}
+      ARENO_MODAL_EPOCHS: ${{ inputs.epochs || '1' }}
+      ARENO_MODAL_MAX_STEPS: ${{ inputs.max_steps || '5' }}
+      ARENO_MODAL_EXTRA_TRAIN_ARGS: ${{ inputs.extra_train_args || '' }}
+      ARENO_MODAL_KEEP_ROLLOUT_STATE: ${{ inputs.keep_rollout_state || false }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Modal client
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade modal
+
+      - name: Validate Modal secrets
+        id: modal-secrets
+        run: |
+          if [ -z "$MODAL_TOKEN_ID" ] || [ -z "$MODAL_TOKEN_SECRET" ]; then
+            echo "::notice::Skipping Modal train because MODAL_TOKEN_ID or MODAL_TOKEN_SECRET is not configured."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
+      - name: Launch Modal train
+        if: steps.modal-secrets.outputs.available == 'true'
+        run: |
+          args=(
+            python ci/modal_gsm8k_gspo.py
+            --branch "$ARENO_MODAL_BRANCH"
+            --modal-token-id "$MODAL_TOKEN_ID"
+            --modal-token-secret "$MODAL_TOKEN_SECRET"
+            --ckpt "$ARENO_MODAL_CKPT"
+            --algo "$ARENO_MODAL_ALGO"
+            --dataset-path "$ARENO_MODAL_DATASET_PATH"
+            --dataset-loader-fn "$ARENO_MODAL_DATASET_LOADER_FN"
+            --reward-fn-path "$ARENO_MODAL_REWARD_FN_PATH"
+            --tp-size "$ARENO_MODAL_TP_SIZE"
+            --world-size "$ARENO_MODAL_WORLD_SIZE"
+            --batch-size "$ARENO_MODAL_BATCH_SIZE"
+            --n-samples "$ARENO_MODAL_N_SAMPLES"
+            --mini-bs "$ARENO_MODAL_MINI_BS"
+            --max-running-prompts "$ARENO_MODAL_MAX_RUNNING_PROMPTS"
+            --max-new-tokens "$ARENO_MODAL_MAX_NEW_TOKENS"
+            --epochs "$ARENO_MODAL_EPOCHS"
+            --max-steps "$ARENO_MODAL_MAX_STEPS"
+          )
+
+          if [ -n "$ARENO_MODAL_AGENT_FN" ]; then
+            args+=(--agent-fn "$ARENO_MODAL_AGENT_FN")
+          fi
+          if [ -n "$ARENO_MODAL_MAX_PROMPT_TOKENS" ]; then
+            args+=(--max-prompt-tokens "$ARENO_MODAL_MAX_PROMPT_TOKENS")
+          fi
+          if [ -n "$ARENO_MODAL_MAX_CONTEXT_LEN" ]; then
+            args+=(--max-context-len "$ARENO_MODAL_MAX_CONTEXT_LEN")
+          fi
+          if [ -n "$ARENO_MODAL_EXTRA_TRAIN_ARGS" ]; then
+            args+=(--extra-train-args "$ARENO_MODAL_EXTRA_TRAIN_ARGS")
+          fi
+          if [ "$ARENO_MODAL_KEEP_ROLLOUT_STATE" = "true" ]; then
+            args+=(--keep-rollout-state)
+          fi
+
+          printf 'Modal AReno train: branch=%s algo=%s dataset=%s ckpt=%s\n' \
+            "$ARENO_MODAL_BRANCH" "$ARENO_MODAL_ALGO" "$ARENO_MODAL_DATASET_PATH" "$ARENO_MODAL_CKPT"
+          "${args[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,12 @@ RUN python -m pip install --index-url "${PIP_INDEX_URL}" \
         "tqdm>=4.66"
 
 ARG ARENO_REPO_URL=https://github.com/inclusionAI/AReno.git
-ARG ARENO_BRANCH=
+ARG ARENO_BRANCH=__local__
 
 WORKDIR /workspace/areno
 COPY . /workspace/areno
 
-RUN if [[ -n "${ARENO_BRANCH}" ]]; then \
+RUN if [[ "${ARENO_BRANCH}" != "__local__" ]]; then \
         cd /workspace && \
         rm -rf /workspace/areno && \
         git clone --depth 1 --branch "${ARENO_BRANCH}" "${ARENO_REPO_URL}" /workspace/areno; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ ENV PIP_NO_CACHE_DIR=1 \
     PYTHONUNBUFFERED=1 \
     CUDA_HOME=/usr/local/cuda
 
+RUN apt-get update && \
+        apt-get install -y --no-install-recommends git && \
+        rm -rf /var/lib/apt/lists/*
+
 RUN python -m pip install --index-url "${PIP_INDEX_URL}" --upgrade pip setuptools wheel packaging ninja
 
 RUN python -m pip install --index-url "${PIP_INDEX_URL}" \
@@ -21,8 +25,17 @@ RUN python -m pip install --index-url "${PIP_INDEX_URL}" \
         "accelerate" \
         "tqdm>=4.66"
 
+ARG ARENO_REPO_URL=https://github.com/inclusionAI/AReno.git
+ARG ARENO_BRANCH=
+
 WORKDIR /workspace/areno
 COPY . /workspace/areno
+
+RUN if [[ -n "${ARENO_BRANCH}" ]]; then \
+        cd /workspace && \
+        rm -rf /workspace/areno && \
+        git clone --depth 1 --branch "${ARENO_BRANCH}" "${ARENO_REPO_URL}" /workspace/areno; \
+    fi
 
 RUN python -m pip install -e . --no-build-isolation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN python -m pip install --index-url "${PIP_INDEX_URL}" \
         "einops" \
         "safetensors>=0.4" \
         "accelerate" \
-        "tqdm>=4.66"
+        "tqdm>=4.66" \
+        "math-verify"
 
 ARG ARENO_REPO_URL=https://github.com/inclusionAI/AReno.git
 ARG ARENO_BRANCH=__local__

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -31,6 +31,7 @@ class TrainerConfig:
     save_path: str | None = None
     save_interval: int = 100
     epochs: int = 10
+    max_steps: int | None = None
     tp_size: int = 4
     world_size: int = 8
     batch_size: int = 32

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -117,6 +117,9 @@ class DPOTrainer:
                 self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
                 self._maybe_save(epoch, step)
                 step += 1
+                if self.config.max_steps is not None and step >= self.config.max_steps:
+                    self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
+                    return
             self.logger.info("epoch=%d stage=epoch_end", epoch)
 
     def _iter_train_batches(self, tokenizer, *, max_seq_len: int):

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -115,6 +115,9 @@ class PolicyOnlyTrainer:
                         self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
                         self.areno.finish_step()
                         step += 1
+                        if self.config.max_steps is not None and step >= self.config.max_steps:
+                            self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
+                            return
                         continue
                     self.logger.info("epoch=%d step=%d role=%s stage=train_start", epoch, step, role)
                     train_start = time.perf_counter()
@@ -133,6 +136,9 @@ class PolicyOnlyTrainer:
                     self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
                     self._maybe_save(epoch, step)
                 step += 1
+                if self.config.max_steps is not None and step >= self.config.max_steps:
+                    self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
+                    return
             self.logger.info("epoch=%d stage=epoch_end", epoch)
 
     def _policy_role_name(self) -> str:

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -83,6 +83,9 @@ class SFTTrainer:
                 self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
                 self._maybe_save(epoch, step)
                 step += 1
+                if self.config.max_steps is not None and step >= self.config.max_steps:
+                    self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
+                    return
             self.logger.info("epoch=%d stage=epoch_end", epoch)
 
     def _iter_train_batches(self, tokenizer, *, max_prompt_tokens: int, max_new_tokens: int):

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -60,6 +60,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "mem_frac",
             "tune_max_samples",
             "epochs",
+            "max_steps",
             "world_size",
             "tp_size",
         ),
@@ -190,6 +191,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--save-interval must be positive")
     if args.epochs <= 0:
         raise click.UsageError("--epochs must be positive")
+    if args.max_steps is not None and args.max_steps <= 0:
+        raise click.UsageError("--max-steps must be positive")
     if args.tp_size <= 0:
         raise click.UsageError("--tp-size must be positive")
     if args.world_size <= 0:
@@ -304,6 +307,7 @@ def _format_training_config_summary(
         (
             "Training",
             [
+                ("max_steps", _format_optional(config.max_steps)),
                 ("mini_bs", str(config.mini_bs)),
                 ("gradient_accumulation_steps", _format_optional(config.gradient_accumulation_steps, default="auto")),
                 (
@@ -558,6 +562,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             save_path=args.save_path,
             save_interval=args.save_interval,
             epochs=args.epochs,
+            max_steps=args.max_steps,
             tp_size=args.tp_size,
             world_size=args.world_size,
             batch_size=args.batch_size,
@@ -596,6 +601,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             save_path=args.save_path,
             save_interval=args.save_interval,
             epochs=args.epochs,
+            max_steps=args.max_steps,
             tp_size=args.tp_size,
             world_size=args.world_size,
             batch_size=args.batch_size,
@@ -633,6 +639,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             save_path=args.save_path,
             save_interval=args.save_interval,
             epochs=args.epochs,
+            max_steps=args.max_steps,
             tp_size=args.tp_size,
             world_size=args.world_size,
             batch_size=args.batch_size,
@@ -677,6 +684,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         save_path=args.save_path,
         save_interval=args.save_interval,
         epochs=args.epochs,
+        max_steps=args.max_steps,
         tp_size=args.tp_size,
         world_size=args.world_size,
         batch_size=args.batch_size,
@@ -946,6 +954,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--metrics-log-dir", default=DEFAULT_METRICS_LOG_DIR, show_default=True, help="TensorBoard metrics log directory."
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
+@click.option("--max-steps", type=int, default=None, help="Stop after this many trainer steps.")
 @click.option(
     "--tune-params",
     "tune_params",

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -167,6 +167,7 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     """Build a typed trainer config from Click option values."""
 
     args = SimpleNamespace(**options)
+    args.max_steps = getattr(args, "max_steps", None)
     # Required-argument checks live here so offline trainers can omit reward
     # inputs while RL algorithms still require a reward function or model.
     if args.ckpt is None:
@@ -551,6 +552,7 @@ def _function_accepts_positional_args(function: ast.FunctionDef | ast.AsyncFunct
 def _trainer_config_from_args(args) -> TrainerConfig:
     # Each algorithm gets the narrowest config dataclass it needs; offline
     # trainers do not receive rollout/reward/GSPO fields by construction.
+    args.max_steps = getattr(args, "max_steps", None)
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -5,15 +5,19 @@ import os
 import shlex
 import subprocess
 import sys
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import modal
 
-APP_NAME = "areno-gsm8k-gspo"
+APP_NAME = "areno-train"
 REPO_URL = "https://github.com/inclusionAI/AReno.git"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 REMOTE_REPO_DIR = Path("/workspace/areno")
 DEFAULT_CKPT = "Qwen/Qwen3.5-0.8B"
+DEFAULT_DATASET_PATH = "gsm8k:main"
+DEFAULT_DATASET_LOADER_FN = "examples/math/dataset_loader.py"
+DEFAULT_REWARD_FN_PATH = "examples/math/math_verify_reward.py"
 MODAL_BRANCH_ENV = "ARENO_MODAL_BRANCH"
 
 
@@ -33,73 +37,167 @@ def _run(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | N
     subprocess.run(command, cwd=str(cwd) if cwd else None, env=env, check=True)
 
 
+@dataclass
+class TrainJobConfig:
+    branch: str
+    ckpt: str
+    algo: str
+    dataset_path: str
+    dataset_loader_fn: str | None
+    reward_fn_path: str | None
+    agent_fn: str | None
+    tp_size: int
+    world_size: int
+    batch_size: int
+    n_samples: int
+    mini_bs: int
+    max_running_prompts: int | None
+    max_prompt_tokens: int | None
+    max_new_tokens: int | None
+    max_context_len: int | None
+    epochs: int
+    max_steps: int | None
+    extra_train_args: list[str]
+
+
+def _add_optional(command: list[str], option: str, value: str | int | float | None) -> None:
+    if value not in (None, ""):
+        command.extend([option, str(value)])
+
+
+def _build_train_command(config: TrainJobConfig) -> list[str]:
+    command = [
+        "areno",
+        "train",
+        "--ckpt",
+        config.ckpt,
+        "--dataset-path",
+        config.dataset_path,
+        "--algo",
+        config.algo,
+        "--tp-size",
+        str(config.tp_size),
+        "--world-size",
+        str(config.world_size),
+        "--batch-size",
+        str(config.batch_size),
+        "--n-samples",
+        str(config.n_samples),
+        "--mini-bs",
+        str(config.mini_bs),
+        "--epochs",
+        str(config.epochs),
+    ]
+    _add_optional(command, "--dataset-loader-fn", config.dataset_loader_fn)
+    _add_optional(command, "--reward-fn-path", config.reward_fn_path)
+    _add_optional(command, "--agent-fn", config.agent_fn)
+    _add_optional(command, "--max-running-prompts", config.max_running_prompts)
+    _add_optional(command, "--max-prompt-tokens", config.max_prompt_tokens)
+    _add_optional(command, "--max-new-tokens", config.max_new_tokens)
+    _add_optional(command, "--max-context-len", config.max_context_len)
+    _add_optional(command, "--max-steps", config.max_steps)
+    command.extend(config.extra_train_args)
+    return command
+
+
 @app.function(
     image=image,
     gpu="L4",
     timeout=60 * 60 * 3,
 )
-def run_gsm8k_gspo(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
-    """Run a short GSM8K GSPO train task on Modal."""
+def run_areno_train(config_dict: dict) -> None:
+    """Run an AReno train task on Modal."""
 
-    print(f"Running AReno branch built into image: {branch}", flush=True)
+    config = TrainJobConfig(**config_dict)
+    print(f"Running AReno branch built into image: {config.branch}", flush=True)
 
     env = os.environ.copy()
     env.setdefault("PYTHONUNBUFFERED", "1")
     env.setdefault("TOKENIZERS_PARALLELISM", "false")
 
-    _run(
-        [
-            "areno",
-            "train",
-            "--ckpt",
-            ckpt,
-            "--dataset-path",
-            "gsm8k:main",
-            "--dataset-loader-fn",
-            "examples/math/dataset_loader.py",
-            "--reward-fn-path",
-            "examples/math/math_verify_reward.py",
-            "--algo",
-            "gspo",
-            "--tp-size",
-            "1",
-            "--world-size",
-            "1",
-            "--batch-size",
-            "2",
-            "--n-samples",
-            "8",
-            "--mini-bs",
-            "1",
-            "--max-running-prompts",
-            "16",
-            "--max-new-tokens",
-            "1024",
-            "--epochs",
-            "1",
-            "--max-steps",
-            "10",
-            "--drop-rollout-state",
-        ],
-        cwd=REMOTE_REPO_DIR,
-        env=env,
-    )
+    _run(_build_train_command(config), cwd=REMOTE_REPO_DIR, env=env)
 
 
 @app.local_entrypoint()
-def main(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
-    run_gsm8k_gspo.remote(branch=branch, ckpt=ckpt)
+def main(config_json: str) -> None:
+    import json
+
+    run_areno_train.remote(json.loads(config_json))
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Launch AReno GSM8K GSPO training on Modal.")
+    parser = argparse.ArgumentParser(description="Launch an AReno training job on Modal.")
     parser.add_argument("--branch", required=True, help="AReno git branch to checkout inside the Modal job.")
     parser.add_argument("--modal-token-id", required=True, help="Modal token ID used by the local Modal client.")
     parser.add_argument(
         "--modal-token-secret", required=True, help="Modal token secret used by the local Modal client."
     )
     parser.add_argument("--ckpt", default=DEFAULT_CKPT, help=f"Actor checkpoint or HF repo ID. Default: {DEFAULT_CKPT}")
+    parser.add_argument("--algo", default="gspo", help="AReno training algorithm. Default: gspo")
+    parser.add_argument(
+        "--dataset-path", default=DEFAULT_DATASET_PATH, help=f"Dataset path. Default: {DEFAULT_DATASET_PATH}"
+    )
+    parser.add_argument(
+        "--dataset-loader-fn",
+        default=DEFAULT_DATASET_LOADER_FN,
+        help=f"Dataset loader file/function. Default: {DEFAULT_DATASET_LOADER_FN}",
+    )
+    parser.add_argument(
+        "--reward-fn-path",
+        default=DEFAULT_REWARD_FN_PATH,
+        help=f"Reward function file. Default: {DEFAULT_REWARD_FN_PATH}",
+    )
+    parser.add_argument("--agent-fn", default=None, help="Optional agentic run_agent.py file/function.")
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size. Default: 1")
+    parser.add_argument("--world-size", type=int, default=1, help="World size. Default: 1")
+    parser.add_argument("--batch-size", type=int, default=2, help="Prompt batch size. Default: 2")
+    parser.add_argument("--n-samples", type=int, default=8, help="Rollout samples per prompt. Default: 8")
+    parser.add_argument("--mini-bs", type=int, default=1, help="Training microbatch size. Default: 1")
+    parser.add_argument("--max-running-prompts", type=int, default=16, help="Concurrent rollout prompts. Default: 16")
+    parser.add_argument("--max-prompt-tokens", type=int, default=None, help="Optional max prompt tokens.")
+    parser.add_argument("--max-new-tokens", type=int, default=1024, help="Max generated tokens. Default: 1024")
+    parser.add_argument("--max-context-len", type=int, default=None, help="Optional total context limit.")
+    parser.add_argument("--epochs", type=int, default=1, help="Epoch count. Default: 1")
+    parser.add_argument("--max-steps", type=int, default=5, help="Optional trainer step cap. Default: 5")
+    parser.add_argument(
+        "--extra-train-arg",
+        action="append",
+        default=[],
+        help="Additional areno train argument. Repeat for multiple args. Default: --drop-rollout-state",
+    )
+    parser.add_argument(
+        "--extra-train-args",
+        default="",
+        help='Additional areno train arguments parsed with shell-style splitting, e.g. "--greedy --temperature 0.7".',
+    )
+    parser.add_argument("--keep-rollout-state", action="store_true", help="Do not add --drop-rollout-state by default.")
     return parser.parse_args()
+
+
+def _config_from_args(args: argparse.Namespace) -> TrainJobConfig:
+    return TrainJobConfig(
+        branch=args.branch,
+        ckpt=args.ckpt,
+        algo=args.algo,
+        dataset_path=args.dataset_path,
+        dataset_loader_fn=args.dataset_loader_fn,
+        reward_fn_path=args.reward_fn_path,
+        agent_fn=args.agent_fn,
+        tp_size=args.tp_size,
+        world_size=args.world_size,
+        batch_size=args.batch_size,
+        n_samples=args.n_samples,
+        mini_bs=args.mini_bs,
+        max_running_prompts=args.max_running_prompts,
+        max_prompt_tokens=args.max_prompt_tokens,
+        max_new_tokens=args.max_new_tokens,
+        max_context_len=args.max_context_len,
+        epochs=args.epochs,
+        max_steps=args.max_steps,
+        extra_train_args=([] if args.keep_rollout_state else ["--drop-rollout-state"])
+        + args.extra_train_arg
+        + shlex.split(args.extra_train_args),
+    )
 
 
 def _launch_with_modal_cli(args: argparse.Namespace) -> None:
@@ -109,6 +207,8 @@ def _launch_with_modal_cli(args: argparse.Namespace) -> None:
     env["ARENO_MODAL_LAUNCHED"] = "1"
     env[MODAL_BRANCH_ENV] = args.branch
 
+    import json
+
     script = Path(__file__).resolve()
     command = [
         sys.executable,
@@ -116,10 +216,8 @@ def _launch_with_modal_cli(args: argparse.Namespace) -> None:
         "modal",
         "run",
         str(script),
-        "--branch",
-        args.branch,
-        "--ckpt",
-        args.ckpt,
+        "--config-json",
+        json.dumps(asdict(_config_from_args(args))),
     ]
     _run(command, env=env)
 

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -77,6 +77,8 @@ def run_gsm8k_gspo(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
             "1024",
             "--epochs",
             "1",
+            "--max-steps",
+            "10",
             "--drop-rollout-state",
         ],
         cwd=REMOTE_REPO_DIR,

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -12,7 +12,7 @@ import modal
 APP_NAME = "areno-gsm8k-gspo"
 REPO_URL = "https://github.com/inclusionAI/AReno.git"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-REMOTE_REPO_DIR = Path("/workspace/areno-run")
+REMOTE_REPO_DIR = Path("/workspace/areno")
 DEFAULT_CKPT = "Qwen/Qwen3.5-0.8B"
 
 
@@ -28,17 +28,15 @@ def _run(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | N
 
 @app.function(
     image=image,
-    gpu="A100",
+    gpu="L4",
     timeout=60 * 60 * 3,
 )
 def run_gsm8k_gspo(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
     """Run a short GSM8K GSPO train task on Modal."""
 
-    if REMOTE_REPO_DIR.exists():
-        _run(["rm", "-rf", str(REMOTE_REPO_DIR)])
-
-    _run(["git", "clone", "--depth", "1", "--branch", branch, REPO_URL, str(REMOTE_REPO_DIR)])
-    _run([sys.executable, "-m", "pip", "install", "-e", ".", "--no-build-isolation"], cwd=REMOTE_REPO_DIR)
+    _run(["git", "remote", "set-url", "origin", REPO_URL], cwd=REMOTE_REPO_DIR)
+    _run(["git", "fetch", "--depth", "1", "origin", branch], cwd=REMOTE_REPO_DIR)
+    _run(["git", "checkout", "--force", "FETCH_HEAD"], cwd=REMOTE_REPO_DIR)
 
     env = os.environ.copy()
     env.setdefault("PYTHONUNBUFFERED", "1")

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -23,7 +23,7 @@ image = modal.Image.from_dockerfile(
     str(PROJECT_ROOT / "Dockerfile"),
     build_args={
         "ARENO_REPO_URL": REPO_URL,
-        "ARENO_BRANCH": os.environ.get(MODAL_BRANCH_ENV, ""),
+        "ARENO_BRANCH": os.environ.get(MODAL_BRANCH_ENV, "__local__"),
     },
 )
 

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -14,11 +14,18 @@ REPO_URL = "https://github.com/inclusionAI/AReno.git"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 REMOTE_REPO_DIR = Path("/workspace/areno")
 DEFAULT_CKPT = "Qwen/Qwen3.5-0.8B"
+MODAL_BRANCH_ENV = "ARENO_MODAL_BRANCH"
 
 
 app = modal.App(APP_NAME)
 
-image = modal.Image.from_dockerfile(str(PROJECT_ROOT / "Dockerfile")).apt_install("git")
+image = modal.Image.from_dockerfile(
+    str(PROJECT_ROOT / "Dockerfile"),
+    build_args={
+        "ARENO_REPO_URL": REPO_URL,
+        "ARENO_BRANCH": os.environ.get(MODAL_BRANCH_ENV, ""),
+    },
+)
 
 
 def _run(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
@@ -34,9 +41,7 @@ def _run(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | N
 def run_gsm8k_gspo(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
     """Run a short GSM8K GSPO train task on Modal."""
 
-    _run(["git", "remote", "set-url", "origin", REPO_URL], cwd=REMOTE_REPO_DIR)
-    _run(["git", "fetch", "--depth", "1", "origin", branch], cwd=REMOTE_REPO_DIR)
-    _run(["git", "checkout", "--force", "FETCH_HEAD"], cwd=REMOTE_REPO_DIR)
+    print(f"Running AReno branch built into image: {branch}", flush=True)
 
     env = os.environ.copy()
     env.setdefault("PYTHONUNBUFFERED", "1")
@@ -100,6 +105,7 @@ def _launch_with_modal_cli(args: argparse.Namespace) -> None:
     env["MODAL_TOKEN_ID"] = args.modal_token_id
     env["MODAL_TOKEN_SECRET"] = args.modal_token_secret
     env["ARENO_MODAL_LAUNCHED"] = "1"
+    env[MODAL_BRANCH_ENV] = args.branch
 
     script = Path(__file__).resolve()
     command = [

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -70,6 +70,8 @@ def run_gsm8k_gspo(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
             "1",
             "--max-running-prompts",
             "16",
+            "--max-new-tokens",
+            "1024",
             "--epochs",
             "1",
             "--drop-rollout-state",

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import modal
+
+APP_NAME = "areno-gsm8k-gspo"
+REPO_URL = "https://github.com/inclusionAI/AReno.git"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REMOTE_REPO_DIR = Path("/workspace/areno-run")
+DEFAULT_CKPT = "Qwen/Qwen3.5-0.8B"
+
+
+app = modal.App(APP_NAME)
+
+image = modal.Image.from_dockerfile(str(PROJECT_ROOT / "Dockerfile")).apt_install("git")
+
+
+def _run(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    print("+", " ".join(shlex.quote(part) for part in command), flush=True)
+    subprocess.run(command, cwd=str(cwd) if cwd else None, env=env, check=True)
+
+
+@app.function(
+    image=image,
+    gpu="A100",
+    timeout=60 * 60 * 3,
+)
+def run_gsm8k_gspo(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
+    """Run a short GSM8K GSPO train task on Modal."""
+
+    if REMOTE_REPO_DIR.exists():
+        _run(["rm", "-rf", str(REMOTE_REPO_DIR)])
+
+    _run(["git", "clone", "--depth", "1", "--branch", branch, REPO_URL, str(REMOTE_REPO_DIR)])
+    _run([sys.executable, "-m", "pip", "install", "-e", ".", "--no-build-isolation"], cwd=REMOTE_REPO_DIR)
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+    _run(
+        [
+            "areno",
+            "train",
+            "--ckpt",
+            ckpt,
+            "--dataset-path",
+            "gsm8k:main",
+            "--dataset-loader-fn",
+            "examples/math/dataset_loader.py",
+            "--reward-fn-path",
+            "examples/math/math_verify_reward.py",
+            "--algo",
+            "gspo",
+            "--tp-size",
+            "1",
+            "--world-size",
+            "1",
+            "--batch-size",
+            "2",
+            "--n-samples",
+            "8",
+            "--mini-bs",
+            "1",
+            "--max-running-prompts",
+            "16",
+            "--epochs",
+            "1",
+            "--drop-rollout-state",
+        ],
+        cwd=REMOTE_REPO_DIR,
+        env=env,
+    )
+
+
+@app.local_entrypoint()
+def main(branch: str, ckpt: str = DEFAULT_CKPT) -> None:
+    run_gsm8k_gspo.remote(branch=branch, ckpt=ckpt)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Launch AReno GSM8K GSPO training on Modal.")
+    parser.add_argument("--branch", required=True, help="AReno git branch to checkout inside the Modal job.")
+    parser.add_argument("--modal-token-id", required=True, help="Modal token ID used by the local Modal client.")
+    parser.add_argument(
+        "--modal-token-secret", required=True, help="Modal token secret used by the local Modal client."
+    )
+    parser.add_argument("--ckpt", default=DEFAULT_CKPT, help=f"Actor checkpoint or HF repo ID. Default: {DEFAULT_CKPT}")
+    return parser.parse_args()
+
+
+def _launch_with_modal_cli(args: argparse.Namespace) -> None:
+    env = os.environ.copy()
+    env["MODAL_TOKEN_ID"] = args.modal_token_id
+    env["MODAL_TOKEN_SECRET"] = args.modal_token_secret
+    env["ARENO_MODAL_LAUNCHED"] = "1"
+
+    script = Path(__file__).resolve()
+    command = [
+        sys.executable,
+        "-m",
+        "modal",
+        "run",
+        str(script),
+        "--branch",
+        args.branch,
+        "--ckpt",
+        args.ckpt,
+    ]
+    _run(command, env=env)
+
+
+if __name__ == "__main__" and os.environ.get("ARENO_MODAL_LAUNCHED") != "1":
+    _launch_with_modal_cli(_parse_args())

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -68,6 +68,10 @@ Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
 ``--epochs INTEGER``
    Number of dataset epochs to train. Default: ``10``.
 
+``--max-steps INTEGER``
+   Optional global trainer step cap. Training stops after this many step
+   indices have completed, even if the current epoch still has more batches.
+
 ``--world-size INTEGER``
    Total device count for the backend. Default: ``8``.
 

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -52,6 +52,7 @@ def test_train_config_requires_world_size_divisible_by_tp_size():
     [
         ("save_interval", 0, "--save-interval must be positive"),
         ("epochs", 0, "--epochs must be positive"),
+        ("max_steps", 0, "--max-steps must be positive"),
         ("tp_size", 0, "--tp-size must be positive"),
         ("world_size", 0, "--world-size must be positive"),
         ("batch_size", 0, "--batch-size must be positive"),
@@ -188,6 +189,7 @@ def test_train_config_builds_policy_shape_for_gspo_and_grpo(algo, clip_attr, cli
             algo=algo,
             n_samples=3,
             max_running_prompts=12,
+            max_steps=7,
             max_context_len=512,
             temperature=0.7,
             top_k=10,
@@ -202,6 +204,7 @@ def test_train_config_builds_policy_shape_for_gspo_and_grpo(algo, clip_attr, cli
     assert cfg.reward_fn_path is None
     assert cfg.n_samples == 3
     assert cfg.resolved_max_running_prompts() == 12
+    assert cfg.max_steps == 7
     assert cfg.max_context_len == 512
     assert cfg.temperature == 0.7
     assert cfg.top_k == 10
@@ -275,6 +278,7 @@ def test_training_config_summary_shows_resolved_values_and_warning():
             world_size=8,
             tp_size=2,
             batch_size=4,
+            max_steps=11,
             n_samples=3,
             max_running_prompts=None,
             temperature=0.7,
@@ -301,6 +305,7 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "attn_backend  flash" in summary
     assert "max_running_prompts  12" in summary
     assert "sampling             greedy=no, temperature=0.7, top_k=20, top_p=0.9" in summary
+    assert "max_steps                    11" in summary
     assert "optimizer                    lr=2e-06, min_lr=0.0, decay=cosine/100" in summary
     assert "metrics_log_dir  /tmp/metrics" in summary
     assert "WARNING: no checkpoint output path configured (--save-path)" in summary
@@ -570,6 +575,7 @@ def _options(**overrides):
         mem_frac=0.9,
         tune_max_samples=256,
         epochs=2,
+        max_steps=None,
         tp_size=1,
         world_size=1,
         batch_size=2,


### PR DESCRIPTION
## Summary
- Add a reusable Modal train workflow that reads Modal credentials from GitHub Environment secrets.
- Add a math algorithms workflow that invokes the reusable workflow for small GSPO and PPO smoke runs.
- Generalize the Modal launcher script so algo, dataset, loader, reward, agent function, and training sizes are configurable.

## Smoke Scope
- Qwen/Qwen3.5-0.8B
- max_new_tokens=1024
- max_steps=5
- batch_size=2, n_samples=8, max_running_prompts=16

## Validation
- python -m py_compile ci/modal_gsm8k_gspo.py
- ruff check ci/modal_gsm8k_gspo.py
- YAML parse check for the new workflows
- git diff --check

Closes #123