### PR TITLE
feat(agentic): add elevator-dispatch agentic RL demo

### DIFF
--- a/docs/cookbook/elevator-dispatch-agentic-rl.rst
+++ b/docs/cookbook/elevator-dispatch-agentic-rl.rst
@@ -1,0 +1,43 @@
+Elevator-dispatch agentic RL
+============================
+
+Elevator dispatch is an episodic agentic AReno recipe with a time dimension.
+Each prompt presents a building (floors, car capacity, waiting passengers, and a
+pending arrival schedule) and the policy returns a full episode as an ordered
+``move/open/close`` action string via a ``dispatch`` tool call. AReno replays
+the episode deterministically, advancing the clock one tick per action and
+landing arrivals on schedule, then scores delivered passengers, wait, and
+invalid actions.
+
+.. code-block:: bash
+
+   python examples/agentic/elevator/dataset_generator.py \
+     --output /tmp/areno-elevator.jsonl --count 2048 --seed 2026 --arrivals 6
+
+   areno train \
+     --agent-fn examples/agentic/elevator/run_agent.py \
+     --dataset-loader-fn examples/agentic/elevator/dataset_loader.py \
+     --reward-fn-path examples/agentic/elevator/reward.py \
+     --algo gspo
+
+A first-come-first-served (FCFS) baseline is available so trained-vs-baseline
+improvement is reportable:
+
+.. code-block:: bash
+
+   python examples/agentic/elevator/baseline.py --count 256 --seed 2026 --arrivals 6
+
+Key adaptation points:
+
+* Replace the dispatch-contract action space with your own, but keep one
+  ``AgentTrajectory`` turn so AReno tokenizes the episode as a single assistant
+  output.
+* Keep the event-queue advance inside the engine so the same building plus
+  action string replays deterministically.
+* Score with delivered passengers, mean wait, and an invalid-action penalty so
+  a no-op policy cannot win, and board only up to capacity (overload
+  prevention).
+* Report ``delivered_passengers``, ``mean_wait``, and ``invalid_rate`` and
+  compare against the FCFS baseline.
+
+See :doc:`/reference/agentic-rollout-api` for the agentic rollout API contract.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ AReno documentation
 
    cookbook/math-rlvr
    cookbook/tictactoe-agentic-rl
+   cookbook/elevator-dispatch-agentic-rl
    cookbook/duelgrid-visual-agent
 
 .. toctree::

