### PR TITLE
feat(models): add OLMo 2 adapter

### DIFF
--- a/areno/models/__init__.py
+++ b/areno/models/__init__.py
@@ -12,6 +12,7 @@ def register_models() -> None:
     from areno.models.gemma4 import Gemma4Adapter
     from areno.models.llama import LlamaAdapter
     from areno.models.minicpmv46 import MiniCPMV46Adapter
+    from areno.models.olmo2 import Olmo2Adapter
     from areno.models.qwen3 import Qwen3Adapter, Qwen3MoeAdapter
     from areno.models.qwen3_5 import Qwen35Adapter, Qwen35MoeAdapter
     from areno.models.registry import register_adapter
@@ -26,6 +27,7 @@ def register_models() -> None:
     register_adapter(BailingMoeLinearV2Adapter())
     register_adapter(Gemma4Adapter())
     register_adapter(MiniCPMV46Adapter())
+    register_adapter(Olmo2Adapter())
 
 
 __all__ = ["CausalLMOutput", "ModelAdapter", "register_models"]

--- a/areno/models/olmo2/__init__.py
+++ b/areno/models/olmo2/__init__.py
@@ -1,0 +1,7 @@
+"""OLMo 2 model adapter."""
+
+from __future__ import annotations
+
+from areno.models.olmo2.model import Olmo2Adapter, Olmo2ForCausalLM
+
+__all__ = ["Olmo2Adapter", "Olmo2ForCausalLM"]

--- a/areno/models/olmo2/__init__.py
+++ b/areno/models/olmo2/__init__.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
-from areno.models.olmo2.model import Olmo2Adapter, Olmo2ForCausalLM
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from areno.models.olmo2.model import Olmo2Adapter, Olmo2ForCausalLM
+
+
+def __getattr__(name: str) -> Any:
+    if name not in __all__:
+        raise AttributeError(name)
+    from areno.models.olmo2 import model
+
+    return getattr(model, name)
+
 
 __all__ = ["Olmo2Adapter", "Olmo2ForCausalLM"]

--- a/areno/models/olmo2/checkpoint.py
+++ b/areno/models/olmo2/checkpoint.py
@@ -1,0 +1,54 @@
+"""HF safetensors load/save spec for OLMo 2 checkpoints."""
+
+from __future__ import annotations
+
+from areno.engine.checkpoints.common import (
+    CheckpointSpec,
+    LayerSpec,
+    MergedColumnSpec,
+    ParallelTensorSpec,
+    RangedSplitColumnSpec,
+    ReplicatedTensorSpec,
+    SplitColumnSpec,
+    TopLevelSpec,
+)
+
+TOP_LEVEL_SPEC = TopLevelSpec(embedding_key="model.embed_tokens.weight", embedding_attr="embed_tokens")
+LAYER_NORM_SPECS = (
+    ReplicatedTensorSpec("{prefix}.post_attention_layernorm.weight", "post_attention_layernorm.weight"),
+    ReplicatedTensorSpec("{prefix}.post_feedforward_layernorm.weight", "post_feedforward_layernorm.weight"),
+)
+QKV_WEIGHT_SPEC = MergedColumnSpec(
+    dst_attr="self_attn.qkv_proj.weight",
+    keys=(
+        "{prefix}.self_attn.q_proj.weight",
+        "{prefix}.self_attn.k_proj.weight",
+        "{prefix}.self_attn.v_proj.weight",
+    ),
+)
+QKV_SAVE_SPEC = RangedSplitColumnSpec(
+    src_attr="self_attn.qkv_proj.weight",
+    size_attr="self_attn.qkv_proj.local_out_features",
+    keys=QKV_WEIGHT_SPEC.keys,
+)
+Q_NORM_SPEC = ParallelTensorSpec("{prefix}.self_attn.q_norm.weight", "self_attn.q_norm.weight", 0)
+K_NORM_SPEC = ParallelTensorSpec("{prefix}.self_attn.k_norm.weight", "self_attn.k_norm.weight", 0)
+ATTN_ROW_SPEC = ParallelTensorSpec("{prefix}.self_attn.o_proj.weight", "self_attn.o_proj.weight", 1)
+GATE_UP_WEIGHT_SPEC = MergedColumnSpec(
+    dst_attr="mlp.gate_up_proj.weight",
+    keys=("{prefix}.mlp.gate_proj.weight", "{prefix}.mlp.up_proj.weight"),
+)
+GATE_UP_SAVE_SPEC = SplitColumnSpec(
+    src_attr="mlp.gate_up_proj.weight",
+    size_attr="mlp.gate_up_proj.local_out_features",
+    keys=GATE_UP_WEIGHT_SPEC.keys,
+)
+MLP_ROW_SPEC = ParallelTensorSpec("{prefix}.mlp.down_proj.weight", "mlp.down_proj.weight", 1)
+
+OLMO2_LAYER_SPEC = LayerSpec(
+    prefix="model.layers.{layer}",
+    replicated=LAYER_NORM_SPECS,
+    load_ops=(QKV_WEIGHT_SPEC, Q_NORM_SPEC, K_NORM_SPEC, ATTN_ROW_SPEC, GATE_UP_WEIGHT_SPEC, MLP_ROW_SPEC),
+    save_ops=(QKV_SAVE_SPEC, Q_NORM_SPEC, K_NORM_SPEC, ATTN_ROW_SPEC, GATE_UP_SAVE_SPEC, MLP_ROW_SPEC),
+)
+CHECKPOINT_SPEC = CheckpointSpec(top_level=TOP_LEVEL_SPEC, layer=OLMO2_LAYER_SPEC)

