### PR TITLE
ci: publish docker image to Aliyun ACR

### DIFF
--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -1,4 +1,4 @@
-name: create docker image
+name: publish image to aliyun acr
 
 permissions: write-all
 
@@ -9,10 +9,6 @@ on:
         description: "Git branch, tag, or SHA to build"
         required: false
         default: "main"
-      image_name:
-        description: "GHCR image name"
-        required: true
-        default: "areno"
       tag:
         description: "Docker image tag"
         required: true
@@ -27,7 +23,10 @@ on:
         default: "."
 
 env:
-  REGISTRY: ghcr.io
+  ALIYUN_ACR_REGISTRY: ${{ vars.ALIYUN_ACR_REGISTRY }}
+  ALIYUN_ACR_NAMESPACE: ${{ vars.ALIYUN_ACR_NAMESPACE }}
+  ALIYUN_ACR_IMAGE: ${{ vars.ALIYUN_ACR_IMAGE }}
+  ALIYUN_ACR_USERNAME: ${{ vars.ALIYUN_ACR_USERNAME }}
 
 jobs:
   build-and-push:
@@ -39,18 +38,22 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Set lowercase image owner
-        run: echo "OWNER_LOWER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Validate Aliyun ACR configuration
+        run: |
+          test -n "${ALIYUN_ACR_REGISTRY}" || (echo "ALIYUN_ACR_REGISTRY repository variable is required" && exit 1)
+          test -n "${ALIYUN_ACR_NAMESPACE}" || (echo "ALIYUN_ACR_NAMESPACE repository variable is required" && exit 1)
+          test -n "${ALIYUN_ACR_IMAGE}" || (echo "ALIYUN_ACR_IMAGE repository variable is required" && exit 1)
+          test -n "${ALIYUN_ACR_USERNAME}" || (echo "ALIYUN_ACR_USERNAME repository variable is required" && exit 1)
+
+      - name: Login to Aliyun Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.ALIYUN_ACR_REGISTRY }}
+          username: ${{ env.ALIYUN_ACR_USERNAME }}
+          password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -58,4 +61,7 @@ jobs:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.OWNER_LOWER }}/${{ inputs.image_name }}:${{ inputs.tag }}
+          tags: ${{ env.ALIYUN_ACR_REGISTRY }}/${{ env.ALIYUN_ACR_NAMESPACE }}/${{ env.ALIYUN_ACR_IMAGE }}:${{ inputs.tag }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/create-docker-image.yml
+++ b/.github/workflows/create-docker-image.yml
@@ -1,4 +1,4 @@
-name: publish image to aliyun acr
+name: create docker image
 
 permissions: write-all
 
@@ -9,6 +9,10 @@ on:
         description: "Git branch, tag, or SHA to build"
         required: false
         default: "main"
+      image_name:
+        description: "GHCR image name"
+        required: true
+        default: "areno"
       tag:
         description: "Docker image tag"
         required: true
@@ -23,10 +27,7 @@ on:
         default: "."
 
 env:
-  ALIYUN_ACR_REGISTRY: ${{ vars.ALIYUN_ACR_REGISTRY }}
-  ALIYUN_ACR_NAMESPACE: ${{ vars.ALIYUN_ACR_NAMESPACE }}
-  ALIYUN_ACR_IMAGE: ${{ vars.ALIYUN_ACR_IMAGE }}
-  ALIYUN_ACR_USERNAME: ${{ vars.ALIYUN_ACR_USERNAME }}
+  REGISTRY: ghcr.io
 
 jobs:
   build-and-push:
@@ -38,22 +39,18 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Set lowercase image owner
+        run: echo "OWNER_LOWER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Validate Aliyun ACR configuration
-        run: |
-          test -n "${ALIYUN_ACR_REGISTRY}" || (echo "ALIYUN_ACR_REGISTRY repository variable is required" && exit 1)
-          test -n "${ALIYUN_ACR_NAMESPACE}" || (echo "ALIYUN_ACR_NAMESPACE repository variable is required" && exit 1)
-          test -n "${ALIYUN_ACR_IMAGE}" || (echo "ALIYUN_ACR_IMAGE repository variable is required" && exit 1)
-          test -n "${ALIYUN_ACR_USERNAME}" || (echo "ALIYUN_ACR_USERNAME repository variable is required" && exit 1)
-
-      - name: Login to Aliyun Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.ALIYUN_ACR_REGISTRY }}
-          username: ${{ env.ALIYUN_ACR_USERNAME }}
-          password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -61,7 +58,4 @@ jobs:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           push: true
-          tags: ${{ env.ALIYUN_ACR_REGISTRY }}/${{ env.ALIYUN_ACR_NAMESPACE }}/${{ env.ALIYUN_ACR_IMAGE }}:${{ inputs.tag }}
-          provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ env.REGISTRY }}/${{ env.OWNER_LOWER }}/${{ inputs.image_name }}:${{ inputs.tag }}

