### PR TITLE
fix(engine): skip bf16 compile on unsupported GPUs

### DIFF
--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -45,6 +45,7 @@ class RuntimeConfig:
 
     kv_block_size: int = 256
     attn_backend: Literal["flash", "native"] = "flash"
+    compile_model: bool = True
     activation_checkpointing: bool = True
     keep_rollout_state: bool = True
     eager_decode: bool = False
@@ -80,6 +81,22 @@ class RuntimeConfig:
             stacklevel=2,
         )
         self.attn_backend = "native"
+
+    def resolve_compile_model(self, *, model: ModelConfig, devices: list[int]) -> None:
+        """Disable torch.compile when the selected hardware cannot compile the model dtype."""
+
+        if not self.compile_model:
+            return
+        reason = torch_compile_unsupported_gpu_reason(model, devices)
+        if reason is None:
+            return
+        warnings.warn(
+            f"torch.compile does not support the detected runtime configuration ({reason}); "
+            "falling back to eager model execution.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        self.compile_model = False
 
 
 @dataclass(slots=True)
@@ -235,6 +252,7 @@ class EngineConfig:
         if self.runtime.kv_block_size % 256 != 0:
             raise ValueError("runtime.kv_block_size must be a multiple of 256 for FlashAttention paged KV")
         self.runtime.resolve_attn_backend(model=self.model, devices=self.devices)
+        self.runtime.resolve_compile_model(model=self.model, devices=self.devices)
         self.model.attn_backend = self.runtime.attn_backend
 
 
@@ -278,6 +296,34 @@ def flash_attention_unsupported_gpu_reason(devices: list[int] | None = None) -> 
         except Exception:
             name = f"cuda:{device}"
         unsupported.append(f"{name} cc {major}.{minor}")
+    if not unsupported:
+        return None
+    return ", ".join(unsupported)
+
+
+def torch_compile_unsupported_gpu_reason(model: ModelConfig, devices: list[int] | None = None) -> str | None:
+    """Return a reason when torch.compile cannot compile the model dtype on visible GPUs."""
+
+    if model.dtype is not torch.bfloat16:
+        return None
+    if not torch.cuda.is_available():
+        return None
+    device_count = torch.cuda.device_count()
+    if device_count <= 0:
+        return None
+    selected_devices = devices if devices is not None else list(range(device_count))
+    unsupported: list[str] = []
+    for device in selected_devices:
+        if device < 0 or device >= device_count:
+            continue
+        major, minor = torch.cuda.get_device_capability(device)
+        if (int(major), int(minor)) >= (8, 0):
+            continue
+        try:
+            name = torch.cuda.get_device_name(device)
+        except Exception:
+            name = f"cuda:{device}"
+        unsupported.append(f"{name} cc {major}.{minor} lacks native BF16 support")
     if not unsupported:
         return None
     return ", ".join(unsupported)

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -60,7 +60,8 @@ class ArenoWorker:
         self.model = build_model_on_device(config, self.device)
         if config.model_path is not None and not config.dummy_load:
             load_model_weights(self.model, config.model, config.model_path)
-        self.model = torch.compile(self.model)
+        if config.runtime.compile_model:
+            self.model = torch.compile(self.model)
         opt = config.optimizer
         self.optimizer = build_optimizer(self.model.parameters(), opt, ctx)
         self.grad_clip_norm = opt.grad_clip_norm

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -119,6 +119,68 @@ class ConfigAndDataTest(unittest.TestCase):
         self.assertEqual(cfg.runtime.attn_backend, "native")
         self.assertEqual(model.attn_backend, "native")
 
+    def test_runtime_config_disables_compile_for_bf16_on_turing_gpu(self):
+        """T4 cannot compile BF16 backward graphs, so training should stay eager."""
+        model = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            dtype=torch.bfloat16,
+        )
+        runtime = RuntimeConfig(attn_backend="native", compile_model=True)
+
+        with (
+            patch("areno.engine.config.torch.cuda.is_available", return_value=True),
+            patch("areno.engine.config.torch.cuda.device_count", return_value=1),
+            patch("areno.engine.config.torch.cuda.get_device_capability", return_value=(7, 5)),
+            patch("areno.engine.config.torch.cuda.get_device_name", return_value="Tesla T4"),
+            self.assertWarnsRegex(RuntimeWarning, "torch.compile.*falling back to eager"),
+        ):
+            cfg = EngineConfig(model=model, tp_size=1, devices=[0], runtime=runtime)
+
+        self.assertFalse(cfg.runtime.compile_model)
+
+    def test_runtime_config_keeps_compile_for_bf16_on_ampere_gpu(self):
+        """Ampere and newer GPUs have native BF16 support and can keep compile enabled."""
+        model = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            dtype=torch.bfloat16,
+        )
+        runtime = RuntimeConfig(attn_backend="native", compile_model=True)
+
+        with (
+            patch("areno.engine.config.torch.cuda.is_available", return_value=True),
+            patch("areno.engine.config.torch.cuda.device_count", return_value=1),
+            patch("areno.engine.config.torch.cuda.get_device_capability", return_value=(8, 0)),
+        ):
+            cfg = EngineConfig(model=model, tp_size=1, devices=[0], runtime=runtime)
+
+        self.assertTrue(cfg.runtime.compile_model)
+
+    def test_runtime_config_keeps_compile_for_fp16_on_turing_gpu(self):
+        """The T4 restriction is specific to BF16 compilation."""
+        model = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            dtype=torch.float16,
+        )
+        runtime = RuntimeConfig(attn_backend="native", compile_model=True)
+
+        with (
+            patch("areno.engine.config.torch.cuda.is_available", return_value=True),
+            patch("areno.engine.config.torch.cuda.device_count", return_value=1),
+            patch("areno.engine.config.torch.cuda.get_device_capability", return_value=(7, 5)),
+        ):
+            cfg = EngineConfig(model=model, tp_size=1, devices=[0], runtime=runtime)
+
+        self.assertTrue(cfg.runtime.compile_model)
+
     def test_flash_attention_supported_gpu_keeps_flash_backend(self):
         """Ampere and newer GPUs should keep the explicit flash attention backend."""
         model = ModelConfig(num_attention_heads=4, num_key_value_heads=4, intermediate_size=16, vocab_size=32)


### PR DESCRIPTION
## Summary

This PR prevents AReno training from failing on GPUs that do not support native BF16 compilation, such as Tesla T4.

On these devices, BF16 model training can reach torch.compile / inductor backward compilation and fail with `torch._dynamo.exc.SkipFrame: BF16 is not supported`. The model itself may still be runnable, but compiling the BF16 backward graph is not supported by the hardware/compiler path.

The change adds a runtime compatibility check during engine configuration:

- keep torch.compile enabled by default on supported GPUs
- automatically disable model compilation when the model dtype is BF16 and any selected CUDA device is below Ampere capability
- leave FP16 on Turing unaffected
- leave BF16 on Ampere and newer GPUs unaffected
- make the worker respect the resolved `runtime.compile_model` flag before wrapping the model with torch.compile

This keeps the fast compiled path for supported hardware while making T4-class environments fall back to eager execution instead of crashing during SFT/RL training.
