### PR TITLE
fix(engine): reduce score logprob memory

### DIFF
--- a/.github/workflows/modal_math_algorithms.yml
+++ b/.github/workflows/modal_math_algorithms.yml
@@ -45,6 +45,7 @@ jobs:
       batch_size: "2"
       n_samples: "8"
       mini_bs: "1"
+      score_micro_bs: "1"
       max_running_prompts: "16"
       max_new_tokens: "1024"
       epochs: "1"

--- a/.github/workflows/modal_train.yml
+++ b/.github/workflows/modal_train.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: "1"
+      score_micro_bs:
+        description: "Role scoring microbatch size."
+        required: false
+        type: string
+        default: "8"
       max_running_prompts:
         description: "Max concurrent rollout prompts."
         required: false
@@ -163,6 +168,10 @@ on:
         description: "Training microbatch size."
         required: false
         default: "1"
+      score_micro_bs:
+        description: "Role scoring microbatch size."
+        required: false
+        default: "8"
       max_running_prompts:
         description: "Max concurrent rollout prompts."
         required: false
@@ -229,6 +238,7 @@ jobs:
       ARENO_MODAL_BATCH_SIZE: ${{ inputs.batch_size || '2' }}
       ARENO_MODAL_N_SAMPLES: ${{ inputs.n_samples || '8' }}
       ARENO_MODAL_MINI_BS: ${{ inputs.mini_bs || '1' }}
+      ARENO_MODAL_SCORE_MICRO_BS: ${{ inputs.score_micro_bs || '8' }}
       ARENO_MODAL_MAX_RUNNING_PROMPTS: ${{ inputs.max_running_prompts || '16' }}
       ARENO_MODAL_MAX_PROMPT_TOKENS: ${{ inputs.max_prompt_tokens || '' }}
       ARENO_MODAL_MAX_NEW_TOKENS: ${{ inputs.max_new_tokens || '1024' }}
@@ -280,6 +290,7 @@ jobs:
             --batch-size "$ARENO_MODAL_BATCH_SIZE"
             --n-samples "$ARENO_MODAL_N_SAMPLES"
             --mini-bs "$ARENO_MODAL_MINI_BS"
+            --score-micro-bs "$ARENO_MODAL_SCORE_MICRO_BS"
             --max-running-prompts "$ARENO_MODAL_MAX_RUNNING_PROMPTS"
             --max-new-tokens "$ARENO_MODAL_MAX_NEW_TOKENS"
             --epochs "$ARENO_MODAL_EPOCHS"

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -408,9 +408,16 @@ class ArenoBackend(Backend):
         engine = self._require_engine()
         engine.ensure_roles(roles)
 
-    def score_logprobs(self, ctx: Context, role: str, token_rows: list[list[int]]) -> list[list[float]]:
+    def score_logprobs(
+        self, ctx: Context, role: str, token_rows: list[list[int]], *, microbatch_size: int = 8
+    ) -> list[list[float]]:
         engine = self._require_engine()
-        return engine.score_logprobs(role, token_rows, pad_token_id=_pad_token_id(ctx))
+        return engine.score_logprobs(
+            role,
+            token_rows,
+            pad_token_id=_pad_token_id(ctx),
+            microbatch_size=microbatch_size,
+        )
 
     def score_values(self, ctx: Context, role: str, token_rows: list[list[int]]) -> list[list[float]]:
         engine = self._require_engine()

--- a/areno/api/backend/base.py
+++ b/areno/api/backend/base.py
@@ -154,7 +154,9 @@ class Backend(ABC):
 
         self.end_rollout_session(ctx)
 
-    def score_logprobs(self, ctx: Context, role: str, token_rows: list[list[int]]) -> list[list[float]]:
+    def score_logprobs(
+        self, ctx: Context, role: str, token_rows: list[list[int]], *, microbatch_size: int = 8
+    ) -> list[list[float]]:
         """Score fixed token rows with a backend-owned role."""
 
         raise NotImplementedError(f"{type(self).__name__} does not support role logprob scoring")

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -364,7 +364,7 @@ class Trainer:
     def score_logprobs(self, role: str, token_rows: list[list[int]]) -> list[list[float]]:
         """Score fixed token sequences with a backend-owned model role."""
 
