### PR TITLE
feat(agentic): add Codebreaker TUI workflow

### DIFF
--- a/examples/agentic/codebreaker/README.md
+++ b/examples/agentic/codebreaker/README.md
@@ -17,6 +17,14 @@ rewritten into successful calls.
 python examples/agentic/codebreaker/tui.py --seed 7
 ```
 
+Point the same TUI at an OpenAI-compatible inference endpoint to let a model
+play. It preserves the complete assistant tool-call and tool-result history:
+
+```bash
+python examples/agentic/codebreaker/tui.py --agent --seed 7 \
+  --base-url http://127.0.0.1:8000/v1 --model policy --api-key token
+```
+
 ## Generate data
 
 ```bash

--- a/examples/agentic/codebreaker/README.md
+++ b/examples/agentic/codebreaker/README.md
@@ -1,0 +1,39 @@
+# Agentic Codebreaker TUI
+
+Codebreaker is a deterministic multi-turn Bulls and Cows game. A hidden code
+contains four distinct digits and may begin with zero. The policy calls
+`guess_code` up to six times; each tool result reports `exact` digits in the
+right position and `present` digits in the wrong position. The secret never
+appears in the prompt or tool result.
+
+This differs from the other agentic examples: it is a partial-observability
+deduction game with state accumulated exclusively through tool results. Missing,
+malformed, repeated, and invalid guesses remain failures rather than being
+rewritten into successful calls.
+
+## Play in the terminal
+
+```bash
+python examples/agentic/codebreaker/tui.py --seed 7
+```
+
+## Generate data
+
+```bash
+python examples/agentic/codebreaker/dataset_generator.py \
+  --output /tmp/codebreaker.jsonl --count 256 --seed 2026
+```
+
+## Train
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-0.6B \
+  --model-hub modelscope \
+  --dataset-path /tmp/codebreaker.jsonl \
+  --dataset-loader-fn examples/agentic/codebreaker/dataset_loader.py \
+  --reward-fn-path examples/agentic/codebreaker/reward.py \
+  --agent-fn examples/agentic/codebreaker/run_agent.py \
+  --algo gspo --tp-size 1 --world-size 1 \
+  --batch-size 1 --n-samples 2 --max-new-tokens 64
+```

--- a/examples/agentic/codebreaker/dataset_generator.py
+++ b/examples/agentic/codebreaker/dataset_generator.py
@@ -1,0 +1,49 @@
+"""Generate reproducible Codebreaker tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+from game import DEFAULT_CODE_LENGTH, DEFAULT_MAX_GUESSES, normalize_code
+
+
+def generate_records(count: int = 256, *, seed: int = 2026) -> list[dict]:
+    """Return deterministic unique-digit secrets."""
+
+    rng = random.Random(seed)
+    records = []
+    seen: set[str] = set()
+    while len(records) < count:
+        secret = "".join(rng.sample("0123456789", DEFAULT_CODE_LENGTH))
+        if secret in seen:
+            continue
+        seen.add(secret)
+        records.append(
+            {
+                "id": f"codebreaker-{len(records) + 1:05d}",
+                "secret": normalize_code(secret),
+                "code_length": DEFAULT_CODE_LENGTH,
+                "max_guesses": DEFAULT_MAX_GUESSES,
+            }
+        )
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--count", type=int, default=256)
+    parser.add_argument("--seed", type=int, default=2026)
+    args = parser.parse_args()
+    records = generate_records(args.count, seed=args.seed)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/codebreaker/dataset_loader.py
+++ b/examples/agentic/codebreaker/dataset_loader.py
@@ -1,0 +1,26 @@
+"""Dataset loader for Codebreaker agentic training."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import DEFAULT_CODE_LENGTH, DEFAULT_MAX_GUESSES, make_prompt, normalize_code  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> list[dict]:
+    """Normalize records while remaining tokenizer and processor independent."""
+
+    records = []
+    for index, row in enumerate(default_loader(dataset_path), start=1):
+        record = dict(row)
+        record["code_length"] = int(record.get("code_length", DEFAULT_CODE_LENGTH))
+        if record["code_length"] != DEFAULT_CODE_LENGTH:
+            raise ValueError(f"Codebreaker code_length must be {DEFAULT_CODE_LENGTH}")
+        record["max_guesses"] = min(max(int(record.get("max_guesses", DEFAULT_MAX_GUESSES)), 1), 6)
+        record["secret"] = normalize_code(record["secret"], code_length=record["code_length"])
+        record["id"] = str(record.get("id", f"codebreaker-{index:05d}"))
+        record["prompt"] = make_prompt(record)
+        records.append(record)
+    return records

--- a/examples/agentic/codebreaker/game.py
+++ b/examples/agentic/codebreaker/game.py
@@ -8,6 +8,26 @@ DIGITS = "0123456789"
 DEFAULT_CODE_LENGTH = 4
 DEFAULT_MAX_GUESSES = 6
 
+GUESS_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "guess_code",
+        "description": "Guess the hidden unique-digit code and receive Bulls and Cows clues.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "pattern": "^[0-9]{4}$",
+                    "description": "Exactly four distinct digits; a leading zero is allowed.",
+                }
+            },
+            "required": ["code"],
+            "additionalProperties": False,
+        },
+    },
+}
+
 
 def normalize_code(value: object, *, code_length: int = DEFAULT_CODE_LENGTH) -> str:
     """Return a validated unique-digit code."""

--- a/examples/agentic/codebreaker/game.py
+++ b/examples/agentic/codebreaker/game.py
@@ -1,0 +1,69 @@
+"""Deterministic Bulls and Cows rules for the Codebreaker example."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DIGITS = "0123456789"
+DEFAULT_CODE_LENGTH = 4
+DEFAULT_MAX_GUESSES = 6
+
+
+def normalize_code(value: object, *, code_length: int = DEFAULT_CODE_LENGTH) -> str:
+    """Return a validated unique-digit code."""
+
+    code = str(value)
+    if len(code) != code_length or any(digit not in DIGITS for digit in code):
+        raise ValueError(f"code must contain exactly {code_length} digits")
+    if len(set(code)) != len(code):
+        raise ValueError("code digits must be unique")
+    return code
+
+
+def score_guess(secret: str, guess: object) -> dict[str, Any]:
+    """Score one guess without revealing the secret."""
+
+    secret = normalize_code(secret, code_length=len(secret))
+    try:
+        normalized_guess = normalize_code(guess, code_length=len(secret))
+    except ValueError as exc:
+        return {"valid": False, "error": str(exc), "guess": str(guess)}
+    exact = sum(left == right for left, right in zip(secret, normalized_guess, strict=True))
+    present = len(set(secret) & set(normalized_guess)) - exact
+    return {
+        "valid": True,
+        "guess": normalized_guess,
+        "exact": exact,
+        "present": present,
+        "solved": exact == len(secret),
+    }
+
+
+def make_prompt(record: dict[str, Any]) -> str:
+    """Build one prompt without leaking the hidden code."""
+
+    code_length = int(record.get("code_length", DEFAULT_CODE_LENGTH))
+    max_guesses = int(record.get("max_guesses", DEFAULT_MAX_GUESSES))
+    return (
+        "Crack the terminal lock's hidden code. "
+        f"It has {code_length} unique digits and may begin with 0. "
+        f"You have at most {max_guesses} guesses. After each guess, exact is the number of digits "
+        "in the correct position and present is the number of other correct digits in wrong positions. "
+        "Call guess_code once per turn and use every clue to deduce the code."
+    )
+
+
+def score_episode(secret: str, guesses: list[object], *, max_guesses: int = DEFAULT_MAX_GUESSES) -> float:
+    """Reward solving efficiently, partial valid progress, and invalid paths separately."""
+
+    if not guesses:
+        return -1.0
+    valid_results = [score_guess(secret, guess) for guess in guesses[:max_guesses]]
+    if any(not result["valid"] for result in valid_results):
+        return -1.0
+    for index, result in enumerate(valid_results, start=1):
+        if result["solved"]:
+            efficiency = (max_guesses - index) / max(max_guesses - 1, 1)
+            return 0.8 + 0.2 * efficiency
+    best_information = max(result["exact"] + result["present"] for result in valid_results)
+    return 0.1 * best_information / len(secret)

--- a/examples/agentic/codebreaker/reward.py
+++ b/examples/agentic/codebreaker/reward.py
@@ -1,0 +1,32 @@
+"""Outcome and process reward for Codebreaker trajectories."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import score_episode  # noqa: E402
+
+
+def reward_fn(record) -> float:
+    """Reward valid, non-repeated deduction and efficient success."""
+
+    source = dict(record.source_record)
+    guesses = []
+    for call in record.tool_calls:
+        if call.get("name") != "guess_code":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return -1.0
+        if not isinstance(arguments, dict) or "code" not in arguments:
+            return -1.0
+        guesses.append(arguments["code"])
+    if len(guesses) != len(set(map(str, guesses))):
+        return -0.5
+    return score_episode(source["secret"], guesses, max_guesses=int(source["max_guesses"]))

--- a/examples/agentic/codebreaker/run_agent.py
+++ b/examples/agentic/codebreaker/run_agent.py
@@ -1,0 +1,144 @@
+"""Bounded multi-turn agent loop for Codebreaker."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import score_guess  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are a rigorous codebreaker. On every turn call guess_code exactly once. "
+    "Use prior tool clues, never repeat a guess, and do not answer in plain text."
+)
+
+GUESS_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "guess_code",
+        "description": "Guess the hidden unique-digit code and receive Bulls and Cows clues.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "pattern": "^[0-9]{4}$",
+                    "description": "Exactly four distinct digits; a leading zero is allowed.",
+                }
+            },
+            "required": ["code"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+async def run_agent(ctx, batch):
+    """Run bounded concurrent Codebreaker episodes and preserve exact model outputs."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError("Codebreaker requires `openai` and `httpx`. Install them with `pip install openai`.") from exc
+
+    items = list(batch.iter_samples())
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+    try:
+        grouped = await asyncio.gather(*(_run_episode(item, client) for item in items))
+        return AgentTrajectory(turns=[turn for episode in grouped for turn in episode])
+    finally:
+        await client.close()
+
+
+async def _run_episode(item, client) -> list[AgentTrajectoryTurn]:
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": item.prompt}]
+    turns = []
+    max_guesses = min(max(int(item.record["max_guesses"]), 1), 6)
+    for guess_number in range(1, max_guesses + 1):
+        turn_messages = [
+            *messages,
+            {"role": "user", "content": f"Guess {guess_number} of {max_guesses}: call guess_code now."},
+        ]
+        tool_choice = {"type": "function", "function": {"name": "guess_code"}}
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=turn_messages,
+            tools=[GUESS_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        turns.append(
+            AgentTrajectoryTurn(
+                item=item,
+                messages=turn_messages,
+                response=response,
+                tools=[GUESS_TOOL],
+                tool_choice=tool_choice,
+            )
+        )
+        assistant_message = _assistant_message(response)
+        tool_result = _execute_guess(assistant_message, item.record)
+        if tool_result is None:
+            logger.warning("Codebreaker model returned no executable guess_code call")
+            break
+        messages.extend(_tool_messages(assistant_message, tool_result))
+        if tool_result.get("solved") or not tool_result.get("valid"):
+            break
+    return turns
+
+
+def _assistant_message(response) -> dict:
+    message = response.choices[0].message
+    return {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": call.type,
+                "function": {"name": call.function.name, "arguments": call.function.arguments},
+            }
+            for call in (message.tool_calls or [])
+        ],
+    }
+
+
+def _execute_guess(assistant_message: dict, record: dict) -> dict | None:
+    calls = assistant_message.get("tool_calls") or []
+    if len(calls) != 1 or calls[0].get("function", {}).get("name") != "guess_code":
+        return None
+    try:
+        arguments = json.loads(calls[0]["function"].get("arguments") or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(arguments, dict) or "code" not in arguments:
+        return None
+    return score_guess(record["secret"], arguments["code"])
+
+
+def _tool_messages(assistant_message: dict, tool_result: dict) -> list[dict]:
+    call = assistant_message["tool_calls"][0]
+    return [
+        assistant_message,
+        {
+            "role": "tool",
+            "tool_call_id": call["id"],
+            "name": "guess_code",
+            "content": json.dumps(tool_result),
+        },
+    ]

--- a/examples/agentic/codebreaker/run_agent.py
+++ b/examples/agentic/codebreaker/run_agent.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 SYSTEM_PROMPT = (
-    "You are a rigorous codebreaker. On every turn call guess_code exactly once. "
-    "Use prior tool clues, never repeat a guess, and do not answer in plain text."
+    "You are a rigorous codebreaker. On every guessing turn call guess_code exactly once. "
+    "Use prior tool clues and never repeat a guess. After the game ends, summarize the outcome without a tool call."
 )
 
 async def run_agent(ctx, batch):
@@ -76,7 +76,24 @@ async def _run_episode(item, client) -> list[AgentTrajectoryTurn]:
             logger.warning("Codebreaker model returned no executable guess_code call")
             break
         messages.extend(_tool_messages(assistant_message, tool_result))
-        if tool_result.get("solved") or not tool_result.get("valid"):
+        game_over = tool_result.get("solved") or not tool_result.get("valid") or guess_number == max_guesses
+        if game_over:
+            finish_messages = [
+                *messages,
+                {"role": "user", "content": "The game is over. Briefly summarize the outcome without calling a tool."},
+            ]
+            finish_response = await client.chat.completions.create(
+                model="policy",
+                messages=finish_messages,
+                stream=False,
+            )
+            turns.append(
+                AgentTrajectoryTurn(
+                    item=item,
+                    messages=finish_messages,
+                    response=finish_response,
+                )
+            )
             break
     return turns
 

--- a/examples/agentic/codebreaker/run_agent.py
+++ b/examples/agentic/codebreaker/run_agent.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from game import score_guess  # noqa: E402
+from game import GUESS_TOOL, score_guess  # noqa: E402
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -20,27 +20,6 @@ SYSTEM_PROMPT = (
     "You are a rigorous codebreaker. On every turn call guess_code exactly once. "
     "Use prior tool clues, never repeat a guess, and do not answer in plain text."
 )
-
-GUESS_TOOL = {
-    "type": "function",
-    "function": {
-        "name": "guess_code",
-        "description": "Guess the hidden unique-digit code and receive Bulls and Cows clues.",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string",
-                    "pattern": "^[0-9]{4}$",
-                    "description": "Exactly four distinct digits; a leading zero is allowed.",
-                }
-            },
-            "required": ["code"],
-            "additionalProperties": False,
-        },
-    },
-}
-
 
 async def run_agent(ctx, batch):
     """Run bounded concurrent Codebreaker episodes and preserve exact model outputs."""

--- a/examples/agentic/codebreaker/run_agent.py
+++ b/examples/agentic/codebreaker/run_agent.py
@@ -21,6 +21,7 @@ SYSTEM_PROMPT = (
     "Use prior tool clues and never repeat a guess. After the game ends, summarize the outcome without a tool call."
 )
 
+
 async def run_agent(ctx, batch):
     """Run bounded concurrent Codebreaker episodes and preserve exact model outputs."""
 
@@ -28,7 +29,9 @@ async def run_agent(ctx, batch):
         import httpx
         from openai import AsyncOpenAI
     except ImportError as exc:
-        raise RuntimeError("Codebreaker requires `openai` and `httpx`. Install them with `pip install openai`.") from exc
+        raise RuntimeError(
+            "Codebreaker requires `openai` and `httpx`. Install them with `pip install openai`."
+        ) from exc
 
     items = list(batch.iter_samples())
     max_connections = max(len(items), ctx.max_running_prompts)

--- a/examples/agentic/codebreaker/tui.py
+++ b/examples/agentic/codebreaker/tui.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import random
 
-from game import DEFAULT_CODE_LENGTH, DEFAULT_MAX_GUESSES, score_guess
+from game import DEFAULT_CODE_LENGTH, DEFAULT_MAX_GUESSES, GUESS_TOOL, make_prompt, score_guess
+
+SYSTEM_PROMPT = (
+    "You are a rigorous codebreaker. Call guess_code exactly once per turn, use all prior clues, "
+    "never repeat a guess, and do not answer in plain text."
+)
 
 
 def _secret(seed: int | None) -> str:
@@ -16,23 +22,103 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--seed", type=int)
     parser.add_argument("--max-guesses", type=int, default=DEFAULT_MAX_GUESSES)
+    parser.add_argument("--agent", action="store_true", help="Let an OpenAI-compatible model crack the code")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
+    parser.add_argument("--api-key", default="token")
+    parser.add_argument("--model", default="policy")
     args = parser.parse_args()
     secret = _secret(args.seed)
-    history: list[dict] = []
     print("\033[1;36mCODEBREAKER // TERMINAL LOCK\033[0m")
     print("Crack 4 unique digits. exact=right place, present=wrong place.\n")
-    for turn in range(1, args.max_guesses + 1):
-        guess = input(f"[{turn}/{args.max_guesses}] code> ").strip()
+    if args.agent:
+        _run_llm(secret, args)
+    else:
+        _run_human(secret, args.max_guesses)
+
+
+def _run_human(secret: str, max_guesses: int) -> None:
+    for turn in range(1, max_guesses + 1):
+        guess = input(f"[{turn}/{max_guesses}] code> ").strip()
         result = score_guess(secret, guess)
-        history.append(result)
-        if not result["valid"]:
-            print(f"\033[31mINVALID\033[0m {result['error']}")
-            continue
-        print(f"  exact: \033[32m{result['exact']}\033[0m  present: \033[33m{result['present']}\033[0m")
-        if result["solved"]:
-            print("\n\033[1;32mACCESS GRANTED\033[0m")
+        if _render_result(result):
             return
     print(f"\n\033[1;31mLOCKED OUT\033[0m  code was {secret}")
+
+
+def _run_llm(secret: str, args: argparse.Namespace) -> None:
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise RuntimeError("LLM mode requires `openai`. Install it with `pip install openai`.") from exc
+
+    max_guesses = min(max(int(args.max_guesses), 1), DEFAULT_MAX_GUESSES)
+    client = OpenAI(base_url=args.base_url, api_key=args.api_key, max_retries=0)
+    record = {"code_length": DEFAULT_CODE_LENGTH, "max_guesses": max_guesses}
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": make_prompt(record)}]
+    tool_choice = {"type": "function", "function": {"name": "guess_code"}}
+    for turn in range(1, max_guesses + 1):
+        turn_prompt = {"role": "user", "content": f"Guess {turn} of {max_guesses}: call guess_code now."}
+        response = client.chat.completions.create(
+            model=args.model,
+            messages=[*messages, turn_prompt],
+            tools=[GUESS_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        message = response.choices[0].message
+        calls = list(message.tool_calls or [])
+        if len(calls) != 1 or calls[0].function.name != "guess_code":
+            print("\033[31mMODEL ERROR\033[0m expected exactly one guess_code call")
+            break
+        try:
+            arguments = json.loads(calls[0].function.arguments or "")
+        except json.JSONDecodeError:
+            print("\033[31mMODEL ERROR\033[0m invalid JSON tool arguments")
+            break
+        if not isinstance(arguments, dict) or "code" not in arguments:
+            print("\033[31mMODEL ERROR\033[0m missing code argument")
+            break
+        result = score_guess(secret, arguments["code"])
+        print(f"[{turn}/{max_guesses}] model> {arguments['code']}")
+        assistant_message = {
+            "role": "assistant",
+            "content": message.content,
+            "tool_calls": [
+                {
+                    "id": calls[0].id,
+                    "type": calls[0].type,
+                    "function": {"name": "guess_code", "arguments": calls[0].function.arguments},
+                }
+            ],
+        }
+        messages.extend(
+            [
+                turn_prompt,
+                assistant_message,
+                {
+                    "role": "tool",
+                    "tool_call_id": calls[0].id,
+                    "name": "guess_code",
+                    "content": json.dumps(result),
+                },
+            ]
+        )
+        if _render_result(result):
+            return
+        if not result["valid"]:
+            break
+    print(f"\n\033[1;31mLOCKED OUT\033[0m  code was {secret}")
+
+
+def _render_result(result: dict) -> bool:
+    if not result["valid"]:
+        print(f"\033[31mINVALID\033[0m {result['error']}")
+        return False
+    print(f"  exact: \033[32m{result['exact']}\033[0m  present: \033[33m{result['present']}\033[0m")
+    if result["solved"]:
+        print("\n\033[1;32mACCESS GRANTED\033[0m")
+        return True
+    return False
 
 
 if __name__ == "__main__":

--- a/examples/agentic/codebreaker/tui.py
+++ b/examples/agentic/codebreaker/tui.py
@@ -1,0 +1,39 @@
+"""Interactive terminal UI for the Codebreaker rule engine."""
+
+from __future__ import annotations
+
+import argparse
+import random
+
+from game import DEFAULT_CODE_LENGTH, DEFAULT_MAX_GUESSES, score_guess
+
+
+def _secret(seed: int | None) -> str:
+    return "".join(random.Random(seed).sample("0123456789", DEFAULT_CODE_LENGTH))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--max-guesses", type=int, default=DEFAULT_MAX_GUESSES)
+    args = parser.parse_args()
+    secret = _secret(args.seed)
+    history: list[dict] = []
+    print("\033[1;36mCODEBREAKER // TERMINAL LOCK\033[0m")
+    print("Crack 4 unique digits. exact=right place, present=wrong place.\n")
+    for turn in range(1, args.max_guesses + 1):
+        guess = input(f"[{turn}/{args.max_guesses}] code> ").strip()
+        result = score_guess(secret, guess)
+        history.append(result)
+        if not result["valid"]:
+            print(f"\033[31mINVALID\033[0m {result['error']}")
+            continue
+        print(f"  exact: \033[32m{result['exact']}\033[0m  present: \033[33m{result['present']}\033[0m")
+        if result["solved"]:
+            print("\n\033[1;32mACCESS GRANTED\033[0m")
+            return
+    print(f"\n\033[1;31mLOCKED OUT\033[0m  code was {secret}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agentic_codebreaker_example_cpu.py
+++ b/tests/test_agentic_codebreaker_example_cpu.py
@@ -101,8 +101,8 @@ def test_reward_separates_invalid_partial_repeated_and_optimal_paths():
 
 
 def test_tool_schema_is_closed_and_bounded_episode_defaults_to_six_turns():
-    run_agent = _load_module("run_agent")
-    parameters = run_agent.GUESS_TOOL["function"]["parameters"]
+    game = _load_module("game")
+    parameters = game.GUESS_TOOL["function"]["parameters"]
 
     assert parameters["additionalProperties"] is False
     assert parameters["required"] == ["code"]
@@ -154,3 +154,44 @@ def test_episode_preserves_tool_order_and_stops_on_success_or_parser_failure():
         run_agent._run_episode(item, SimpleNamespace(chat=SimpleNamespace(completions=failed)))
     )
     assert len(failed_turns) == 1
+
+
+def test_tui_llm_mode_uses_openai_tool_call_and_solves(capsys):
+    tui = _load_module("tui")
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            call = SimpleNamespace(
+                id="call-win",
+                type="function",
+                function=SimpleNamespace(name="guess_code", arguments='{"code":"0123"}'),
+            )
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[call]))]
+            )
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    previous_openai = sys.modules.get("openai")
+    sys.modules["openai"] = SimpleNamespace(OpenAI=FakeOpenAI)
+    try:
+        args = SimpleNamespace(
+            max_guesses=6,
+            base_url="http://127.0.0.1:8000/v1",
+            api_key="token",
+            model="policy",
+        )
+        tui._run_llm("0123", args)
+    finally:
+        sys.modules.pop("openai", None)
+        if previous_openai is not None:
+            sys.modules["openai"] = previous_openai
+
+    assert captured["tool_choice"]["function"]["name"] == "guess_code"
+    assert captured["tools"] == [tui.GUESS_TOOL]
+    assert "ACCESS GRANTED" in capsys.readouterr().out

--- a/tests/test_agentic_codebreaker_example_cpu.py
+++ b/tests/test_agentic_codebreaker_example_cpu.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "codebreaker"
+
+
+def _load_module(name: str):
+    path = EXAMPLE_DIR / f"{name}.py"
+    previous_game = sys.modules.pop("game", None)
+    previous_agentic = sys.modules.get("areno.api.agentic")
+    if name == "run_agent":
+        sys.modules["areno.api.agentic"] = SimpleNamespace(
+            AgentTrajectory=type("AgentTrajectory", (), {}),
+            AgentTrajectoryTurn=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(f"agentic_codebreaker_{name}_for_tests", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+        if name == "run_agent":
+            sys.modules.pop("areno.api.agentic", None)
+            if previous_agentic is not None:
+                sys.modules["areno.api.agentic"] = previous_agentic
+
+
+def test_rules_validate_and_score_leading_zero_codes():
+    game = _load_module("game")
+
+    assert game.normalize_code("0123") == "0123"
+    assert game.score_guess("0123", "0145") == {
+        "valid": True,
+        "guess": "0145",
+        "exact": 2,
+        "present": 0,
+        "solved": False,
+    }
+    assert game.score_guess("0123", "3210")["present"] == 4
+    assert game.score_guess("0123", "0012")["valid"] is False
+
+
+def test_generator_is_reproducible_and_loader_hides_secret_from_prompt():
+    generator = _load_module("dataset_generator")
+    loader = _load_module("dataset_loader")
+    rows = generator.generate_records(8, seed=4)
+
+    assert rows == generator.generate_records(8, seed=4)
+    assert len({row["secret"] for row in rows}) == 8
+    records = loader.load_training_dataset("unused", default_loader=lambda _: rows)
+    assert all(record["secret"] not in record["prompt"] for record in records)
+    assert all("at most 6 guesses" in record["prompt"] for record in records)
+
+
+def test_agent_executes_strict_single_guess_and_does_not_fabricate_calls():
+    run_agent = _load_module("run_agent")
+    record = {"secret": "0123", "max_guesses": 6}
+    valid = {
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "function": {"name": "guess_code", "arguments": json.dumps({"code": "0145"})},
+            }
+        ]
+    }
+
+    assert run_agent._execute_guess(valid, record)["exact"] == 2
+    assert run_agent._execute_guess({"tool_calls": []}, record) is None
+    assert run_agent._execute_guess({"tool_calls": [valid["tool_calls"][0], valid["tool_calls"][0]]}, record) is None
+    assert run_agent._execute_guess(
+        {"tool_calls": [{"function": {"name": "guess_code", "arguments": "not-json"}}]}, record
+    ) is None
+
+
+def test_reward_separates_invalid_partial_repeated_and_optimal_paths():
+    reward = _load_module("reward")
+    source = {"secret": "0123", "max_guesses": 6}
+
+    def score(guesses):
+        calls = [{"name": "guess_code", "arguments": json.dumps({"code": guess})} for guess in guesses]
+        return reward.reward_fn(SimpleNamespace(source_record=source, tool_calls=calls))
+
+    assert score([]) == -1.0
+    assert score(["0012"]) == -1.0
+    assert score(["0145"]) > 0.0
+    assert score(["0145", "0145"]) == -0.5
+    assert score(["0123"]) == 1.0
+    assert score(["4567", "0123"]) < 1.0
+
+
+def test_tool_schema_is_closed_and_bounded_episode_defaults_to_six_turns():
+    run_agent = _load_module("run_agent")
+    parameters = run_agent.GUESS_TOOL["function"]["parameters"]
+
+    assert parameters["additionalProperties"] is False
+    assert parameters["required"] == ["code"]
+    assert parameters["properties"]["code"]["pattern"] == "^[0-9]{4}$"
+
+
+def test_episode_preserves_tool_order_and_stops_on_success_or_parser_failure():
+    run_agent = _load_module("run_agent")
+
+    class FakeCompletions:
+        def __init__(self, responses):
+            self.responses = iter(responses)
+            self.messages = []
+
+        async def create(self, **kwargs):
+            self.messages.append(kwargs["messages"])
+            return next(self.responses)
+
+    def response(code=None):
+        calls = []
+        if code is not None:
+            calls = [
+                SimpleNamespace(
+                    id=f"call-{code}",
+                    type="function",
+                    function=SimpleNamespace(name="guess_code", arguments=json.dumps({"code": code})),
+                )
+            ]
+        message = SimpleNamespace(content=None if calls else "I cannot guess", tool_calls=calls)
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    item = SimpleNamespace(
+        prompt="crack it",
+        record={"secret": "0123", "max_guesses": 20},
+    )
+    completions = FakeCompletions([response("4567"), response("0123")])
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    turns = asyncio.run(run_agent._run_episode(item, client))
+
+    assert len(turns) == 2
+    second_messages = completions.messages[1]
+    assert second_messages[-3]["role"] == "assistant"
+    assert second_messages[-2]["role"] == "tool"
+    assert second_messages[-2]["tool_call_id"] == "call-4567"
+    assert second_messages[-1]["role"] == "user"
+
+    failed = FakeCompletions([response()])
+    failed_turns = asyncio.run(
+        run_agent._run_episode(item, SimpleNamespace(chat=SimpleNamespace(completions=failed)))
+    )
+    assert len(failed_turns) == 1

--- a/tests/test_agentic_codebreaker_example_cpu.py
+++ b/tests/test_agentic_codebreaker_example_cpu.py
@@ -138,16 +138,21 @@ def test_episode_preserves_tool_order_and_stops_on_success_or_parser_failure():
         prompt="crack it",
         record={"secret": "0123", "max_guesses": 20},
     )
-    completions = FakeCompletions([response("4567"), response("0123")])
+    completions = FakeCompletions([response("4567"), response("0123"), response()])
     client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
     turns = asyncio.run(run_agent._run_episode(item, client))
 
-    assert len(turns) == 2
+    assert len(turns) == 3
     second_messages = completions.messages[1]
     assert second_messages[-3]["role"] == "assistant"
     assert second_messages[-2]["role"] == "tool"
     assert second_messages[-2]["tool_call_id"] == "call-4567"
     assert second_messages[-1]["role"] == "user"
+    finish_messages = completions.messages[2]
+    assert finish_messages[-3]["role"] == "assistant"
+    assert finish_messages[-2]["role"] == "tool"
+    assert finish_messages[-2]["tool_call_id"] == "call-0123"
+    assert finish_messages[-1]["role"] == "user"
 
     failed = FakeCompletions([response()])
     failed_turns = asyncio.run(

--- a/tests/test_agentic_codebreaker_example_cpu.py
+++ b/tests/test_agentic_codebreaker_example_cpu.py
@@ -79,9 +79,12 @@ def test_agent_executes_strict_single_guess_and_does_not_fabricate_calls():
     assert run_agent._execute_guess(valid, record)["exact"] == 2
     assert run_agent._execute_guess({"tool_calls": []}, record) is None
     assert run_agent._execute_guess({"tool_calls": [valid["tool_calls"][0], valid["tool_calls"][0]]}, record) is None
-    assert run_agent._execute_guess(
-        {"tool_calls": [{"function": {"name": "guess_code", "arguments": "not-json"}}]}, record
-    ) is None
+    assert (
+        run_agent._execute_guess(
+            {"tool_calls": [{"function": {"name": "guess_code", "arguments": "not-json"}}]}, record
+        )
+        is None
+    )
 
 
 def test_reward_separates_invalid_partial_repeated_and_optimal_paths():
@@ -155,9 +158,7 @@ def test_episode_preserves_tool_order_and_stops_on_success_or_parser_failure():
     assert finish_messages[-1]["role"] == "user"
 
     failed = FakeCompletions([response()])
-    failed_turns = asyncio.run(
-        run_agent._run_episode(item, SimpleNamespace(chat=SimpleNamespace(completions=failed)))
-    )
+    failed_turns = asyncio.run(run_agent._run_episode(item, SimpleNamespace(chat=SimpleNamespace(completions=failed))))
     assert len(failed_turns) == 1
 
 
@@ -173,9 +174,7 @@ def test_tui_llm_mode_uses_openai_tool_call_and_solves(capsys):
                 type="function",
                 function=SimpleNamespace(name="guess_code", arguments='{"code":"0123"}'),
             )
-            return SimpleNamespace(
-                choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[call]))]
-            )
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[call]))])
 
     class FakeOpenAI:
         def __init__(self, **kwargs):


### PR DESCRIPTION
## What does this PR do?

Adds Codebreaker, a deterministic multi-turn Bulls and Cows environment for validating AReno agentic RL workflows end to end.

- Provides a reproducible dataset generator and tokenizer-independent loader.
- Implements a strict, bounded `guess_code` tool loop with complete assistant/tool-result ordering.
- Separates outcome and process rewards for invalid, partial, repeated, and successful trajectories.
- Adds an interactive terminal UI for both human play and OpenAI-compatible LLM inference.
- Covers rules, dataset normalization, reward behavior, schema constraints, bounded execution, parser failures, transcript ordering, and TUI inference with CPU tests.
- Documents dataset generation, terminal play, inference, and GSPO training commands.

The implementation was validated with a capacity-tuned, one-step agentic GSPO run on an NVIDIA GB10 using `Qwen/Qwen3-0.6B` from ModelScope. The final run retained all four trajectories, produced 15 matched tool calls and tool results, advanced the trainer to step 1, and recorded nonzero gradients.

## Related issue

Fixes #173

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

Local CPU and static validation:

- `pytest tests/test_agentic_codebreaker_example_cpu.py -q` — 7 passed.
- `ruff check examples/agentic/codebreaker tests/test_agentic_codebreaker_example_cpu.py`
- `git diff --check`
- `python -m compileall -q examples/agentic/codebreaker`
- Scripted human-TUI smoke execution.

Remote dataset and environment validation on one NVIDIA GB10:

- Dataset inspection returned `"ok": true` for eight normalized GSPO records.
- `areno env --json` and `areno check` confirmed PyTorch 2.9.0+cu130, CUDA availability, and one visible GB10.
- ModelScope resolved `Qwen/Qwen3-0.6B` to the local snapshot cache.

Capacity tuning with `--mem-frac 0.85 --tune-max-samples 4` selected:

- `batch_size=2`
- `n_samples=2`
- `mini_bs=2`
- `max_running_prompts=4`
- Rollout peak memory fraction: `0.0282`
- Training peak memory fraction: `0.1105`

Final bounded GSPO validation used TP 1, world size 1, native attention, 64 new tokens per turn, a 4096-token trajectory context, and `--max-steps 1`:

- Trainer advanced from step 0 to step 1.
- Four trajectories retained; zero overlong trajectories skipped.
- 15 tool calls and 15 matching tool results.
- Reward mean/std: `-0.75 / 0.25`.
- Gradient norm: `20.5021`; nonzero gradient ratio: `0.7929`.
- Persisted transcript validation returned `"ok": true`.

The complete repository CPU suite was not run in this session. The remote environment did not have pytest installed, so remote validation used the real AReno training command and persisted metrics/transcript artifacts instead.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`) — the targeted 7-test CPU suite passed; the complete CPU suite was not run.
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md) — no public API or CLI surface changed.
