### PR TITLE
feat: add guided all-in-one source installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,46 +34,49 @@ AReno's mission is to make LLM RL **accessible** for a broad community of resear
 
 ## Installation
 
-**Requirements:**
-
-- Linux with an NVIDIA GPU (CUDA compute capability 8.0+)
-- CUDA toolkit, with `CUDA_HOME` set (so `nvcc` is on the build path)
-- PyTorch >= 2.6, matching your installed CUDA version
-
-> **Platform support:** AReno targets Linux with NVIDIA CUDA. Windows users
-> should use [WSL2](https://learn.microsoft.com/windows/wsl/). macOS, CPU-only,
-> and non-NVIDIA GPU environments are limited to metadata, docs, and lightweight
-> tests.
-
-**To install:**
-
-```bash
-pip install psutil
-pip install flash-linear-attention
-pip install areno --no-build-isolation
-```
-
-`--no-build-isolation` is required so that pip uses your existing CUDA-enabled PyTorch instead of installing a CPU-only torch in an isolated build environment.
-Because build isolation is disabled, build-time helpers are not installed automatically; `psutil` must already be present because PyTorch's CUDA extension builder imports it while sizing parallel compile jobs.
-Install `flash-attn` only when using the default high-throughput `--attn-backend flash` path. If you run with `--attn-backend native`, or AReno automatically falls back to native attention on Turing GPUs like T4, `flash-attn` is optional and does not need to be installed.
-
-**Post-install readiness check:**
-
-```bash
-areno check
-areno env --json  # attach this to setup/support reports
-```
-
-`areno check` fails fast with next steps for common setup problems such as missing or CPU-only PyTorch, unsupported PyTorch versions, missing `CUDA_HOME`/`nvcc`, missing build-time dependencies, unsupported platforms, or a skipped `areno_accel` build. Use `areno env --json` when opening an issue so maintainers can see the Python, CUDA, PyTorch, GPU, and extension state without guessing from low-level build errors.
-
-**From source** (recommended if you want the examples or plan to contribute):
+Clone AReno and run the installer:
 
 ```bash
 git clone https://github.com/inclusionAI/AReno.git
 cd AReno
-pip install psutil
-pip install flash-linear-attention
-pip install -e . --no-build-isolation
+bash scripts/install.sh
+```
+
+No installation options or prior setup decisions are required before running
+the script.
+Before changing Python, the script checks required system tools, rejects WSL1,
+and verifies that `nvidia-smi` can see a GPU. It then uses the active Python
+environment when appropriate. In preconfigured IDE environments where
+activation metadata is unavailable, it detects and reuses a Python interpreter
+that already provides PyTorch instead of creating an empty `.venv`; otherwise
+it prepares `.venv`. It then checks for a CUDA-enabled PyTorch 2.6 or newer
+build, installs the remaining dependencies in the required order, detects the
+CUDA build environment, builds AReno, and finishes by running `areno check`.
+The installer never installs or upgrades PyTorch because the correct build
+depends on the machine's CUDA platform. If PyTorch is missing or incompatible,
+it stops with guidance for the selected Python environment. Other installed
+packages are reused when they satisfy AReno's requirements; only missing or
+incompatible packages are installed or updated.
+If a step fails, it reports the failed stage, preserves the complete output in
+the user state directory (usually `~/.local/state/areno/install.log`), and
+prints suggestions specific to that failure.
+
+AReno training and serving target Linux with NVIDIA CUDA. The installer checks
+platform support before changing the environment. Windows users should run it
+inside [WSL2](https://learn.microsoft.com/windows/wsl/). The installer does not
+support macOS or CPU-only environments.
+
+To preview what the installer will do without making changes:
+
+```bash
+bash scripts/install.sh --dry-run
+```
+
+For setup or support reports:
+
+```bash
+areno check
+areno env --json  # attach this to setup/support reports
 ```
 
 **Docker setup escape hatch** (recommended when you want to verify AReno before debugging local build state):
@@ -103,30 +106,10 @@ docker run --gpus all --rm areno areno check
 
 Docker gives you a known-good Python/PyTorch/CUDA user-space install path and reuses the same `areno check` diagnostic flow. It does not replace host requirements: the host still needs a working NVIDIA driver, NVIDIA Container Toolkit support for `--gpus all`, and a driver new enough for the container CUDA runtime. Docker also does not solve model downloads, Hugging Face tokens, cache paths, network access, disk space, or multi-node networking; those remain user environment concerns.
 
-**Tips:**
-
-- Install `ninja` (`pip install ninja`) before building so CUDA kernels compile in parallel.
-- If installation fails with `No module named 'psutil'`, install it first (`pip install psutil`) and retry. This is required specifically for `--no-build-isolation` builds.
-- Install `flash-attn` before AReno only if you plan to use `--attn-backend flash`, the default high-throughput backend:
-  ```bash
-  pip install flash-attn
-  ```
-  If building `flash-attn` from source is too slow for your environment, install a pre-built wheel from the [flash-attention releases](https://github.com/Dao-AILab/flash-attention/releases) that matches your Python, PyTorch, CUDA, and platform.
-- If you use `--attn-backend native`, `flash-attn` is optional. AReno also automatically falls back to native attention on flash-attn-unsupported GPUs such as Tesla T4 and prints a warning that native attention is a slower compatibility path.
-- By default, source builds target the visible GPU architecture. To build for a specific GPU family or when building on a host where the target GPU is not visible, set `TORCH_CUDA_ARCH_LIST` explicitly. Common values are `9.0` for H100/H200, `8.0` for A100, and `8.9` for L40/RTX 4090:
-  ```bash
-  TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
-  ```
-- If your machine has many CPU cores but limited RAM, cap the parallel build jobs with `MAX_JOBS`:
-  ```bash
-  MAX_JOBS=4 pip install -e . --no-build-isolation
-  ```
-- For iterative CUDA development, enable `ccache` before rebuilding:
-  ```bash
-  export CC="ccache gcc"
-  export CXX="ccache g++"
-  ```
-- To install the Python package without building the CUDA extension (for docs/metadata or a dry run), set `ARENO_BUILD_EXT=0`. The engine will not run without the extension, but the installation will succeed.
+The installer selects the attention setup automatically. It installs
+FlashAttention for supported GPUs and leaves older GPUs on AReno's native
+compatibility backend. Build helpers, visible GPU architectures, and CUDA
+variables are handled by the script.
 
 ## Quick Start
 
@@ -406,11 +389,7 @@ If you want to contribute to AReno or customize it for your own needs, read the 
 ```bash
 git clone https://github.com/inclusionAI/AReno.git
 cd AReno
-pip install psutil
-pip install flash-linear-attention
-# Optional: install flash-attn when developing against --attn-backend flash.
-pip install flash-attn
-pip install -e . --no-build-isolation
+bash scripts/install.sh
 
 # Set up pre-commit hooks (formatting, linting, commit message checks)
 pip install pre-commit

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,9 +1,47 @@
 Installation
 ============
 
-This page covers the setup paths used by contributors and local operators:
-Docker images, editable installs, source/wheel distributions, and local
-installation.
+The installer is the single entry point for local AReno setup. Users do not
+need to choose PyTorch packages, set CUDA build variables, or order Python
+dependencies before running it.
+
+Install AReno
+-------------
+
+Clone the repository and run one command:
+
+.. code-block:: bash
+
+   git clone https://github.com/inclusionAI/AReno.git
+   cd AReno
+   bash scripts/install.sh
+
+Before changing Python, the installer checks required system tools, rejects
+WSL1, and verifies that ``nvidia-smi`` can see a GPU. It then uses an active
+virtualenv or conda environment when available, reuses the repository's
+``.venv`` when it is ready, or creates ``.venv`` automatically. If an IDE does
+not expose environment activation metadata, the installer detects and reuses a
+Python interpreter that already provides PyTorch instead of creating an empty
+``.venv``. Finally, it checks for CUDA-enabled PyTorch 2.6 or newer, detects
+CUDA build support, installs AReno's remaining dependencies, selects the
+attention setup, builds the CUDA extension, and runs ``areno check``. The
+installer never installs or upgrades PyTorch because the correct build depends
+on the machine's CUDA platform. If PyTorch is missing or incompatible, it stops
+with guidance for the selected Python environment. Other packages that already
+satisfy AReno's requirements are reused; only missing or incompatible packages
+are installed or updated.
+
+Successful installation ends with ``AReno is ready`` and the exact command to
+start using AReno. If installation stops, the same script reports the failed
+stage, explains the immediate reason, prints targeted suggestions, and
+preserves complete command output in the user state directory, usually
+``~/.local/state/areno/install.log``.
+
+To preview the plan without changing the environment:
+
+.. code-block:: bash
+
+   bash scripts/install.sh --dry-run
 
 Compatibility matrix
 --------------------
@@ -19,16 +57,16 @@ Compatibility matrix
      - Primary training/serving target. Use CUDA-enabled PyTorch >= 2.6 and build ``areno_accel``.
    * - Linux aarch64 / Grace-Blackwell
      - Supported
-     - Install a matching ``aarch64`` CUDA PyTorch build first, then build AReno with ``--no-build-isolation``.
+     - Start from a compatible CUDA-enabled ``aarch64`` PyTorch environment, such as a current NVIDIA NGC PyTorch development container. The installer validates it and builds AReno against it.
    * - Windows WSL2 + NVIDIA GPU
      - Supported
      - Follow the Linux install path inside WSL2. Native Windows is not supported.
    * - macOS Apple Silicon
-     - Metadata/docs only
-     - Use ``ARENO_BUILD_EXT=0`` for docs or packaging checks. Training/serving is not supported.
+     - Not supported
+     - The installer requires Linux with NVIDIA CUDA.
    * - CPU-only environments
-     - Metadata/docs/tests only
-     - CPU-only PyTorch can run lightweight docs/tests, but cannot train or serve AReno models.
+     - Not supported
+     - AReno training and serving require an NVIDIA GPU and CUDA-enabled PyTorch.
 
 Docker
 ------
@@ -72,71 +110,11 @@ enough for the container CUDA runtime. Model downloads, Hugging Face tokens,
 cache paths, network access, disk space, and multi-node or custom networking
 remain user environment concerns and are outside the first Docker setup path.
 
-Python distributions
---------------------
-
-By default, package builds compile the ``areno_accel`` CUDA extension. Run the
-build in an environment with PyTorch extension tooling and ``CUDA_HOME``:
-
-.. code-block:: bash
-
-   python -m pip install build
-   python -m build --no-isolation
-
-The generated artifacts are written to ``dist/``. That directory is ignored by
-git.
-
-For metadata or pure-Python packaging checks that should not require local
-PyTorch/CUDA, explicitly skip extension compilation:
-
-.. code-block:: bash
-
-   ARENO_BUILD_EXT=0 python -m build --no-isolation
-
-Installation
-------------
-
-Install a CUDA-enabled PyTorch environment first. Then install the project from
-the repository root:
-
-.. code-block:: bash
-
-   pip install psutil
-   pip install flash-linear-attention
-   pip install -e . --no-build-isolation
-
-.. note::
-
-   ``--no-build-isolation`` uses the packages already installed in your
-   environment. Install ``psutil`` first because PyTorch's CUDA extension
-   builder imports it while sizing parallel compile jobs. CUDA and PyTorch
-   must be ABI compatible. The editable install builds the ``areno_accel``
-   CUDA extension used by local kernels.
-   Install ``flash-attn`` before AReno only if you use the default
-   ``--attn-backend flash`` high-throughput path. ``flash-attn`` is optional
-   when running with ``--attn-backend native``; AReno automatically falls back
-   to native attention on flash-attn-unsupported GPUs such as Tesla T4 and
-   warns that native attention is a slower compatibility path. If building
-   ``flash-attn`` from source is too slow for your environment, install a
-   pre-built wheel from the
-   `flash-attention releases <https://github.com/Dao-AILab/flash-attention/releases>`_
-   that matches your Python, PyTorch, CUDA, and platform.
-   When ``TORCH_CUDA_ARCH_LIST`` is not set, AReno targets the visible GPU
-   architectures. Set it explicitly when cross-building or narrowing the build
-   target. Common values include ``9.0`` for H100/H200, ``8.0`` for A100, and
-   ``8.9`` for L40/RTX 4090:
-
-   .. code-block:: bash
-
-      TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
-
-   For iterative CUDA work, configure ``ccache`` with ``CC="ccache gcc"`` and
-   ``CXX="ccache g++"`` before rebuilding.
-
 Post-install checklist
 ----------------------
 
-Run the readiness check after every fresh install:
+The installer runs the readiness check automatically. You can rerun it at any
+time:
 
 .. code-block:: bash
 
@@ -151,5 +129,4 @@ For setup reports, also collect a machine-readable environment bundle:
 ``areno check`` reports common build-time and runtime setup problems with next
 steps: missing or CPU-only PyTorch, unsupported PyTorch versions, missing
 ``CUDA_HOME`` or ``nvcc``, missing build-time dependencies such as ``psutil``,
-unsupported platforms, and ``ARENO_BUILD_EXT=0`` installs that try to train or
-serve without the compiled ``areno_accel`` extension.
+and unsupported platforms.

--- a/docs/getting-started/welcome.rst
+++ b/docs/getting-started/welcome.rst
@@ -25,11 +25,9 @@ Start
    <div class="areno-command-grid">
      <div class="areno-command-card">
        <p class="areno-card-kicker">Install</p>
-       <h3>Build against your CUDA PyTorch environment.</h3>
-      <pre><code>pip install psutil
-   pip install flash-linear-attention
-   pip install -e . --no-build-isolation</code></pre>
-       <p>Use <code>ARENO_BUILD_EXT=0</code> for metadata-only docs or package checks on CPU-only machines.</p>
+       <h3>Run one installer.</h3>
+      <pre><code>bash scripts/install.sh</code></pre>
+       <p>AReno prepares the environment, builds the CUDA runtime, verifies the result, and explains the next action if a step fails.</p>
      </div>
      <div class="areno-command-card">
        <p class="areno-card-kicker">Check</p>
@@ -40,9 +38,9 @@ Start
      </div>
    </div>
 
-``flash-attn`` is optional unless you use the default ``--attn-backend flash``
-path. Use ``--attn-backend native`` when you want to run without FlashAttention
-or when the local GPU is unsupported by FlashAttention.
+The installer selects the attention setup automatically: it prepares
+FlashAttention for supported GPUs and leaves older GPUs on AReno's native
+compatibility backend.
 
 Core workflows
 --------------

--- a/docs/troubleshooting/areno-accel.rst
+++ b/docs/troubleshooting/areno-accel.rst
@@ -6,23 +6,14 @@ areno_accel issues
 ``areno_accel`` contains AReno-owned CUDA extension paths. Build failures
 usually point to compiler, CUDA, PyTorch, or architecture mismatch.
 
-Useful setup commands:
+Rerun the installer to rebuild the extension against the selected environment:
 
 .. code-block:: bash
 
-   pip install psutil
-   pip install -e . --no-build-isolation
+   bash scripts/install.sh
 
-For targeted extension builds, set the architecture list explicitly:
-
-.. code-block:: bash
-
-   TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 pip install -e . --no-build-isolation
-
-For metadata-only checks on a CPU machine:
+For a targeted developer build, pass build overrides to the same installer:
 
 .. code-block:: bash
 
-   ARENO_BUILD_EXT=0 pip install -e . --no-build-isolation
-
-Do not treat a metadata-only install as a runnable training environment.
+   TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=64 bash scripts/install.sh

--- a/docs/troubleshooting/installation.rst
+++ b/docs/troubleshooting/installation.rst
@@ -6,22 +6,41 @@ Installation issues
 Most installation issues come from mismatched Python, PyTorch, CUDA, compiler,
 or optional acceleration packages.
 
-First checks:
+Start by rerunning the installer. It preserves the full command output in the
+user state directory, usually ``~/.local/state/areno/install.log``, and ends
+failures with the stage, reason, and suggested actions:
 
 .. code-block:: bash
 
-   python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
+   bash scripts/install.sh
+
+Failures before Python setup usually mean a required system tool is missing,
+WSL1 was detected, or ``nvidia-smi`` cannot see a usable GPU. Correct the
+reported host issue and rerun the same command.
+
+PyTorch is checked but never installed or upgraded automatically. If the
+installer reports missing, outdated, CPU-only, or unusable PyTorch, prepare
+CUDA-enabled PyTorch 2.6 or newer in the Python environment named in the error,
+then rerun the installer. Use the `official PyTorch selector
+<https://pytorch.org/get-started/locally/>`_ for standard Linux GPU systems.
+For DGX Spark, start from NVIDIA's provided Jupyter environment or follow the
+`DGX Spark PyTorch playbook
+<https://build.nvidia.com/spark/pytorch-fine-tune/instructions>`_ to select a
+current NGC PyTorch development container.
+
+Some IDE terminals provide a preconfigured Python environment without setting
+``VIRTUAL_ENV`` or ``CONDA_PREFIX``. The installer detects a PyTorch-providing
+Python on ``PATH`` and reuses it automatically. To select an interpreter
+explicitly, rerun with ``PYTHON=/path/to/python bash scripts/install.sh``.
+
+If installation completes but a later runtime check fails, collect:
+
+.. code-block:: bash
+
    areno check
    areno env --json
 
-Common fixes:
-
-* Install AReno inside an environment that already has the intended PyTorch
-  and CUDA stack.
-* Use ``pip install -e . --no-build-isolation`` so extension builds use the
-  installed PyTorch.
-* Set ``ARENO_BUILD_EXT=0`` only for docs, metadata, or CPU-only package
-  checks.
-* Use Docker when you need a cleaner reproduction path.
+Use Docker when the installer reports a host CUDA or system-toolchain problem
+and a clean reproduction path is preferable.
 
 See :doc:`/getting-started/installation` for supported setup paths.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,704 @@
+#!/usr/bin/env bash
+
+# Keep all work inside main so an incomplete copy of this script cannot run.
+main() {
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+DRY_RUN=0
+CREATED_VENV=0
+CURRENT_STEP_ID="startup"
+CURRENT_STEP_LABEL="Start installation"
+if [[ -n "${XDG_STATE_HOME:-}" ]]; then
+  DEFAULT_LOG_DIRECTORY="$XDG_STATE_HOME/areno"
+elif [[ -n "${HOME:-}" ]]; then
+  DEFAULT_LOG_DIRECTORY="$HOME/.local/state/areno"
+else
+  DEFAULT_LOG_DIRECTORY="${TMPDIR:-/tmp}/areno"
+fi
+LOG_FILE="${ARENO_INSTALL_LOG:-$DEFAULT_LOG_DIRECTORY/install.log}"
+
+usage() {
+  cat <<'EOF'
+AReno installer
+
+Usage:
+  bash scripts/install.sh
+
+Options:
+  --dry-run   Show the installation plan without changing the environment.
+  -h, --help  Show this help text.
+
+The normal installation needs no options. It prepares the Python environment,
+installs dependencies, builds AReno's CUDA extension, and verifies the result.
+EOF
+}
+
+usage_error() {
+  printf 'ERROR: %s\n\n' "$*" >&2
+  usage >&2
+  exit 2
+}
+
+startup_error() {
+  local message="$1"
+  local action="$2"
+  printf '\nAReno installation could not start\n'
+  printf '==================================\n'
+  printf '%s\n\n' "$message"
+  printf 'Suggested action: %s\n' "$action"
+  exit 1
+}
+
+available() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+require_commands() {
+  local command_name
+  local missing=()
+
+  for command_name in "$@"; do
+    if ! available "$command_name"; then
+      missing+=("$command_name")
+    fi
+  done
+
+  if ((${#missing[@]})); then
+    startup_error \
+      "Required system tools are missing: ${missing[*]}." \
+      "install the missing tools with the system package manager, then rerun the installer"
+  fi
+}
+
+detect_wsl() {
+  local kernel_release
+  kernel_release="$(uname -r 2>/dev/null || true)"
+
+  case "$kernel_release" in
+    *[Mm]icrosoft*[Ww][Ss][Ll]2*)
+      IS_WSL2=1
+      ;;
+    *[Mm]icrosoft*)
+      startup_error \
+        "AReno does not support WSL1." \
+        "upgrade the distribution to WSL2, then rerun the installer"
+      ;;
+  esac
+}
+
+check_nvidia_host() {
+  local failure_action
+  local nvidia_smi_output
+  local nvidia_smi_status
+
+  if [[ "$IS_WSL2" == "1" ]]; then
+    failure_action="install or repair the Windows NVIDIA driver until nvidia-smi -L works inside WSL2"
+  else
+    failure_action="install or repair the NVIDIA driver until nvidia-smi -L lists the GPU"
+  fi
+
+  if ! available nvidia-smi; then
+    startup_error "The NVIDIA driver tool nvidia-smi was not found." "$failure_action"
+  fi
+
+  set +e
+  nvidia_smi_output="$(nvidia-smi -L 2>&1)"
+  nvidia_smi_status=$?
+  set -e
+  if ((nvidia_smi_status != 0)) ||
+    [[ -z "$nvidia_smi_output" || "$nvidia_smi_output" == *"No devices"* ]]; then
+    startup_error \
+      "The NVIDIA driver is installed, but it did not report a usable GPU." \
+      "$failure_action"
+  fi
+
+  NVIDIA_GPU_SUMMARY="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || true)"
+  if [[ -z "$NVIDIA_GPU_SUMMARY" ]]; then
+    NVIDIA_GPU_SUMMARY="$nvidia_smi_output"
+  fi
+}
+
+while (($#)); do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage_error "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+if [[ ! -f "$REPO_ROOT/pyproject.toml" || ! -f "$REPO_ROOT/setup.py" ]]; then
+  startup_error \
+    "AReno must be installed from a complete source checkout." \
+    "git clone https://github.com/inclusionAI/AReno.git && cd AReno && bash scripts/install.sh"
+fi
+
+cd "$REPO_ROOT"
+
+require_commands cat date dirname env mkdir tee uname
+
+SYSTEM_NAME="$(uname -s 2>/dev/null || printf unknown)"
+MACHINE_NAME="$(uname -m 2>/dev/null || printf unknown)"
+IS_WSL2=0
+NVIDIA_GPU_SUMMARY=""
+
+if [[ "$DRY_RUN" == "0" ]]; then
+  if [[ "$SYSTEM_NAME" != "Linux" ]]; then
+    startup_error \
+      "AReno training and serving require Linux with NVIDIA CUDA; detected $SYSTEM_NAME $MACHINE_NAME." \
+      "run this installer on a Linux NVIDIA system"
+  fi
+  case "$MACHINE_NAME" in
+    x86_64|amd64|aarch64|arm64)
+      ;;
+    *)
+      startup_error \
+        "AReno does not support CUDA extension builds on $MACHINE_NAME." \
+        "use Linux x86_64 or Linux aarch64"
+      ;;
+  esac
+  detect_wsl
+  check_nvidia_host
+fi
+
+find_python() {
+  local candidate
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return
+    fi
+  done
+  return 1
+}
+
+select_bootstrap_python() {
+  local requested="$1"
+  local not_found_message="$2"
+  local suggested_action="$3"
+
+  if [[ -n "$requested" ]]; then
+    BOOTSTRAP_PYTHON="$(command -v "$requested" 2>/dev/null || true)"
+  else
+    BOOTSTRAP_PYTHON="$(find_python || true)"
+  fi
+
+  if [[ -z "$BOOTSTRAP_PYTHON" ]]; then
+    startup_error "$not_found_message" "$suggested_action"
+  fi
+}
+
+check_torch() {
+  local python_bin="$1"
+  "$python_bin" -c '
+import importlib.util
+import re
+
+if importlib.util.find_spec("torch") is None:
+    raise SystemExit(10)
+
+try:
+    import torch
+except Exception as exc:
+    print(f"{type(exc).__name__}: {exc}")
+    raise SystemExit(14)
+
+parts = [int(value) for value in re.findall(r"\d+", torch.__version__.split("+", 1)[0])[:2]]
+if tuple(parts + [0] * (2 - len(parts))) < (2, 6):
+    print(torch.__version__)
+    raise SystemExit(11)
+if not getattr(torch.version, "cuda", None):
+    print(torch.__version__)
+    raise SystemExit(12)
+if not torch.cuda.is_available():
+    print(f"PyTorch {torch.__version__}; CUDA {torch.version.cuda}")
+    raise SystemExit(13)
+print(f"PyTorch {torch.__version__}; CUDA {torch.version.cuda}; GPUs {torch.cuda.device_count()}")
+'
+}
+
+torch_status_for_python() {
+  local python_bin="$1"
+  local status
+
+  if [[ ! -x "$python_bin" ]]; then
+    printf '10\n'
+    return
+  fi
+
+  if check_torch "$python_bin" >/dev/null 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+  printf '%s\n' "$status"
+}
+
+VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
+NEED_VENV=0
+
+if [[ -n "${PYTHON:-}" ]]; then
+  select_bootstrap_python \
+    "$PYTHON" \
+    "The Python selected by PYTHON was not found." \
+    "set PYTHON to a Python 3.10 or newer executable and rerun the installer"
+  ENVIRONMENT_DESCRIPTION="the Python selected by PYTHON"
+elif [[ -n "${VIRTUAL_ENV:-}" || -n "${CONDA_PREFIX:-}" ]]; then
+  select_bootstrap_python \
+    "" \
+    "Python was not found in the active environment." \
+    "repair or deactivate the environment, then rerun the installer"
+  ENVIRONMENT_DESCRIPTION="the active Python environment"
+else
+  select_bootstrap_python \
+    "" \
+    "Python was not found." \
+    "install Python 3.10 or newer and rerun bash scripts/install.sh"
+
+  VENV_TORCH_STATUS="$(torch_status_for_python "$VENV_PYTHON")"
+  DETECTED_TORCH_STATUS="$(torch_status_for_python "$BOOTSTRAP_PYTHON")"
+
+  if [[ -x "$VENV_PYTHON" && "$VENV_TORCH_STATUS" == "0" ]]; then
+    BOOTSTRAP_PYTHON="$VENV_PYTHON"
+    ENVIRONMENT_DESCRIPTION="$REPO_ROOT/.venv"
+  elif [[ "$DETECTED_TORCH_STATUS" == "0" ]]; then
+    ENVIRONMENT_DESCRIPTION="the detected PyTorch environment at $BOOTSTRAP_PYTHON"
+  elif [[ -x "$VENV_PYTHON" && "$VENV_TORCH_STATUS" != "10" ]]; then
+    BOOTSTRAP_PYTHON="$VENV_PYTHON"
+    ENVIRONMENT_DESCRIPTION="$REPO_ROOT/.venv"
+  elif [[ "$DETECTED_TORCH_STATUS" != "10" ]]; then
+    ENVIRONMENT_DESCRIPTION="the detected PyTorch environment at $BOOTSTRAP_PYTHON"
+  elif [[ -x "$VENV_PYTHON" ]]; then
+    BOOTSTRAP_PYTHON="$VENV_PYTHON"
+    ENVIRONMENT_DESCRIPTION="$REPO_ROOT/.venv"
+  else
+    NEED_VENV=1
+    ENVIRONMENT_DESCRIPTION="$REPO_ROOT/.venv"
+  fi
+fi
+
+PYTHON_BIN="$BOOTSTRAP_PYTHON"
+if [[ "$NEED_VENV" == "1" ]]; then
+  PYTHON_BIN="$VENV_PYTHON"
+fi
+
+if ! "$BOOTSTRAP_PYTHON" -c \
+  'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+  startup_error \
+    "$("$BOOTSTRAP_PYTHON" --version 2>&1 || printf 'The selected Python environment') is not supported." \
+    "remove the existing .venv or select Python 3.10 or newer with PYTHON"
+fi
+
+quote_command() {
+  printf '%q ' "$@"
+  printf '\n'
+}
+
+start_step() {
+  local number="$1"
+  local total="$2"
+  CURRENT_STEP_ID="$3"
+  CURRENT_STEP_LABEL="$4"
+  printf '\n[%s/%s] %s\n' "$number" "$total" "$CURRENT_STEP_LABEL"
+}
+
+print_failure_suggestions() {
+  case "$CURRENT_STEP_ID" in
+    environment)
+      printf '%s\n' \
+        '- Confirm Python includes the venv and ensurepip modules.' \
+        '- Remove an incomplete .venv directory, then rerun the installer.'
+      ;;
+    packaging)
+      printf '%s\n' \
+        '- Check network, proxy, package-index, and disk-space availability.' \
+        '- Confirm the selected Python environment is writable.'
+      ;;
+    pytorch)
+      printf '%s\n' \
+        "- Prepare CUDA-enabled PyTorch 2.6 or newer in the selected environment: $PYTHON_BIN" \
+        '- Use the official selector: https://pytorch.org/get-started/locally/' \
+        '- On DGX Spark, use the NVIDIA-provided Jupyter environment or a current NGC PyTorch development container.' \
+        '- Rerun bash scripts/install.sh after PyTorch is ready.'
+      ;;
+    cuda)
+      printf '%s\n' \
+        '- Install the CUDA development toolkit, including nvcc and CUDA headers.' \
+        '- Install a C++ compiler (for example, the build-essential package on Ubuntu).' \
+        '- Ensure CUDA_HOME points to the toolkit root and CUDA_HOME/bin is on PATH.' \
+        '- On DGX systems, apply current DGX OS updates or use an NVIDIA CUDA development container.'
+      ;;
+    dependencies)
+      printf '%s\n' \
+        '- Check that the named dependency supports the installed PyTorch, CUDA, Python, and CPU architecture.' \
+        '- On DGX Spark, use the NVIDIA-provided Jupyter environment or a current NGC PyTorch development container.' \
+        '- Review the final package error above and the complete installation log.'
+      ;;
+    build)
+      printf '%s\n' \
+        '- Confirm the PyTorch CUDA version and nvcc toolkit are compatible.' \
+        '- Confirm the detected GPU architecture is supported by the installed toolkit.' \
+        '- Attach the installation log and `areno env --json` output when requesting support.'
+      ;;
+    verify)
+      printf '%s\n' \
+        '- Review the `areno check` failure above for the missing runtime component.' \
+        '- Rerun the installer after correcting the reported environment issue.'
+      ;;
+    *)
+      printf '%s\n' \
+        '- Review the final error above and the complete installation log.' \
+        '- Correct the reported environment issue, then rerun the installer.'
+      ;;
+  esac
+}
+
+installation_failed() {
+  local status="$1"
+  local message="${2:-The command shown above did not complete successfully.}"
+  printf '\nAReno installation failed\n'
+  printf '=========================\n'
+  printf 'Step: %s\n' "$CURRENT_STEP_LABEL"
+  printf 'Exit code: %s\n' "$status"
+  printf 'Reason: %s\n\n' "$message"
+  printf 'Suggested actions:\n'
+  print_failure_suggestions
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '\nNo changes were made.\n'
+  else
+    printf '\nInstallation log: %s\n' "$LOG_FILE"
+  fi
+  exit "$status"
+}
+
+run_current_step() {
+  local failure_reason="$1"
+  shift
+  printf '+ '
+  quote_command "$@"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    return
+  fi
+
+  printf '\n[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$CURRENT_STEP_LABEL" >>"$LOG_FILE"
+  printf '+ ' >>"$LOG_FILE"
+  quote_command "$@" >>"$LOG_FILE"
+
+  set +e
+  "$@" 2>&1 | tee -a "$LOG_FILE"
+  local status=${PIPESTATUS[0]}
+  set -e
+  if [[ "$status" != "0" ]]; then
+    installation_failed "$status" "$failure_reason"
+  fi
+}
+
+check_python_packages() {
+  "$PYTHON_BIN" - "$@" <<'PY'
+import re
+import sys
+from importlib.metadata import PackageNotFoundError, version
+
+
+def version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", value))
+
+
+installed = []
+for requirement in sys.argv[1:]:
+    name, separator, minimum = requirement.partition(">=")
+    try:
+        current = version(name)
+    except PackageNotFoundError:
+        raise SystemExit(1)
+    if separator and version_tuple(current) < version_tuple(minimum):
+        raise SystemExit(1)
+    installed.append(f"{name} {current}")
+
+print("Using installed " + ", ".join(installed))
+PY
+}
+
+prepare_python_packages() {
+  local failure_reason="$1"
+  local package_output
+  shift
+
+  if [[ -x "$PYTHON_BIN" ]] && package_output="$(check_python_packages "$@" 2>/dev/null)"; then
+    printf '%s\n' "$package_output"
+    return
+  fi
+
+  run_current_step "$failure_reason" "$PYTHON_BIN" -m pip install "$@"
+  if [[ "$DRY_RUN" == "0" ]]; then
+    if ! package_output="$(check_python_packages "$@" 2>&1)"; then
+      installation_failed 1 "$failure_reason"
+    fi
+    printf '%s\n' "$package_output"
+  fi
+}
+
+initialize_log() {
+  local log_directory
+  if [[ "$DRY_RUN" == "1" ]]; then
+    return
+  fi
+  log_directory="$(dirname "$LOG_FILE")"
+  if ! (umask 077 && mkdir -p "$log_directory" && : >"$LOG_FILE"); then
+    startup_error \
+      "The installation log cannot be written to $LOG_FILE." \
+      "set ARENO_INSTALL_LOG to a writable path and rerun the installer"
+  fi
+  {
+    printf 'AReno installation log\n'
+    printf 'Platform: %s %s\n' "$SYSTEM_NAME" "$MACHINE_NAME"
+    printf 'Repository: %s\n' "$REPO_ROOT"
+    printf 'NVIDIA GPUs:\n%s\n' "$NVIDIA_GPU_SUMMARY"
+  } >>"$LOG_FILE"
+}
+
+initialize_log
+
+printf 'AReno installer\n'
+printf '===============\n'
+if [[ "$DRY_RUN" == "1" ]]; then
+  printf 'Installation plan only; no commands will be executed.\n'
+else
+  printf 'AReno will prepare and verify the installation automatically.\n'
+  printf 'Detected NVIDIA GPU(s):\n%s\n' "$NVIDIA_GPU_SUMMARY"
+  printf 'Installation log: %s\n' "$LOG_FILE"
+fi
+TOTAL_STEPS=7
+
+start_step 1 "$TOTAL_STEPS" environment "Check and Prepare Python environment"
+if [[ "$NEED_VENV" == "1" ]]; then
+  run_current_step "Python could not create the .venv environment." \
+    "$BOOTSTRAP_PYTHON" -m venv "$REPO_ROOT/.venv"
+  if [[ "$DRY_RUN" == "0" ]]; then
+    CREATED_VENV=1
+  fi
+else
+  printf 'Using %s\n' "$ENVIRONMENT_DESCRIPTION"
+fi
+
+if [[ "$DRY_RUN" == "0" ]]; then
+  if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+    run_current_step "pip could not be bootstrapped in the selected Python environment." \
+      "$PYTHON_BIN" -m ensurepip --upgrade
+  fi
+elif [[ "$NEED_VENV" == "0" ]]; then
+  if "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+    printf 'pip is available.\n'
+  else
+    printf 'pip will be bootstrapped if it is missing.\n'
+  fi
+fi
+
+start_step 2 "$TOTAL_STEPS" pytorch "Check PyTorch"
+
+PYTORCH_READY=1
+if [[ -x "$PYTHON_BIN" ]]; then
+  set +e
+  TORCH_STATUS_OUTPUT="$(check_torch "$PYTHON_BIN" 2>&1)"
+  TORCH_STATUS=$?
+  set -e
+else
+  TORCH_STATUS_OUTPUT=""
+  TORCH_STATUS=10
+fi
+
+case "$TORCH_STATUS" in
+  0)
+    printf 'Using installed %s\n' "$TORCH_STATUS_OUTPUT"
+    ;;
+  10)
+    PYTORCH_FAILURE_REASON="PyTorch is not installed in the selected Python environment."
+    ;;
+  11)
+    PYTORCH_FAILURE_REASON="PyTorch $TORCH_STATUS_OUTPUT is older than the required version 2.6."
+    ;;
+  12)
+    PYTORCH_FAILURE_REASON="PyTorch $TORCH_STATUS_OUTPUT is CPU-only; AReno requires a CUDA-enabled build."
+    ;;
+  13)
+    PYTORCH_FAILURE_REASON="$TORCH_STATUS_OUTPUT cannot access a usable NVIDIA GPU."
+    ;;
+  14)
+    PYTORCH_FAILURE_REASON="PyTorch is installed but could not be imported: $TORCH_STATUS_OUTPUT"
+    ;;
+  *)
+    PYTORCH_FAILURE_REASON="PyTorch could not be validated in the selected Python environment."
+    ;;
+esac
+
+if [[ "$TORCH_STATUS" != "0" ]]; then
+  PYTORCH_READY=0
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf 'PyTorch check: FAILED\n'
+    printf 'Reason: %s\n\n' "$PYTORCH_FAILURE_REASON"
+    printf 'Suggested actions:\n'
+    print_failure_suggestions
+  else
+    installation_failed 1 "$PYTORCH_FAILURE_REASON"
+  fi
+fi
+
+start_step 3 "$TOTAL_STEPS" packaging "Check and Prepare packaging tools"
+prepare_python_packages "setuptools 69 or newer and wheel could not be prepared." \
+  'setuptools>=69' wheel
+
+start_step 4 "$TOTAL_STEPS" cuda "Check GPU support"
+
+resolve_cuda_home() {
+  local candidate=""
+  if [[ -n "${CUDA_HOME:-}" && -x "${CUDA_HOME}/bin/nvcc" ]]; then
+    printf '%s\n' "$CUDA_HOME"
+    return
+  fi
+  if [[ -n "${CUDA_PATH:-}" && -x "${CUDA_PATH}/bin/nvcc" ]]; then
+    printf '%s\n' "$CUDA_PATH"
+    return
+  fi
+  if command -v nvcc >/dev/null 2>&1; then
+    candidate="$(command -v nvcc)"
+    candidate="$("$PYTHON_BIN" -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$candidate")"
+    candidate="$(cd "$(dirname "$candidate")/.." && pwd -P)"
+    printf '%s\n' "$candidate"
+    return
+  fi
+  for candidate in /usr/local/cuda /opt/cuda; do
+    if [[ -x "$candidate/bin/nvcc" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  return 1
+}
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  printf 'The installer will locate nvcc, set CUDA_HOME, and detect visible GPU architectures.\n'
+else
+  DETECTED_CUDA_HOME="$(resolve_cuda_home || true)"
+  if [[ -z "$DETECTED_CUDA_HOME" ]]; then
+    installation_failed 1 "The CUDA compiler nvcc was not found."
+  fi
+  export CUDA_HOME="$DETECTED_CUDA_HOME"
+  if ! command -v c++ >/dev/null 2>&1 && ! command -v g++ >/dev/null 2>&1; then
+    installation_failed 1 "A C++ compiler was not found."
+  fi
+
+  if [[ -z "${TORCH_CUDA_ARCH_LIST:-}" ]]; then
+    TORCH_CUDA_ARCH_LIST="$("$PYTHON_BIN" -c '
+import torch
+
+architectures = {
+    f"{major}.{minor}"
+    for index in range(torch.cuda.device_count())
+    for major, minor in [torch.cuda.get_device_capability(index)]
+}
+print(";".join(sorted(architectures)))
+')"
+    if [[ -z "$TORCH_CUDA_ARCH_LIST" ]]; then
+      installation_failed 1 "The GPU compute capability could not be detected."
+    fi
+    export TORCH_CUDA_ARCH_LIST
+  fi
+  printf 'CUDA toolkit: %s\n' "$CUDA_HOME"
+  printf 'GPU architecture: %s\n' "$TORCH_CUDA_ARCH_LIST"
+fi
+
+start_step 5 "$TOTAL_STEPS" dependencies "Check and Prepare AReno dependencies"
+prepare_python_packages "AReno's build helpers (psutil and ninja) could not be installed." \
+  psutil ninja
+prepare_python_packages "flash-linear-attention 0.2 or newer could not be installed." \
+  'flash-linear-attention>=0.2'
+if [[ "$DRY_RUN" == "1" ]]; then
+  if [[ -x "$PYTHON_BIN" ]] && FLASH_ATTN_OUTPUT="$(check_python_packages 'flash-attn>=2.7' 2>/dev/null)"; then
+    printf '%s\n' "$FLASH_ATTN_OUTPUT"
+  else
+    printf 'FlashAttention will be installed when every visible GPU supports the flash backend.\n'
+    run_current_step "FlashAttention could not be installed for the detected GPU." \
+      "$PYTHON_BIN" -m pip install 'flash-attn>=2.7' --no-build-isolation
+  fi
+else
+  if "$PYTHON_BIN" -c '
+import torch
+
+raise SystemExit(
+    0
+    if torch.cuda.device_count() > 0
+    and all(torch.cuda.get_device_capability(index) >= (8, 0) for index in range(torch.cuda.device_count()))
+    else 1
+)
+'; then
+    if FLASH_ATTN_OUTPUT="$(check_python_packages 'flash-attn>=2.7' 2>/dev/null)"; then
+      printf '%s\n' "$FLASH_ATTN_OUTPUT"
+    else
+      run_current_step "FlashAttention could not be installed for the detected GPU." \
+        "$PYTHON_BIN" -m pip install 'flash-attn>=2.7' --no-build-isolation
+      if ! FLASH_ATTN_OUTPUT="$(check_python_packages 'flash-attn>=2.7' 2>&1)"; then
+        installation_failed 1 "The installed FlashAttention does not satisfy version 2.7 or newer."
+      fi
+      printf '%s\n' "$FLASH_ATTN_OUTPUT"
+    fi
+  else
+    printf 'The visible GPU uses AReno native attention; FlashAttention is not required.\n'
+  fi
+fi
+
+start_step 6 "$TOTAL_STEPS" build "Build and install AReno"
+if [[ "$DRY_RUN" == "1" ]]; then
+  run_current_step "AReno's CUDA extension build failed." \
+    env 'CUDA_HOME=<detected>' 'TORCH_CUDA_ARCH_LIST=<detected>' \
+    "$PYTHON_BIN" -m pip install -e . --no-build-isolation
+  printf '\n[7/7] Verify the installation\n'
+  printf '+ areno check\n'
+  if [[ "$PYTORCH_READY" == "1" ]]; then
+    printf '\nInstallation plan complete. No changes were made.\n'
+    exit 0
+  fi
+  printf '\nInstallation plan complete, but PyTorch is not ready. No changes were made.\n'
+  exit 1
+fi
+
+BUILD_ENV=(env "CUDA_HOME=$CUDA_HOME" "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST")
+if [[ -n "${MAX_JOBS:-}" ]]; then
+  BUILD_ENV+=("MAX_JOBS=$MAX_JOBS")
+fi
+run_current_step "AReno's CUDA extension build failed." \
+  "${BUILD_ENV[@]}" "$PYTHON_BIN" -m pip install -e . --no-build-isolation
+
+CURRENT_STEP_ID="verify"
+CURRENT_STEP_LABEL="Verify the installation"
+printf '\n[7/7] %s\n' "$CURRENT_STEP_LABEL"
+SCRIPTS_DIR="$("$PYTHON_BIN" -c 'import sysconfig; print(sysconfig.get_path("scripts"))')"
+ARENO_BIN="$SCRIPTS_DIR/areno"
+if [[ ! -x "$ARENO_BIN" ]]; then
+  installation_failed 1 "The areno command was not created in the selected Python environment."
+fi
+run_current_step "The installed AReno runtime did not pass its readiness check." \
+  "$ARENO_BIN" check
+
+printf '\nAReno is ready\n'
+printf '==============\n'
+printf 'Installation and environment checks completed successfully.\n'
+if [[ "$CREATED_VENV" == "1" ]]; then
+  printf '\nActivate the prepared environment:\n'
+  printf '  source %q\n' "$REPO_ROOT/.venv/bin/activate"
+fi
+printf '\nStart with:\n'
+printf '  %q --help\n' "$ARENO_BIN"
+printf '\nInstallation log: %s\n' "$LOG_FILE"
+}
+
+main "$@"


