### PR TITLE
docs: update documentation structure

### DIFF
--- a/docs/_static/areno-sidebar.js
+++ b/docs/_static/areno-sidebar.js
@@ -1,0 +1,58 @@
+(function () {
+  function setupSidebarSections() {
+    var toc = document.querySelector(".globaltoc");
+
+    if (!toc || toc.dataset.arenoCollapsible === "ready") {
+      return;
+    }
+
+    toc.dataset.arenoCollapsible = "ready";
+
+    Array.prototype.forEach.call(toc.children, function (caption, index) {
+      if (!caption.matches("p.caption")) {
+        return;
+      }
+
+      var list = caption.nextElementSibling;
+
+      if (!list || !list.matches("ul") || caption.querySelector(".areno-sidebar-toggle")) {
+        return;
+      }
+
+      if (!list.id) {
+        list.id = "areno-sidebar-section-" + index;
+      }
+
+      caption.classList.add("areno-sidebar-caption");
+      list.classList.add("areno-sidebar-section-list");
+
+      var button = document.createElement("button");
+      button.type = "button";
+      button.className = "areno-sidebar-toggle";
+      button.setAttribute("aria-controls", list.id);
+      button.setAttribute("aria-expanded", "true");
+
+      while (caption.firstChild) {
+        button.appendChild(caption.firstChild);
+      }
+
+      var caret = document.createElement("span");
+      caret.className = "areno-sidebar-caret";
+      caret.setAttribute("aria-hidden", "true");
+      button.appendChild(caret);
+      caption.appendChild(button);
+
+      button.addEventListener("click", function () {
+        var expanded = button.getAttribute("aria-expanded") === "true";
+        button.setAttribute("aria-expanded", expanded ? "false" : "true");
+        list.hidden = expanded;
+      });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setupSidebarSections);
+  } else {
+    setupSidebarSections();
+  }
+})();

--- a/docs/_static/areno.css
+++ b/docs/_static/areno.css
@@ -253,6 +253,7 @@ html.dark .sidebar-theme .theme-switch:hover .theme-icon {
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 9999px;
+  box-sizing: border-box;
   box-shadow:
     0 10px 20px rgba(0, 0, 0, .04),
     0 2px 6px rgba(0, 0, 0, .04),
@@ -265,10 +266,10 @@ html.dark .sidebar-theme .theme-switch:hover .theme-icon {
   font-weight: 400;
   height: 1.875rem;
   line-height: 1.25rem;
-  margin-bottom: .5rem;
+  margin: 0 .75rem .5rem;
   padding: .25rem .5rem;
   text-align: left;
-  width: 100%;
+  width: calc(100% - 1.5rem);
 }
 
 html.dark .sidebar-searchbox {
@@ -375,7 +376,63 @@ html.dark .sy-page .sy-lside {
 }
 
 .sy-lside .sy-scrollbar {
+  box-sizing: border-box;
   padding: 1.5rem 1.75rem 2rem;
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+}
+
+@supports not selector(::-webkit-scrollbar) {
+  .sy-lside .sy-scrollbar {
+    scrollbar-color: #c1c1c1 #fafafa;
+  }
+
+  html.dark .sy-lside .sy-scrollbar {
+    scrollbar-color: #7d7d7d #111111;
+  }
+}
+
+.sy-lside .sy-scrollbar::-webkit-scrollbar {
+  width: 14px;
+}
+
+.sy-lside .sy-scrollbar::-webkit-scrollbar-track {
+  background-color: #fafafa;
+}
+
+.sy-lside .sy-scrollbar::-webkit-scrollbar-thumb {
+  background-clip: content-box;
+  background-color: #c1c1c1;
+  border: 3px solid transparent;
+  border-radius: 999px;
+}
+
+.sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:hover,
+.sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:vertical:hover {
+  background-color: #7d7d7d;
+}
+
+.sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:active,
+.sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:vertical:active {
+  background-color: #6b6b6b;
+}
+
+html.dark .sy-lside .sy-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #7d7d7d;
+}
+
+html.dark .sy-lside .sy-scrollbar::-webkit-scrollbar-track {
+  background-color: #111111;
+}
+
+html.dark .sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:hover,
+html.dark .sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:vertical:hover {
+  background-color: #a3a3a3;
+}
+
+html.dark .sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:active,
+html.dark .sy-lside .sy-scrollbar::-webkit-scrollbar-thumb:vertical:active {
+  background-color: #b8b8b8;
 }
 
 .globaltoc {
@@ -395,12 +452,85 @@ html.dark .sy-page .sy-lside {
   font-weight: 500;
   letter-spacing: 0;
   margin: 0;
-  padding: 1.5rem 0 .62rem 1rem;
+  padding: .95rem 0 .45rem 1rem;
   text-transform: none;
 }
 
 .globaltoc > p.caption:first-of-type {
   padding-top: 0;
+}
+
+.globaltoc .areno-sidebar-caption {
+  padding-right: .25rem;
+}
+
+.globaltoc .areno-sidebar-toggle {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  justify-content: space-between;
+  letter-spacing: inherit;
+  line-height: inherit;
+  margin: 0;
+  min-height: 1.5rem;
+  padding: 0;
+  text-align: left;
+  text-transform: inherit;
+  width: 100%;
+}
+
+.globaltoc .areno-sidebar-toggle:hover,
+.globaltoc .areno-sidebar-toggle:focus-visible {
+  color: var(--areno-ink);
+}
+
+.globaltoc .areno-sidebar-toggle:focus-visible {
+  border-radius: .25rem;
+  outline: 2px solid color-mix(in srgb, var(--areno-accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
+.globaltoc .areno-sidebar-caret {
+  color: currentColor;
+  flex: 0 0 auto;
+  height: .875rem;
+  margin-left: .75rem;
+  opacity: 0;
+  position: relative;
+  transition: opacity .16s ease;
+  width: .875rem;
+}
+
+.globaltoc .areno-sidebar-caret::before {
+  border: solid currentColor;
+  border-width: 0 1.5px 1.5px 0;
+  content: "";
+  display: block;
+  height: .375rem;
+  left: 50%;
+  position: absolute;
+  top: 45%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition: transform .16s ease, opacity .16s ease;
+  width: .375rem;
+}
+
+.globaltoc .areno-sidebar-toggle:hover .areno-sidebar-caret,
+.globaltoc .areno-sidebar-toggle:focus-visible .areno-sidebar-caret {
+  opacity: .72;
+}
+
+.globaltoc .areno-sidebar-toggle[aria-expanded="false"] .areno-sidebar-caret {
+  opacity: .62;
+}
+
+.globaltoc .areno-sidebar-toggle[aria-expanded="false"] .areno-sidebar-caret::before {
+  transform: translate(-50%, -35%) rotate(-45deg);
 }
 
 .globaltoc .caption-text {
@@ -409,11 +539,15 @@ html.dark .sy-page .sy-lside {
 }
 
 .globaltoc .caption + ul {
-  margin: 0 0 1.5rem;
+  margin: 0 0 .85rem;
+}
+
+.globaltoc .areno-sidebar-section-list[hidden] {
+  display: none;
 }
 
 .globaltoc ul + .caption {
-  margin-top: .5rem;
+  margin-top: .1rem;
 }
 
 .globaltoc ul {
@@ -511,19 +645,42 @@ html.dark .globaltoc a:hover {
 
   .sy-page .sy-lside {
     bottom: 0;
+    height: 100dvh;
     left: 0;
+    max-height: 100dvh;
+    min-height: 100dvh;
     position: fixed;
     top: 0;
     width: 19rem;
     z-index: 50;
   }
 
+  .sy-page .sy-lside::after {
+    background: #e8e8e8;
+    bottom: 0;
+    content: "";
+    pointer-events: none;
+    position: absolute;
+    right: 14px;
+    top: 0;
+    width: 1px;
+    z-index: 1;
+  }
+
+  html.dark .sy-page .sy-lside::after {
+    background: #262626;
+  }
+
   .sy-lside-inner {
-    height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
+    min-height: 100dvh;
   }
 
   .sy-lside .sy-scrollbar {
-    height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
+    min-height: 100dvh;
     overflow-y: auto;
   }
 }

--- a/docs/cli/dataset_loaders.rst
+++ b/docs/cli/dataset_loaders.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Dataset loaders
 ===============
 

--- a/docs/cli/diagnostics.rst
+++ b/docs/cli/diagnostics.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Diagnostics CLI reference
 =========================
 

--- a/docs/cli/inference.rst
+++ b/docs/cli/inference.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Inference CLI reference
 =======================
 

--- a/docs/cli/observability.rst
+++ b/docs/cli/observability.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Observability
 =============
 

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Training CLI reference
 ======================
 

--- a/docs/concepts/chat-templates.rst
+++ b/docs/concepts/chat-templates.rst
@@ -1,0 +1,27 @@
+Chat templates
+==============
+
+Chat templates turn structured messages into the exact prompt text expected by
+the selected tokenizer. AReno keeps this rendering close to rollout and serving
+so a training run and an OpenAI-compatible endpoint can use the same model
+conversation format.
+
+Use chat templates when a model expects role-based messages such as ``system``,
+``user``, ``assistant``, or tool-related turns. Dataset loaders should keep raw
+task fields and normalized prompts separate; tokenizer-specific formatting
+belongs in the training or serving path.
+
+Thinking mode
+-------------
+
+Some reasoning or chat checkpoints expose an ``enable_thinking`` option through
+their tokenizer chat template. AReno's CLI exposes ``--disable-thinking`` for
+training and serving, which passes ``enable_thinking=False`` when supported and
+falls back to the normal template call otherwise.
+
+Where to go next
+----------------
+
+* :doc:`/cli/training` documents the training flag.
+* :doc:`/cli/inference` documents the serving flag.
+* :doc:`dataset-formats` explains how dataset rows provide prompt inputs.

--- a/docs/concepts/dataset-formats.rst
+++ b/docs/concepts/dataset-formats.rst
@@ -1,0 +1,42 @@
+Dataset formats
+===============
+
+AReno loaders normalize external datasets into small dictionaries consumed by
+the selected algorithm. Keep tokenization out of the dataset layer; trainers
+own tokenizer rendering, sequence limits, and chat-template behavior.
+
+SFT rows
+--------
+
+SFT rows provide a supervised prompt and target response:
+
+.. code-block:: python
+
+   {"prompt": "Instruction: ...", "response": "..."}
+
+DPO rows
+--------
+
+DPO rows provide one shared prompt and two ranked answers:
+
+.. code-block:: python
+
+   {"prompt": "...", "chosen": "...", "rejected": "..."}
+
+Prompt-based RL rows
+--------------------
+
+GSPO, GRPO, and PPO prompt datasets provide ``prompt``. They can also preserve
+task metadata such as ``solutions`` for reward functions.
+
+Agentic rows
+------------
+
+Agentic datasets provide ``prompt`` plus any task metadata consumed by the agent
+and reward files.
+
+Where to go next
+----------------
+
+* :doc:`/cli/dataset_loaders` documents loader shapes and examples.
+* :doc:`reward-functions` explains how preserved metadata is used for scoring.

--- a/docs/concepts/reward-functions.rst
+++ b/docs/concepts/reward-functions.rst
@@ -1,0 +1,33 @@
+Reward functions
+================
+
+Reward functions turn generated completions or trajectories into numeric scores.
+They are task-specific Python files loaded by AReno's training path and should
+be deterministic while you are debugging a run.
+
+The public shape is:
+
+.. code-block:: python
+
+   def reward_fn(example, completions) -> list[float]:
+       ...
+
+The function receives the original example plus generated completions, then
+returns one score per completion. For agentic workflows, keep enough task state
+in the dataset row for the reward function to explain why a trajectory passed or
+failed.
+
+Practical rules
+---------------
+
+* Keep parsing and scoring explicit.
+* Return one score for each completion.
+* Avoid network calls in the hot path unless the task requires them.
+* Log enough context to debug wrong scores.
+
+Where to go next
+----------------
+
+* :doc:`/cli/training` documents the training CLI flag.
+* :doc:`/troubleshooting/reward-function` covers debugging workflow.
+* :doc:`/reference/reward-function-api` documents the API contract.

--- a/docs/concepts/training-loop.rst
+++ b/docs/concepts/training-loop.rst
@@ -1,0 +1,33 @@
+Training Loop
+=============
+
+AReno models post-training as one local loop:
+
+.. code-block:: text
+
+   Dataset or task
+     -> Prompt or initial state
+     -> Rollout engine
+         -> Model inference
+         -> Environment or tools
+         -> Multi-turn trajectory
+     -> Reward function
+     -> Advantage or loss
+     -> Trainer
+     -> Checkpoint, metrics, and logs
+
+This shape matters because most failures happen at the boundaries. A dataset
+can produce the wrong prompt, an agent can return a malformed trajectory, a
+reward function can score the wrong completion, or a trainer can receive rows
+that do not match the selected algorithm.
+
+AReno keeps these boundaries visible. The CLI wires them together for common
+tasks, while the SDK lets you control rollout, reward calculation, training,
+and checkpoint cadence directly.
+
+Where to go next
+----------------
+
+* :doc:`chat-templates` explains how messages become model prompts.
+* :doc:`dataset-formats` explains the fields expected by each training mode.
+* :doc:`reward-functions` explains how task outcomes become scores.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ html_theme = "shibuya"
 html_title = "AReno docs"
 html_static_path = ["_static"]
 html_css_files = ["areno.css"]
+html_js_files = ["areno-sidebar.js"]
 html_show_sourcelink = False
 
 html_theme_options = {
@@ -24,9 +25,10 @@ html_theme_options = {
     "ethical_ads_publisher": "",
     "github_url": "",
     "nav_links": [
-        {"title": "Quickstart", "url": "getting-started/build"},
-        {"title": "Training", "url": "cli/training"},
-        {"title": "Serving", "url": "cli/inference"},
-        {"title": "SDK", "url": "sdk/trainer"},
+        {"title": "Get Started", "url": "getting-started/welcome"},
+        {"title": "Concepts", "url": "concepts/training-loop"},
+        {"title": "Cookbook", "url": "cookbook/math-rlvr"},
+        {"title": "Reference", "url": "reference/cli"},
+        {"title": "Troubleshooting", "url": "troubleshooting/index"},
     ],
 }

--- a/docs/cookbook/duelgrid-visual-agent.rst
+++ b/docs/cookbook/duelgrid-visual-agent.rst
@@ -1,0 +1,20 @@
+DuelGrid visual agent
+=====================
+
+DuelGrid is a browser-game agentic example with multi-action turns, reward
+curves, and replayable behavior before and after training.
+
+The example lives under ``examples/agentic/duelgrid`` and includes:
+
+* A rule engine.
+* A fixed-path dataset loader.
+* A reward function.
+* An OpenAI-compatible agent.
+* A browser UI for replaying the task.
+
+Before GSPO/RLVR post-training, the model often moves back and forth without
+progress. After training, it learns to collect pickups, chase the user, attack
+when in range, and avoid trap tiles.
+
+Use this recipe after TicTacToe when you need richer environment state or a
+visual replay loop.

--- a/docs/cookbook/math-rlvr.rst
+++ b/docs/cookbook/math-rlvr.rst
@@ -1,0 +1,25 @@
+Math RLVR recipe
+================
+
+This recipe runs a small math RLVR task with a GSM8K-style dataset loader and
+math verification reward function.
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1
+
+Key files:
+
+* ``examples/math/dataset_loader.py`` normalizes the dataset.
+* ``examples/math/math_verify_reward.py`` scores completions.
+* :doc:`/cli/training` documents rollout, loss, and checkpoint flags.
+
+Adapt this recipe by replacing the dataset loader and reward function first.
+Keep the batch size small until the environment and reward signal are stable.

--- a/docs/cookbook/tictactoe-agentic-rl.rst
+++ b/docs/cookbook/tictactoe-agentic-rl.rst
@@ -1,0 +1,24 @@
+TicTacToe agentic RL
+====================
+
+TicTacToe is the smallest agentic AReno recipe. It exercises an agent function,
+the local OpenAI-compatible proxy, a task rule loop, and a reward function.
+
+.. code-block:: bash
+
+   areno train \
+     --agent-fn examples/agentic/tictactoe/run_agent.py \
+     --reward-fn-path examples/agentic/tictactoe/reward.py \
+     --algo gspo
+
+Use it when you want to learn the shape of an agentic task before moving to a
+larger environment.
+
+Key adaptation points:
+
+* Replace the rule loop with your environment.
+* Keep the agent function responsible for external actions.
+* Return trajectory turns that AReno can tokenize and score.
+* Add reward diagnostics before increasing concurrency.
+
+See :doc:`/reference/agentic-rollout-api` for the agentic rollout API contract.

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,5 +1,5 @@
-Build and installation
-======================
+Installation
+============
 
 This page covers the setup paths used by contributors and local operators:
 Docker images, editable installs, source/wheel distributions, and local

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -1,0 +1,59 @@
+Quickstart
+==========
+
+Use these commands after installation to validate the main AReno paths. Full
+training and agentic rollout require a CUDA-capable NVIDIA GPU.
+
+Training smoke test
+-------------------
+
+Run the smallest official training task to verify that the CLI can load a
+model, build batches, execute the training loop, and write outputs locally.
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 1
+
+RLVR path
+---------
+
+RLVR connects a dataset, model rollout, reward function, and policy loss. The
+math example is the fastest way to see that path end to end.
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1
+
+Read :doc:`/concepts/training-loop` for the mental model and
+:doc:`/cookbook/math-rlvr` for the runnable recipe shape.
+
+Agentic rollout path
+--------------------
+
+Agentic rollout is for tasks where the model interacts with tools, games,
+services, or an environment before AReno scores the trajectory.
+
+.. code-block:: bash
+
+   areno train \
+     --agent-fn examples/agentic/tictactoe/run_agent.py \
+     --reward-fn-path examples/agentic/tictactoe/reward.py \
+     --algo gspo
+
+Read :doc:`/reference/agentic-rollout-api` for the agentic rollout boundary and
+:doc:`/cookbook/tictactoe-agentic-rl` for the first recipe.

--- a/docs/getting-started/welcome.rst
+++ b/docs/getting-started/welcome.rst
@@ -1,0 +1,163 @@
+.. rst-class:: landing-page
+
+AReno documentation
+===================
+
+.. raw:: html
+
+   <div class="areno-hero">
+     <div class="areno-hero-copy">
+       <p class="areno-eyebrow">Local post-training and serving</p>
+       <h1>Train and serve local LLMs with one CUDA-native loop.</h1>
+       <p class="areno-lede">AReno keeps rollout, reward scoring, inference, optimizer steps, and checkpoint I/O in one compact engine for SFT, DPO, GSPO, GRPO, PPO, and agentic RL workflows.</p>
+       <div class="areno-hero-actions" aria-label="Primary documentation links">
+        <a class="areno-button areno-button-primary" href="installation.html">Get started</a>
+        <a class="areno-button" href="../cli/training.html">Train a model</a>
+       </div>
+     </div>
+   </div>
+
+Start
+-----
+
+.. raw:: html
+
+   <div class="areno-command-grid">
+     <div class="areno-command-card">
+       <p class="areno-card-kicker">Install</p>
+       <h3>Build against your CUDA PyTorch environment.</h3>
+      <pre><code>pip install psutil
+   pip install flash-linear-attention
+   pip install -e . --no-build-isolation</code></pre>
+       <p>Use <code>ARENO_BUILD_EXT=0</code> for metadata-only docs or package checks on CPU-only machines.</p>
+     </div>
+     <div class="areno-command-card">
+       <p class="areno-card-kicker">Check</p>
+       <h3>Verify the local runtime before training.</h3>
+      <pre><code>areno check
+   areno env --json</code></pre>
+       <p><code>areno check</code> reports common CUDA, PyTorch, extension, and platform setup issues with next steps.</p>
+     </div>
+   </div>
+
+``flash-attn`` is optional unless you use the default ``--attn-backend flash``
+path. Use ``--attn-backend native`` when you want to run without FlashAttention
+or when the local GPU is unsupported by FlashAttention.
+
+Core workflows
+--------------
+
+.. raw:: html
+
+   <div class="areno-doc-grid">
+    <a class="areno-doc-card" href="../cli/training.html">
+       <span class="areno-icon">01</span>
+       <strong>Train</strong>
+       <p>Run SFT, DPO, GSPO, GRPO, or PPO from the CLI with dataset loading, rollout, reward scoring, and checkpoint saving in one loop.</p>
+     </a>
+    <a class="areno-doc-card" href="../cli/inference.html">
+       <span class="areno-icon">02</span>
+       <strong>Serve</strong>
+       <p>Start an OpenAI-compatible chat-completions server backed by the local AReno inference engine.</p>
+     </a>
+    <a class="areno-doc-card" href="../sdk/trainer.html">
+       <span class="areno-icon">03</span>
+       <strong>Customize</strong>
+       <p>Use <code>from areno import Trainer</code> for custom rollout, reward, loss, and checkpoint loops.</p>
+     </a>
+    <a class="areno-doc-card" href="../models/supported.html">
+       <span class="areno-icon">04</span>
+       <strong>Load models</strong>
+       <p>Review the checkpoint families currently supported by AReno model adapters.</p>
+     </a>
+   </div>
+
+.. raw:: html
+
+   <div class="areno-command-grid areno-command-grid-wide">
+     <div class="areno-command-card">
+       <p class="areno-card-kicker">Training</p>
+       <h3>Run a small GSPO smoke task.</h3>
+      <pre><code>areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 1</code></pre>
+     </div>
+     <div class="areno-command-card">
+       <p class="areno-card-kicker">Serving</p>
+       <h3>Open a local chat-completions endpoint.</h3>
+      <pre><code>areno serve \
+     --model-path /path/to/model \
+     --tp-size 1 \
+     --world-size 1 \
+     --port 8000</code></pre>
+     </div>
+   </div>
+
+Training and serving require a CUDA-capable NVIDIA GPU. CPU-only machines can
+run docs, packaging checks, and lightweight CPU tests, but cannot run the AReno
+training or serving engine.
+
+Agentic rollout
+---------------
+
+.. raw:: html
+
+   <div class="areno-split">
+     <div>
+       <p class="areno-eyebrow">Agentic RL</p>
+       <h3>Collect trajectories through a local OpenAI-compatible proxy.</h3>
+       <p>Agent functions call the local server, return explicit trajectory turns, and let AReno convert responses into completions, tokens, logprobs, rewards, and loss masks.</p>
+     </div>
+     <div class="areno-terminal areno-terminal-compact" aria-label="Agentic rollout command">
+       <div class="areno-terminal-bar"><span></span><span></span><span></span></div>
+      <pre><code>areno train \
+     --agent-fn examples/agentic/tictactoe/run_agent.py \
+     --reward-fn-path examples/agentic/tictactoe/reward.py \
+     --algo gspo</code></pre>
+     </div>
+   </div>
+
+DuelGrid is a browser-game demo with multi-action turns. Before GSPO/RLVR
+post-training, Gemma-E2B-it often moves back and forth without progress. After
+training, it learns to collect pickups, chase the user, attack when in range,
+and avoid trap tiles.
+
+.. rst-class:: areno-showcase-table
+
+.. list-table::
+   :header-rows: 1
+   :widths: 1 1 1
+
+   * - Train before
+     - Reward
+     - Train after
+   * - .. image:: ../../examples/agentic/duelgrid/images/train_before.gif
+          :alt: DuelGrid before training
+          :width: 260px
+     - .. image:: ../../examples/agentic/duelgrid/images/train_reward.jpg
+          :alt: DuelGrid reward curve
+          :width: 260px
+     - .. image:: ../../examples/agentic/duelgrid/images/train_after.gif
+          :alt: DuelGrid after training
+          :width: 260px
+
+See ``examples/agentic/duelgrid`` for the rule engine, fixed-path dataset
+loader, reward function, OpenAI-compatible agent, and browser UI.
+
+What AReno owns
+---------------
+
+.. raw:: html
+
+   <div class="areno-layer-list">
+     <div><span>Kernels</span><p>Fused CUDA paths in <code>areno_accel</code> for runtime hot paths.</p></div>
+     <div><span>Engine</span><p>Tensor-parallel workers, KV/cache layout, CUDA graph support, rollout state, scoring, optimizer steps, and checkpoint I/O.</p></div>
+     <div><span>Algorithms</span><p>SFT, DPO, GSPO, GRPO, PPO, and agentic rollouts implemented inside the project rather than delegated to a separate trainer framework.</p></div>
+     <div><span>Checkpoints</span><p>Hugging Face-compatible load/save adapters for supported model families.</p></div>
+   </div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,183 +1,55 @@
-.. rst-class:: landing-page
-
 AReno documentation
 ===================
 
 .. raw:: html
 
-   <div class="areno-hero">
-     <div class="areno-hero-copy">
-       <p class="areno-eyebrow">Local post-training and serving</p>
-       <h1>Train and serve local LLMs with one CUDA-native loop.</h1>
-       <p class="areno-lede">AReno keeps rollout, reward scoring, inference, optimizer steps, and checkpoint I/O in one compact engine for SFT, DPO, GSPO, GRPO, PPO, and agentic RL workflows.</p>
-       <div class="areno-hero-actions" aria-label="Primary documentation links">
-         <a class="areno-button areno-button-primary" href="getting-started/build.html">Get started</a>
-         <a class="areno-button" href="cli/training.html">Train a model</a>
-       </div>
-     </div>
-   </div>
-
-Start
------
-
-.. raw:: html
-
-   <div class="areno-command-grid">
-     <div class="areno-command-card">
-       <p class="areno-card-kicker">Install</p>
-       <h3>Build against your CUDA PyTorch environment.</h3>
-      <pre><code>pip install psutil
-   pip install flash-linear-attention
-   pip install -e . --no-build-isolation</code></pre>
-       <p>Use <code>ARENO_BUILD_EXT=0</code> for metadata-only docs or package checks on CPU-only machines.</p>
-     </div>
-     <div class="areno-command-card">
-       <p class="areno-card-kicker">Check</p>
-       <h3>Verify the local runtime before training.</h3>
-      <pre><code>areno check
-   areno env --json</code></pre>
-       <p><code>areno check</code> reports common CUDA, PyTorch, extension, and platform setup issues with next steps.</p>
-     </div>
-   </div>
-
-``flash-attn`` is optional unless you use the default ``--attn-backend flash``
-path. Use ``--attn-backend native`` when you want to run without FlashAttention
-or when the local GPU is unsupported by FlashAttention.
-
-Core workflows
---------------
-
-.. raw:: html
-
-   <div class="areno-doc-grid">
-     <a class="areno-doc-card" href="cli/training.html">
-       <span class="areno-icon">01</span>
-       <strong>Train</strong>
-       <p>Run SFT, DPO, GSPO, GRPO, or PPO from the CLI with dataset loading, rollout, reward scoring, and checkpoint saving in one loop.</p>
-     </a>
-     <a class="areno-doc-card" href="cli/inference.html">
-       <span class="areno-icon">02</span>
-       <strong>Serve</strong>
-       <p>Start an OpenAI-compatible chat-completions server backed by the local AReno inference engine.</p>
-     </a>
-     <a class="areno-doc-card" href="sdk/trainer.html">
-       <span class="areno-icon">03</span>
-       <strong>Customize</strong>
-       <p>Use <code>from areno import Trainer</code> for custom rollout, reward, loss, and checkpoint loops.</p>
-     </a>
-     <a class="areno-doc-card" href="models/supported.html">
-       <span class="areno-icon">04</span>
-       <strong>Load models</strong>
-       <p>Review the checkpoint families currently supported by AReno model adapters.</p>
-     </a>
-   </div>
-
-.. raw:: html
-
-   <div class="areno-command-grid areno-command-grid-wide">
-     <div class="areno-command-card">
-       <p class="areno-card-kicker">Training</p>
-       <h3>Run a small GSPO smoke task.</h3>
-      <pre><code>areno train \
-     --ckpt Qwen/Qwen3-0.6B \
-     --dataset-path gsm8k:main \
-     --dataset-loader-fn examples/math/dataset_loader.py \
-     --reward-fn-path examples/math/math_verify_reward.py \
-     --algo gspo \
-     --tp-size 1 \
-     --world-size 1 \
-     --batch-size 1</code></pre>
-     </div>
-     <div class="areno-command-card">
-       <p class="areno-card-kicker">Serving</p>
-       <h3>Open a local chat-completions endpoint.</h3>
-      <pre><code>areno serve \
-     --model-path /path/to/model \
-     --tp-size 1 \
-     --world-size 1 \
-     --port 8000</code></pre>
-     </div>
-   </div>
-
-Training and serving require a CUDA-capable NVIDIA GPU. CPU-only machines can
-run docs, packaging checks, and lightweight CPU tests, but cannot run the AReno
-training or serving engine.
-
-Agentic rollout
----------------
-
-.. raw:: html
-
-   <div class="areno-split">
-     <div>
-       <p class="areno-eyebrow">Agentic RL</p>
-       <h3>Collect trajectories through a local OpenAI-compatible proxy.</h3>
-       <p>Agent functions call the local server, return explicit trajectory turns, and let AReno convert responses into completions, tokens, logprobs, rewards, and loss masks.</p>
-     </div>
-     <div class="areno-terminal areno-terminal-compact" aria-label="Agentic rollout command">
-       <div class="areno-terminal-bar"><span></span><span></span><span></span></div>
-      <pre><code>areno train \
-     --agent-fn examples/agentic/tictactoe/run_agent.py \
-     --reward-fn-path examples/agentic/tictactoe/reward.py \
-     --algo gspo</code></pre>
-     </div>
-   </div>
-
-DuelGrid is a browser-game demo with multi-action turns. Before GSPO/RLVR
-post-training, Gemma-E2B-it often moves back and forth without progress. After
-training, it learns to collect pickups, chase the user, attack when in range,
-and avoid trap tiles.
-
-.. rst-class:: areno-showcase-table
-
-.. list-table::
-   :header-rows: 1
-   :widths: 1 1 1
-
-   * - Train before
-     - Reward
-     - Train after
-   * - .. image:: ../examples/agentic/duelgrid/images/train_before.gif
-          :alt: DuelGrid before training
-          :width: 260px
-     - .. image:: ../examples/agentic/duelgrid/images/train_reward.jpg
-          :alt: DuelGrid reward curve
-          :width: 260px
-     - .. image:: ../examples/agentic/duelgrid/images/train_after.gif
-          :alt: DuelGrid after training
-          :width: 260px
-
-See ``examples/agentic/duelgrid`` for the rule engine, fixed-path dataset
-loader, reward function, OpenAI-compatible agent, and browser UI.
-
-What AReno owns
----------------
-
-.. raw:: html
-
-   <div class="areno-layer-list">
-     <div><span>Kernels</span><p>Fused CUDA paths in <code>areno_accel</code> for runtime hot paths.</p></div>
-     <div><span>Engine</span><p>Tensor-parallel workers, KV/cache layout, CUDA graph support, rollout state, scoring, optimizer steps, and checkpoint I/O.</p></div>
-     <div><span>Algorithms</span><p>SFT, DPO, GSPO, GRPO, PPO, and agentic rollouts implemented inside the project rather than delegated to a separate trainer framework.</p></div>
-     <div><span>Checkpoints</span><p>Hugging Face-compatible load/save adapters for supported model families.</p></div>
-   </div>
+   <script>window.location.replace("getting-started/welcome.html");</script>
+   <noscript>
+     <p>Continue to <a href="getting-started/welcome.html">Welcome</a>.</p>
+   </noscript>
 
 .. toctree::
    :hidden:
-   :maxdepth: 2
-   :caption: Get started
+   :maxdepth: 1
+   :caption: Get Started
 
-   getting-started/build
-   models/supported
+   Welcome <getting-started/welcome>
+   getting-started/installation
+   getting-started/quickstart
 
 .. toctree::
    :hidden:
-   :maxdepth: 2
+   :maxdepth: 1
+   :caption: Conceptual Guides
+
+   Training Loop <concepts/training-loop>
+   Chat Templates <concepts/chat-templates>
+   Dataset Formats <concepts/dataset-formats>
+   Reward Functions <concepts/reward-functions>
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Cookbook
+
+   cookbook/math-rlvr
+   cookbook/tictactoe-agentic-rl
+   cookbook/duelgrid-visual-agent
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
    :caption: Reference
 
-   cli/training
-   cli/dataset_loaders
-   cli/observability
-   cli/inference
-   cli/diagnostics
-   sdk/trainer
+   CLI Reference <reference/cli>
+   SDK Reference <sdk/trainer>
+   Supported Models <models/supported>
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Troubleshooting & FAQ
+
+   Troubleshooting <troubleshooting/index>
+   FAQ <troubleshooting/faq>
+   Report an issue <troubleshooting/report-issue>

--- a/docs/reference/agentic-rollout-api.rst
+++ b/docs/reference/agentic-rollout-api.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+Agentic rollout API
+===================
+
+Agentic rollout uses an agent function to run task-specific interaction and
+return trajectory turns for training.
+
+The training CLI accepts the agent entry point through ``--agent-fn``:
+
+.. code-block:: bash
+
+   areno train \
+     --agent-fn examples/agentic/tictactoe/run_agent.py \
+     --reward-fn-path examples/agentic/tictactoe/reward.py \
+     --algo gspo
+
+The agent function can use the local OpenAI-compatible proxy to call the model
+and can execute tools or environment logic between model turns.
+
+See :doc:`/cli/training` for current flags and
+:doc:`/cookbook/tictactoe-agentic-rl` for the smallest runnable recipe.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -1,0 +1,13 @@
+CLI Reference
+=============
+
+Use these pages when you need exact command options, dataset loader shapes, or
+runtime observability fields.
+
+Command pages:
+
+* :doc:`/cli/training`
+* :doc:`/cli/inference`
+* :doc:`/cli/dataset_loaders`
+* :doc:`/cli/observability`
+* :doc:`/cli/diagnostics`

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+Config reference
+================
+
+AReno configuration is currently exposed primarily through CLI flags and SDK
+dataclasses.
+
+Use these pages first:
+
+* :doc:`/cli/training` for training, rollout, checkpoint, and observability
+  options.
+* :doc:`/cli/inference` for local serving options.
+* :doc:`/sdk/trainer` for SDK-level trainer configuration and data classes.
+
+When adding new configuration documentation, keep the reference complete and
+searchable. Put tutorials and recipes in Get Started or Cookbook instead.

--- a/docs/reference/dataset-loader-api.rst
+++ b/docs/reference/dataset-loader-api.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+Dataset loader API
+==================
+
+Dataset loaders normalize external records for the selected training path.
+The exact record shape depends on the algorithm family.
+
+Current loader shapes are documented in :doc:`/cli/dataset_loaders`:
+
+* SFT loaders provide prompts and target responses.
+* DPO loaders provide prompt, chosen, and rejected responses.
+* Prompt-based RL loaders provide prompts and task metadata for reward
+  scoring.
+* Agentic RL loaders provide task state for agent functions.
+
+Keep loaders small, deterministic, and testable outside the GPU training loop.

--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+Environment variables
+=====================
+
+AReno uses a small number of environment variables for build and runtime
+control.
+
+``ARENO_BUILD_EXT``
+   Set ``ARENO_BUILD_EXT=0`` to skip CUDA extension compilation for
+   metadata-only installs, docs builds, or CPU-only packaging checks.
+
+``TORCH_CUDA_ARCH_LIST``
+   Set this when narrowing CUDA extension builds to a target GPU architecture,
+   for example ``TORCH_CUDA_ARCH_LIST="9.0"`` for H100/H200-only builds.
+
+``MAX_JOBS``
+   Set this to control parallel compilation jobs during editable installs.
+
+For environment inspection, use :doc:`/cli/diagnostics`.

--- a/docs/reference/experimental.rst
+++ b/docs/reference/experimental.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+Experimental and auxiliary APIs
+===============================
+
+Experimental or auxiliary APIs should stay out of the new-user path until
+their contracts are stable.
+
+When documenting an experimental surface:
+
+* Say which AReno version or branch it applies to.
+* Link to the owning module or example.
+* Mark the expected stability level.
+* Keep migration notes close to the page that users will find by search.
+
+Stable public surfaces should graduate into the relevant Reference page once
+the contract is ready.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+Reference
+=========
+
+Reference pages are for users who already know what they need to look up:
+commands, options, SDK types, supported models, APIs, and environment
+variables.
+
+For guided setup, start with :doc:`/getting-started/welcome`. For runnable
+tasks, use :doc:`/cookbook/math-rlvr`.
+
+Reference pages:
+
+* :doc:`cli`
+* :doc:`/sdk/trainer`
+* :doc:`/models/supported`

--- a/docs/reference/reward-function-api.rst
+++ b/docs/reference/reward-function-api.rst
@@ -1,0 +1,27 @@
+:orphan:
+
+Reward function API
+===================
+
+Reward files should expose a callable named ``reward_fn``:
+
+.. code-block:: python
+
+   def reward_fn(example, completions) -> list[float]:
+       ...
+
+Parameters:
+
+``example``
+   The source record returned by the dataset loader.
+
+``completions``
+   The generated completions to score.
+
+Return value:
+
+``list[float]``
+   One reward score per completion.
+
+Keep this API stable for task code. If the reward needs extra metadata, add it
+through the dataset loader record rather than through global state.

--- a/docs/troubleshooting/agentic-rollout.rst
+++ b/docs/troubleshooting/agentic-rollout.rst
@@ -1,0 +1,24 @@
+:orphan:
+
+Agentic rollout issues
+======================
+
+Agentic failures can come from model output, tool execution, environment
+state, reward scoring, timeout limits, or context length.
+
+Start with a tiny run:
+
+* One task or environment seed.
+* Low batch size.
+* Verbose trajectory diagnostics.
+* Deterministic tool and environment behavior.
+* A reward function that logs the final state and score.
+
+Common symptoms:
+
+* Trajectories are dropped: check context length and message formatting.
+* Rewards are missing: check the reward function and final trajectory state.
+* Runs hang: check external tool or environment calls before model calls.
+* Tool calls fail to parse: inspect raw assistant turns and schema format.
+
+Use :doc:`/cookbook/tictactoe-agentic-rl` as the smallest reference recipe.

--- a/docs/troubleshooting/areno-accel.rst
+++ b/docs/troubleshooting/areno-accel.rst
@@ -1,0 +1,28 @@
+:orphan:
+
+areno_accel issues
+==================
+
+``areno_accel`` contains AReno-owned CUDA extension paths. Build failures
+usually point to compiler, CUDA, PyTorch, or architecture mismatch.
+
+Useful setup commands:
+
+.. code-block:: bash
+
+   pip install psutil
+   pip install -e . --no-build-isolation
+
+For targeted extension builds, set the architecture list explicitly:
+
+.. code-block:: bash
+
+   TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
+
+For metadata-only checks on a CPU machine:
+
+.. code-block:: bash
+
+   ARENO_BUILD_EXT=0 pip install -e . --no-build-isolation
+
+Do not treat a metadata-only install as a runnable training environment.

--- a/docs/troubleshooting/cuda-pytorch.rst
+++ b/docs/troubleshooting/cuda-pytorch.rst
@@ -1,0 +1,24 @@
+:orphan:
+
+CUDA and PyTorch issues
+=======================
+
+AReno training and serving require a CUDA-capable NVIDIA GPU and a compatible
+PyTorch install. CPU-only environments can run docs and lightweight tests, but
+they cannot run the training or serving engine.
+
+Check GPU visibility:
+
+.. code-block:: bash
+
+   python -c "import torch; print('GPU:', torch.cuda.is_available())"
+
+If the result is ``False``:
+
+* Confirm the machine has an NVIDIA GPU.
+* Confirm the driver and CUDA runtime match the installed PyTorch wheel.
+* Confirm the Python environment is the one used to install AReno.
+* Run ``areno env --json`` and attach it to issue reports.
+
+If CUDA is visible but training fails, move next to
+:doc:`oom-timeout` or :doc:`areno-accel` depending on the error.

--- a/docs/troubleshooting/faq.rst
+++ b/docs/troubleshooting/faq.rst
@@ -1,0 +1,18 @@
+FAQ
+===
+
+Can I run AReno training on CPU?
+   No. CPU-only machines can build docs, run packaging checks, and run
+   lightweight CPU tests, but AReno training and serving require CUDA hardware.
+
+Is FlashAttention required?
+   It is optional unless the selected attention backend requires it. Use
+   ``--attn-backend native`` when debugging unsupported FlashAttention setups.
+
+Should examples be copied from Cookbook or Reference?
+   Start from Cookbook for runnable recipes. Use Reference when you already
+   know which command, SDK type, or API contract you need.
+
+Where should I start after installation?
+   Run :doc:`/getting-started/quickstart`, then choose the RLVR or agentic
+   rollout path that matches your task.

--- a/docs/troubleshooting/flash-attn.rst
+++ b/docs/troubleshooting/flash-attn.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+FlashAttention issues
+=====================
+
+FlashAttention is optional unless you select an attention backend that needs
+it. If FlashAttention is unavailable or unsupported on the local GPU, switch
+to native attention while debugging:
+
+.. code-block:: bash
+
+   areno train \
+     --attn-backend native \
+     ...
+
+Common checks:
+
+* Confirm the installed FlashAttention package matches PyTorch and CUDA.
+* Confirm the GPU architecture is supported by the package.
+* Try the native attention backend before changing algorithm settings.
+* Keep the failing command and ``areno env --json`` output for issue reports.

--- a/docs/troubleshooting/index.rst
+++ b/docs/troubleshooting/index.rst
@@ -1,0 +1,18 @@
+Troubleshooting
+===============
+
+Troubleshooting starts with environment facts. Run the diagnostics commands
+before changing training parameters:
+
+.. code-block:: bash
+
+   areno check
+   areno env --json
+
+Use this section when setup, CUDA, PyTorch, FlashAttention, ``areno_accel``,
+OOM, timeout, reward, tool-call, or agentic rollout issues block progress.
+
+Troubleshooting pages:
+
+* :doc:`faq`
+* :doc:`report-issue`

--- a/docs/troubleshooting/installation.rst
+++ b/docs/troubleshooting/installation.rst
@@ -1,0 +1,27 @@
+:orphan:
+
+Installation issues
+===================
+
+Most installation issues come from mismatched Python, PyTorch, CUDA, compiler,
+or optional acceleration packages.
+
+First checks:
+
+.. code-block:: bash
+
+   python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
+   areno check
+   areno env --json
+
+Common fixes:
+
+* Install AReno inside an environment that already has the intended PyTorch
+  and CUDA stack.
+* Use ``pip install -e . --no-build-isolation`` so extension builds use the
+  installed PyTorch.
+* Set ``ARENO_BUILD_EXT=0`` only for docs, metadata, or CPU-only package
+  checks.
+* Use Docker when you need a cleaner reproduction path.
+
+See :doc:`/getting-started/installation` for supported setup paths.

--- a/docs/troubleshooting/oom-timeout.rst
+++ b/docs/troubleshooting/oom-timeout.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+Training OOM and timeout
+========================
+
+Out-of-memory and timeout failures usually come from rollout volume, sequence
+length, tensor parallelism, model size, or slow external agent work.
+
+First reductions:
+
+* Lower ``--batch-size``.
+* Lower rollout or sequence length settings.
+* Use a smaller checkpoint for the first reproduction.
+* Reduce agent concurrency for tool or environment tasks.
+* Confirm no unrelated GPU process is consuming memory.
+
+For agentic tasks, distinguish model time from environment time. Tool calls,
+tests, sleeps, browser work, and sandbox actions can dominate rollout wall
+time before the model is called again.
+
+See :doc:`/cli/observability` for timing and metric interpretation.

--- a/docs/troubleshooting/report-issue.rst
+++ b/docs/troubleshooting/report-issue.rst
@@ -1,0 +1,20 @@
+How to report an issue
+======================
+
+Good issue reports include enough environment, command, and task context for
+another person to reproduce the failure.
+
+Include:
+
+* The exact command.
+* The relevant stack trace or error message.
+* ``areno check`` output.
+* ``areno env --json`` output.
+* GPU type and count.
+* PyTorch, CUDA, FlashAttention, and AReno versions.
+* Whether ``ARENO_BUILD_EXT=0`` was used.
+* Dataset loader, reward function, and agent function paths when relevant.
+* The smallest batch size or task seed that reproduces the issue.
+
+For private data, replace examples with a minimal synthetic record that keeps
+the same shape and failure.

--- a/docs/troubleshooting/reward-function.rst
+++ b/docs/troubleshooting/reward-function.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+Reward function issues
+======================
+
+Reward issues often look like training instability. Debug the reward function
+before changing algorithms.
+
+Check:
+
+* The file passed to ``--reward-fn-path`` exports ``reward_fn``.
+* The reward list length matches the completions list length.
+* Parsing handles empty, malformed, or unexpected completions.
+* Scores match a hand-checked example.
+* Logged examples include enough context to explain wrong scores.
+
+If rewards are always zero, inspect answer parsing first. If rewards are
+always one, verify the checker actually reads the completion.
+
+See :doc:`/concepts/reward-functions` and :doc:`/reference/reward-function-api`.

--- a/docs/troubleshooting/tool-call.rst
+++ b/docs/troubleshooting/tool-call.rst
@@ -1,0 +1,18 @@
+:orphan:
+
+Tool call issues
+================
+
+Tool-call failures usually happen at the schema, parser, or trajectory
+boundary.
+
+Check:
+
+* The model output matches the expected tool-call format.
+* Tool arguments are validated before execution.
+* Tool results are recorded in the message history.
+* Parser failures are logged with the raw assistant turn.
+* Dropped trajectories include enough context to reproduce the bad turn.
+
+For serving-side tool-call behavior, see :doc:`/cli/inference`. For agentic
+diagnostics, see :doc:`/cli/observability`.


### PR DESCRIPTION
Summary:
- reorganize the documentation navigation into the current visible sections
- add collapsible sidebar groups and refine sidebar scrollbar/search/menu styling
- add focused getting started, concepts, cookbook, reference, and troubleshooting pages

Verification:
- .venv/bin/sphinx-build -E -a -b html docs /private/tmp/areno-docs-preview