### PR TITLE
docs: support copy page functionality

### DIFF
--- a/docs/_static/areno-sidebar.js
+++ b/docs/_static/areno-sidebar.js
@@ -1,4 +1,179 @@
 (function () {
+  var copyResetDelay = 1600;
+
+  function normalizeCopyText(text) {
+    return text
+      .replace(/\u00a0/g, " ")
+      .split("\n")
+      .map(function (line) {
+        return line.trim();
+      })
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  }
+
+  function getPageCopyText(article) {
+    var excludedNodes;
+    var originalDisplays = [];
+    var text;
+
+    if (!article) {
+      return "";
+    }
+
+    if (typeof article.querySelectorAll !== "function") {
+      return normalizeCopyText(article.innerText || article.textContent || "");
+    }
+
+    excludedNodes = article.querySelectorAll(".areno-copy-page, .headerlink, script, style");
+
+    Array.prototype.forEach.call(excludedNodes, function (node) {
+      originalDisplays.push({
+        node: node,
+        display: node.style.display
+      });
+      node.style.display = "none";
+    });
+
+    try {
+      text = article.innerText || article.textContent || "";
+    } finally {
+      Array.prototype.forEach.call(originalDisplays, function (item) {
+        item.node.style.display = item.display;
+      });
+    }
+
+    return normalizeCopyText(text);
+  }
+
+  function setCopyPageButtonLabel(button, label) {
+    var labelNode = button.querySelector(".areno-copy-page-label");
+
+    if (labelNode) {
+      labelNode.textContent = label;
+    }
+  }
+
+  function resetCopyPageButton(button) {
+    window.clearTimeout(button._arenoCopyTimer);
+    button.dataset.arenoCopyState = "idle";
+    setCopyPageButtonLabel(button, "Copy page");
+  }
+
+  function showCopyPageButtonState(button, state, label) {
+    window.clearTimeout(button._arenoCopyTimer);
+    button.dataset.arenoCopyState = state;
+    setCopyPageButtonLabel(button, label);
+    button._arenoCopyTimer = window.setTimeout(function () {
+      resetCopyPageButton(button);
+    }, copyResetDelay);
+  }
+
+  function copyTextWithFallback(text) {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+      return navigator.clipboard.writeText(text).catch(function () {
+        return copyTextWithTextarea(text);
+      });
+    }
+
+    return copyTextWithTextarea(text);
+  }
+
+  function copyTextWithTextarea(text) {
+    var textarea = document.createElement("textarea");
+
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      if (!document.execCommand("copy")) {
+        return Promise.reject(new Error("Copy command failed"));
+      }
+
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+
+  function createCopyPageButton(article) {
+    var button = document.createElement("button");
+
+    button.type = "button";
+    button.className = "areno-copy-page";
+    button.setAttribute("aria-label", "Copy this page");
+    button.setAttribute("title", "Copy page");
+    button.innerHTML = [
+      '<svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">',
+      '<path d="M14.25 5.25H7.25C6.14543 5.25 5.25 6.14543 5.25 7.25V14.25C5.25 15.3546 6.14543 16.25 7.25 16.25H14.25C15.3546 16.25 16.25 15.3546 16.25 14.25V7.25C16.25 6.14543 15.3546 5.25 14.25 5.25Z"></path>',
+      '<path d="M2.80103 11.998L1.77203 5.07397C1.61003 3.98097 2.36403 2.96397 3.45603 2.80197L10.38 1.77297C11.313 1.63397 12.19 2.16297 12.528 3.00097"></path>',
+      "</svg>",
+      '<span class="areno-copy-page-label">Copy page</span>'
+    ].join("");
+
+    button.addEventListener("click", function () {
+      var text = getPageCopyText(article);
+
+      if (!text) {
+        showCopyPageButtonState(button, "error", "Nothing to copy");
+        return;
+      }
+
+      copyTextWithFallback(text)
+        .then(function () {
+          showCopyPageButtonState(button, "copied", "Copied");
+        })
+        .catch(function () {
+          showCopyPageButtonState(button, "error", "Copy failed");
+        });
+    });
+
+    return button;
+  }
+
+  function setupCopyPageButton() {
+    var article = document.querySelector(".yue");
+    var header;
+    var heading;
+    var actions;
+
+    if (
+      !article ||
+      article.classList.contains("landing-page") ||
+      article.querySelector(".areno-copy-page")
+    ) {
+      return;
+    }
+
+    heading = article.querySelector("h1");
+
+    if (!heading) {
+      return;
+    }
+
+    if (!heading.parentNode) {
+      return;
+    }
+
+    header = document.createElement("div");
+    header.className = "areno-page-header";
+    heading.parentNode.insertBefore(header, heading);
+    header.appendChild(heading);
+
+    actions = document.createElement("div");
+    actions.className = "areno-page-actions";
+    actions.appendChild(createCopyPageButton(article));
+    header.appendChild(actions);
+  }
+
   function setupSidebarSections() {
     var toc = document.querySelector(".globaltoc");
 
@@ -50,9 +225,17 @@
     });
   }
 
