### PR TITLE
feat(cli): support selectable model hubs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN python -m pip install --index-url "${PIP_INDEX_URL}" --upgrade pip setuptool
 RUN python -m pip install --index-url "${PIP_INDEX_URL}" \
         "psutil" \
         "transformers==${TRANSFORMERS_VERSION}" \
-        "datasets>=3.3.0" \
+        "datasets==4.0.0" \
         "einops" \
         "safetensors>=0.4" \
         "accelerate" \

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ areno train \
   --tp-size 4
 ```
 
-`--ckpt` and `--dataset-path` accept either local paths or Hugging Face repo IDs. Switch algorithms by changing `--algo` (e.g. `--algo grpo`, `--algo sft`).
+`--ckpt` and `--dataset-path` accept either local paths or remote repo IDs. By default, remote refs use Hugging Face. Add `--model-hub modelscope` to pull non-local model and dataset refs from ModelScope, or use `--model-hub hf` explicitly for Hugging Face. Switch algorithms by changing `--algo` (e.g. `--algo grpo`, `--algo sft`).
 
 For models whose tokenizer chat template supports a thinking-mode switch, add `--disable-thinking` to pass `enable_thinking=False` during training prompt rendering. Tokenizers that do not support this argument automatically use their normal chat-template path.
 

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -27,6 +27,7 @@ class TrainerConfig:
     algo: str
     ckpt: str
     dataset_path: str
+    model_hub: str = "hf"
     dataset_loader_fn: str | None = None
     save_path: str | None = None
     save_interval: int = 100
@@ -63,6 +64,8 @@ class TrainerConfig:
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:
             raise ValueError("attn_backend must be one of: flash, native")
+        if self.model_hub not in {"hf", "modelscope"}:
+            raise ValueError("model_hub must be one of: hf, modelscope")
 
     def optimizer_config(self) -> dict:
         """Build the optimizer dict consumed by the backend config."""

--- a/areno/cli/model_refs.py
+++ b/areno/cli/model_refs.py
@@ -28,7 +28,9 @@ def _snapshot_download(model_ref: str, *, model_hub: str) -> str:
         try:
             from huggingface_hub import snapshot_download
         except ImportError as exc:
-            raise RuntimeError(f"{model_ref!r} is not a local checkpoint path and huggingface_hub is unavailable") from exc
+            raise RuntimeError(
+                f"{model_ref!r} is not a local checkpoint path and huggingface_hub is unavailable"
+            ) from exc
         return snapshot_download(model_ref)
     if model_hub == "modelscope":
         try:

--- a/areno/cli/model_refs.py
+++ b/areno/cli/model_refs.py
@@ -1,4 +1,4 @@
-"""Shared CLI helpers for local checkpoint paths and Hugging Face model ids."""
+"""Shared CLI helpers for local checkpoint paths and remote model ids."""
 
 from __future__ import annotations
 
@@ -8,37 +8,51 @@ from typing import TypeVar
 ConfigT = TypeVar("ConfigT")
 
 
-def resolve_model_ref(model_ref: str, cache: dict[str, str] | None = None) -> str:
-    """Resolve a local path or Hugging Face repo id to a local checkpoint directory."""
+def resolve_model_ref(model_ref: str, cache: dict[str, str] | None = None, *, model_hub: str = "hf") -> str:
+    """Resolve a local path or remote model id to a local checkpoint directory."""
 
     path = Path(model_ref)
     if path.exists():
         return str(path)
-    if cache is not None and model_ref in cache:
-        return cache[model_ref]
-    try:
-        from huggingface_hub import snapshot_download
-    except ImportError as exc:
-        raise RuntimeError(f"{model_ref!r} is not a local checkpoint path and huggingface_hub is unavailable") from exc
-    resolved = snapshot_download(model_ref)
+    cache_key = f"{model_hub}:{model_ref}"
+    if cache is not None and cache_key in cache:
+        return cache[cache_key]
+    resolved = _snapshot_download(model_ref, model_hub=model_hub)
     if cache is not None:
-        cache[model_ref] = resolved
+        cache[cache_key] = resolved
     return resolved
+
+
+def _snapshot_download(model_ref: str, *, model_hub: str) -> str:
+    if model_hub == "hf":
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise RuntimeError(f"{model_ref!r} is not a local checkpoint path and huggingface_hub is unavailable") from exc
+        return snapshot_download(model_ref)
+    if model_hub == "modelscope":
+        try:
+            from modelscope import snapshot_download
+        except ImportError as exc:
+            raise RuntimeError(f"{model_ref!r} is not a local checkpoint path and modelscope is unavailable") from exc
+        return snapshot_download(model_ref)
+    raise ValueError("model_hub must be one of: hf, modelscope")
 
 
 def resolve_model_refs_for_config(config: ConfigT) -> ConfigT:
     """Resolve all model references in a trainer config, sharing duplicate downloads."""
 
     cache: dict[str, str] = {}
-    config.ckpt = resolve_model_ref(config.ckpt, cache)
+    model_hub = str(getattr(config, "model_hub", "hf"))
+    config.ckpt = resolve_model_ref(config.ckpt, cache, model_hub=model_hub)
     algo = str(getattr(config, "algo", "")).lower()
     if algo == "dpo" and getattr(config, "ref_ckpt", None) is not None:
-        config.ref_ckpt = resolve_model_ref(config.ref_ckpt, cache)
+        config.ref_ckpt = resolve_model_ref(config.ref_ckpt, cache, model_hub=model_hub)
     if algo == "ppo":
         if getattr(config, "ref_ckpt", None) is not None:
-            config.ref_ckpt = resolve_model_ref(config.ref_ckpt, cache)
+            config.ref_ckpt = resolve_model_ref(config.ref_ckpt, cache, model_hub=model_hub)
         if getattr(config, "reward_ckpt", None) is not None:
-            config.reward_ckpt = resolve_model_ref(config.reward_ckpt, cache)
+            config.reward_ckpt = resolve_model_ref(config.reward_ckpt, cache, model_hub=model_hub)
         if getattr(config, "critic_ckpt", None) is not None:
-            config.critic_ckpt = resolve_model_ref(config.critic_ckpt, cache)
+            config.critic_ckpt = resolve_model_ref(config.critic_ckpt, cache, model_hub=model_hub)
     return config

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -917,8 +917,15 @@ def _load_modelscope_dataset_ref(name: str, config: str | None, split: str):
     except ImportError as exc:
         raise RuntimeError(f"ModelScope dataset loading requires modelscope dataset dependencies: {exc}") from exc
     if config is None:
-        return MsDataset.load(name, split=split, trust_remote_code=True).to_hf_dataset()
-    return MsDataset.load(name, subset_name=config, split=split, trust_remote_code=True).to_hf_dataset()
+        return _modelscope_to_hf_dataset(MsDataset.load(name, split=split, trust_remote_code=True))
+    return _modelscope_to_hf_dataset(MsDataset.load(name, subset_name=config, split=split, trust_remote_code=True))
+
+
+def _modelscope_to_hf_dataset(dataset):
+    to_hf_dataset = getattr(dataset, "to_hf_dataset", None)
+    if callable(to_hf_dataset):
+        return to_hf_dataset()
+    return dataset
 
 
 def _load_raw_dataset_files(builder: str, data_files, *, load_dataset):

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -915,7 +915,7 @@ def _load_modelscope_dataset_ref(name: str, config: str | None, split: str):
     try:
         from modelscope.msdatasets import MsDataset
     except ImportError as exc:
-        raise RuntimeError("ModelScope dataset loading requires the 'modelscope' package") from exc
+        raise RuntimeError(f"ModelScope dataset loading requires modelscope dataset dependencies: {exc}") from exc
     if config is None:
         return MsDataset.load(name, split=split).to_hf_dataset()
     return MsDataset.load(name, subset_name=config, split=split).to_hf_dataset()

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -917,8 +917,8 @@ def _load_modelscope_dataset_ref(name: str, config: str | None, split: str):
     except ImportError as exc:
         raise RuntimeError(f"ModelScope dataset loading requires modelscope dataset dependencies: {exc}") from exc
     if config is None:
-        return MsDataset.load(name, split=split).to_hf_dataset()
-    return MsDataset.load(name, subset_name=config, split=split).to_hf_dataset()
+        return MsDataset.load(name, split=split, trust_remote_code=True).to_hf_dataset()
+    return MsDataset.load(name, subset_name=config, split=split, trust_remote_code=True).to_hf_dataset()
 
 
 def _load_raw_dataset_files(builder: str, data_files, *, load_dataset):

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -917,8 +917,8 @@ def _load_modelscope_dataset_ref(name: str, config: str | None, split: str):
     except ImportError as exc:
         raise RuntimeError("ModelScope dataset loading requires the 'modelscope' package") from exc
     if config is None:
-        return MsDataset.load(name, split=split)
-    return MsDataset.load(name, subset_name=config, split=split)
+        return MsDataset.load(name, split=split).to_hf_dataset()
+    return MsDataset.load(name, subset_name=config, split=split).to_hf_dataset()
 
 
 def _load_raw_dataset_files(builder: str, data_files, *, load_dataset):

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -55,6 +55,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "algo",
             "ckpt",
             "dataset_path",
+            "model_hub",
             "dataset_loader_fn",
             "tune_params",
             "mem_frac",
@@ -170,12 +171,15 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args = SimpleNamespace(**options)
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
+    args.model_hub = getattr(args, "model_hub", "hf")
     # Required-argument checks live here so offline trainers can omit reward
     # inputs while RL algorithms still require a reward function or model.
     if args.ckpt is None:
         raise click.UsageError("--ckpt is required")
     if args.dataset_path is None:
         raise click.UsageError("--dataset-path is required")
+    if args.model_hub not in {"hf", "modelscope"}:
+        raise click.UsageError("--model-hub must be one of: hf, modelscope")
     algorithm = _algorithm_for_cli(args.algo)
     if algorithm.name == "sft" and args.dataset_loader_fn is None:
         raise click.UsageError("--dataset-loader-fn is required for --algo sft")
@@ -286,6 +290,7 @@ def _format_training_config_summary(
             [
                 ("ckpt", config.ckpt),
                 ("dataset_path", config.dataset_path),
+                ("model_hub", config.model_hub),
                 ("dataset_loader", _format_optional(config.dataset_loader_fn)),
                 (
                     "reward_fn",
@@ -559,6 +564,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     # trainers do not receive rollout/reward/GSPO fields by construction.
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
+    args.model_hub = getattr(args, "model_hub", "hf")
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
@@ -566,6 +572,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             algo=algorithm.name,
             ckpt=args.ckpt,
             dataset_path=args.dataset_path,
+            model_hub=args.model_hub,
             dataset_loader_fn=args.dataset_loader_fn,
             save_path=args.save_path,
             save_interval=args.save_interval,
@@ -606,6 +613,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             algo=algorithm.name,
             ckpt=args.ckpt,
             dataset_path=args.dataset_path,
+            model_hub=args.model_hub,
             dataset_loader_fn=args.dataset_loader_fn,
             save_path=args.save_path,
             save_interval=args.save_interval,
@@ -644,6 +652,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             algo=algorithm.name,
             ckpt=args.ckpt,
             dataset_path=args.dataset_path,
+            model_hub=args.model_hub,
             dataset_loader_fn=args.dataset_loader_fn,
             reward_fn_path=args.reward_fn_path,
             save_path=args.save_path,
@@ -690,6 +699,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         algo=algorithm.name,
         ckpt=args.ckpt,
         dataset_path=args.dataset_path,
+        model_hub=args.model_hub,
         dataset_loader_fn=args.dataset_loader_fn,
         reward_fn_path=args.reward_fn_path,
         save_path=args.save_path,
@@ -774,6 +784,7 @@ def run(trainer_config: TrainerConfig):
     dataset = _load_dataset_for_training(
         trainer_config.dataset_path,
         dataset_loader_fn=trainer_config.dataset_loader_fn,
+        model_hub=trainer_config.model_hub,
         load_dataset=load_dataset,
         load_from_disk=load_from_disk,
     )
@@ -802,9 +813,16 @@ def _reward_fn_path_for_config(config: TrainerConfig) -> str | None:
     return None
 
 
-def _load_dataset_for_training(dataset_path: str, *, dataset_loader_fn: str | None, load_dataset, load_from_disk):
+def _load_dataset_for_training(
+    dataset_path: str, *, model_hub: str = "hf", dataset_loader_fn: str | None, load_dataset, load_from_disk
+):
     def default_loader(path):
-        return _load_dataset_from_path(path, load_dataset=load_dataset, load_from_disk=load_from_disk)
+        return _load_dataset_from_path(
+            path,
+            model_hub=model_hub,
+            load_dataset=load_dataset,
+            load_from_disk=load_from_disk,
+        )
 
     if dataset_loader_fn is not None:
         loader_fn = _load_dataset_loader_fn(dataset_loader_fn)
@@ -841,7 +859,7 @@ def _split_loader_fn_spec(spec_text: str) -> tuple[Path, str]:
     return Path(spec_text).resolve(), "load_training_dataset"
 
 
-def _load_dataset_from_path(dataset_path: str, *, load_dataset, load_from_disk):
+def _load_dataset_from_path(dataset_path: str, *, model_hub: str = "hf", load_dataset, load_from_disk):
     # Existing local paths may be either HF `save_to_disk` outputs or raw
     # files. Non-existing values without a known suffix are treated as
     # Hugging Face dataset IDs such as `gsm8k:main` or `AI-MO/NuminaMath-TIR`.
@@ -858,25 +876,29 @@ def _load_dataset_from_path(dataset_path: str, *, load_dataset, load_from_disk):
     if path.exists() or path.suffix.lower() in _SUPPORTED_DATASET_SUFFIXES:
         builder = _dataset_builder_for_suffix(path.suffix)
         return _load_raw_dataset_files(builder, str(path), load_dataset=load_dataset)
-    return _load_hf_dataset_ref(dataset_path, load_dataset=load_dataset)
+    return _load_remote_dataset_ref(dataset_path, model_hub=model_hub, load_dataset=load_dataset)
 
 
 _SUPPORTED_DATASET_SUFFIXES = {".json", ".jsonl", ".parquet", ".csv", ".tsv", ".arrow"}
 
 
-def _load_hf_dataset_ref(dataset_ref: str, *, load_dataset):
-    # Keep one CLI arg while supporting common HF forms:
+def _load_remote_dataset_ref(dataset_ref: str, *, model_hub: str, load_dataset):
+    # Keep one CLI arg while supporting common remote-dataset forms:
     #   repo/name
     #   repo/name:config
     #   repo/name:config:split
     parts = dataset_ref.split(":")
     if len(parts) > 3:
-        raise ValueError(f"Invalid Hugging Face dataset reference for --dataset-path: {dataset_ref}")
+        raise ValueError(f"Invalid {model_hub} dataset reference for --dataset-path: {dataset_ref}")
     name = parts[0]
     config = parts[1] if len(parts) >= 2 and parts[1] else None
     split = parts[2] if len(parts) == 3 and parts[2] else "train"
     if not name:
-        raise ValueError(f"Invalid Hugging Face dataset reference for --dataset-path: {dataset_ref}")
+        raise ValueError(f"Invalid {model_hub} dataset reference for --dataset-path: {dataset_ref}")
+    if model_hub == "modelscope":
+        return _load_modelscope_dataset_ref(name, config, split)
+    if model_hub != "hf":
+        raise ValueError("model_hub must be one of: hf, modelscope")
     if config is None:
         try:
             return load_dataset(name, split=split)
@@ -887,6 +909,16 @@ def _load_hf_dataset_ref(dataset_ref: str, *, load_dataset):
                 raise
             return load_dataset(name, "main", split=split)
     return load_dataset(name, config, split=split)
+
+
+def _load_modelscope_dataset_ref(name: str, config: str | None, split: str):
+    try:
+        from modelscope.msdatasets import MsDataset
+    except ImportError as exc:
+        raise RuntimeError("ModelScope dataset loading requires the 'modelscope' package") from exc
+    if config is None:
+        return MsDataset.load(name, split=split)
+    return MsDataset.load(name, subset_name=config, split=split)
 
 
 def _load_raw_dataset_files(builder: str, data_files, *, load_dataset):
@@ -947,19 +979,26 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     help="Run SFT, DPO, GSPO, GRPO, or PPO training with the areno backend.",
 )
 @click.option("--algo", type=str, default="gspo", show_default=True, help="Training algorithm registered in areno.api.")
-@click.option("--ckpt", default=None, help="Actor model/tokenizer checkpoint path or Hugging Face repo ID.")
+@click.option("--ckpt", default=None, help="Actor model/tokenizer checkpoint path or remote model repo ID.")
 @click.option(
-    "--dataset-path", default=None, help="Training dataset path, HF save_to_disk directory, or HF dataset ref."
+    "--dataset-path", default=None, help="Training dataset path, HF save_to_disk directory, or remote dataset ref."
+)
+@click.option(
+    "--model-hub",
+    type=click.Choice(["hf", "modelscope"], case_sensitive=False),
+    default="hf",
+    show_default=True,
+    help="Remote hub for non-local model and dataset refs. Use 'modelscope' for ModelScope or 'hf' for Hugging Face.",
 )
 @click.option(
     "--dataset-loader-fn", default=None, help="Optional Python dataset loader function as file.py or file.py:function."
 )
 @click.option("--reward-fn-path", default=None, help="Python file defining reward_fn(record).")
 @click.option(
-    "--ref-ckpt", default=None, help="Optional PPO/DPO reference model checkpoint path or Hugging Face repo ID."
+    "--ref-ckpt", default=None, help="Optional PPO/DPO reference model checkpoint path or remote model repo ID."
 )
-@click.option("--reward-ckpt", default=None, help="Optional PPO reward model checkpoint path or Hugging Face repo ID.")
-@click.option("--critic-ckpt", default=None, help="Optional PPO critic model checkpoint path or Hugging Face repo ID.")
+@click.option("--reward-ckpt", default=None, help="Optional PPO reward model checkpoint path or remote model repo ID.")
+@click.option("--critic-ckpt", default=None, help="Optional PPO critic model checkpoint path or remote model repo ID.")
 @click.option("--save-path", default=None, help="Optional checkpoint output directory.")
 @click.option("--save-interval", type=int, default=100, show_default=True, help="Save checkpoint every N train steps.")
 @click.option(

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -40,11 +40,16 @@ Basic
 Inputs, dataset loader, the algorithm and run length, and device counts.
 
 ``--ckpt TEXT``
-   Actor model/tokenizer checkpoint path or Hugging Face repo ID.
+   Actor model/tokenizer checkpoint path or remote model repo ID.
 
 ``--dataset-path TEXT``
-   Training dataset path, Hugging Face ``save_to_disk`` directory, or Hugging
-   Face dataset reference.
+   Training dataset path, Hugging Face ``save_to_disk`` directory, or remote
+   dataset reference.
+
+``--model-hub [hf|modelscope]``
+   Remote hub used when ``--ckpt``, role checkpoints, or ``--dataset-path`` are
+   not local paths. Use ``--model-hub hf`` for Hugging Face and
+   ``--model-hub modelscope`` for ModelScope. Default: ``hf``.
 
 Dataset references use ``repo/name``, ``repo/name:config``, or
 ``repo/name:config:split``. Examples: ``gsm8k:main`` and
@@ -189,7 +194,7 @@ Reward files should expose:
        return 0.0
 
 ``--reward-ckpt TEXT``
-   Optional PPO reward model checkpoint path or Hugging Face repo ID.
+   Optional PPO reward model checkpoint path or remote model repo ID.
 
 Parameter tuning
 ~~~~~~~~~~~~~~~~
@@ -297,10 +302,10 @@ in its description; flags for other algorithms are ignored.
    Policy gradient clipping norm. Default: ``1.0``.
 
 ``--ref-ckpt TEXT``
-   Optional PPO/DPO reference model checkpoint path or Hugging Face repo ID.
+   Optional PPO/DPO reference model checkpoint path or remote model repo ID.
 
 ``--critic-ckpt TEXT``
-   Optional PPO critic model checkpoint path or Hugging Face repo ID.
+   Optional PPO critic model checkpoint path or remote model repo ID.
 
 ``--critic-lr FLOAT``
    PPO critic optimizer learning rate. Default: ``1.0e-5``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "safetensors>=0.4",
   "transformers>=4.56",
   "huggingface-hub>=0.25",
+  "modelscope>=1.20",
   "datasets>=3.3.0",
   "numpy",
   "tensorboard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "transformers>=4.56",
   "huggingface-hub>=0.25",
   "modelscope>=1.20",
+  "addict>=2.4",
   "datasets>=3.3.0",
   "numpy",
   "tensorboard",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "huggingface-hub>=0.25",
   "modelscope>=1.20",
   "addict>=2.4",
-  "datasets>=3.3.0",
+  "datasets==4.0.0",
   "numpy",
   "tensorboard",
   "pydantic>=2",

--- a/tests/test_cli_model_refs_cpu.py
+++ b/tests/test_cli_model_refs_cpu.py
@@ -32,6 +32,17 @@ class CliModelReferenceTest(unittest.TestCase):
         self.assertEqual(second, first)
         self.assertEqual(calls, ["Qwen/Qwen3-4B"])
 
+    def test_resolve_model_ref_uses_modelscope_when_selected(self):
+        """ModelScope model refs should use the ModelScope downloader explicitly."""
+        calls: list[str] = []
+        fake_modelscope = types.SimpleNamespace(snapshot_download=lambda repo: calls.append(repo) or f"/ms/{repo}")
+
+        with patch.dict(sys.modules, {"modelscope": fake_modelscope}):
+            resolved = model_refs.resolve_model_ref("Qwen/Qwen3-4B", model_hub="modelscope")
+
+        self.assertEqual(resolved, "/ms/Qwen/Qwen3-4B")
+        self.assertEqual(calls, ["Qwen/Qwen3-4B"])
+
     def test_resolve_model_refs_for_ppo_config_reuses_duplicate_roles(self):
         """Train config resolution should not download the same repo once per role."""
         calls: list[str] = []
@@ -52,6 +63,28 @@ class CliModelReferenceTest(unittest.TestCase):
         self.assertEqual(resolved.ref_ckpt, "/cache/org/actor")
         self.assertEqual(resolved.critic_ckpt, "/cache/org/actor")
         self.assertEqual(resolved.reward_ckpt, "/cache/org/reward")
+        self.assertEqual(calls, ["org/actor", "org/reward"])
+
+    def test_resolve_model_refs_for_config_honors_modelscope_for_all_roles(self):
+        calls: list[str] = []
+        fake_modelscope = types.SimpleNamespace(snapshot_download=lambda repo: calls.append(repo) or f"/ms/{repo}")
+        config = SimpleNamespace(
+            algo="ppo",
+            model_hub="modelscope",
+            ckpt="org/actor",
+            dataset_path="/data",
+            ref_ckpt="org/actor",
+            reward_ckpt="org/reward",
+            critic_ckpt="org/actor",
+        )
+
+        with patch.dict(sys.modules, {"modelscope": fake_modelscope}):
+            resolved = model_refs.resolve_model_refs_for_config(config)
+
+        self.assertEqual(resolved.ckpt, "/ms/org/actor")
+        self.assertEqual(resolved.ref_ckpt, "/ms/org/actor")
+        self.assertEqual(resolved.critic_ckpt, "/ms/org/actor")
+        self.assertEqual(resolved.reward_ckpt, "/ms/org/reward")
         self.assertEqual(calls, ["org/actor", "org/reward"])
 
 

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -386,6 +387,43 @@ class ConfigAndDataTest(unittest.TestCase):
             )
 
         self.assertEqual(dataset, [{"prompt": "loaded"}])
+
+    def test_cli_remote_dataset_loader_uses_hugging_face_by_default(self):
+        """Remote dataset refs should keep using Hugging Face unless another hub is selected."""
+        calls = []
+
+        dataset = train_cli._load_dataset_from_path(
+            "gsm8k:main:test",
+            load_dataset=lambda *args, **kwargs: calls.append((args, kwargs)) or [{"source": "hf"}],
+            load_from_disk=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(dataset, [{"source": "hf"}])
+        self.assertEqual(calls, [(("gsm8k", "main"), {"split": "test"})])
+
+    def test_cli_remote_dataset_loader_uses_modelscope_when_selected(self):
+        """--model-hub modelscope should route non-local dataset refs through ModelScope."""
+        calls = []
+
+        class FakeMsDataset:
+            @staticmethod
+            def load(*args, **kwargs):
+                calls.append((args, kwargs))
+                return [{"source": "modelscope"}]
+
+        fake_modelscope = types.ModuleType("modelscope")
+        fake_msdatasets = types.ModuleType("modelscope.msdatasets")
+        fake_msdatasets.MsDataset = FakeMsDataset
+        with patch.dict(sys.modules, {"modelscope": fake_modelscope, "modelscope.msdatasets": fake_msdatasets}):
+            dataset = train_cli._load_dataset_from_path(
+                "gsm8k:main:test",
+                model_hub="modelscope",
+                load_dataset=lambda *_args, **_kwargs: [{"source": "hf"}],
+                load_from_disk=lambda *_args, **_kwargs: None,
+            )
+
+        self.assertEqual(dataset, [{"source": "modelscope"}])
+        self.assertEqual(calls, [(("gsm8k",), {"subset_name": "main", "split": "test"})])
 
     def test_train_cli_preflight_rejects_missing_dataset_loader_file(self):
         """Dataset loader path failures should be UsageError before backend init."""

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -427,7 +427,7 @@ class ConfigAndDataTest(unittest.TestCase):
             )
 
         self.assertEqual(dataset, [{"source": "modelscope"}])
-        self.assertEqual(calls, [(("gsm8k",), {"subset_name": "main", "split": "test"})])
+        self.assertEqual(calls, [(("gsm8k",), {"subset_name": "main", "split": "test", "trust_remote_code": True})])
 
     def test_train_cli_preflight_rejects_missing_dataset_loader_file(self):
         """Dataset loader path failures should be UsageError before backend init."""

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -405,11 +405,15 @@ class ConfigAndDataTest(unittest.TestCase):
         """--model-hub modelscope should route non-local dataset refs through ModelScope."""
         calls = []
 
+        class FakeMsDatasetResult:
+            def to_hf_dataset(self):
+                return [{"source": "modelscope"}]
+
         class FakeMsDataset:
             @staticmethod
             def load(*args, **kwargs):
                 calls.append((args, kwargs))
-                return [{"source": "modelscope"}]
+                return FakeMsDatasetResult()
 
         fake_modelscope = types.ModuleType("modelscope")
         fake_msdatasets = types.ModuleType("modelscope.msdatasets")

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -429,6 +429,12 @@ class ConfigAndDataTest(unittest.TestCase):
         self.assertEqual(dataset, [{"source": "modelscope"}])
         self.assertEqual(calls, [(("gsm8k",), {"subset_name": "main", "split": "test", "trust_remote_code": True})])
 
+    def test_modelscope_dataset_loader_accepts_hf_dataset_return(self):
+        """Some ModelScope paths return HF Dataset objects directly."""
+        dataset = [{"source": "hf-direct"}]
+
+        self.assertIs(train_cli._modelscope_to_hf_dataset(dataset), dataset)
+
     def test_train_cli_preflight_rejects_missing_dataset_loader_file(self):
         """Dataset loader path failures should be UsageError before backend init."""
         missing = Path(tempfile.gettempdir()) / "areno_missing_loader.py"

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -27,6 +27,11 @@ def test_train_config_requires_dataset_path():
         _trainer_config_from_options(**_options(dataset_path=None, algo="sft"))
 
 
+def test_train_config_validates_model_hub():
+    with pytest.raises(UsageError, match="--model-hub must be one of: hf, modelscope"):
+        _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None, model_hub="bogus"))
+
+
 def test_train_config_requires_dataset_loader_for_sft():
     with pytest.raises(UsageError, match="--dataset-loader-fn is required for --algo sft"):
         _trainer_config_from_options(**_options(algo="sft", dataset_loader_fn=None))
@@ -148,6 +153,7 @@ def test_train_config_builds_sft_shape_without_rollout_or_role_fields():
     assert cfg.algo == "sft"
     assert cfg.ckpt == "actor"
     assert cfg.dataset_path == "dataset"
+    assert cfg.model_hub == "hf"
     assert cfg.optimizer_min_lr == 0.0
     assert cfg.attn_backend == "native"
     assert cfg.areno_config().runtime["attn_backend"] == "native"
@@ -166,6 +172,14 @@ def test_train_config_disable_thinking_sets_chat_template_option():
 
     assert default_cfg.chat_template_enable_thinking is None
     assert disabled_cfg.chat_template_enable_thinking is False
+
+
+def test_train_config_preserves_model_hub():
+    cfg = _trainer_config_from_options(
+        **_options(algo="sft", reward_fn_path=None, reward_ckpt=None, model_hub="modelscope")
+    )
+
+    assert cfg.model_hub == "modelscope"
 
 
 def test_train_config_builds_dpo_shape_and_ref_ckpt():
@@ -302,6 +316,7 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "requires_rollout  yes" in summary
     assert "ckpt            actor" in summary
     assert "dataset_path    dataset" in summary
+    assert "model_hub       hf" in summary
     assert "reward_fn       none" in summary
     assert "reward_ckpt     reward-model" in summary
     assert "dp_size       4" in summary
@@ -571,6 +586,7 @@ def _options(**overrides):
         algo="gspo",
         ckpt="actor",
         dataset_path="dataset",
+        model_hub="hf",
         dataset_loader_fn=None,
         reward_fn_path=None,
         save_path="save",


### PR DESCRIPTION
## Summary
- Add `--model-hub hf|modelscope` to `areno train` for explicit remote hub selection.
- Route non-local model refs and dataset refs through Hugging Face by default or ModelScope when selected.
- Add ModelScope as a runtime dependency and document the new CLI behavior.

## Tests
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_cli_model_refs_cpu.py tests/test_train_cli_config_cpu.py tests/test_config_data_cpu.py -q`
- `ruff check areno/cli/model_refs.py areno/cli/train.py areno/api/trainer_config.py tests/test_cli_model_refs_cpu.py tests/test_train_cli_config_cpu.py tests/test_config_data_cpu.py`
- `python -m py_compile areno/cli/model_refs.py areno/cli/train.py areno/api/trainer_config.py`
- `git diff --check`

Closes #130