### PR TITLE
feat(engine): 为模型加载各阶段添加进度与耗时日志(#230)

### DIFF
--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -49,6 +49,11 @@ from areno.engine.runtime.common import (
     split_list_by_dp,
 )
 from areno.engine.runtime.decode_graph import ceil_div
+from areno.engine.runtime.load_progress import (
+    ModelLoadTracker,
+    STAGE_CONFIG_TOKENIZER,
+    STAGE_REFERENCE_RESOLUTION,
+)
 from areno.engine.runtime.rollout import _build_rollout_from_rows, _merge_dp_rollouts_in_input_order, _merge_rollouts
 from areno.engine.worker import ArenoWorker
 from areno.models.registry import config_from_hf
@@ -197,12 +202,18 @@ class ArenoEngine:
 
         if model is None:
             raise ValueError("from_pretrained() requires a local model path or Hugging Face model id")
+        # The driver process is single-threaded here, so rank0=True avoids
+        # duplicate progress lines without consulting the TP context (which is
+        # not initialized until workers start).
+        tracker = ModelLoadTracker(rank0=True)
         # Resolve HF repo id or local dir to an on-disk checkpoint directory.
-        model_path = resolve_model_path(model)
+        with tracker.stage(STAGE_REFERENCE_RESOLUTION, detail=str(model)):
+            model_path = resolve_model_path(model)
         if model_path is None:
             raise ValueError(f"could not resolve model path: {model!r}")
         # Translate the HF config.json into the engine's internal model schema.
-        model_config = config_from_hf(model_path)
+        with tracker.stage(STAGE_CONFIG_TOKENIZER, detail=model_path):
+            model_config = config_from_hf(model_path)
         cfg = EngineConfig(
             model=model_config,
             model_path=model_path,

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -202,9 +202,8 @@ class ArenoEngine:
 
         if model is None:
             raise ValueError("from_pretrained() requires a local model path or Hugging Face model id")
-        # The driver process is single-threaded here, so rank0=True avoids
-        # duplicate progress lines without consulting the TP context (which is
-        # not initialized until workers start).
+        # driver 进程在这里是单线程的，所以 rank0=True 即可避免重复进度行，
+        # 无需查询 TP context（它要到 worker 启动后才初始化）。
         tracker = ModelLoadTracker(rank0=True)
         # Resolve HF repo id or local dir to an on-disk checkpoint directory.
         with tracker.stage(STAGE_REFERENCE_RESOLUTION, detail=str(model)):

--- a/areno/engine/roles.py
+++ b/areno/engine/roles.py
@@ -12,6 +12,12 @@ from areno.engine.optim import AdamW8bit, AdamWFP32Master
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.protocol import EnsureRolesPayload, ScorePayload, TrainValuesPayload
 from areno.engine.runtime.logprobs import next_token_logprobs
+from areno.engine.runtime.load_progress import (
+    ModelLoadTracker,
+    STAGE_CONFIG_TOKENIZER,
+    STAGE_DEVICE_PLACEMENT,
+    STAGE_WEIGHT_SHARD_READING,
+)
 from areno.engine.runtime.train_step import _dense_train_meta
 from areno.models.registry import config_from_hf, load_model_weights
 
@@ -181,7 +187,10 @@ class WorkerRole:
     ) -> WorkerRole:
         """Construct a role from a HF-style checkpoint at `path`."""
 
-        model_config = config_from_hf(path)
+        # Rank 0 reports role-loading progress; other ranks stay silent (#230).
+        tracker = ModelLoadTracker(rank0=get_tp_context().rank == 0)
+        with tracker.stage(STAGE_CONFIG_TOKENIZER, detail=path):
+            model_config = config_from_hf(path)
         role_config = EngineConfig(
             model=model_config,
             model_path=path,
@@ -193,9 +202,11 @@ class WorkerRole:
             devices=devices,
             dummy_load=False,
         )
-        model = build_model_on_device(role_config, device)
+        with tracker.stage(STAGE_DEVICE_PLACEMENT, detail=str(device)):
+            model = build_model_on_device(role_config, device)
         if source_model is None:
-            load_model_weights(model, model_config, path)
+            with tracker.stage(STAGE_WEIGHT_SHARD_READING, detail=path):
+                load_model_weights(model, model_config, path)
         else:
             model.load_state_dict(unwrap_model(source_model).state_dict())
         checkpoint_head_out = _maybe_reward_head_out_features(path) if critic else None

--- a/areno/engine/roles.py
+++ b/areno/engine/roles.py
@@ -187,7 +187,7 @@ class WorkerRole:
     ) -> WorkerRole:
         """Construct a role from a HF-style checkpoint at `path`."""
 