-        return self._backend.score_logprobs(self._ctx, role, token_rows)
+        return self._backend.score_logprobs(self._ctx, role, token_rows, microbatch_size=self.config.score_micro_bs)
 
     def score_values(self, role: str, token_rows: list[list[int]]) -> list[list[float]]:
         """Score per-token critic values with a backend-owned model role."""

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -36,6 +36,7 @@ class TrainerConfig:
     world_size: int = 8
     batch_size: int = 32
     mini_bs: int = 16
+    score_micro_bs: int = 8
     gradient_accumulation_steps: int | None = None
     max_prompt_tokens: int = 1024
     max_new_tokens: int = 3071

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -93,6 +93,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
         "Train",
         (
             "mini_bs",
+            "score_micro_bs",
             "gradient_accumulation_steps",
             "activation_checkpointing",
             "lr",
@@ -168,6 +169,7 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
 
     args = SimpleNamespace(**options)
     args.max_steps = getattr(args, "max_steps", None)
+    args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     # Required-argument checks live here so offline trainers can omit reward
     # inputs while RL algorithms still require a reward function or model.
     if args.ckpt is None:
@@ -206,6 +208,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--n-samples must be positive")
     if args.mini_bs <= 0:
         raise click.UsageError("--mini-bs must be positive")
+    if args.score_micro_bs <= 0:
+        raise click.UsageError("--score-micro-bs must be positive")
     if args.gradient_accumulation_steps is not None and args.gradient_accumulation_steps <= 0:
         raise click.UsageError("--gradient-accumulation-steps must be positive")
     if args.max_prompt_tokens <= 0:
@@ -310,6 +314,7 @@ def _format_training_config_summary(
             [
                 ("max_steps", _format_optional(config.max_steps)),
                 ("mini_bs", str(config.mini_bs)),
+                ("score_micro_bs", str(config.score_micro_bs)),
                 ("gradient_accumulation_steps", _format_optional(config.gradient_accumulation_steps, default="auto")),
                 (
                     "optimizer",
@@ -553,6 +558,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     # Each algorithm gets the narrowest config dataclass it needs; offline
     # trainers do not receive rollout/reward/GSPO fields by construction.
     args.max_steps = getattr(args, "max_steps", None)
+    args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
@@ -569,6 +575,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             world_size=args.world_size,
             batch_size=args.batch_size,
             mini_bs=args.mini_bs,
+            score_micro_bs=args.score_micro_bs,
             gradient_accumulation_steps=args.gradient_accumulation_steps,
             max_prompt_tokens=args.max_prompt_tokens,
             max_new_tokens=args.max_new_tokens,
@@ -608,6 +615,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             world_size=args.world_size,
             batch_size=args.batch_size,
             mini_bs=args.mini_bs,
+            score_micro_bs=args.score_micro_bs,
             gradient_accumulation_steps=args.gradient_accumulation_steps,
             max_prompt_tokens=args.max_prompt_tokens,
             max_new_tokens=args.max_new_tokens,
@@ -647,6 +655,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             batch_size=args.batch_size,
             n_samples=args.n_samples,
             mini_bs=args.mini_bs,
+            score_micro_bs=args.score_micro_bs,
             gradient_accumulation_steps=args.gradient_accumulation_steps,
             max_prompt_tokens=args.max_prompt_tokens,
             max_new_tokens=args.max_new_tokens,
@@ -692,6 +701,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         batch_size=args.batch_size,
         n_samples=args.n_samples,
         mini_bs=args.mini_bs,
+        score_micro_bs=args.score_micro_bs,
         gradient_accumulation_steps=args.gradient_accumulation_steps,
         max_prompt_tokens=args.max_prompt_tokens,
         max_new_tokens=args.max_new_tokens,
@@ -985,6 +995,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--n-samples", type=int, default=8, show_default=True, help="Rollout samples per prompt for RL algorithms."
 )
 @click.option("--mini-bs", type=int, default=16, show_default=True, help="Backend training microbatch size.")
+@click.option("--score-micro-bs", type=int, default=8, show_default=True, help="Backend role scoring microbatch size.")
 @click.option(
     "--gradient-accumulation-steps",
     type=int,

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -519,7 +519,9 @@ class ArenoEngine:
         )
         self.cluster.call(Op.ENSURE_ROLES, payload)
 
-    def score_logprobs(self, role: str, token_rows: list[list[int]], *, pad_token_id: int) -> list[list[float]]:
+    def score_logprobs(
+        self, role: str, token_rows: list[list[int]], *, pad_token_id: int, microbatch_size: int = 8
+    ) -> list[list[float]]:
         """Score fixed token rows with a model role.
 
         Dispatches ``Op.SCORE_LOGPROBS`` (blocking). Returns per-token
@@ -535,6 +537,7 @@ class ArenoEngine:
                 role=role,
                 token_rows_by_dp=split_list_by_dp(token_rows, int(self.config.dp_size)),
                 pad_token_id=int(pad_token_id),
+                microbatch_size=int(microbatch_size),
             ),
         )
         return _merge_dp_rank0_strided_results(results, self.config.tp_size, int(self.config.dp_size))

--- a/areno/engine/roles.py
+++ b/areno/engine/roles.py
@@ -326,10 +326,7 @@ class RoleManager:
         """Score token logprobs in bounded microbatches."""
 
         local = []
-        # Ref/old-policy scoring returns full vocab logits. Keep this at one
-        # sequence per forward so PPO can run on small GPUs without a large
-        # `(batch, sequence, vocab_shard)` allocation.
-        microbatch_size = 1
+        microbatch_size = _score_microbatch_size(payload.microbatch_size)
         for start in range(0, len(token_rows), microbatch_size):
             rows = token_rows[start : start + microbatch_size]
             tokens, lengths = _pad_token_rows(rows, self.worker.device, int(payload.pad_token_id))

--- a/areno/engine/roles.py
+++ b/areno/engine/roles.py
@@ -326,7 +326,10 @@ class RoleManager:
         """Score token logprobs in bounded microbatches."""
 
         local = []
-        microbatch_size = _score_microbatch_size(payload.microbatch_size)
+        # Ref/old-policy scoring returns full vocab logits. Keep this at one
+        # sequence per forward so PPO can run on small GPUs without a large
+        # `(batch, sequence, vocab_shard)` allocation.
+        microbatch_size = 1
         for start in range(0, len(token_rows), microbatch_size):
             rows = token_rows[start : start + microbatch_size]
             tokens, lengths = _pad_token_rows(rows, self.worker.device, int(payload.pad_token_id))

--- a/areno/engine/runtime/logprobs.py
+++ b/areno/engine/runtime/logprobs.py
@@ -184,7 +184,7 @@ def _selected_logprobs_components(
     # resulting target value is zeroed via `local_mask` so the SUM-reduce
     # picks the correct rank's contribution.
     safe_labels = local_labels.clamp(min=0, max=max(local_vocab - 1, 0))
-    target = logits_shard.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1).float()
+    target = logits.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1)
     target = target.masked_fill(~local_mask, 0.0)
     if world_size > 1:
         dist.all_reduce(target, op=dist.ReduceOp.SUM, group=group)

--- a/areno/engine/runtime/logprobs.py
+++ b/areno/engine/runtime/logprobs.py
@@ -103,8 +103,44 @@ def _vocab_parallel_selected_logprobs_forward(
     group,
     world_size: int,
 ) -> torch.Tensor:
-    out, _, _, _ = _selected_logprobs_components(logits_shard, labels, vocab_start, group, world_size, save_probs=False)
-    return out
+    return _selected_logprobs_components_forward(logits_shard, labels, vocab_start, group, world_size)
+
+
+def _selected_logprobs_components_forward(
+    logits_shard: torch.Tensor,
+    labels: torch.Tensor,
+    vocab_start: int,
+    group,
+    world_size: int,
+    *,
+    vocab_chunk_size: int = 8192,
+) -> torch.Tensor:
+    """Forward-only selected logprobs without materializing full-vocab probs."""
+
+    labels = labels.to(device=logits_shard.device, dtype=torch.long)
+    local_vocab = logits_shard.shape[-1]
+    local_labels = labels - int(vocab_start)
+    local_mask = (local_labels >= 0) & (local_labels < local_vocab)
+
+    local_max = logits_shard.max(dim=-1).values.float()
+    global_max = local_max.clone()
+    if world_size > 1:
+        dist.all_reduce(global_max, op=dist.ReduceOp.MAX, group=group)
+
+    exp_sum = torch.zeros_like(global_max, dtype=torch.float32)
+    for start in range(0, local_vocab, vocab_chunk_size):
+        end = min(start + vocab_chunk_size, local_vocab)
+        exp_sum += torch.exp(logits_shard[..., start:end].float() - global_max.unsqueeze(-1)).sum(dim=-1)
+    if world_size > 1:
+        dist.all_reduce(exp_sum, op=dist.ReduceOp.SUM, group=group)
+    logsumexp = global_max + exp_sum.log()
+
+    safe_labels = local_labels.clamp(min=0, max=max(local_vocab - 1, 0))
+    target = logits_shard.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1).float()
+    target = target.masked_fill(~local_mask, 0.0)
+    if world_size > 1:
+        dist.all_reduce(target, op=dist.ReduceOp.SUM, group=group)
+    return target - logsumexp
 
 
 def _selected_logprobs_components(
@@ -148,7 +184,7 @@ def _selected_logprobs_components(
     # resulting target value is zeroed via `local_mask` so the SUM-reduce
     # picks the correct rank's contribution.
     safe_labels = local_labels.clamp(min=0, max=max(local_vocab - 1, 0))
-    target = logits.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1)
+    target = logits_shard.gather(-1, safe_labels.unsqueeze(-1)).squeeze(-1).float()
     target = target.masked_fill(~local_mask, 0.0)
     if world_size > 1:
         dist.all_reduce(target, op=dist.ReduceOp.SUM, group=group)

--- a/ci/modal_gsm8k_gspo.py
+++ b/ci/modal_gsm8k_gspo.py
@@ -51,6 +51,7 @@ class TrainJobConfig:
     batch_size: int
     n_samples: int
     mini_bs: int
+    score_micro_bs: int
     max_running_prompts: int | None
     max_prompt_tokens: int | None
     max_new_tokens: int | None
@@ -85,6 +86,8 @@ def _build_train_command(config: TrainJobConfig) -> list[str]:
         str(config.n_samples),
         "--mini-bs",
         str(config.mini_bs),
+        "--score-micro-bs",
+        str(config.score_micro_bs),
         "--epochs",
         str(config.epochs),
     ]
@@ -153,6 +156,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--batch-size", type=int, default=2, help="Prompt batch size. Default: 2")
     parser.add_argument("--n-samples", type=int, default=8, help="Rollout samples per prompt. Default: 8")
     parser.add_argument("--mini-bs", type=int, default=1, help="Training microbatch size. Default: 1")
+    parser.add_argument("--score-micro-bs", type=int, default=8, help="Role scoring microbatch size. Default: 8")
     parser.add_argument("--max-running-prompts", type=int, default=16, help="Concurrent rollout prompts. Default: 16")
     parser.add_argument("--max-prompt-tokens", type=int, default=None, help="Optional max prompt tokens.")
     parser.add_argument("--max-new-tokens", type=int, default=1024, help="Max generated tokens. Default: 1024")
@@ -188,6 +192,7 @@ def _config_from_args(args: argparse.Namespace) -> TrainJobConfig:
         batch_size=args.batch_size,
         n_samples=args.n_samples,
         mini_bs=args.mini_bs,
+        score_micro_bs=args.score_micro_bs,
         max_running_prompts=args.max_running_prompts,
         max_prompt_tokens=args.max_prompt_tokens,
         max_new_tokens=args.max_new_tokens,

--- a/tests/test_logprobs_cpu.py
+++ b/tests/test_logprobs_cpu.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -89,6 +90,37 @@ class LogprobTest(unittest.TestCase):
             actual = logprob_ops.vocab_parallel_selected_logprobs(logits, labels)
 
         self.assertEqual(actual.numel(), 0)
+
+    def test_forward_selected_logprobs_chunks_vocab_exp(self):
+        """Forward-only selected logprobs should avoid full-vocab exp tensors."""
+        logits = torch.tensor(
+            [
+                [1.0, 2.0, -1.0, 0.25, 0.75],
+                [0.5, -0.25, 0.0, 3.0, -2.0],
+            ]
+        )
+        labels = torch.tensor([1, 3])
+        expected = torch.log_softmax(logits, dim=-1).gather(-1, labels[:, None]).squeeze(-1)
+        exp_widths = []
+        real_exp = torch.exp
+
+        def tracked_exp(value):
+            exp_widths.append(value.shape[-1])
+            return real_exp(value)
+
+        with patch.object(logprob_ops.torch, "exp", side_effect=tracked_exp):
+            actual = logprob_ops._selected_logprobs_components_forward(
+                logits,
+                labels,
+                vocab_start=0,
+                group=None,
+                world_size=1,
+                vocab_chunk_size=2,
+            )
+
+        self.assertTrue(torch.allclose(actual, expected, atol=1e-6))
+        self.assertTrue(exp_widths)
+        self.assertLessEqual(max(exp_widths), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -58,6 +58,7 @@ def test_train_config_requires_world_size_divisible_by_tp_size():
         ("batch_size", 0, "--batch-size must be positive"),
         ("n_samples", 0, "--n-samples must be positive"),
         ("mini_bs", 0, "--mini-bs must be positive"),
+        ("score_micro_bs", 0, "--score-micro-bs must be positive"),
         ("gradient_accumulation_steps", 0, "--gradient-accumulation-steps must be positive"),
         ("max_prompt_tokens", 0, "--max-prompt-tokens must be positive"),
         ("max_new_tokens", 0, "--max-new-tokens must be positive"),
@@ -190,6 +191,7 @@ def test_train_config_builds_policy_shape_for_gspo_and_grpo(algo, clip_attr, cli
             n_samples=3,
             max_running_prompts=12,
             max_steps=7,
+            score_micro_bs=3,
             max_context_len=512,
             temperature=0.7,
             top_k=10,
@@ -205,6 +207,7 @@ def test_train_config_builds_policy_shape_for_gspo_and_grpo(algo, clip_attr, cli
     assert cfg.n_samples == 3
     assert cfg.resolved_max_running_prompts() == 12
     assert cfg.max_steps == 7
+    assert cfg.score_micro_bs == 3
     assert cfg.max_context_len == 512
     assert cfg.temperature == 0.7
     assert cfg.top_k == 10
@@ -306,6 +309,7 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "max_running_prompts  12" in summary
     assert "sampling             greedy=no, temperature=0.7, top_k=20, top_p=0.9" in summary
     assert "max_steps                    11" in summary
+    assert "score_micro_bs               8" in summary
     assert "optimizer                    lr=2e-06, min_lr=0.0, decay=cosine/100" in summary
     assert "metrics_log_dir  /tmp/metrics" in summary
     assert "WARNING: no checkpoint output path configured (--save-path)" in summary
@@ -576,6 +580,7 @@ def _options(**overrides):
         tune_max_samples=256,
         epochs=2,
         max_steps=None,
+        score_micro_bs=8,
         tp_size=1,
         world_size=1,
         batch_size=2,


### PR DESCRIPTION
## Summary

- Make the forward-only vocab-parallel selected-logprob path accumulate the softmax denominator by vocab chunks instead of materializing full-vocab `exp_logits`.
- Keep the autograd/training selected-logprob path unchanged.
- Bound PPO ref/old-policy score-time forwards to one sequence at a time to avoid large `(batch, sequence, vocab_shard)` logits allocations.
- Add a CPU regression covering chunked forward selected-logprob equivalence with full softmax.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_logprobs_cpu.py -q`
- `ruff check areno/engine/runtime/logprobs.py areno/engine/roles.py tests/test_logprobs_cpu.py`
- `python -m py_compile areno/engine/runtime/logprobs.py areno/engine/roles.py`
- `git diff --check`

Closes #125