--- a/examples/agentic/elevator/README.md
+++ b/examples/agentic/elevator/README.md
@@ -1,0 +1,87 @@
+# Agentic Elevator-Dispatch Example
+
+This example trains a policy to dispatch an elevator: it plans a sequence of
+move/open/close actions that picks up arriving passengers, delivers them to
+their destinations, and minimizes wait while never exceeding car capacity.
+Each prompt describes the building; the model calls a `dispatch` tool with an
+action string. AReno replays the episode deterministically and scores it. The
+environment is deterministic and self-contained.
+
+## Files
+
+- `game.py` is the pure-Python elevator engine: building validation, a door
+  state machine, capacity-bounded boarding (overload prevention), a deterministic
+  event queue, episode replay, terminal detection, prompt formatting, and the
+  FCFS baseline policy.
+- `dataset_generator.py` generates reproducible building JSONL (seeded arrival
+  schedules).
+- `dataset_loader.py` converts JSONL records into Areno prompt records.
+- `run_agent.py` is the agent entrypoint: one `dispatch` tool call per building.
+- `reward.py` replays the model's action string with `game.play`, writes the
+  episode metrics onto the source record, and returns a scalar shaped by
+  delivered passengers, mean wait, and invalid-action rate.
+- `baseline.py` reports a first-come-first-served (FCFS) baseline so
+  trained-vs-baseline improvement is measurable.
+
+## Action Letters
+
+- `U` move the car up one floor; `D` move down one floor.
+- `O` open the door and exchange passengers (drop off matches, then board up to
+  capacity from the floor's waiting queue).
+- `C` close the door.
+
+Invalid actions (wrong door state, moving past the top/bottom floor) are skipped
+but counted in `n_invalid`. Each action advances the clock by one tick, so
+arrivals land deterministically.
+
+## Generate Buildings
+
+```bash
+python examples/agentic/elevator/dataset_generator.py \
+  --output /tmp/areno-elevator.jsonl \
+  --count 2048 \
+  --seed 2026 \
+  --arrivals 6
+```
+
+## Run with Tool Calls
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-1.7B \
+  --dataset-path /tmp/areno-elevator.jsonl \
+  --dataset-loader-fn examples/agentic/elevator/dataset_loader.py \
+  --reward-fn-path examples/agentic/elevator/reward.py \
+  --agent-fn examples/agentic/elevator/run_agent.py \
+  --algo gspo \
+  --batch-size 2 \
+  --n-samples 4 \
+  --max-new-tokens 96
+```
+
+(This command trains on GPU. The engine, generator, loader, reward, and
+baseline run on CPU with no network access.)
+
+## Report a FCFS Baseline
+
+```bash
+python examples/agentic/elevator/baseline.py \
+  --count 256 \
+  --seed 2026 \
+  --arrivals 6
+```
+
+The output prints mean delivered passengers, mean wait, and mean invalid-action
+rate. Compare a trained run against this baseline to report improvement.
+
+## Episode Replay Contract
+
+`game.play(building, actions, *, max_steps)` returns:
+
+- `delivered_passengers`: passengers dropped at their destination.
+- `mean_wait` / `max_wait` / `total_wait`: wait time in ticks.
+- `n_steps` / `n_attempts` / `n_invalid` / `invalid_rate`: action accounting.
+- `remaining_passengers`: aboard + waiting + pending-arrival passengers.
+- `terminal`: whether nothing remains to dispatch (game over).
+
+The same `building + actions + max_steps` is bit-identical across runs.

--- a/examples/agentic/elevator/baseline.py
+++ b/examples/agentic/elevator/baseline.py
@@ -1,0 +1,103 @@
+"""First-come-first-served baseline for the elevator-dispatch example.
+
+The issue asks for a comparison against a first-come-first-served (FCFS) policy
+on delivered passengers, mean wait, and invalid actions. This module runs the
+engine's FCFS policy over a seeded set of buildings and reports those metrics,
+reusing :func:`game.play` so the metric channels are identical to a trained
+policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = game.DEFAULT_SEED
+DEFAULT_MAX_STEPS = game.DEFAULT_MAX_STEPS
+
+
+def fcfs_baseline(
+    count: int = DEFAULT_COUNT,
+    *,
+    seed: int = DEFAULT_SEED,
+    max_steps: int = DEFAULT_MAX_STEPS,
+    floors: int = game.DEFAULT_FLOORS,
+    capacity: int = game.DEFAULT_CAPACITY,
+    arrivals_per_building: int = 6,
+) -> dict[str, float]:
+    """Aggregate FCFS metrics over ``count`` seeded buildings.
+
+    Returns mean ``delivered_passengers``, mean ``mean_wait``, mean
+    ``invalid_rate``, and the episode ``count``. Fully reproducible given the
+    seed.
+    """
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+    buildings = dataset_generator.generate_records(
+        count, seed=seed, floors=floors, capacity=capacity, arrivals_per_building=arrivals_per_building
+    )
+    delivered: list[float] = []
+    waits: list[float] = []
+    invalid_rates: list[float] = []
+    for building in buildings:
+        actions = game.fcfs_actions(building)
+        metrics = game.play(building, actions, max_steps=max_steps)
+        delivered.append(float(metrics["delivered_passengers"]))
+        waits.append(float(metrics["mean_wait"]))
+        invalid_rates.append(float(metrics["invalid_rate"]))
+    return {
+        "count": float(count),
+        "mean_delivered": sum(delivered) / count,
+        "mean_wait": sum(waits) / count,
+        "mean_invalid_rate": sum(invalid_rates) / count,
+    }
+
+
+def _format_stats(stats: dict[str, float]) -> str:
+    return (
+        f"FCFS baseline over {int(stats['count'])} buildings: "
+        f"mean_delivered={stats['mean_delivered']:.2f} "
+        f"mean_wait={stats['mean_wait']:.2f} "
+        f"mean_invalid_rate={stats['mean_invalid_rate']:.3f}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Report FCFS baseline metrics for the Areno elevator agentic example.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of buildings.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    parser.add_argument("--max-steps", type=int, default=DEFAULT_MAX_STEPS, help="Maximum valid actions per episode.")
+    parser.add_argument("--floors", type=int, default=game.DEFAULT_FLOORS, help="Floors per building.")
+    parser.add_argument("--capacity", type=int, default=game.DEFAULT_CAPACITY, help="Car capacity.")
+    parser.add_argument("--arrivals", type=int, default=6, help="Arrivals per building.")
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise ValueError("--count must be positive")
+    if args.max_steps <= 0:
+        raise ValueError("--max-steps must be positive")
+    if args.floors < 2:
+        raise ValueError("--floors must be >= 2")
+    if args.capacity < 1:
+        raise ValueError("--capacity must be >= 1")
+
+    stats = fcfs_baseline(
+        args.count,
+        seed=args.seed,
+        max_steps=args.max_steps,
+        floors=args.floors,
+        capacity=args.capacity,
+        arrivals_per_building=args.arrivals,
+    )
+    print(_format_stats(stats))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/elevator/dataset_generator.py
+++ b/examples/agentic/elevator/dataset_generator.py
@@ -1,0 +1,112 @@
+"""Generate elevator-dispatch buildings for the agentic example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = game.DEFAULT_SEED
+DEFAULT_FLOORS = game.DEFAULT_FLOORS
+DEFAULT_CAPACITY = game.DEFAULT_CAPACITY
+
+
+def generate_records(
+    count: int = DEFAULT_COUNT,
+    *,
+    seed: int = DEFAULT_SEED,
+    floors: int = DEFAULT_FLOORS,
+    capacity: int = DEFAULT_CAPACITY,
+    arrivals_per_building: int = 6,
+    max_tick: int = 24,
+) -> list[dict]:
+    """Generate reproducible dispatch buildings.
+
+    Each building starts with the car at floor 0, the door closed, and a seeded
+    arrival schedule; two runs with the same ``seed`` are identical.
+    """
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+    if floors < 2:
+        raise ValueError("floors must be >= 2")
+    if arrivals_per_building < 0:
+        raise ValueError("arrivals_per_building must be >= 0")
+    rng = random.Random(seed)
+    records: list[dict] = []
+    for idx in range(count):
+        arrivals = _seeded_arrivals(rng, floors, arrivals_per_building, max_tick)
+        records.append(
+            {
+                "id": f"generated-{idx:05d}",
+                "floors": floors,
+                "capacity": capacity,
+                "arrivals": arrivals,
+                "car": {"floor": 0, "direction": "U", "door_open": False, "passengers": []},
+            }
+        )
+    return records
+
+
+def _seeded_arrivals(rng: random.Random, floors: int, n: int, max_tick: int) -> list[dict]:
+    arrivals: list[dict] = []
+    for _ in range(n):
+        from_floor = rng.randrange(floors)
+        to_floor = rng.randrange(floors - 1)
+        if to_floor >= from_floor:
+            to_floor += 1  # keep from != to impossible
+        tick = rng.randrange(max_tick + 1)
+        arrivals.append({"tick": tick, "from_floor": from_floor, "to_floor": to_floor})
+    arrivals.sort(key=lambda e: (e["tick"], e["from_floor"]))
+    return arrivals
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write generated records as JSONL."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate JSONL buildings for the Areno elevator agentic example.")
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of buildings to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    parser.add_argument("--floors", type=int, default=DEFAULT_FLOORS, help="Number of floors per building.")
+    parser.add_argument("--capacity", type=int, default=DEFAULT_CAPACITY, help="Car passenger capacity.")
+    parser.add_argument("--arrivals", type=int, default=6, help="Arrivals per building.")
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise ValueError("--count must be positive")
+    if args.floors < 2:
+        raise ValueError("--floors must be >= 2")
+    if args.capacity < 1:
+        raise ValueError("--capacity must be >= 1")
+
+    records = generate_records(
+        args.count,
+        seed=args.seed,
+        floors=args.floors,
+        capacity=args.capacity,
+        arrivals_per_building=args.arrivals,
+    )
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/elevator/dataset_loader.py
+++ b/examples/agentic/elevator/dataset_loader.py
@@ -1,0 +1,57 @@
+"""Dataset loader for the elevator-dispatch tool-call example.
+
+Each record becomes an Areno prompt that asks the policy for one dispatch
+episode (an action string). The building is stored on the record so the reward
+function can replay it deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+DEFAULT_MAX_STEPS = game.DEFAULT_MAX_STEPS
+
+
+def load_training_dataset(
+    dataset_path: str,
+    *,
+    default_loader=None,
+    max_steps: int = DEFAULT_MAX_STEPS,
+    **_: object,
+) -> list[dict]:
+    """Load JSONL buildings and convert them to Areno prompt records."""
+
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx, max_steps=max_steps, xml=False) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "buildings.jsonl"
+    if not path.exists():
+        return dataset_generator.generate_records()
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int, *, max_steps: int, xml: bool) -> dict:
+    building = game.normalize_building(raw)
+    return {
+        "id": raw.get("id", f"building-{index:05d}"),
+        "prompt": game.format_xml_prompt(building) if xml else game.format_prompt(building),
+        "building": building,
+        "max_steps": int(raw.get("max_steps", max_steps)),
+    }

--- a/examples/agentic/elevator/game.py
+++ b/examples/agentic/elevator/game.py
@@ -1,0 +1,491 @@
+"""Small elevator-dispatch helpers for agentic examples.
+
+A building has ``floors`` levels and one car with ``capacity`` passenger slots.
+Passengers arrive at floors with a destination and wait in a per-floor hall
+queue; the car dispatches them by moving (``U``/``D``), opening its door to let
+passengers off and on (``O``), and closing again (``C``). The event queue
+advances one tick per action, so the same building + sequence + seed replays
+bit-identically.
+
+Action letters
+---------------
+``U`` move the car up one floor, ``D`` move down one floor, ``O`` open the door
+(lets passengers off then on, bounded by ``capacity``), ``C`` close the door.
+Invalid actions -- moving past the top/bottom floor, opening when the door is
+open, closing when it is closed -- are skipped but counted as ``n_invalid``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+ACTIONS = ("U", "D", "O", "C")
+DEFAULT_FLOORS = 6
+DEFAULT_CAPACITY = 4
+DEFAULT_MAX_STEPS = 200
+DEFAULT_SEED = 2026
+
+# Built via concatenation so the raw source never carries a literal think tag,
+# which keeps some editors/tooling from mis-parsing the module.
+_THINK_OPEN = r"<think" + r"\b[^>]*>"
+_THINK_CLOSE = r"</" + r"think>"
+_THINK_RE = re.compile(_THINK_OPEN + r".*?" + _THINK_CLOSE, re.IGNORECASE | re.DOTALL)
+_XML_ACTIONS_RE = re.compile(r"<dispatch>\s*([UDROC]+)\s*</dispatch>", re.IGNORECASE | re.DOTALL)
+_CHAT_SPECIAL_RE = re.compile(r"<\|[^>]+?\|>|</?s>", re.IGNORECASE)
+
+
+def normalize_building(building: dict[str, Any]) -> dict[str, Any]:
+    """Return a validated elevator building.
+
+    Required keys: ``floors`` (>=2), ``capacity`` (>=1, the integer slot count
+    of the car), ``arrivals`` (a list of ``(tick, from_floor, to_floor)``).
+    Optional: ``car`` (overridden position/door), ``seed``. Malformed values
+    raise ``ValueError`` before any model or worker initialization.
+    """
+
+    floors = int(building["floors"])
+    capacity = int(building["capacity"])
+    if floors < 2:
+        raise ValueError("floors must be >= 2")
+    if capacity < 1:
+        raise ValueError("capacity must be >= 1")
+
+    car = dict(building.get("car") or {})
+    car_floor = int(car.get("floor", 0))
+    if not 0 <= car_floor < floors:
+        raise ValueError(f"car floor out of range: {car_floor}")
+
+    hall_queues: list[list[dict[str, int]]] = [[] for _ in range(floors)]
+    raw_hall = building.get("hall_queues")
+    if isinstance(raw_hall, dict):
+        for raw_from, queue in raw_hall.items():
+            from_floor = int(raw_from)
+            if not 0 <= from_floor < floors:
+                raise ValueError(f"hall queue floor out of range: {from_floor}")
+            for passenger in queue:
+                hall_queues[from_floor].append(_normalize_passenger(passenger, floors))
+    elif isinstance(raw_hall, list):
+        # Already normalized form (one list per floor).
+        for from_floor, queue in enumerate(raw_hall):
+            for passenger in queue:
+                hall_queues[from_floor].append(_normalize_passenger(passenger, floors))
+
+    car_passengers = [_normalize_passenger(p, floors) for p in (car.get("passengers") or [])]
+    if len(car_passengers) > capacity:
+        raise ValueError("car carries more passengers than capacity")
+
+    arrivals = _normalize_arrivals(building["arrivals"], floors)
+
+    return {
+        "floors": floors,
+        "capacity": capacity,
+        "car": {
+            "floor": car_floor,
+            "direction": str(car.get("direction", "U")).upper(),
+            "door_open": bool(car.get("door_open", False)),
+            "passengers": car_passengers,
+        },
+        "hall_queues": hall_queues,
+        "arrivals": arrivals,
+        "tick": int(building.get("tick", 0)),
+        "seed": int(building.get("seed", DEFAULT_SEED)),
+    }
+
+
+def _normalize_passenger(passenger: Any, floors: int) -> dict[str, int]:
+    if isinstance(passenger, dict):
+        to_floor = int(passenger["to_floor"])
+        arrive_tick = int(passenger.get("arrive_tick", 0))
+    else:
+        values = list(passenger)
+        to_floor = int(values[0])
+        arrive_tick = int(values[1]) if len(values) > 1 else 0
+    if not 0 <= to_floor < floors:
+        raise ValueError(f"passenger to_floor out of range: {to_floor}")
+    return {"to_floor": to_floor, "arrive_tick": arrive_tick}
+
+
+def _normalize_arrivals(arrivals: Iterable, floors: int) -> list[dict[str, int]]:
+    normalized: list[dict[str, int]] = []
+    for idx, raw in enumerate(arrivals):
+        if isinstance(raw, dict):
+            tick = int(raw["tick"])
+            from_floor = int(raw["from_floor"])
+            to_floor = int(raw["to_floor"])
+        else:
+            tick, from_floor, to_floor = (int(v) for v in raw)
+        if not 0 <= from_floor < floors or not 0 <= to_floor < floors:
+            raise ValueError(f"arrival floor out of range: {raw}")
+        if from_floor == to_floor:
+            raise ValueError(f"arrival source equals destination: {raw}")
+        normalized.append({"tick": tick, "seq": idx, "from_floor": from_floor, "to_floor": to_floor})
+    normalized.sort(key=lambda e: (e["tick"], e["seq"]))
+    return normalized
+
+
+def clone_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Deep-ish copy of mutable simulation state for safe replay."""
+
+    car = dict(state["car"])
+    car["passengers"] = [dict(p) for p in car["passengers"]]
+    return {
+        "floors": state["floors"],
+        "capacity": state["capacity"],
+        "car": car,
+        "hall_queues": [[dict(p) for p in queue] for queue in state["hall_queues"]],
+        "arrivals": [dict(e) for e in state["arrivals"]],
+        "tick": state["tick"],
+        "seed": state["seed"],
+    }
+
+
+def advance_events(state: dict[str, Any], until_tick: int) -> None:
+    """Land every arrival whose scheduled tick is <= ``until_tick`` in place.
+
+    Mutates the building state: pending arrivals enter the hall queue of their
+    floor so the same sequence of ticks always yields the same queues.
+    """
+
+    remaining: list[dict[str, int]] = []
+    for event in state["arrivals"]:
+        if event["tick"] <= until_tick:
+            state["hall_queues"][event["from_floor"]].append(
+                {"to_floor": event["to_floor"], "arrive_tick": event["tick"]}
+            )
+        else:
+            remaining.append(event)
+    state["arrivals"] = remaining
+
+
+def step(state: dict[str, Any], action: str, stats: dict[str, int]) -> bool:
+    """Apply one action to ``state`` and return whether it was valid.
+
+    ``stats`` accumulates counters (``delivered``/``total_wait``/``max_wait``).
+    Every action advances the clock by one tick and lands any due arrivals, so
+    action ordering fully determines the simulation.
+    """
+
+    action = str(action).upper()
+    if action not in ACTIONS:
+        return False
+    car = state["car"]
+    floors = state["floors"]
+
+    # The clock always advances by one tick per action; arrivals land first so a
+    # passenger arriving on this tick can be served by this tick's door open.
+    state["tick"] += 1
+    advance_events(state, state["tick"])
+
+    if action == "U":
+        if car["door_open"] or car["floor"] + 1 >= floors:
+            return False
+        car["floor"] += 1
+        car["direction"] = "U"
+        return True
+    if action == "D":
+        if car["door_open"] or car["floor"] - 1 < 0:
+            return False
+        car["floor"] -= 1
+        car["direction"] = "D"
+        return True
+    if action == "C":
+        if not car["door_open"]:
+            return False
+        car["door_open"] = False
+        return True
+    # action == "O": open the door and exchange passengers.
+    if car["door_open"]:
+        return False
+    car["door_open"] = True
+    _exchange_passengers(state, stats)
+    return True
+
+
+def _exchange_passengers(state: dict[str, Any], stats: dict[str, int]) -> None:
+    """Let passengers off, then on up to ``capacity`` (overload prevention)."""
+
+    car = state["car"]
+    floor = car["floor"]
+    tick = state["tick"]
+
+    staying: list[dict[str, int]] = []
+    for passenger in car["passengers"]:
+        if passenger["to_floor"] == floor:
+            wait = tick - passenger["arrive_tick"]
+            stats["delivered"] += 1
+            stats["total_wait"] += wait
+            if wait > stats["max_wait"]:
+                stats["max_wait"] = wait
+        else:
+            staying.append(passenger)
+    car["passengers"] = staying
+
+    # Board from this floor's waiting queue, FIFO, up to remaining capacity.
+    queue = state["hall_queues"][floor]
+    boarded: list[dict[str, int]] = []
+    leftover: list[dict[str, int]] = []
+    for passenger in queue:
+        if len(boarded) + len(car["passengers"]) < state["capacity"]:
+            boarded.append(passenger)
+        else:
+            leftover.append(passenger)
+    car["passengers"].extend(boarded)
+    state["hall_queues"][floor] = leftover
+
+
+def remaining_passengers(state: dict[str, Any]) -> int:
+    """Count passengers still waiting or aboard -- those not yet delivered."""
+
+    aboard = len(state["car"]["passengers"])
+    waiting = sum(len(queue) for queue in state["hall_queues"])
+    pending = len(state["arrivals"])
+    return aboard + waiting + pending
+
+
+def is_terminal(state: dict[str, Any]) -> bool:
+    """Return whether nothing remains to dispatch (game over)."""
+
+    car = state["car"]
+    return (
+        not car["passengers"]
+        and all(len(queue) == 0 for queue in state["hall_queues"])
+        and not state["arrivals"]
+    )
+
+
+def play(
+    building: dict[str, Any],
+    sequence: str,
+    *,
+    max_steps: int = DEFAULT_MAX_STEPS,
+) -> dict[str, Any]:
+    """Replay an action sequence deterministically and return metrics.
+
+    Each action consumes one tick and advances the clock, so the same building
+    + sequence is bit-identical. Invalid actions (no-ops) are counted but do not
+    stop the episode. The episode also stops at ``max_steps`` valid actions or a
+    terminal building. The metric dict matches the fields checked by tests and
+    the reward function.
+    """
+
+    state = clone_state(normalize_building(building))
+    sequence = "".join(ch for ch in str(sequence).upper() if ch in ACTIONS)
+    max_steps = int(max_steps)
+    if max_steps <= 0:
+        raise ValueError("max_steps must be positive")
+
+    stats = {"delivered": 0, "total_wait": 0, "max_wait": 0}
+    n_valid = 0
+    n_invalid = 0
+    terminal = False
+    for action in sequence:
+        if n_valid >= max_steps:
+            break
+        if step(state, action, stats):
+            n_valid += 1
+        else:
+            n_invalid += 1
+        if is_terminal(state):
+            terminal = True
+            break
+    if not terminal:
+        terminal = is_terminal(state)
+
+    delivered = stats["delivered"]
+    counts = n_valid + n_invalid
+    return {
+        "state": state,
+        "delivered_passengers": delivered,
+        "mean_wait": (stats["total_wait"] / delivered) if delivered else 0.0,
+        "max_wait": stats["max_wait"],
+        "total_wait": stats["total_wait"],
+        "n_steps": n_valid,
+        "n_attempts": counts,
+        "n_invalid": n_invalid,
+        "invalid_rate": (n_invalid / counts) if counts else 0.0,
+        "remaining_passengers": remaining_passengers(state),
+        "terminal": terminal,
+    }
+
+
+def building_to_text(building: dict[str, Any]) -> str:
+    """Render the building for the policy prompt.
+
+    Shows floors with the waiting queue sizes and destinations, the car's
+    position/door state, and the names of pending arrivals so the model can
+    plan without guessing.
+    """
+
+    state = normalize_building(building)
+    lines = []
+    floors = state["floors"]
+    for floor in reversed(range(floors)):
+        queue = state["hall_queues"][floor]
+        marker = "[CAR>" if state["car"]["floor"] == floor else "      "
+        door = "open ]" if state["car"]["door_open"] else "closed]"
+        aboard = [str(p["to_floor"]) for p in state["car"]["passengers"]] if state["car"]["floor"] == floor else []
+        waiting = ",".join(str(p["to_floor"]) for p in queue) if queue else "-"
+        lines.append(f"F{floor} {marker}{door} aboard=[{','.join(aboard)}] waiting->{waiting}")
+    pending = ",".join(f"t{e['tick']}:F{e['from_floor']}->F{e['to_floor']}" for e in state["arrivals"]) or "-"
+    lines.append(f"pending arrivals: {pending}")
+    lines.append(f"tick={state['tick']} capacity={state['capacity']}")
+    return "\n".join(lines)
+
+
+def format_prompt(building: dict[str, Any]) -> str:
+    """Build the episode prompt for the tool-call agent."""
+
+    return (
+        "You are dispatching an elevator. Minimize passenger wait and deliver "
+        "everyone, never exceeding capacity.\n\n"
+        "Output format:\n"
+        "- Call the dispatch tool with a string of single-letter actions.\n"
+        "- U move up one floor, D move down one floor, O open the door to let "
+        "passengers off and on, C close the door.\n"
+        "- The door must be open to exchange passengers and closed to move.\n"
+        "- Each action takes one tick; invalid actions (wrong door state, "
+        "moving past the top/bottom floor) are penalized.\n\n"
+        f"Building:\n{building_to_text(building)}\n\nDispatch:"
+    )
+
+
+def format_xml_prompt(building: dict[str, Any]) -> str:
+    """Build the episode prompt for the XML no-tool agent."""
+
+    return (
+        "You are dispatching an elevator. Minimize passenger wait and deliver "
+        "everyone, never exceeding capacity.\n\n"
+        "Output format:\n"
+        "- Answer with exactly one XML tag such as <dispatch>UDOCUD</dispatch>.\n"
+        "- U move up, D move down, O open the door, C close the door.\n"
+        "- The door must be open to exchange passengers and closed to move.\n"
+        "- Each action takes one tick; invalid actions are penalized.\n\n"
+        f"Building:\n{building_to_text(building)}\n\nDispatch:"
+    )
+
+
+def parse_action_sequence(text: str) -> str:
+    """Return the final action sequence from a model response.
+
+    Strips reasoning spans and chat-template sentinels first, then takes the
+    last ``<dispatch>UDOC</dispatch>`` tag. Empty result means nothing parsed;
+    the reward function maps that to a failing score -- mirroring how the
+    other agentic examples parse without a raw-token fallback.
+    """
+
+    text = _CHAT_SPECIAL_RE.sub(" ", _THINK_RE.sub(" ", text)).strip()
+    matches = list(_XML_ACTIONS_RE.finditer(text))
+    return matches[-1].group(1).upper() if matches else ""
+
+
+def fresh_building(rng, *, floors: int = DEFAULT_FLOORS, capacity: int = DEFAULT_CAPACITY) -> dict[str, Any]:
+    """Return a new building with a couple of seeded starter passengers.
+
+    Uses random.Random directly so generation stays deterministic given a seed
+    and free of any heavy dependency.
+    """
+
+    if floors < 2:
+        raise ValueError("floors must be >= 2")
+    arrivals = []
+    for _ in range(2):
+        from_floor = rng.randrange(floors)
+        to_floor = rng.randrange(floors - 1)
+        if to_floor >= from_floor:
+            to_floor += 1  # keep from == to impossible
+        arrivals.append({"tick": 0, "from_floor": from_floor, "to_floor": to_floor})
+    return {
+        "floors": floors,
+        "capacity": capacity,
+        "arrivals": arrivals,
+        "car": {"floor": 0, "direction": "U", "door_open": False, "passengers": []},
+    }
+
+
+def fcfs_actions(building: dict[str, Any]) -> str:
+    """Build a first-come-first-served action string for a building.
+
+    Greedily drives the car to the lowest floor that has waiting passengers or
+    the lowest destination of an aboard passenger, opens to exchange, closes,
+    and repeats. Routing every move through :func:`step` keeps the tick and
+    event-queue advancement identical to :func:`play`, so a FCFS string replays
+    cleanly. Side-effect free -- only reads ``building``.
+    """
+
+    state = clone_state(normalize_building(building))
+    actions: list[str] = []
+    stats = {"delivered": 0, "total_wait": 0, "max_wait": 0}
+    guard = state["floors"] * 8 + 120
+    while not is_terminal(state) and len(actions) < guard:
+        if state["car"]["door_open"]:
+            actions.append("C")
+            step(state, "C", stats)
+            continue
+        # Land any arrivals already due so target selection sees them.
+        advance_events(state, state["tick"])
+        target = _fcfs_target(state)
+        if target is None:
+            # Nothing ready yet; coast one tick in the car's direction to keep
+            # the clock advancing and land future arrivals.
+            if not state["arrivals"] and not state["car"]["passengers"]:
+                break
+            coast = _coast(state)
+            if coast is not None:
+                actions.append(coast)
+                step(state, coast, stats)
+            continue
+        if state["car"]["floor"] == target:
+            actions.append("O")
+            step(state, "O", stats)
+            continue
+        action = "U" if target > state["car"]["floor"] else "D"
+        actions.append(action)
+        step(state, action, stats)
+    return "".join(actions)
+
+
+def _coast(state: dict[str, Any]) -> str | None:
+    """Pick a valid idle action when only future arrivals remain.
+
+    Keeps the car moving in its current direction without running past an edge;
+    returns None if no legal coasting move exists (car pinned at an edge), so the
+    caller can drive the clock another way.
+    """
+
+    if state["car"]["door_open"]:
+        return "C"
+    floor = state["car"]["floor"]
+    direction = state["car"]["direction"] or "U"
+    if direction == "U" and floor + 1 < state["floors"]:
+        return "U"
+    if direction == "D" and floor - 1 >= 0:
+        return "D"
+    # Flip direction and try again.
+    if floor + 1 < state["floors"]:
+        state["car"]["direction"] = "U"
+        return "U"
+    if floor - 1 >= 0:
+        state["car"]["direction"] = "D"
+        return "D"
+    return None
+
+
+def _fcfs_target(state: dict[str, Any]) -> int | None:
+    """Pick the lowest floor worth stopping at for FCFS dispatch.
+
+    Deliver aboard passengers first (their drop-off floor), because a full car
+    cannot board anyone; once the car is empty, pick up the lowest waiting hall
+    passenger. This keeps the policy first-come-first-served while respecting
+    capacity.
+    """
+
+    aboard = state["car"]["passengers"]
+    if aboard:
+        return min(p["to_floor"] for p in aboard)
+    floors = state["floors"]
+    for floor in range(floors):
+        if state["hall_queues"][floor]:
+            return floor
+    return None

--- a/examples/agentic/elevator/reward.py
+++ b/examples/agentic/elevator/reward.py
@@ -1,0 +1,83 @@
+"""Reward function for the elevator-dispatch tool-call example.
+
+The reward function replays the model's action string with :func:`game.play`,
+returns a scalar shaped by delivered passengers, mean wait, and invalid-action
+rate, and writes the full metric dict onto ``source_record["metrics"]`` so
+downstream metrics and tests can assert the emitted fields.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DELIVERED_VALUE = 1.0
+WAIT_WEIGHT = 0.01
+INVALID_PENALTY = 0.1
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by replaying its ``dispatch`` action string."""
+
+    source = record.source_record
+    building = game.normalize_building(source["building"])
+    actions = _tool_actions(record)
+    metrics = _play(building, actions, source)
+    source["metrics"] = metrics
+    return _scalar_reward(metrics, actions)
+
+
+def _play(building: dict[str, Any], actions: str, source: dict) -> dict:
+    max_steps = int(source.get("max_steps", game.DEFAULT_MAX_STEPS))
+    return game.play(building, actions, max_steps=max_steps)
+
+
+def _scalar_reward(metrics: dict, actions: str) -> float:
+    """Float reward shaped like delivered passengers minus wait and invalids.
+
+    Empty or unparseable action strings map to ``-1.0`` -- mirroring the other
+    agentic examples' failing-score convention -- and an episode that delivered
+    nobody scores below zero so a no-op policy cannot win.
+    """
+
+    if not actions:
+        return -1.0
+    delivered = float(metrics["delivered_passengers"])
+    wait_term = WAIT_WEIGHT * float(metrics["mean_wait"])
+    invalid_term = INVALID_PENALTY * float(metrics["invalid_rate"])
+    reward = DELIVERED_VALUE * delivered - wait_term - invalid_term
+    if delivered == 0:
+        return min(reward, -1.0)
+    return reward
+
+
+def _tool_actions(record: Any) -> str:
+    """Extract the final ``dispatch.actions`` string from a reward record."""
+
+    for call in record.tool_calls:
+        name = call.get("name") if isinstance(call, dict) else None
+        if name != "dispatch":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return ""
+        if isinstance(arguments, dict):
+            return _clean_actions(arguments.get("actions"))
+    # Fall back to a <dispatch> tag if the policy answered in text instead of a tool call.
+    completion = getattr(record, "completion", "") or ""
+    return game.parse_action_sequence(completion) if completion else ""
+
+
+def _clean_actions(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).upper()
+    return "".join(ch for ch in text if ch in game.ACTIONS)

--- a/examples/agentic/elevator/run_agent.py
+++ b/examples/agentic/elevator/run_agent.py
@@ -1,0 +1,92 @@
+"""Agent entrypoint for one-episode elevator-dispatch tool-call rollouts.
+
+The policy returns a full dispatch episode as a single ``dispatch`` tool call.
+The agent itself stays a thin model caller -- exactly like the Tic-Tac-Toe and
+2048 examples -- and AReno replays the actions deterministically in the reward
+function.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are an elevator dispatcher. Pick a sequence of single-letter actions to "
+    "deliver every passenger while minimizing wait. Call the dispatch tool with a "
+    "string of letters: U move up, D move down, O open the door to let passengers "
+    "off and on, C close the door. The door must be open to exchange passengers and "
+    "closed to move. Keep capacity; invalid actions are penalized."
+)
+
+DISPATCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "dispatch",
+        "description": "Submit a full elevator-dispatch episode as an ordered action sequence.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "actions": {
+                    "type": "string",
+                    "description": "Ordered actions, one letter each from U/D/O/C, e.g. 'OCUUOC'.",
+                    "pattern": "^[UDOC]+$",
+                }
+            },
+            "required": ["actions"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+async def run_agent(ctx, batch):
+    """Run one tool-call model request for each building."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The elevator agentic example requires `openai` and `httpx`. Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info("elevator agent start requests=%d max_running_prompts=%d", len(items), ctx.max_running_prompts)
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+
+    async def run_one(item):
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+        tool_choice = {"type": "function", "function": {"name": "dispatch"}}
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=messages,
+            tools=[DISPATCH_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        return AgentTrajectoryTurn(
+            item=item,
+            messages=messages,
+            response=response,
+            tools=[DISPATCH_TOOL],
+            tool_choice=tool_choice,
+        )
+
+    try:
+        return AgentTrajectory(turns=list(await asyncio.gather(*(run_one(item) for item in items))))
+    finally:
+        await client.close()

--- a/tests/test_agentic_elevator_example_cpu.py
+++ b/tests/test_agentic_elevator_example_cpu.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_module(name: str):
+    path = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "elevator" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"agentic_elevator_{name}_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _building(arrivals=None, *, floors=4, capacity=2, hall=None, car=None):
+    building = {
+        "floors": floors,
+        "capacity": capacity,
+        "arrivals": list(arrivals or []),
+        "car": {"floor": 0, "direction": "U", "door_open": False, "passengers": []},
+    }
+    if hall is not None:
+        building["hall_queues"] = hall
+    if car is not None:
+        building["car"] = car
+    return building
+
+
+def test_elevator_overload_prevention_respects_capacity():
+    game = _load_module("game")
+
+    # Five passengers wait at floor 0 with capacity 2: opening boards only two.
+    building = _building(
+        floors=4,
+        capacity=2,
+        hall={"0": [{"to_floor": 2}, {"to_floor": 2}, {"to_floor": 3}, {"to_floor": 1}, {"to_floor": 1}]},
+        arrivals=[],
+    )
+    state = game.clone_state(game.normalize_building(building))
+    stats = {"delivered": 0, "total_wait": 0, "max_wait": 0}
+    assert game.step(state, "O", stats) is True
+    assert len(state["car"]["passengers"]) == 2
+    assert len(state["hall_queues"][0]) == 3  # overload leaves the rest waiting
+
+
+def test_elevator_empty_door_operation_is_safe_and_counted():
+    game = _load_module("game")
+
+    # Opening on an empty floor is a legal but useless action; the door opens.
+    # The episode terminates immediately after the open (nothing left to do),
+    # so only the open is counted -- the close is skipped, never invalid.
+    empty = _building(floors=4, capacity=2, car={"floor": 1, "door_open": False, "passengers": []}, arrivals=[])
+    result = game.play(empty, "OC", max_steps=5)
+    assert result["n_steps"] == 1
+    assert result["n_invalid"] == 0
+    assert result["delivered_passengers"] == 0
+
+    # A separate door state-machine check: closing a closed door is invalid.
+    closed = _building(floors=4, capacity=2, car={"floor": 1, "door_open": False, "passengers": []}, arrivals=[])
+    state = game.clone_state(game.normalize_building(closed))
+    stats = {"delivered": 0, "total_wait": 0, "max_wait": 0}
+    assert game.step(state, "C", stats) is False  # door already closed
+
+
+def test_elevator_simultaneous_requests_are_handled():
+    game = _load_module("game")
+
+    # Two passengers arrive on tick 0 at different floors; FCFS delivers both.
+    building = _building(
+        floors=5,
+        capacity=2,
+        arrivals=[{"tick": 0, "from_floor": 0, "to_floor": 4}, {"tick": 0, "from_floor": 3, "to_floor": 1}],
+    )
+    actions = game.fcfs_actions(building)
+    result = game.play(building, actions, max_steps=60)
+    assert result["delivered_passengers"] == 2
+    assert result["remaining_passengers"] == 0
+    assert result["terminal"] is True
+
+
+def test_elevator_peak_traffic_runs_to_termination():
+    game = _load_module("game")
+
+    # A dense arrival schedule across many floors; FCFS clears it deterministically.
+    arrivals = [
+        {"tick": t, "from_floor": f, "to_floor": (f + 2) % 5}
+        for t, f in zip(range(0, 24, 2), [0, 2, 1, 3, 4, 0, 2, 1, 3, 4, 0, 1])
+    ]
+    building = _building(floors=5, capacity=3, arrivals=arrivals)
+    result = game.play(building, game.fcfs_actions(building), max_steps=400)
+    assert result["terminal"] is True
+    assert result["remaining_passengers"] == 0
+    assert result["delivered_passengers"] == len(arrivals)
+
+
+def test_elevator_termination_when_nothing_remains():
+    game = _load_module("game")
+
+    delivered = {"floors": 4, "capacity": 2, "arrivals": [], "car": {"floor": 0, "door_open": False, "passengers": []}}
+    state = game.normalize_building(delivered)
+    assert game.is_terminal(state) is True
+
+    pending = _building(arrivals=[{"tick": 0, "from_floor": 0, "to_floor": 2}])
+    state = game.normalize_building(pending)
+    assert game.is_terminal(state) is False
+
+
+def test_elevator_seeded_replay_is_deterministic():
+    game = _load_module("game")
+    import random
+
+    building = game.fresh_building(random.Random(2026))
+    sequence = "OCUUOCUDDOC"
+
+    first = game.play(building, sequence, max_steps=40)
+    second = game.play(building, sequence, max_steps=40)
+
+    def no_state(d):
+        return {k: v for k, v in d.items() if k != "state"}
+
+    assert no_state(first) == no_state(second)
+    assert first["state"] == second["state"]
+
+
+def test_elevator_normalize_rejects_malformed_buildings():
+    game = _load_module("game")
+
+    for bad in (
+        {"floors": 1, "capacity": 2, "arrivals": []},  # too few floors
+        {"floors": 4, "capacity": 0, "arrivals": []},  # no capacity
+        {"floors": 3, "capacity": 2, "arrivals": [{"tick": 0, "from_floor": 0, "to_floor": 0}]},  # self-arrival
+        {"floors": 3, "capacity": 2, "car": {"floor": 9}, "arrivals": []},  # car off-grid
+    ):
+        try:
+            game.normalize_building(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected ValueError for building {bad}")
+
+
+def test_elevator_reward_scores_dispatch_actions_and_writes_metrics():
+    reward = _load_module("reward")
+    game = _load_module("game")
+
+    building = _building(
+        floors=4, capacity=2, arrivals=[{"tick": 0, "from_floor": 0, "to_floor": 2}]
+    )
+    source = {"building": building, "max_steps": 60}
+
+    # A FCFS-style dispatch that delivers scores above zero and writes metrics.
+    good = SimpleNamespace(
+        source_record=dict(source),
+        completion="",
+        tool_calls=[{"name": "dispatch", "arguments": {"actions": game.fcfs_actions(building)}}],
+    )
+    good_reward = reward.reward_fn(good)
+    metrics = good.source_record["metrics"]
+    assert good_reward > 0.0
+    assert metrics["delivered_passengers"] >= 1
+    assert {"delivered_passengers", "mean_wait", "invalid_rate", "n_steps", "n_invalid", "terminal"} <= set(metrics)
+
+    # Empty tool calls map to the failing score.
+    empty = SimpleNamespace(source_record=dict(source), completion="", tool_calls=[])
+    assert reward.reward_fn(empty) == -1.0
+
+    # JSON-string arguments (the real OpenAI shape) parse correctly.
+    json_str = SimpleNamespace(
+        source_record=dict(source),
+        completion="",
+        tool_calls=[{"name": "dispatch", "arguments": '{"actions": "OCUUOC"}'}],
+    )
+    assert reward.reward_fn(json_str) >= -1.0
+
+    # Non-UDOC characters are stripped, not fatal.
+    cleaned = reward._clean_actions("U?O!xxC")  # noqa: SLF001
+    assert cleaned == "UOC"
+
+
+def test_elevator_generator_is_reproducible_and_valid():
+    generator = _load_module("dataset_generator")
+    game = _load_module("game")
+
+    first = generator.generate_records(8, seed=2026, arrivals_per_building=4)
+    second = generator.generate_records(8, seed=2026, arrivals_per_building=4)
+    assert first == second
+    for record in first:
+        # normalize must succeed; arrivals respect floors and from != to.
+        building = game.normalize_building(record)
+        for arrival in building["arrivals"]:
+            assert arrival["from_floor"] != arrival["to_floor"]
+
+
+def test_elevator_fcfs_baseline_beats_or_matches_random_idle():
+    """A pure no-op/idle policy must not outscoop FCFS: baseline metrics stay sane
+    and a FCFS dispatch at worst delivers the same passengers with finite wait."""
+
+    baseline = _load_module("baseline")
+    game = _load_module("game")
+
+    stats = baseline.fcfs_baseline(16, seed=2026, arrivals_per_building=4)
+    assert stats["count"] == 16.0
+    assert stats["mean_delivered"] >= 0.0
+    assert stats["mean_wait"] >= 0.0
+    assert 0.0 <= stats["mean_invalid_rate"] <= 1.0
+    # FCFS never emits an invalid action.
+    assert stats["mean_invalid_rate"] == 0.0
+
+    # Reproducible aggregation.
+    again = baseline.fcfs_baseline(16, seed=2026, arrivals_per_building=4)
+    assert stats == again


### PR DESCRIPTION
Implements a focused, self-contained elevator-dispatch agentic example for AReno (issue #195), modeled on the existing tic-tac-toe agentic recipe. The pure-Python engine simulates floors, car capacity, passenger arrivals, and a deterministic event queue; the policy returns one episode as a single `dispatch` tool call (U/D/O/C action string) and AReno replays it deterministically to score delivered passengers, mean wait, and invalid actions. A first-come-first-served (FCFS) baseline is included for trained-vs-baseline comparison.

Files:
- examples/agentic/elevator/{game,dataset_generator,dataset_loader, run_agent,reward,baseline}.py + README.md
- tests/test_agentic_elevator_example_cpu.py (CPU, deterministic, no network)
- docs/cookbook/elevator-dispatch-agentic-rl.rst + toctree entry

Reuses existing AReno agentic contracts (--agent-fn / --reward-fn-path / --dataset-loader-fn); no core, CLI, or pyproject changes. CPU tests cover overload prevention, empty door operations, simultaneous requests, peak traffic, termination, seeded replay, malformed input, reward/metrics, and FCFS comparison.

<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?

<!-- A clear and concise description of the change and its motivation. -->

## Related issue
Build an elevator-dispatch agentic RL demo
 #195

<!-- Link the issue this PR addresses so GitHub closes it on merge, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

<!-- Select ONE that best describes this PR. -->

- [ ] 🐛 Bug fix
- [✅] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?


<!-- Note the test commands you ran (e.g. `pytest tests/ -k cpu`) and any hardware limitations. New behavior must be covered by tests — no testing, no merge. -->

## Checklist

- [ ] The PR title summarizes the contribution.
- [ ] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [ ] New behavior is covered by tests.
- [ ] Described the test commands run and any hardware limitations.
- [ ] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Breaking change details

<!-- If this is a breaking change, describe what breaks and how users should migrate. Otherwise delete this section. -->