-        # Rank 0 reports role-loading progress; other ranks stay silent (#230).
+        # rank 0 上报角色加载进度，其他 rank 保持静默（#230）。
         tracker = ModelLoadTracker(rank0=get_tp_context().rank == 0)
         with tracker.stage(STAGE_CONFIG_TOKENIZER, detail=path):
             model_config = config_from_hf(path)

--- a/areno/engine/runtime/load_progress.py
+++ b/areno/engine/runtime/load_progress.py
@@ -1,15 +1,12 @@
-"""Bounded progress and timing for model-loading stages.
+"""模型加载各阶段的进度与耗时追踪。
 
-Issue #230: emit per-stage progress and elapsed time for the five model-loading
-stages (reference resolution, config/tokenizer load, weight shard reading,
-device placement, worker distribution). Output is human-readable and structured
-so non-interactive consumers can parse it; only rank 0 logs to avoid spam in
-multi-rank runs. The last completed stage is retained on failure so the caller
-can report which stage and input caused the problem.
+Issue #230：为模型加载的五个阶段（引用解析、配置/分词器加载、权重分片读取、
+设备放置、worker 分发）输出每个阶段的进度和耗时。输出既人类可读又结构化，
+方便非交互式消费者解析；仅在 rank 0 打印日志，避免多 rank 运行时刷屏。
+失败时保留最后完成的阶段，调用方可以据此定位是哪个阶段、哪个输入出了问题。
 
-The tracker is intentionally dependency-free: it uses ``time.perf_counter`` and
-the existing ``areno`` logger. It does not change any default behavior beyond
-adding INFO-level log lines, so backward compatibility is preserved.
+追踪器刻意不引入任何依赖：只用 ``time.perf_counter`` 和现有的 ``areno`` logger。
+除新增几行 INFO 级日志外，不改变任何默认行为，保持向后兼容。
 """
 
 from __future__ import annotations
@@ -21,8 +18,8 @@ from typing import Iterator
 
 logger = logging.getLogger("areno.engine.load_progress")
 
-# Fixed stage order lets callers and tests refer to stages by name without
-# importing arbitrary enums; the tracker records the last completed one.
+# 固定的阶段顺序，调用方和测试通过名字引用阶段，无需引入额外枚举；
+# 追踪器会记录最后一个完成的阶段。
 STAGE_REFERENCE_RESOLUTION = "reference_resolution"
 STAGE_CONFIG_TOKENIZER = "config_tokenizer_load"
 STAGE_WEIGHT_SHARD_READING = "weight_shard_reading"
@@ -31,12 +28,11 @@ STAGE_WORKER_DISTRIBUTION = "worker_distribution"
 
 
 class ModelLoadTracker:
-    """Record per-stage timing and emit bounded progress lines on rank 0.
+    """记录每个阶段的耗时，并在 rank 0 输出有界的进度日志。
 
-    ``rank0`` gates logging so only one process prints in distributed runs;
-    callers pass ``get_tp_context().rank == 0``. The tracker keeps
-    ``last_completed_stage`` so a failing run can surface which stage and input
-    caused the problem without re-running.
+    ``rank0`` 门控日志输出，分布式运行时只有一个进程打印；
+    调用方传入 ``get_tp_context().rank == 0``。追踪器维护
+    ``last_completed_stage``，失败时无需重跑即可定位是哪个阶段、哪个输入出问题。
     """
 
     def __init__(self, *, rank0: bool = True):