+  window.__arenoDocs = window.__arenoDocs || {};
+  window.__arenoDocs.getPageCopyText = getPageCopyText;
+  window.__arenoDocs.setupCopyPageButton = setupCopyPageButton;
+
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", setupSidebarSections);
+    document.addEventListener("DOMContentLoaded", function () {
+      setupSidebarSections();
+      setupCopyPageButton();
+    });
   } else {
     setupSidebarSections();
+    setupCopyPageButton();
   }
 })();

--- a/docs/_static/areno.css
+++ b/docs/_static/areno.css
@@ -754,6 +754,97 @@ body:has(.landing-page) .sy-main > .flex > .relative {
   line-height: 1.08;
 }
 
+.areno-page-header {
+  align-items: center;
+  display: flex;
+  gap: .75rem;
+  margin: 0 0 1.65rem;
+  min-width: 0;
+  position: relative;
+}
+
+.areno-page-header > h1 {
+  flex: 1 1 auto;
+  margin: 0;
+  min-width: 0;
+}
+
+.areno-page-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  margin-left: auto;
+  min-width: 9.75rem;
+}
+
+.areno-copy-page {
+  align-items: center;
+  background: var(--areno-bg);
+  border: 1px solid var(--areno-border);
+  border-radius: 12px;
+  color: var(--areno-ink);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: .875rem;
+  font-weight: 500;
+  gap: .5rem;
+  justify-content: center;
+  line-height: 1.25rem;
+  min-height: 2.125rem;
+  min-width: 7.75rem;
+  padding: .375rem .75rem;
+  transition:
+    background-color .16s ease,
+    border-color .16s ease,
+    color .16s ease;
+}
+
+.areno-copy-page:hover {
+  background: var(--areno-surface);
+  border-color: var(--areno-border);
+  color: var(--areno-ink);
+}
+
+.areno-copy-page:focus-visible {
+  outline: 2px solid var(--areno-ink);
+  outline-offset: 2px;
+}
+
+.areno-copy-page svg {
+  flex: 0 0 auto;
+}
+
+.areno-copy-page[data-areno-copy-state="copied"] {
+  border-color: color-mix(in srgb, var(--areno-good) 45%, var(--areno-border));
+  color: var(--areno-good);
+}
+
+.areno-copy-page[data-areno-copy-state="error"] {
+  border-color: #b91c1c;
+  color: #b91c1c;
+}
+
+html.dark .areno-copy-page[data-areno-copy-state="error"] {
+  border-color: #f87171;
+  color: #f87171;
+}
+
+@media (max-width: 640px) {
+  .areno-page-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: .75rem;
+  }
+
+  .areno-page-actions {
+    justify-content: flex-start;
+    margin-left: 0;
+    min-width: 0;
+  }
+}
+
 .yue h2 {
   border-top: 1px solid var(--areno-border);
   margin-top: 3rem;


### PR DESCRIPTION
## What does this PR do?

Adds copy-page support to the documentation site sidebar behavior and styling.

- Extends `docs/_static/areno-sidebar.js` with copy-page UI behavior.
- Adds the related copy affordance and feedback-state styles in `docs/_static/areno.css`.
- Addresses review feedback by avoiding full article DOM cloning, keeping timer state off `dataset`, removing `Object.assign`, and improving dark-mode error contrast.

## Related issue

No related issue.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

- Rebuilt the documentation site locally:
  `make html SPHINXBUILD=../.venv/bin/python\ -m\ sphinx`
- Previewed the rebuilt docs locally at:
  `http://127.0.0.1:8124/`
- Verified the preview server responded with `HTTP/1.0 200 OK` via:
  `curl -I http://127.0.0.1:8124/`

I did not run `pytest tests/ -k cpu`; this change is limited to documentation static assets.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [ ] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