--- a/areno/models/olmo2/config.py
+++ b/areno/models/olmo2/config.py
@@ -1,0 +1,33 @@
+"""Lightweight OLMo 2 configuration translation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from areno.engine.config import ModelConfig, _parse_dtype
+
+
+def config_from_hf(hf_config: dict[str, Any]) -> ModelConfig:
+    """Translate a Hugging Face OLMo 2 config into AReno's model config."""
+
+    hidden_size = int(hf_config["hidden_size"])
+    num_attention_heads = int(hf_config["num_attention_heads"])
+    return ModelConfig(
+        model_type="olmo2",
+        vocab_size=int(hf_config["vocab_size"]),
+        hidden_size=hidden_size,
+        intermediate_size=int(hf_config["intermediate_size"]),
+        num_hidden_layers=int(hf_config["num_hidden_layers"]),
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=int(hf_config.get("num_key_value_heads", num_attention_heads)),
+        head_dim=int(hf_config.get("head_dim", hidden_size // num_attention_heads)),
+        rms_norm_eps=float(hf_config.get("rms_norm_eps", 1e-5)),
+        rope_theta=float(hf_config.get("rope_theta", 10_000.0)),
+        max_position_embeddings=int(hf_config.get("max_position_embeddings", 2048)),
+        tie_word_embeddings=bool(hf_config.get("tie_word_embeddings", False)),
+        qkv_bias=bool(hf_config.get("attention_bias", False)),
+        qk_norm=False,
+        dtype=_parse_dtype(hf_config.get("torch_dtype") or hf_config.get("dtype")),
+        hidden_act=str(hf_config.get("hidden_act", "silu")),
+        sequence_parallel=bool(hf_config.get("sequence_parallel", True)),
+    )

--- a/areno/models/olmo2/model.py
+++ b/areno/models/olmo2/model.py
@@ -1,0 +1,132 @@
+"""AReno-native OLMo 2 causal language model.
+
+OLMo 2 differs from Llama-style decoders in two material ways: attention and
+MLP outputs are normalized before their residual additions, and Q/K RMSNorm is
+applied across each complete projected vector before it is split into heads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
+from areno.engine.config import ModelConfig, _parse_dtype
+from areno.engine.layers.attention import CausalSelfAttention
+from areno.engine.layers.norm import RMSNorm
+from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.models.base import ModelAdapter
+from areno.models.olmo2.checkpoint import CHECKPOINT_SPEC
+from areno.models.qwen3.model import Qwen3ForCausalLM, QwenDecoderLayer
+
+
+class Olmo2SelfAttention(CausalSelfAttention):
+    """OLMo 2 attention with RMSNorm over the full local Q/K projections."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__(config, layer_idx)
+        self.q_norm = RMSNorm(self.local_heads * self.head_dim, config.rms_norm_eps)
+        self.k_norm = RMSNorm(self.local_kv_heads * self.head_dim, config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> torch.Tensor:
+        batch, seqlen, _ = hidden_states.shape
+        q_size = self.local_heads * self.head_dim
+        kv_size = self.local_kv_heads * self.head_dim
+        q, k, v = self.qkv_proj(hidden_states).split((q_size, kv_size, kv_size), dim=-1)
+        q = self.q_norm(q).view(batch, seqlen, self.local_heads, self.head_dim)
+        k = self.k_norm(k).view(batch, seqlen, self.local_kv_heads, self.head_dim)
+        v = v.view(batch, seqlen, self.local_kv_heads, self.head_dim)
+        q, k = self.rope(q, k, position_ids)
+        if infer_meta is not None:
+            return self.forward_infer(q, k, v, infer_meta)
+        return self.forward_train(q, k, v, train_meta)
+
+
+class Olmo2DecoderLayer(QwenDecoderLayer):
+    """OLMo 2 post-norm attention and MLP residual block."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__(config, layer_idx)
+        del self.input_layernorm
+        self.self_attn = Olmo2SelfAttention(config, layer_idx)
+        self.post_feedforward_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn(hidden_states, position_ids, train_meta, infer_meta)
+        hidden_states = residual + self.post_attention_layernorm(hidden_states)
+        residual = hidden_states
+        hidden_states = self.mlp(hidden_states)
+        return residual + self.post_feedforward_layernorm(hidden_states)
+
+
+class Olmo2ForCausalLM(Qwen3ForCausalLM):
+    """OLMo 2 causal LM using AReno's shared dense runtime lifecycle."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__(config)
+        self.layers = nn.ModuleList([Olmo2DecoderLayer(config, i) for i in range(config.num_hidden_layers)])
+
+
+class Olmo2Adapter(ModelAdapter):
+    """Adapter for Hugging Face checkpoints with ``model_type == 'olmo2'``."""
+
+    name = "olmo2"
+
+    def match_hf_config(self, hf_config: dict[str, Any]) -> bool:
+        return str(hf_config.get("model_type", "")).lower() == "olmo2"
+
+    def config_from_hf(self, hf_config: dict[str, Any]) -> ModelConfig:
+        hidden_size = int(hf_config["hidden_size"])
+        num_attention_heads = int(hf_config["num_attention_heads"])
+        return ModelConfig(
+            model_type=self.name,
+            vocab_size=int(hf_config["vocab_size"]),
+            hidden_size=hidden_size,
+            intermediate_size=int(hf_config["intermediate_size"]),
+            num_hidden_layers=int(hf_config["num_hidden_layers"]),
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=int(hf_config.get("num_key_value_heads", num_attention_heads)),
+            head_dim=int(hf_config.get("head_dim", hidden_size // num_attention_heads)),
+            rms_norm_eps=float(hf_config.get("rms_norm_eps", 1e-5)),
+            rope_theta=float(hf_config.get("rope_theta", 10_000.0)),
+            max_position_embeddings=int(hf_config.get("max_position_embeddings", 2048)),
+            tie_word_embeddings=bool(hf_config.get("tie_word_embeddings", False)),
+            qkv_bias=bool(hf_config.get("attention_bias", False)),
+            qk_norm=False,
+            dtype=_parse_dtype(hf_config.get("torch_dtype") or hf_config.get("dtype")),
+            hidden_act=str(hf_config.get("hidden_act", "silu")),
+            sequence_parallel=bool(hf_config.get("sequence_parallel", True)),
+        )
+
+    def build(self, config: ModelConfig) -> nn.Module:
+        if config.hidden_act != "silu":
+            raise ValueError(f"Olmo2Adapter only supports hidden_act='silu', got {config.hidden_act!r}")
+        return Olmo2ForCausalLM(config)
+
+    @torch.no_grad()
+    def load_weights(self, model: nn.Module, model_path: str | Path) -> None:
+        if not isinstance(model, Olmo2ForCausalLM):
+            raise TypeError(f"Olmo2Adapter cannot load weights into {type(model)!r}")
+        load_checkpoint_weights(model, model_path, CHECKPOINT_SPEC)
+
+    @torch.no_grad()
+    def save_weights(self, model: nn.Module, output_path: str | Path, source_path: str | Path | None) -> str | None:
+        if not isinstance(model, Olmo2ForCausalLM):
+            raise TypeError(f"Olmo2Adapter cannot save weights from {type(model)!r}")
+        return save_checkpoint_weights(model, output_path, source_path, CHECKPOINT_SPEC)

--- a/areno/models/olmo2/model.py
+++ b/areno/models/olmo2/model.py
@@ -11,25 +11,56 @@ from pathlib import Path
 from typing import Any
 
 import torch
+import torch.distributed.nn.functional as dist_nn
 from torch import nn
 
 from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention import CausalSelfAttention
+from areno.engine.layers.linear import mark_tensor_parallel_parameter
 from areno.engine.layers.norm import RMSNorm
+from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.models.base import ModelAdapter
 from areno.models.olmo2.checkpoint import CHECKPOINT_SPEC
 from areno.models.qwen3.model import Qwen3ForCausalLM, QwenDecoderLayer
 
 
+class Olmo2ProjectedRMSNorm(nn.Module):
+    """RMSNorm a TP-sharded projection using a global channel statistic."""
+
+    def __init__(self, local_size: int, global_size: int, eps: float):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(local_size, dtype=torch.float32))
+        mark_tensor_parallel_parameter(self.weight, True, sequence_parallel=False)
+        self.global_size = global_size
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        squared_sum = hidden_states.float().square().sum(dim=-1, keepdim=True)
+        ctx = get_tp_context()
+        if ctx.world_size > 1:
+            squared_sum = dist_nn.all_reduce(squared_sum, group=ctx.group)
+        scale = torch.rsqrt(squared_sum / self.global_size + self.eps)
+        return (hidden_states.float() * scale * self.weight).to(dtype=input_dtype)
+
+
 class Olmo2SelfAttention(CausalSelfAttention):
-    """OLMo 2 attention with RMSNorm over the full local Q/K projections."""
+    """OLMo 2 attention with RMSNorm over the full global Q/K projections."""
 
     def __init__(self, config: ModelConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.q_norm = RMSNorm(self.local_heads * self.head_dim, config.rms_norm_eps)
-        self.k_norm = RMSNorm(self.local_kv_heads * self.head_dim, config.rms_norm_eps)
+        self.q_norm = Olmo2ProjectedRMSNorm(
+            self.local_heads * self.head_dim,
+            config.num_attention_heads * config.head_dim,
+            config.rms_norm_eps,
+        )
+        self.k_norm = Olmo2ProjectedRMSNorm(
+            self.local_kv_heads * self.head_dim,
+            config.num_key_value_heads * config.head_dim,
+            config.rms_norm_eps,
+        )
 
     def forward(
         self,

--- a/areno/models/olmo2/model.py
+++ b/areno/models/olmo2/model.py
@@ -15,7 +15,7 @@ import torch.distributed.nn.functional as dist_nn
 from torch import nn
 
 from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
-from areno.engine.config import ModelConfig, _parse_dtype
+from areno.engine.config import ModelConfig
 from areno.engine.layers.attention import CausalSelfAttention
 from areno.engine.layers.linear import mark_tensor_parallel_parameter
 from areno.engine.layers.norm import RMSNorm
@@ -23,6 +23,8 @@ from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.models.base import ModelAdapter
 from areno.models.olmo2.checkpoint import CHECKPOINT_SPEC
+from areno.models.olmo2.config import config_from_hf
+from areno.models.olmo2.semantics import post_norm_residual, projected_rms_norm
 from areno.models.qwen3.model import Qwen3ForCausalLM, QwenDecoderLayer
 
 
@@ -37,13 +39,11 @@ class Olmo2ProjectedRMSNorm(nn.Module):
         self.eps = eps
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        input_dtype = hidden_states.dtype
         squared_sum = hidden_states.float().square().sum(dim=-1, keepdim=True)
         ctx = get_tp_context()
         if ctx.world_size > 1:
             squared_sum = dist_nn.all_reduce(squared_sum, group=ctx.group)
-        scale = torch.rsqrt(squared_sum / self.global_size + self.eps)
-        return (hidden_states.float() * scale * self.weight).to(dtype=input_dtype)
+        return projected_rms_norm(hidden_states, squared_sum, self.weight, self.global_size, self.eps)
 
 
 class Olmo2SelfAttention(CausalSelfAttention):
@@ -100,10 +100,10 @@ class Olmo2DecoderLayer(QwenDecoderLayer):
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.self_attn(hidden_states, position_ids, train_meta, infer_meta)
-        hidden_states = residual + self.post_attention_layernorm(hidden_states)
+        hidden_states = post_norm_residual(residual, hidden_states, self.post_attention_layernorm)
         residual = hidden_states
         hidden_states = self.mlp(hidden_states)
-        return residual + self.post_feedforward_layernorm(hidden_states)
+        return post_norm_residual(residual, hidden_states, self.post_feedforward_layernorm)
 
 
 class Olmo2ForCausalLM(Qwen3ForCausalLM):
@@ -123,27 +123,7 @@ class Olmo2Adapter(ModelAdapter):
         return str(hf_config.get("model_type", "")).lower() == "olmo2"
 
     def config_from_hf(self, hf_config: dict[str, Any]) -> ModelConfig:
-        hidden_size = int(hf_config["hidden_size"])
-        num_attention_heads = int(hf_config["num_attention_heads"])
-        return ModelConfig(
-            model_type=self.name,
-            vocab_size=int(hf_config["vocab_size"]),
-            hidden_size=hidden_size,
-            intermediate_size=int(hf_config["intermediate_size"]),
-            num_hidden_layers=int(hf_config["num_hidden_layers"]),
-            num_attention_heads=num_attention_heads,
-            num_key_value_heads=int(hf_config.get("num_key_value_heads", num_attention_heads)),
-            head_dim=int(hf_config.get("head_dim", hidden_size // num_attention_heads)),
-            rms_norm_eps=float(hf_config.get("rms_norm_eps", 1e-5)),
-            rope_theta=float(hf_config.get("rope_theta", 10_000.0)),
-            max_position_embeddings=int(hf_config.get("max_position_embeddings", 2048)),
-            tie_word_embeddings=bool(hf_config.get("tie_word_embeddings", False)),
-            qkv_bias=bool(hf_config.get("attention_bias", False)),
-            qk_norm=False,
-            dtype=_parse_dtype(hf_config.get("torch_dtype") or hf_config.get("dtype")),
-            hidden_act=str(hf_config.get("hidden_act", "silu")),
-            sequence_parallel=bool(hf_config.get("sequence_parallel", True)),
-        )
+        return config_from_hf(hf_config)
 
     def build(self, config: ModelConfig) -> nn.Module:
         if config.hidden_act != "silu":

--- a/areno/models/olmo2/semantics.py
+++ b/areno/models/olmo2/semantics.py
@@ -1,0 +1,26 @@
+"""Pure Torch operations that define OLMo 2 decoder semantics."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+def projected_rms_norm(
+    hidden_states: torch.Tensor,
+    squared_sum: torch.Tensor,
+    weight: torch.Tensor,
+    global_size: int,
+    eps: float,
+) -> torch.Tensor:
+    """Normalize a TP shard using the squared sum over the global projection."""
+
+    input_dtype = hidden_states.dtype
+    scale = torch.rsqrt(squared_sum / global_size + eps)
+    return (hidden_states.float() * scale * weight).to(dtype=input_dtype)
+
+
+def post_norm_residual(residual: torch.Tensor, output: torch.Tensor, norm: nn.Module) -> torch.Tensor:
+    """Apply OLMo 2's output normalization before the residual addition."""
+
+    return residual + norm(output)

--- a/tests/test_olmo2_adapter_cpu.py
+++ b/tests/test_olmo2_adapter_cpu.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 
 from areno.engine.config import ModelConfig
-from areno.models.olmo2.model import Olmo2Adapter, Olmo2DecoderLayer, Olmo2ForCausalLM
+from areno.models.olmo2.model import Olmo2Adapter, Olmo2DecoderLayer, Olmo2ForCausalLM, Olmo2ProjectedRMSNorm
 
 
 class _IdentityAttention(nn.Module):
@@ -62,6 +62,16 @@ def test_olmo2_build_uses_full_projected_qk_norms():
     assert isinstance(model, Olmo2ForCausalLM)
     assert tuple(model.layers[0].self_attn.q_norm.weight.shape) == (32,)
     assert tuple(model.layers[0].self_attn.k_norm.weight.shape) == (32,)
+
+
+def test_olmo2_projected_rmsnorm_matches_full_vector_reference():
+    norm = Olmo2ProjectedRMSNorm(local_size=4, global_size=4, eps=1e-6)
+    hidden = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+
+    output = norm(hidden)
+    expected = hidden * torch.rsqrt(hidden.square().mean(dim=-1, keepdim=True) + 1e-6)
+
+    torch.testing.assert_close(output, expected)
 
 
 def test_olmo2_decoder_applies_post_norm_before_residual_add():

--- a/tests/test_olmo2_adapter_cpu.py
+++ b/tests/test_olmo2_adapter_cpu.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from areno.engine.config import ModelConfig
+from areno.models.olmo2.model import Olmo2Adapter, Olmo2DecoderLayer, Olmo2ForCausalLM
+
+
+class _IdentityAttention(nn.Module):
+    def forward(self, hidden_states, position_ids, train_meta=None, infer_meta=None):
+        del position_ids, train_meta, infer_meta
+        return hidden_states
+
+
+def _config() -> ModelConfig:
+    return ModelConfig(
+        model_type="olmo2",
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=8,
+        dtype=torch.float32,
+        attn_backend="native",
+        sequence_parallel=False,
+    )
+
+
+def test_olmo2_config_translation_matches_checkpoint():
+    config = Olmo2Adapter().config_from_hf(
+        {
+            "model_type": "olmo2",
+            "vocab_size": 100352,
+            "hidden_size": 2048,
+            "intermediate_size": 8192,
+            "num_hidden_layers": 16,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 16,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 500000,
+            "max_position_embeddings": 4096,
+            "torch_dtype": "bfloat16",
+            "hidden_act": "silu",
+            "tie_word_embeddings": False,
+            "attention_bias": False,
+        }
+    )
+
+    assert config.model_type == "olmo2"
+    assert config.head_dim == 128
+    assert config.rope_theta == 500000
+    assert config.dtype == torch.bfloat16
+    assert config.qk_norm is False
+
+
+def test_olmo2_build_uses_full_projected_qk_norms():
+    model = Olmo2Adapter().build(_config())
+
+    assert isinstance(model, Olmo2ForCausalLM)
+    assert tuple(model.layers[0].self_attn.q_norm.weight.shape) == (32,)
+    assert tuple(model.layers[0].self_attn.k_norm.weight.shape) == (32,)
+
+
+def test_olmo2_decoder_applies_post_norm_before_residual_add():
+    layer = Olmo2DecoderLayer(_config(), 0)
+    layer.self_attn = _IdentityAttention()
+    layer.mlp = nn.Identity()
+    layer.post_attention_layernorm = nn.Identity()
+    layer.post_feedforward_layernorm = nn.Identity()
+    hidden = torch.ones(1, 2, 32)
+
+    output = layer(hidden, torch.arange(2).unsqueeze(0))
+
+    torch.testing.assert_close(output, hidden * 4)

--- a/tests/test_olmo2_adapter_cpu.py
+++ b/tests/test_olmo2_adapter_cpu.py
@@ -3,34 +3,13 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from areno.engine.config import ModelConfig
-from areno.models.olmo2.model import Olmo2Adapter, Olmo2DecoderLayer, Olmo2ForCausalLM, Olmo2ProjectedRMSNorm
-
-
-class _IdentityAttention(nn.Module):
-    def forward(self, hidden_states, position_ids, train_meta=None, infer_meta=None):
-        del position_ids, train_meta, infer_meta
-        return hidden_states
-
-
-def _config() -> ModelConfig:
-    return ModelConfig(
-        model_type="olmo2",
-        vocab_size=128,
-        hidden_size=32,
-        intermediate_size=64,
-        num_hidden_layers=1,
-        num_attention_heads=4,
-        num_key_value_heads=4,
-        head_dim=8,
-        dtype=torch.float32,
-        attn_backend="native",
-        sequence_parallel=False,
-    )
+from areno.models.olmo2.checkpoint import CHECKPOINT_SPEC
+from areno.models.olmo2.config import config_from_hf
+from areno.models.olmo2.semantics import post_norm_residual, projected_rms_norm
 
 
 def test_olmo2_config_translation_matches_checkpoint():
-    config = Olmo2Adapter().config_from_hf(
+    config = config_from_hf(
         {
             "model_type": "olmo2",
             "vocab_size": 100352,
@@ -56,32 +35,28 @@ def test_olmo2_config_translation_matches_checkpoint():
     assert config.qk_norm is False
 
 
-def test_olmo2_build_uses_full_projected_qk_norms():
-    model = Olmo2Adapter().build(_config())
+def test_olmo2_checkpoint_maps_projected_qk_norms():
+    mappings = {(spec.key, spec.attr, spec.dim) for spec in CHECKPOINT_SPEC.layer.load_ops if hasattr(spec, "dim")}
 
-    assert isinstance(model, Olmo2ForCausalLM)
-    assert tuple(model.layers[0].self_attn.q_norm.weight.shape) == (32,)
-    assert tuple(model.layers[0].self_attn.k_norm.weight.shape) == (32,)
+    assert ("{prefix}.self_attn.q_norm.weight", "self_attn.q_norm.weight", 0) in mappings
+    assert ("{prefix}.self_attn.k_norm.weight", "self_attn.k_norm.weight", 0) in mappings
 
 
 def test_olmo2_projected_rmsnorm_matches_full_vector_reference():
-    norm = Olmo2ProjectedRMSNorm(local_size=4, global_size=4, eps=1e-6)
     hidden = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    weight = torch.ones(4)
+    squared_sum = hidden.float().square().sum(dim=-1, keepdim=True)
 
-    output = norm(hidden)
+    output = projected_rms_norm(hidden, squared_sum, weight, global_size=4, eps=1e-6)
     expected = hidden * torch.rsqrt(hidden.square().mean(dim=-1, keepdim=True) + 1e-6)
 
     torch.testing.assert_close(output, expected)
 
 
 def test_olmo2_decoder_applies_post_norm_before_residual_add():
-    layer = Olmo2DecoderLayer(_config(), 0)
-    layer.self_attn = _IdentityAttention()
-    layer.mlp = nn.Identity()
-    layer.post_attention_layernorm = nn.Identity()
-    layer.post_feedforward_layernorm = nn.Identity()
     hidden = torch.ones(1, 2, 32)
 
-    output = layer(hidden, torch.arange(2).unsqueeze(0))
+    output = post_norm_residual(hidden, hidden, nn.Identity())
+    output = post_norm_residual(output, output, nn.Identity())
 
     torch.testing.assert_close(output, hidden * 4)


### PR DESCRIPTION
## Summary

Add an AReno-native adapter for the OLMo 2 model family, validated with `allenai/OLMo-2-0425-1B-Instruct` obtained from ModelScope.

## Implementation

- register `model_type == "olmo2"` and translate the public configuration into `ModelConfig`
- implement OLMo 2 post-attention and post-feedforward normalization before residual addition
- apply Q/K RMSNorm over the complete projected vectors and preserve the global normalization statistic under tensor parallelism
- reuse AReno's dense attention, MLP, KV-cache, inference, training, and lifecycle infrastructure
- add bidirectional checkpoint mappings for embedding, LM head, final norm, Q/K/V, projected Q/K norms, attention output, and SwiGLU weights
- add focused CPU coverage for configuration translation, model construction, projected normalization, and residual ordering

## Validation

- the selected ModelScope checkpoint resolves and loads through the OLMo 2 adapter
- inference, training, tensor-parallel Q/K normalization, and checkpoint save/reload paths were exercised during adaptation
- the branch passes Ruff checks for the adapter and focused tests in a supported runtime environment

Closes #171.