@@ -46,12 +42,11 @@ class ModelLoadTracker:
 
     @contextmanager
     def stage(self, name: str, *, detail: str | None = None) -> Iterator[None]:
-        """Time one loading stage and log start/done lines on rank 0.
+        """为一个加载阶段计时，并在 rank 0 输出 start/done 日志。
 
-        On exit (success or exception) the elapsed time is logged and
-        ``last_completed_stage`` is updated. Exceptions are re-raised unchanged
-        after a structured ``status=failed`` line is emitted, so the original
-        error is never hidden.
+        退出时（成功或异常）记录耗时并更新 ``last_completed_stage``。
+        异常在输出结构化的 ``status=failed`` 行后被原样 re-raise，
+        不会隐藏原始错误。
         """
 
         if self._rank0:
@@ -82,11 +77,10 @@ class ModelLoadTracker:
             )
 
     def summary(self) -> dict[str, object]:
-        """Return a structured snapshot for non-interactive consumers.
+        """返回结构化快照，供非交互式消费者使用。
 
-        Includes the last completed stage and total elapsed time since the
-        tracker was constructed, so the dashboard or CLI can surface a single
-        record without parsing log lines.
+        包含最后完成的阶段和追踪器构造以来的总耗时，
+        这样 dashboard 或 CLI 无需解析日志行即可展示一条记录。
         """
 
         return {
@@ -97,10 +91,10 @@ class ModelLoadTracker:
 
 @contextmanager
 def tracked_stage(tracker: ModelLoadTracker | None, name: str, *, detail: str | None = None) -> Iterator[None]:
-    """Time ``name`` on ``tracker`` when present, otherwise run untracked.
+    """当 ``tracker`` 存在时为 ``name`` 计时，否则不追踪直接运行。
 
-    Lets call sites keep a single line when tracking is optional (for example
-    inside registry helpers that may be called outside a tracked load flow).
+    让调用点在追踪可选时保持单行写法（例如在可能在追踪加载流程之外
+    被调用的 registry 辅助函数里）。
     """
 
     if tracker is None:

--- a/areno/engine/runtime/load_progress.py
+++ b/areno/engine/runtime/load_progress.py
@@ -1,0 +1,110 @@
+"""Bounded progress and timing for model-loading stages.
+
+Issue #230: emit per-stage progress and elapsed time for the five model-loading
+stages (reference resolution, config/tokenizer load, weight shard reading,
+device placement, worker distribution). Output is human-readable and structured
+so non-interactive consumers can parse it; only rank 0 logs to avoid spam in
+multi-rank runs. The last completed stage is retained on failure so the caller
+can report which stage and input caused the problem.
+
+The tracker is intentionally dependency-free: it uses ``time.perf_counter`` and
+the existing ``areno`` logger. It does not change any default behavior beyond
+adding INFO-level log lines, so backward compatibility is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+logger = logging.getLogger("areno.engine.load_progress")
+
+# Fixed stage order lets callers and tests refer to stages by name without
+# importing arbitrary enums; the tracker records the last completed one.
+STAGE_REFERENCE_RESOLUTION = "reference_resolution"
+STAGE_CONFIG_TOKENIZER = "config_tokenizer_load"
+STAGE_WEIGHT_SHARD_READING = "weight_shard_reading"
+STAGE_DEVICE_PLACEMENT = "device_placement"
+STAGE_WORKER_DISTRIBUTION = "worker_distribution"
+
+
+class ModelLoadTracker:
+    """Record per-stage timing and emit bounded progress lines on rank 0.
+
+    ``rank0`` gates logging so only one process prints in distributed runs;
+    callers pass ``get_tp_context().rank == 0``. The tracker keeps
+    ``last_completed_stage`` so a failing run can surface which stage and input
+    caused the problem without re-running.
+    """
+
+    def __init__(self, *, rank0: bool = True):
+        self._rank0 = bool(rank0)
+        self.last_completed_stage: str | None = None
+        self.start_time: float = time.perf_counter()
+
+    @contextmanager
+    def stage(self, name: str, *, detail: str | None = None) -> Iterator[None]:
+        """Time one loading stage and log start/done lines on rank 0.
+
+        On exit (success or exception) the elapsed time is logged and
+        ``last_completed_stage`` is updated. Exceptions are re-raised unchanged
+        after a structured ``status=failed`` line is emitted, so the original
+        error is never hidden.
+        """
+
+        if self._rank0:
+            prefix = f"model_load stage={name}"
+            if detail:
+                logger.info("%s status=start detail=%s", prefix, detail)
+            else:
+                logger.info("%s status=start", prefix)
+        begin = time.perf_counter()
+        try:
+            yield
+        except BaseException:
+            elapsed = time.perf_counter() - begin
+            if self._rank0:
+                logger.info(
+                    "model_load stage=%s status=failed elapsed=%.3fs",
+                    name,
+                    elapsed,
+                )
+            raise
+        elapsed = time.perf_counter() - begin
+        self.last_completed_stage = name
+        if self._rank0:
+            logger.info(
+                "model_load stage=%s status=done elapsed=%.3fs",
+                name,
+                elapsed,
+            )
+
+    def summary(self) -> dict[str, object]:
+        """Return a structured snapshot for non-interactive consumers.
+
+        Includes the last completed stage and total elapsed time since the
+        tracker was constructed, so the dashboard or CLI can surface a single
+        record without parsing log lines.
+        """
+
+        return {
+            "last_completed_stage": self.last_completed_stage,
+            "total_elapsed_s": time.perf_counter() - self.start_time,
+        }
+
+
+@contextmanager
+def tracked_stage(tracker: ModelLoadTracker | None, name: str, *, detail: str | None = None) -> Iterator[None]:
+    """Time ``name`` on ``tracker`` when present, otherwise run untracked.
+
+    Lets call sites keep a single line when tracking is optional (for example
+    inside registry helpers that may be called outside a tracked load flow).
+    """
+
+    if tracker is None:
+        yield
+        return
+    with tracker.stage(name, detail=detail):
+        yield

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -61,8 +61,8 @@ class ArenoWorker:
         self.config = config
         ctx = get_tp_context()
         self.device = ctx.device
-        # Rank 0 emits per-stage load progress; other ranks stay silent to
-        # avoid duplicate lines across the TP group (issue #230).
+        # rank 0 输出各阶段加载进度，其他 rank 保持静默，
+        # 避免 TP 组内重复打印（issue #230）。
         load_tracker = ModelLoadTracker(rank0=ctx.rank == 0)
         # Build the actor model directly on the shard's device, then wrap in
         # torch.compile so subsequent forward calls use the compiled graph.

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -37,6 +37,12 @@ from areno.engine.protocol import (
 from areno.engine.roles import RoleManager, WorkerRole
 from areno.engine.runtime.common import pad_rollout_rows
 from areno.engine.runtime.decode_graph import DecodeGraph
+from areno.engine.runtime.load_progress import (
+    ModelLoadTracker,
+    STAGE_DEVICE_PLACEMENT,
+    STAGE_WEIGHT_SHARD_READING,
+    STAGE_WORKER_DISTRIBUTION,
+)
 from areno.engine.runtime.rollout import _empty_rollout
 from areno.engine.training import TrainingManager
 from areno.models.registry import load_model_weights, save_model_weights
@@ -55,11 +61,16 @@ class ArenoWorker:
         self.config = config
         ctx = get_tp_context()
         self.device = ctx.device
+        # Rank 0 emits per-stage load progress; other ranks stay silent to
+        # avoid duplicate lines across the TP group (issue #230).
+        load_tracker = ModelLoadTracker(rank0=ctx.rank == 0)
         # Build the actor model directly on the shard's device, then wrap in
         # torch.compile so subsequent forward calls use the compiled graph.
-        self.model = build_model_on_device(config, self.device)
+        with load_tracker.stage(STAGE_DEVICE_PLACEMENT, detail=str(self.device)):
+            self.model = build_model_on_device(config, self.device)
         if config.model_path is not None and not config.dummy_load:
-            load_model_weights(self.model, config.model, config.model_path)
+            with load_tracker.stage(STAGE_WEIGHT_SHARD_READING, detail=config.model_path):
+                load_model_weights(self.model, config.model, config.model_path)
         if config.runtime.compile_model:
             self.model = torch.compile(self.model)
         opt = config.optimizer
@@ -88,9 +99,10 @@ class ArenoWorker:
         self._train_state_ready = False
         self._actor_on_device = True
         self._current_request_ids: list[int | None] = []
-        self.inference = InferenceManager(self)
-        self.roles = RoleManager(self)
-        self.training = TrainingManager(self)
+        with load_tracker.stage(STAGE_WORKER_DISTRIBUTION):
+            self.inference = InferenceManager(self)
+            self.roles = RoleManager(self)
+            self.training = TrainingManager(self)
         if config.train_loss_fn is None:
             raise ValueError("ArenoEngine requires train_loss_fn")
         self.loss_fn = config.train_loss_fn

--- a/tests/test_load_flow_cpu.py
+++ b/tests/test_load_flow_cpu.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import unittest
+
+from areno.engine.runtime.load_progress import (
+    ModelLoadTracker,
+    STAGE_CONFIG_TOKENIZER,
+    STAGE_DEVICE_PLACEMENT,
+    STAGE_REFERENCE_RESOLUTION,
+    STAGE_WEIGHT_SHARD_READING,
+    STAGE_WORKER_DISTRIBUTION,
+)
+
+
+def _fake_resolve(model_ref: str) -> str:
+    """Stand-in for resolve_model_path; returns a fake local path."""
+
+    return f"/cache/{model_ref.split('/')[-1].lower()}"
+
+
+def _fake_config(path: str) -> dict:
+    """Stand-in for config_from_hf; returns a minimal config dict."""
+
+    return {"model_type": "fake", "path": path, "hidden_size": 8}
+
+
+def _fake_build(config: dict) -> dict:
+    """Stand-in for build_model_on_device; returns a fake model object."""
+
+    return {"config": config, "params": []}
+
+
+def _fake_load_weights(model: dict, path: str) -> None:
+    """Stand-in for load_model_weights; mutates the fake model in place."""
+
+    model["loaded_from"] = path
+
+
+class TrackedLoadFlowTest(unittest.TestCase):
+    """Integration-style test: drive a fake 5-stage load flow with the tracker.
+
+    Mirrors the call sequence in ArenoEngine.from_pretrained + ArenoWorker.__init__
+    without importing torch, so it runs in any CPU environment. Asserts the
+    tracker records each stage in order and surfaces the failing stage on error.
+    """
+
+    def _run_load(self, tracker: ModelLoadTracker, model_ref: str) -> dict:
+        """Drive the five stages with the tracker, returning the fake model."""
+
+        with tracker.stage(STAGE_REFERENCE_RESOLUTION, detail=model_ref):
+            path = _fake_resolve(model_ref)
+        with tracker.stage(STAGE_CONFIG_TOKENIZER, detail=path):
+            config = _fake_config(path)
+        with tracker.stage(STAGE_DEVICE_PLACEMENT, detail="cpu"):
+            model = _fake_build(config)
+        with tracker.stage(STAGE_WEIGHT_SHARD_READING, detail=path):
+            _fake_load_weights(model, path)
+        with tracker.stage(STAGE_WORKER_DISTRIBUTION):
+            model["distributed"] = True
+        return model
+
+    def test_full_flow_completes_all_stages_in_order(self):
+        tracker = ModelLoadTracker(rank0=False)
+        model = self._run_load(tracker, "Qwen/Qwen3.5-0.8B")
+
+        self.assertEqual(model["loaded_from"], "/cache/qwen3.5-0.8b")
+        self.assertTrue(model["distributed"])
+        self.assertEqual(tracker.last_completed_stage, STAGE_WORKER_DISTRIBUTION)
+
+    def test_failure_in_weight_stage_keeps_prior_completed_stage(self):
+        tracker = ModelLoadTracker(rank0=False)
+
+        with self.assertRaises(KeyError):
+            with tracker.stage(STAGE_REFERENCE_RESOLUTION):
+                path = _fake_resolve("Qwen/Qwen3.5-0.8B")
+            with tracker.stage(STAGE_CONFIG_TOKENIZER):
+                config = _fake_config(path)
+            with tracker.stage(STAGE_DEVICE_PLACEMENT):
+                model = _fake_build(config)
+            with tracker.stage(STAGE_WEIGHT_SHARD_READING):
+                raise KeyError("missing weight shard")
+            # Later stages never run.
+
+        # device_placement completed; weight_shard_reading did not.
+        self.assertEqual(tracker.last_completed_stage, STAGE_DEVICE_PLACEMENT)
+
+    def test_failure_surfaces_failing_stage_not_completed(self):
+        tracker = ModelLoadTracker(rank0=False)
+
+        with self.assertRaises(ValueError):
+            with tracker.stage(STAGE_REFERENCE_RESOLUTION):
+                _fake_resolve("Qwen/Qwen3.5-0.8B")
+            with tracker.stage(STAGE_CONFIG_TOKENIZER):
+                raise ValueError("malformed config.json")
+
+        # reference_resolution completed; config_tokenizer_load did not, so the
+        # tracker points at the last *completed* stage, not the failing one.
+        self.assertEqual(tracker.last_completed_stage, STAGE_REFERENCE_RESOLUTION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_load_progress_cpu.py
+++ b/tests/test_load_progress_cpu.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+import unittest
+
+from areno.engine.runtime.load_progress import (
+    ModelLoadTracker,
+    STAGE_CONFIG_TOKENIZER,
+    STAGE_REFERENCE_RESOLUTION,
+)
+
+
+class ModelLoadTrackerTest(unittest.TestCase):
+    """CPU-only tests for the model-loading progress tracker."""
+
+    def _capture_logs(self, logger_name: str) -> list[str]:
+        """Attach a list-collecting handler to ``logger_name`` and return it."""
+
+        records: list[str] = []
+
+        class _ListHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
+
+        handler = _ListHandler(level=logging.DEBUG)
+        logger = logging.getLogger(logger_name)
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        self.addCleanup(logger.removeHandler, handler)
+        return records
+
+    def test_rank0_emits_start_and_done_lines(self):
+        tracker = ModelLoadTracker(rank0=True)
+        logs = self._capture_logs("areno.engine.load_progress")
+
+        with tracker.stage(STAGE_REFERENCE_RESOLUTION, detail="Qwen/Qwen3.5-0.8B"):
+            pass
+
+        self.assertTrue(any("status=start" in m and "reference_resolution" in m for m in logs))
+        self.assertTrue(any("status=done" in m and "reference_resolution" in m for m in logs))
+        self.assertEqual(tracker.last_completed_stage, STAGE_REFERENCE_RESOLUTION)
+
+    def test_non_rank0_is_silent_but_still_tracks(self):
+        tracker = ModelLoadTracker(rank0=False)
+        logs = self._capture_logs("areno.engine.load_progress")
+
+        with tracker.stage(STAGE_CONFIG_TOKENIZER):
+            pass
+
+        self.assertEqual(logs, [])
+        # Stage is still recorded for structured consumers even when silent.
+        self.assertEqual(tracker.last_completed_stage, STAGE_CONFIG_TOKENIZER)
+
+    def test_failure_emits_failed_line_and_reraises(self):
+        tracker = ModelLoadTracker(rank0=True)
+        logs = self._capture_logs("areno.engine.load_progress")
+
+        with self.assertRaises(RuntimeError):
+            with tracker.stage(STAGE_CONFIG_TOKENIZER):
+                raise RuntimeError("boom")
+
+        self.assertTrue(any("status=failed" in m and "config_tokenizer_load" in m for m in logs))
+        # The failing stage is NOT marked completed.
+        self.assertIsNone(tracker.last_completed_stage)
+
+    def test_last_completed_stage_updates_across_stages(self):
+        tracker = ModelLoadTracker(rank0=True)
+
+        with tracker.stage(STAGE_REFERENCE_RESOLUTION):
+            pass
+        self.assertEqual(tracker.last_completed_stage, STAGE_REFERENCE_RESOLUTION)
+
+        with tracker.stage(STAGE_CONFIG_TOKENIZER):
+            pass
+        self.assertEqual(tracker.last_completed_stage, STAGE_CONFIG_TOKENIZER)
+
+    def test_summary_returns_structured_snapshot(self):
+        tracker = ModelLoadTracker(rank0=True)
+        with tracker.stage(STAGE_REFERENCE_RESOLUTION):
+            pass
+
+        snapshot = tracker.summary()
+        self.assertEqual(snapshot["last_completed_stage"], STAGE_REFERENCE_RESOLUTION)
+        self.assertIsInstance(snapshot["total_elapsed_s"], float)
+        self.assertGreaterEqual(snapshot["total_elapsed_s"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

关闭 #230。

为 issue 中定义的五个模型加载阶段添加有界的进度和耗时日志：引用解析（reference resolution）、配置/分词器加载（config/tokenizer load）、权重分片读取（weight shard reading）、设备放置（device placement）、worker 分发（worker distribution）。

- 在 `areno/engine/runtime/load_progress.py` 中新增 `ModelLoadTracker`，通过上下文管理器为每个阶段计时，仅在 rank 0 输出 `start`/`done`/`failed` 日志行，并保留最后完成的阶段，以便失败时能定位是哪个阶段、哪个输入出了问题。
- 包裹 `api.py`（`from_pretrained`）、`worker.py`（`__init__`）、`roles.py`（`WorkerRole.from_pretrained`）中已有的加载调用点，不改变任何默认行为、CLI 接口或配置 dataclass。
- 保留现有的 safetensors `tqdm` 进度条；新的追踪器在其之上补充阶段级耗时统计。
- 不引入新依赖；仅使用 `time.perf_counter` 和现有的 `areno` logger。

## 输出示例（rank 0）

```
model_load stage=reference_resolution status=start detail=Qwen/Qwen3.5-0.8B
model_load stage=reference_resolution status=done elapsed=12.345s
model_load stage=config_tokenizer_load status=start detail=/cache/qwen3.5-0.8b
model_load stage=config_tokenizer_load status=done elapsed=0.012s
model_load stage=device_placement status=start detail=cuda:0
model_load stage=device_placement status=done elapsed=1.234s
model_load stage=weight_shard_reading status=start detail=/cache/qwen3.5-0.8b
loading checkpoint: 100%|...| 200/200
model_load stage=weight_shard_reading status=done elapsed=8.456s
model_load stage=worker_distribution status=start
model_load stage=worker_distribution status=done elapsed=0.345s
```

失败时会输出 `status=failed` 行，`last_completed_stage` 指向最后一个完成的阶段，这样无需重跑即可识别出失败的阶段及其输入。

## 验收标准对照

- [x] 覆盖本地和缓存 hub 路径（reference resolution 阶段包裹了 `resolve_model_path`）
- [x] 避免 rank 日志刷屏（worker/roles 用 `ctx.rank == 0` 门控；driver 用单进程 `rank0=True`）
- [x] 失败时保留最后完成的阶段（`last_completed_stage` + `status=failed`）
- [x] 为非交互式消费者提供结构化事件（`summary()` dict + 可解析的 `key=value` 日志行）
- [x] 使用 AReno 现有契约；不引入外部数据库或强制沙箱
- [x] 默认行为向后兼容（仅 INFO 级日志，不改动 CLI/配置）
- [x] 聚焦的 CPU 测试覆盖成功、非法输入和一种边界/失败路径

## 测试计划

- [x] `tests/test_load_progress_cpu.py` —— 5 个测试：rank0 日志、非 rank0 静默、失败重抛、阶段顺序、结构化 summary
- [x] `tests/test_load_flow_cpu.py` —— 3 个测试：完整五阶段流程、weight 阶段失败保留前序阶段、config 阶段失败定位失败阶段
- [ ] 在有 torch 的环境中跑完整 `pytest tests/ -k cpu`（本地未跑；本机无 torch）