--- a/.github/workflows/publish-image-aliyun-acr.yml
+++ b/.github/workflows/publish-image-aliyun-acr.yml
@@ -1,0 +1,67 @@
+name: publish image to aliyun acr
+
+permissions: write-all
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git branch, tag, or SHA to build"
+        required: false
+        default: "main"
+      tag:
+        description: "Docker image tag"
+        required: true
+        default: "latest"
+      dockerfile:
+        description: "Dockerfile path"
+        required: false
+        default: "Dockerfile"
+      context:
+        description: "Docker build context"
+        required: false
+        default: "."
+
+env:
+  ALIYUN_ACR_REGISTRY: ${{ vars.ALIYUN_ACR_REGISTRY }}
+  ALIYUN_ACR_NAMESPACE: ${{ vars.ALIYUN_ACR_NAMESPACE }}
+  ALIYUN_ACR_IMAGE: ${{ vars.ALIYUN_ACR_IMAGE }}
+  ALIYUN_ACR_USERNAME: ${{ vars.ALIYUN_ACR_USERNAME }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Validate Aliyun ACR configuration
+        run: |
+          test -n "${ALIYUN_ACR_REGISTRY}" || (echo "ALIYUN_ACR_REGISTRY repository variable is required" && exit 1)
+          test -n "${ALIYUN_ACR_NAMESPACE}" || (echo "ALIYUN_ACR_NAMESPACE repository variable is required" && exit 1)
+          test -n "${ALIYUN_ACR_IMAGE}" || (echo "ALIYUN_ACR_IMAGE repository variable is required" && exit 1)
+          test -n "${ALIYUN_ACR_USERNAME}" || (echo "ALIYUN_ACR_USERNAME repository variable is required" && exit 1)
+
+      - name: Login to Aliyun Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ALIYUN_ACR_REGISTRY }}
+          username: ${{ env.ALIYUN_ACR_USERNAME }}
+          password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ env.ALIYUN_ACR_REGISTRY }}/${{ env.ALIYUN_ACR_NAMESPACE }}/${{ env.ALIYUN_ACR_IMAGE }}:${{ inputs.tag }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Update the manual Docker image workflow to publish built images to Aliyun Container Registry.

## Details

- Renames the workflow display name to `publish image to aliyun acr`.
- Builds the repository Dockerfile from a selectable branch, tag, or SHA.
- Pushes the resulting image to Aliyun ACR.
- Reads ACR registry, namespace, image name, and username from repository variables instead of hardcoded defaults.
- Reads the ACR password from the `ALIYUN_ACR_PASSWORD` repository secret.
- Enables GitHub Actions build cache and disables provenance output for simpler registry compatibility.

## Required repository variables

- `ALIYUN_ACR_REGISTRY`
- `ALIYUN_ACR_NAMESPACE`
- `ALIYUN_ACR_IMAGE`
- `ALIYUN_ACR_USERNAME`

## Required repository secret

- `ALIYUN_ACR_PASSWORD`