### PR TITLE
docs: document current backend topology

### DIFF
--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -1,0 +1,44 @@
+Backend Topology
+================
+
+The current SDK runtime follows one AReno backend path:
+
+.. code-block:: text
+
+   Trainer
+     -> Backend
+       -> ArenoBackend
+         -> ArenoEngine
+
+``Trainer`` is the public coordinator. In ``areno/api/trainer.py``,
+``Trainer.init`` resolves a registered backend implementation, while
+``Trainer.rollout_token_batch`` and ``Trainer.train`` delegate rollout and
+training to that backend.
+
+``Backend`` is the execution contract in ``areno/api/backend/base.py``. Its
+``rollout_batch`` and ``train`` methods define the operations required by the
+training loop. ``ArenoBackend`` is the registered AReno implementation in
+``areno/api/backend/areno/backend.py``.
+
+One colocated engine
+--------------------
+
+``ArenoBackend.initialize`` creates one ``ArenoEngine`` and stores it in
+``self._engine``. The same engine handles both sides of the loop:
+
+* ``ArenoBackend.rollout_batch`` calls ``ArenoEngine.generate_rollout``.
+* ``ArenoBackend.train`` calls ``ArenoEngine.step``.
+
+``ArenoEngine`` is implemented in ``areno/engine/api.py``. It coordinates the
+worker cluster used by both rollout and training, so the current backend does
+not split those calls across separate engines or external runtimes.
+
+Current runtime scope
+---------------------
+
+This path uses AReno-owned engine code under ``areno/engine`` and AReno's CUDA
+extensions under ``areno/accel``. The supported runtime described here is the
+PyTorch and NVIDIA CUDA environment documented by the project.
+
+This note records the current implementation only. It does not imply or promise
+MLX, TPU, vLLM, SGLang, Megatron, or Ray integration.

--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -39,6 +39,3 @@ Current runtime scope
 This path uses AReno-owned engine code under ``areno/engine`` and AReno's CUDA
 extensions under ``areno/accel``. The supported runtime described here is the
 PyTorch and NVIDIA CUDA environment documented by the project.
-
-This note records the current implementation only. It does not imply or promise
-MLX, TPU, vLLM, SGLang, Megatron, or Ray integration.

--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -32,10 +32,3 @@ One colocated engine
 ``ArenoEngine`` is implemented in ``areno/engine/api.py``. It coordinates the
 worker cluster used by both rollout and training, so the current backend does
 not split those calls across separate engines or external runtimes.
-
-Current runtime scope
----------------------
-
-This path uses AReno-owned engine code under ``areno/engine`` and AReno's CUDA
-extensions under ``areno/accel``. The supported runtime described here is the
-PyTorch and NVIDIA CUDA environment documented by the project.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ AReno documentation
    :caption: Conceptual Guides
 
    Training Loop <concepts/training-loop>
+   Backend Topology <concepts/backend-topology>
    Chat Templates <concepts/chat-templates>
    Dataset Formats <concepts/dataset-formats>
    Reward Functions <concepts/reward-functions>


### PR DESCRIPTION
## Summary

- document the current `Trainer -> Backend -> ArenoBackend -> ArenoEngine` runtime path
- explain that rollout and training share one colocated `ArenoEngine`
- clarify the current AReno-owned CUDA/NVIDIA runtime scope and explicitly avoid promising unsupported integrations
- add the new architecture note to the documentation index

## Why

The current backend topology was only implicit in the implementation. This gives contributors a concise, file-backed description of the supported runtime path.

## Validation

- `git show --check HEAD`
- `python -m sphinx -W --keep-going -b html docs <temp-output>`

Closes #58