### PR TITLE
ci: add docker image build workflow

### DIFF
--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -5,6 +5,10 @@ permissions: write-all
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: "Git branch, tag, or SHA to build"
+        required: false
+        default: "main"
       image_name:
         description: "GHCR image name"
         required: true
@@ -32,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set lowercase image owner
         run: echo "OWNER_LOWER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"

--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -1,0 +1,55 @@
+name: create docker image
+
+permissions: write-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: "GHCR image name"
+        required: true
+        default: "areno"
+      tag:
+        description: "Docker image tag"
+        required: true
+        default: "latest"
+      dockerfile:
+        description: "Dockerfile path"
+        required: false
+        default: "Dockerfile"
+      context:
+        description: "Docker build context"
+        required: false
+        default: "."
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set lowercase image owner
+        run: echo "OWNER_LOWER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.OWNER_LOWER }}/${{ inputs.image_name }}:${{ inputs.tag }}


### PR DESCRIPTION
## Summary

Add a manual GitHub Actions workflow named `create docker image` for building the repository Dockerfile and pushing the resulting image to GHCR.

## Details

- Adds a `workflow_dispatch` workflow for Docker image creation.
- Supports selecting the source branch, tag, or SHA through a `ref` input.
- Supports configuring the GHCR image name, image tag, Dockerfile path, and build context.
- Logs in to GHCR with `GITHUB_TOKEN` and pushes to `ghcr.io/<owner>/<image_name>:<tag>`.
- Reusing an existing tag overwrites the tag with the newly built image.

## Notes

This workflow builds from the repository Dockerfile instead of mirroring an existing DockerHub image.