### PR DESCRIPTION
## What does this PR do?

Adds `scripts/install.sh` as AReno's single guided installation entry point for source checkouts.

The installer:

- checks required system tools, WSL compatibility, and NVIDIA GPU visibility before changing Python
- creates or reuses an isolated Python environment, including preconfigured IDE environments that do not expose activation metadata
- validates CUDA-enabled PyTorch without installing or upgrading it, and stops with targeted setup guidance when it is not ready
- checks packaging tools, AReno dependencies, and attention packages before installing or updating only unmet requirements
- discovers CUDA and visible GPU architectures before building the local extension
- builds AReno and validates the result with `areno check`
- reports the failed stage, exit code, specific reason, suggested actions, and complete log path when installation cannot finish
- provides a side-effect-free `--dry-run` preview

The README and installation/troubleshooting documentation now consistently direct users through the script instead of requiring them to order low-level `pip` and CUDA build commands manually.

## Related issue

Fixes #162

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

```bash
bash -n scripts/install.sh
.venv/bin/python -m pytest tests/ -k cpu -q
bash scripts/install.sh --dry-run
PYTHON=/path/to/python-with-cuda-pytorch bash scripts/install.sh --dry-run
PATH=/path/to/ide-python/bin:$PATH bash scripts/install.sh --dry-run
```

Result: `354 passed`, with 12 existing FastAPI deprecation warnings. The
installer dry-run returned a targeted nonzero result for missing and CPU-only
PyTorch without producing a PyTorch installation command. A simulated
CUDA-enabled PyTorch 2.6 environment completed the dry-run successfully,
reusing every satisfied dependency. A simulated IDE environment with no
activation metadata was detected and reused even when an empty repository
`.venv` remained from an earlier attempt. An installed but unimportable
PyTorch produced the underlying import error. No dry-run changed the
environment.

The current development host is macOS, so the complete Linux NVIDIA GPU/CUDA
build path was not executed. Shell parsing, the existing CPU suite, and the
dry-run path were verified locally. No dedicated installer test file is
included in this PR.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [ ] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
