### PR TITLE
feat: add configurable dataset field mapping and sample filtering (#201)

### DIFF
--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -168,20 +168,20 @@ def check_sample_filter(
             return False, f"empty field: {fname}"
 
     min_prompt = filter_config.get("min_prompt_chars")
-    if min_prompt is not None:
-        prompt_val = record.get("prompt", "")
+    if min_prompt is not None and "prompt" in record:
+        prompt_val = record["prompt"]
         if isinstance(prompt_val, str) and len(prompt_val) < min_prompt:
             return False, f"prompt too short ({len(prompt_val)} < {min_prompt})"
 
     max_prompt = filter_config.get("max_prompt_chars")
-    if max_prompt is not None:
-        prompt_val = record.get("prompt", "")
+    if max_prompt is not None and "prompt" in record:
+        prompt_val = record["prompt"]
         if isinstance(prompt_val, str) and len(prompt_val) > max_prompt:
             return False, f"prompt too long ({len(prompt_val)} > {max_prompt})"
 
     min_response = filter_config.get("min_response_chars")
-    if min_response is not None:
-        resp_val = record.get("response", "")
+    if min_response is not None and "response" in record:
+        resp_val = record["response"]
         if isinstance(resp_val, str) and len(resp_val) < min_response:
             return False, f"response too short ({len(resp_val)} < {min_response})"
 

--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -1,10 +1,20 @@
-"""Dataset tokenization helpers shared by offline trainers."""
+"""Dataset tokenization helpers shared by offline trainers.
+
+This module also provides configurable dataset field mapping, constant-field
+injection, and sample filtering utilities used before AReno contract conversion.
+"""
 
 from __future__ import annotations
 
+import json
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from typing import Any
 
 from areno.api.tokenizer import apply_chat_template_with_options, encode_generation_prompt, normalize_token_ids
+
+logger = logging.getLogger(__name__)
 
 
 def apply_chat_template(tokenizer, messages: list[dict[str, Any]]) -> list[int]:
@@ -75,3 +85,168 @@ def first_value(record: dict[str, Any], keys: tuple[str, ...]):
         if isinstance(value, str | list):
             return value
     return None
+
+
+# ---------------------------------------------------------------------------
+# Configurable dataset field mapping, constant fields, and sample filtering.
+#
+# These utilities let users declaratively rename dataset fields, inject
+# constant fields, and filter samples by field presence or text length —
+# all before AReno's internal contract conversion.  When none of the
+# options are provided the dataset is returned unchanged so existing
+# behaviour is fully preserved.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FilterSummary:
+    """Aggregated keep/drop counts and per-reason breakdowns.
+
+    ``total_in`` is the number of records inspected; ``total_kept`` and
+    ``total_dropped`` reconcile to it.  ``drop_reasons`` maps a human-readable
+    reason string to the number of records dropped for that reason.
+    """
+
+    total_in: int = 0
+    total_kept: int = 0
+    total_dropped: int = 0
+    drop_reasons: dict[str, int] = field(default_factory=dict)
+
+    def as_log_lines(self) -> list[str]:
+        """Return human-readable summary lines for CLI / log output."""
+
+        lines = [
+            f"field-mapping: scanned={self.total_in} kept={self.total_kept} dropped={self.total_dropped}",
+        ]
+        for reason, count in sorted(self.drop_reasons.items()):
+            lines.append(f"  drop reason: {reason} ({count})")
+        return lines
+
+
+def apply_field_mapping(record: dict[str, Any], mapping: dict[str, str]) -> dict[str, Any]:
+    """Rename fields in *record* according to *mapping*.
+
+    For each ``{source: target}`` pair, if *source* is present and *target*
+    is not, the value is moved.  Fields that already have the *target* name
+    are left untouched so users can safely include identity mappings.
+    """
+
+    for source, target in mapping.items():
+        if source == target:
+            continue
+        if source in record and target not in record:
+            record[target] = record.pop(source)
+    return record
+
+
+def apply_constant_fields(record: dict[str, Any], constants: dict[str, Any]) -> dict[str, Any]:
+    """Inject constant key/value pairs into *record* without overwriting existing keys."""
+
+    for key, value in constants.items():
+        record.setdefault(key, value)
+    return record
+
+
+def check_sample_filter(
+    record: dict[str, Any], filter_config: dict[str, Any]
+) -> tuple[bool, str | None]:
+    """Return ``(keep, reason)`` for *record* against *filter_config*.
+
+    Supported keys in *filter_config*:
+    - ``require_fields``: list[str] — all must be present (and non-empty for strings)
+    - ``min_prompt_chars``: int — minimum character length of the ``prompt`` field
+    - ``max_prompt_chars``: int — maximum character length of the ``prompt`` field
+    - ``min_response_chars``: int — minimum character length of the ``response`` field
+    """
+
+    require_fields: list[str] = filter_config.get("require_fields", [])
+    for fname in require_fields:
+        if fname not in record:
+            return False, f"missing field: {fname}"
+        value = record[fname]
+        if isinstance(value, str) and not value:
+            return False, f"empty field: {fname}"
+
+    min_prompt = filter_config.get("min_prompt_chars")
+    if min_prompt is not None:
+        prompt_val = record.get("prompt", "")
+        if isinstance(prompt_val, str) and len(prompt_val) < min_prompt:
+            return False, f"prompt too short ({len(prompt_val)} < {min_prompt})"
+
+    max_prompt = filter_config.get("max_prompt_chars")
+    if max_prompt is not None:
+        prompt_val = record.get("prompt", "")
+        if isinstance(prompt_val, str) and len(prompt_val) > max_prompt:
+            return False, f"prompt too long ({len(prompt_val)} > {max_prompt})"
+
+    min_response = filter_config.get("min_response_chars")
+    if min_response is not None:
+        resp_val = record.get("response", "")
+        if isinstance(resp_val, str) and len(resp_val) < min_response:
+            return False, f"response too short ({len(resp_val)} < {min_response})"
+
+    return True, None
+
+
+def transform_dataset(
+    dataset: Sequence[dict[str, Any]],
+    *,
+    field_mapping: dict[str, str] | None = None,
+    constant_fields: dict[str, Any] | None = None,
+    sample_filter: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], FilterSummary]:
+    """Apply field mapping, constant injection, and filtering to a dataset.
+
+    Returns a tuple of ``(kept_records, summary)``.  When all options are
+    ``None`` the dataset is shallow-copied and returned unchanged with a
+    summary that reports every record as kept — this guarantees backward
+    compatibility when the feature is not used.
+
+    The input dataset is **not** mutated; each kept record is a shallow copy
+    so downstream code can freely modify it.
+    """
+
+    summary = FilterSummary(total_in=len(dataset))
+
+    if not field_mapping and not constant_fields and not sample_filter:
+        kept = [dict(record) for record in dataset]
+        summary.total_kept = len(kept)
+        return kept, summary
+
+    field_mapping = field_mapping or {}
+    constant_fields = constant_fields or {}
+    sample_filter = sample_filter or {}
+
+    kept: list[dict[str, Any]] = []
+    for record in dataset:
+        # Work on a copy so the original dataset is never mutated.
+        transformed = dict(record)
+
+        apply_field_mapping(transformed, field_mapping)
+        apply_constant_fields(transformed, constant_fields)
+
+        if sample_filter:
+            ok, reason = check_sample_filter(transformed, sample_filter)
+            if not ok:
+                summary.total_dropped += 1
+                summary.drop_reasons[reason] = summary.drop_reasons.get(reason, 0) + 1
+                continue
+
+        kept.append(transformed)
+
+    summary.total_kept = len(kept)
+    return kept, summary
+
+
+def parse_json_option(value: str | None, option_name: str) -> dict[str, Any] | None:
+    """Parse a CLI JSON-string option into a dict with a clear error on failure."""
+
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{option_name} is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{option_name} must be a JSON object, got {type(parsed).__name__}")
+    return parsed

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -12,6 +12,7 @@ critic warmup window.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from areno.api.defaults import DEFAULT_METRICS_LOG_DIR
 
@@ -60,6 +61,9 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     chat_template_enable_thinking: bool | None = None
+    field_mapping: dict[str, str] | None = None
+    constant_fields: dict[str, Any] | None = None
+    sample_filter: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 import click
 
 from areno.api.algorithms import get_algorithm
+from areno.api.data_utils import parse_json_option, transform_dataset
 from areno.api.defaults import DEFAULT_METRICS_LOG_DIR
 from areno.api.trainer_config import (
     DPOTrainerConfig,
@@ -59,6 +60,9 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "dataset_path",
             "model_hub",
             "dataset_loader_fn",
+            "field_mapping",
+            "constant_fields",
+            "sample_filter",
             "tune_params",
             "mem_frac",
             "tune_max_samples",
@@ -600,6 +604,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     args.model_hub = getattr(args, "model_hub", "modelscope")
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
+    field_mapping = parse_json_option(getattr(args, "field_mapping", None), "--field-mapping")
+    constant_fields = parse_json_option(getattr(args, "constant_fields", None), "--constant-fields")
+    sample_filter = parse_json_option(getattr(args, "sample_filter", None), "--sample-filter")
     if algorithm.name == "dpo":
         return DPOTrainerConfig(
             algo=algorithm.name,
@@ -607,6 +614,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             dataset_path=args.dataset_path,
             model_hub=args.model_hub,
             dataset_loader_fn=args.dataset_loader_fn,
+            field_mapping=field_mapping,
+            constant_fields=constant_fields,
+            sample_filter=sample_filter,
             save_path=args.save_path,
             save_interval=args.save_interval,
             epochs=args.epochs,
@@ -648,6 +658,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             dataset_path=args.dataset_path,
             model_hub=args.model_hub,
             dataset_loader_fn=args.dataset_loader_fn,
+            field_mapping=field_mapping,
+            constant_fields=constant_fields,
+            sample_filter=sample_filter,
             save_path=args.save_path,
             save_interval=args.save_interval,
             epochs=args.epochs,
@@ -687,6 +700,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             dataset_path=args.dataset_path,
             model_hub=args.model_hub,
             dataset_loader_fn=args.dataset_loader_fn,
+            field_mapping=field_mapping,
+            constant_fields=constant_fields,
+            sample_filter=sample_filter,
             reward_fn_path=args.reward_fn_path,
             save_path=args.save_path,
             save_interval=args.save_interval,
@@ -734,6 +750,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         dataset_path=args.dataset_path,
         model_hub=args.model_hub,
         dataset_loader_fn=args.dataset_loader_fn,
+        field_mapping=field_mapping,
+        constant_fields=constant_fields,
+        sample_filter=sample_filter,
         reward_fn_path=args.reward_fn_path,
         save_path=args.save_path,
         save_interval=args.save_interval,
@@ -822,6 +841,27 @@ def run(trainer_config: TrainerConfig):
         load_dataset=load_dataset,
         load_from_disk=load_from_disk,
     )
+    # Apply optional field mapping, constant-field injection, and sample
+    # filtering before the dataset enters the trainer.  When none of these
+    # options are configured the dataset is returned unchanged.
+    if (
+        trainer_config.field_mapping
+        or trainer_config.constant_fields
+        or trainer_config.sample_filter
+    ):
+        dataset, summary = transform_dataset(
+            dataset,
+            field_mapping=trainer_config.field_mapping,
+            constant_fields=trainer_config.constant_fields,
+            sample_filter=trainer_config.sample_filter,
+        )
+        for line in summary.as_log_lines():
+            click.echo(line)
+        if summary.total_kept == 0:
+            raise click.UsageError(
+                "All samples were filtered out. Check --field-mapping, "
+                "--constant-fields, and --sample-filter settings."
+            )
     trainer = build_trainer(trainer_config, instance=api_trainer, dataset=dataset, reward_fn=reward_fn, loss_fn=loss_fn)
     trainer.fit()
 
@@ -1176,6 +1216,24 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option(
     "--dataset-loader-fn", default=None, help="Optional Python dataset loader function as file.py or file.py:function."
+)
+@click.option(
+    "--field-mapping",
+    default=None,
+    help='JSON object mapping source field names to target names, e.g. \'{"question": "prompt", "answer": "response"}\'.',
+)
+@click.option(
+    "--constant-fields",
+    default=None,
+    help='JSON object of constant fields to inject into every record, e.g. \'{"task_type": "math"}\'.',
+)
+@click.option(
+    "--sample-filter",
+    default=None,
+    help=(
+        'JSON object for sample filtering, e.g. '
+        '\'{"require_fields": ["prompt", "response"], "min_prompt_chars": 5}\'.'
+    ),
 )
 @click.option("--reward-fn-path", default=None, help="Python file defining reward_fn(record).")
 @click.option(

--- a/docs/cli/dataset_loaders.rst
+++ b/docs/cli/dataset_loaders.rst
@@ -65,3 +65,48 @@ Agentic loaders also return ``prompt`` plus task metadata consumed by
 ``run_agent.py`` and ``reward.py``. Examples include
 ``examples/agentic/coding/dataset_loader.py`` and
 ``examples/agentic/shopping/dataset_loader.py``.
+
+Field mapping and sample filtering
+----------------------------------
+
+When a dataset uses non-standard field names (e.g. ``question`` instead of
+``prompt``), you can avoid writing a custom ``--dataset-loader-fn`` by using
+``--field-mapping``, ``--constant-fields``, and ``--sample-filter``. These
+options are applied **after** the loader runs and **before** the trainer
+sees the data.
+
+**``--field-mapping``** renames fields declaratively:
+
+.. code-block:: bash
+
+   areno train --algo sft \
+     --dataset-path my_data.jsonl \
+     --dataset-loader-fn examples/sft/alpaca/dataset_loader.py \
+     --field-mapping '{"question": "prompt", "answer": "response"}'
+
+**``--constant-fields``** injects fixed key/value pairs into every record
+without overwriting existing fields:
+
+.. code-block:: bash
+
+   --constant-fields '{"task_type": "math"}'
+
+**``--sample-filter``** drops records that do not meet the criteria:
+
+.. code-block:: bash
+
+   --sample-filter '{"require_fields": ["prompt", "response"], "min_prompt_chars": 5}'
+
+Supported filter keys:
+
+- ``require_fields`` (list[str]): all must be present and non-empty.
+- ``min_prompt_chars`` (int): minimum character length of ``prompt``.
+- ``max_prompt_chars`` (int): maximum character length of ``prompt``.
+- ``min_response_chars`` (int): minimum character length of ``response``.
+
+When any of these options is active, AReno prints a summary line showing
+how many records were scanned, kept, and dropped (with per-reason counts).
+No sample text is logged — only structural counts.
+
+**Backward compatibility:** when none of these options are provided, the
+dataset passes through unchanged. Existing commands behave identically.

--- a/tests/test_field_mapping_cpu.py
+++ b/tests/test_field_mapping_cpu.py
@@ -280,6 +280,37 @@ class TransformDatasetTest(unittest.TestCase):
         self.assertEqual(summary.total_dropped, 1)
         self.assertEqual(summary.total_kept, 0)
 
+    def test_summary_asserts_specific_field_values(self):
+        """Assert emitted summary fields — not just exit status."""
+        data = [
+            {"question": "valid question here", "answer": "valid answer"},
+            {"question": "ab", "answer": "cd"},         # too short
+            {"question": "ok", "answer": ""},            # empty answer after mapping
+        ]
+        kept, summary = transform_dataset(
+            data,
+            field_mapping={"question": "prompt", "answer": "response"},
+            sample_filter={"require_fields": ["prompt", "response"], "min_prompt_chars": 5},
+        )
+        # Assert exact counts reconcile.
+        self.assertEqual(summary.total_in, 3)
+        self.assertEqual(summary.total_kept, 1)
+        self.assertEqual(summary.total_dropped, 2)
+        # Assert specific drop reasons are present with correct counts.
+        self.assertIn("prompt too short (2 < 5)", summary.drop_reasons)
+        self.assertEqual(summary.drop_reasons["prompt too short (2 < 5)"], 1)
+        self.assertIn("empty field: response", summary.drop_reasons)
+        self.assertEqual(summary.drop_reasons["empty field: response"], 1)
+        # Assert the kept record has correct field names.
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(kept[0]["prompt"], "valid question here")
+        self.assertEqual(kept[0]["response"], "valid answer")
+        # Assert the summary log lines contain the expected counts.
+        lines = summary.as_log_lines()
+        self.assertTrue(any("scanned=3" in line for line in lines))
+        self.assertTrue(any("kept=1" in line for line in lines))
+        self.assertTrue(any("dropped=2" in line for line in lines))
+
 
 class JsonOptionParsingTest(unittest.TestCase):
     """Tests for ``parse_json_option`` — CLI JSON string parsing."""

--- a/tests/test_field_mapping_cpu.py
+++ b/tests/test_field_mapping_cpu.py
@@ -151,6 +151,23 @@ class SampleFilterTest(unittest.TestCase):
         keep, reason = check_sample_filter(record, {"max_prompt_chars": 50})
         self.assertTrue(keep)
 
+    def test_length_check_skipped_when_field_missing(self):
+        """When prompt field is absent, min/max length checks should not fire."""
+        record = {"other": "data"}
+        keep1, _ = check_sample_filter(record, {"min_prompt_chars": 5})
+        keep2, _ = check_sample_filter(record, {"max_prompt_chars": 5})
+        keep3, _ = check_sample_filter(record, {"min_response_chars": 5})
+        self.assertTrue(keep1)
+        self.assertTrue(keep2)
+        self.assertTrue(keep3)
+
+    def test_non_string_prompt_skips_length_check(self):
+        """A list-type prompt (chat messages) should skip text-length checks."""
+        record = {"prompt": [{"role": "user", "content": "hi"}]}
+        keep, reason = check_sample_filter(record, {"min_prompt_chars": 100})
+        self.assertTrue(keep)
+        self.assertIsNone(reason)
+
 
 class TransformDatasetTest(unittest.TestCase):
     """Integration tests for the full ``transform_dataset`` pipeline."""

--- a/tests/test_field_mapping_cpu.py
+++ b/tests/test_field_mapping_cpu.py
@@ -1,0 +1,375 @@
+"""CPU tests for configurable dataset field mapping and sample filtering.
+
+These tests cover the core logic in ``areno.api.data_utils`` for:
+- declarative field renaming (``apply_field_mapping``)
+- constant-field injection (``apply_constant_fields``)
+- sample filtering by field presence and text length (``check_sample_filter``)
+- the combined ``transform_dataset`` pipeline
+- JSON option parsing (``parse_json_option``)
+- backward compatibility when no options are provided
+
+All tests run on CPU without GPU, torch, or network access.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from areno.api.data_utils import (
+    FilterSummary,
+    apply_constant_fields,
+    apply_field_mapping,
+    check_sample_filter,
+    parse_json_option,
+    transform_dataset,
+)
+
+
+class FieldMappingTest(unittest.TestCase):
+    """Tests for ``apply_field_mapping`` — declarative field renaming."""
+
+    def test_renames_source_to_target(self):
+        """A source field present should move to the target name."""
+        record = {"question": "What is 1+1?", "answer": "2"}
+        result = apply_field_mapping(dict(record), {"question": "prompt", "answer": "response"})
+        self.assertIn("prompt", result)
+        self.assertIn("response", result)
+        self.assertNotIn("question", result)
+        self.assertNotIn("answer", result)
+        self.assertEqual(result["prompt"], "What is 1+1?")
+        self.assertEqual(result["response"], "2")
+
+    def test_does_not_overwrite_existing_target(self):
+        """If target already exists, source is left in place."""
+        record = {"question": "What?", "prompt": "Existing prompt"}
+        result = apply_field_mapping(dict(record), {"question": "prompt"})
+        self.assertEqual(result["prompt"], "Existing prompt")
+        self.assertIn("question", result)
+
+    def test_identity_mapping_is_noop(self):
+        """Mapping a field to itself should not move or duplicate."""
+        record = {"prompt": "hello"}
+        result = apply_field_mapping(dict(record), {"prompt": "prompt"})
+        self.assertEqual(result, record)
+
+    def test_missing_source_is_silently_skipped(self):
+        """If source is absent, nothing happens."""
+        record = {"prompt": "hello"}
+        result = apply_field_mapping(dict(record), {"question": "prompt"})
+        self.assertEqual(result, {"prompt": "hello"})
+
+    def test_preserves_unmapped_fields(self):
+        """Fields not mentioned in mapping should survive untouched."""
+        record = {"question": "Hi", "answer": "Hello", "metadata": {"id": 1}}
+        result = apply_field_mapping(dict(record), {"question": "prompt"})
+        self.assertIn("metadata", result)
+        self.assertEqual(result["metadata"], {"id": 1})
+
+
+class ConstantFieldsTest(unittest.TestCase):
+    """Tests for ``apply_constant_fields`` — inject fixed key/values."""
+
+    def test_injects_new_fields(self):
+        record = {"prompt": "hello"}
+        result = apply_constant_fields(dict(record), {"task_type": "math", "split": "train"})
+        self.assertEqual(result["task_type"], "math")
+        self.assertEqual(result["split"], "train")
+
+    def test_does_not_overwrite_existing(self):
+        record = {"prompt": "hello", "task_type": "logic"}
+        result = apply_constant_fields(dict(record), {"task_type": "math"})
+        self.assertEqual(result["task_type"], "logic")
+
+    def test_empty_constants_is_noop(self):
+        record = {"prompt": "hello"}
+        result = apply_constant_fields(dict(record), {})
+        self.assertEqual(result, record)
+
+
+class SampleFilterTest(unittest.TestCase):
+    """Tests for ``check_sample_filter`` — predicate-based record acceptance."""
+
+    def test_keeps_record_with_all_required_fields(self):
+        record = {"prompt": "hello", "response": "world"}
+        keep, reason = check_sample_filter(record, {"require_fields": ["prompt", "response"]})
+        self.assertTrue(keep)
+        self.assertIsNone(reason)
+
+    def test_drops_record_missing_required_field(self):
+        record = {"prompt": "hello"}
+        keep, reason = check_sample_filter(record, {"require_fields": ["prompt", "response"]})
+        self.assertFalse(keep)
+        self.assertIn("missing field: response", reason)
+
+    def test_drops_record_with_empty_required_field(self):
+        record = {"prompt": "hello", "response": ""}
+        keep, reason = check_sample_filter(record, {"require_fields": ["response"]})
+        self.assertFalse(keep)
+        self.assertIn("empty field: response", reason)
+
+    def test_min_prompt_chars_keeps_long_enough(self):
+        record = {"prompt": "a" * 10}
+        keep, reason = check_sample_filter(record, {"min_prompt_chars": 5})
+        self.assertTrue(keep)
+
+    def test_min_prompt_chars_drops_too_short(self):
+        record = {"prompt": "ab"}
+        keep, reason = check_sample_filter(record, {"min_prompt_chars": 5})
+        self.assertFalse(keep)
+        self.assertIn("prompt too short", reason)
+
+    def test_max_prompt_chars_drops_too_long(self):
+        record = {"prompt": "a" * 100}
+        keep, reason = check_sample_filter(record, {"max_prompt_chars": 50})
+        self.assertFalse(keep)
+        self.assertIn("prompt too long", reason)
+
+    def test_min_response_chars_drops_too_short(self):
+        record = {"prompt": "hello", "response": "x"}
+        keep, reason = check_sample_filter(record, {"min_response_chars": 5})
+        self.assertFalse(keep)
+        self.assertIn("response too short", reason)
+
+    def test_empty_filter_keeps_everything(self):
+        record = {"anything": 1}
+        keep, reason = check_sample_filter(record, {})
+        self.assertTrue(keep)
+        self.assertIsNone(reason)
+
+    def test_boundary_exact_min_length(self):
+        """A prompt exactly at the minimum length should be kept."""
+        record = {"prompt": "a" * 5}
+        keep, reason = check_sample_filter(record, {"min_prompt_chars": 5})
+        self.assertTrue(keep)
+
+    def test_boundary_exact_max_length(self):
+        """A prompt exactly at the maximum length should be kept."""
+        record = {"prompt": "a" * 50}
+        keep, reason = check_sample_filter(record, {"max_prompt_chars": 50})
+        self.assertTrue(keep)
+
+
+class TransformDatasetTest(unittest.TestCase):
+    """Integration tests for the full ``transform_dataset`` pipeline."""
+
+    def _fixture_a(self) -> list[dict]:
+        """Dataset using ``question``/``answer`` field names."""
+        return [
+            {"question": "What is 1+1?", "answer": "2"},
+            {"question": "Hi", "answer": "Hello"},
+            {"question": "ab", "answer": "cd"},
+        ]
+
+    def _fixture_b(self) -> list[dict]:
+        """Dataset using ``query``/``response`` field names."""
+        return [
+            {"query": "Explain gravity", "response": "It attracts mass"},
+            {"query": "x", "response": "y"},
+        ]
+
+    def test_two_datasets_converge_to_same_contract(self):
+        """Both fixtures should produce ``prompt``/``response`` after mapping."""
+        mapping_a = {"question": "prompt", "answer": "response"}
+        mapping_b = {"query": "prompt"}
+
+        kept_a, summary_a = transform_dataset(self._fixture_a(), field_mapping=mapping_a)
+        kept_b, summary_b = transform_dataset(self._fixture_b(), field_mapping=mapping_b)
+
+        for record in kept_a + kept_b:
+            self.assertIn("prompt", record)
+            self.assertIn("response", record)
+
+    def test_deterministic_filtering(self):
+        """Same input + same config should always produce same output."""
+        mapping = {"question": "prompt", "answer": "response"}
+        filt = {"min_prompt_chars": 3}
+
+        kept1, summary1 = transform_dataset(self._fixture_a(), field_mapping=mapping, sample_filter=filt)
+        kept2, summary2 = transform_dataset(self._fixture_a(), field_mapping=mapping, sample_filter=filt)
+
+        self.assertEqual(kept1, kept2)
+        self.assertEqual(summary1.total_kept, summary2.total_kept)
+        self.assertEqual(summary1.total_dropped, summary2.total_dropped)
+
+    def test_summary_reconciles_with_input(self):
+        """kept + dropped must equal total_in."""
+        mapping = {"question": "prompt", "answer": "response"}
+        filt = {"min_prompt_chars": 3}
+
+        kept, summary = transform_dataset(self._fixture_a(), field_mapping=mapping, sample_filter=filt)
+
+        self.assertEqual(summary.total_kept + summary.total_dropped, summary.total_in)
+        self.assertEqual(len(kept), summary.total_kept)
+
+    def test_drop_reasons_are_human_readable(self):
+        """Drop reasons should describe why a record was filtered."""
+        mapping = {"question": "prompt", "answer": "response"}
+        filt = {"min_prompt_chars": 3}
+
+        _, summary = transform_dataset(self._fixture_a(), field_mapping=mapping, sample_filter=filt)
+
+        self.assertGreater(len(summary.drop_reasons), 0)
+        for reason in summary.drop_reasons:
+            self.assertIsInstance(reason, str)
+            self.assertTrue(reason)
+
+    def test_constant_fields_appear_in_all_kept_records(self):
+        """Constant fields should be present in every kept record."""
+        mapping = {"question": "prompt", "answer": "response"}
+        constants = {"task_type": "math"}
+
+        kept, _ = transform_dataset(self._fixture_a(), field_mapping=mapping, constant_fields=constants)
+
+        for record in kept:
+            self.assertEqual(record["task_type"], "math")
+
+    def test_does_not_mutate_input(self):
+        """The original dataset records should remain unchanged."""
+        original = self._fixture_a()
+        original_copy = [dict(r) for r in original]
+        mapping = {"question": "prompt", "answer": "response"}
+
+        transform_dataset(original, field_mapping=mapping)
+
+        self.assertEqual(original, original_copy)
+
+    def test_backward_compatible_when_no_options(self):
+        """Without any options, the dataset should be returned unchanged."""
+        data = self._fixture_a()
+        kept, summary = transform_dataset(data)
+
+        self.assertEqual(len(kept), len(data))
+        self.assertEqual(summary.total_kept, len(data))
+        self.assertEqual(summary.total_dropped, 0)
+        # The content should match (shallow copy, so different identity).
+        for orig, kept_record in zip(data, kept, strict=True):
+            self.assertEqual(orig, kept_record)
+
+    def test_empty_dataset(self):
+        """An empty dataset should produce an empty result and zero summary."""
+        kept, summary = transform_dataset([])
+        self.assertEqual(kept, [])
+        self.assertEqual(summary.total_in, 0)
+        self.assertEqual(summary.total_kept, 0)
+
+    def test_all_filtered_out(self):
+        """When everything is dropped, kept is empty and summary reports it."""
+        data = [{"prompt": "a"}]
+        kept, summary = transform_dataset(data, sample_filter={"min_prompt_chars": 100})
+        self.assertEqual(kept, [])
+        self.assertEqual(summary.total_dropped, 1)
+        self.assertEqual(summary.total_kept, 0)
+
+
+class JsonOptionParsingTest(unittest.TestCase):
+    """Tests for ``parse_json_option`` — CLI JSON string parsing."""
+
+    def test_none_returns_none(self):
+        self.assertIsNone(parse_json_option(None, "--test"))
+
+    def test_valid_json_object(self):
+        result = parse_json_option('{"key": "value"}', "--test")
+        self.assertEqual(result, {"key": "value"})
+
+    def test_invalid_json_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "not valid JSON"):
+            parse_json_option("{invalid", "--test")
+
+    def test_non_object_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "must be a JSON object"):
+            parse_json_option("[1, 2, 3]", "--test")
+
+    def test_plain_string_raises_value_error(self):
+        with self.assertRaisesRegex(ValueError, "must be a JSON object"):
+            parse_json_option('"hello"', "--test")
+
+
+class FilterSummaryTest(unittest.TestCase):
+    """Tests for ``FilterSummary`` log output formatting."""
+
+    def test_log_lines_contain_counts(self):
+        summary = FilterSummary(
+            total_in=10, total_kept=7, total_dropped=3,
+            drop_reasons={"too short": 2, "missing field": 1},
+        )
+        lines = summary.as_log_lines()
+        self.assertTrue(any("scanned=10" in line for line in lines))
+        self.assertTrue(any("kept=7" in line for line in lines))
+        self.assertTrue(any("dropped=3" in line for line in lines))
+        self.assertTrue(any("too short" in line for line in lines))
+
+    def test_zero_drops_produces_single_line(self):
+        summary = FilterSummary(total_in=5, total_kept=5, total_dropped=0)
+        lines = summary.as_log_lines()
+        self.assertEqual(len(lines), 1)
+
+
+class SftFixtureConversionTest(unittest.TestCase):
+    """Integration-style test: convert two differently shaped JSONL fixtures
+    into one SFT contract without modifying source files, per acceptance criteria.
+    """
+
+    def test_two_jsonl_fixtures_to_sft_contract(self):
+        """Write two JSONL files with different schemas, then map both to
+        ``prompt``/``response`` and verify deterministic filtering."""
+
+        fixture_a = [
+            {"question": "What is 2+2?", "answer": "4"},
+            {"question": "ab", "answer": "cd"},  # will be filtered (too short)
+        ]
+        fixture_b = [
+            {"query": "Explain photosynthesis", "response": "Plants convert light to energy"},
+            {"query": "x", "response": "y"},  # will be filtered (too short)
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_a = Path(tmpdir) / "data_a.jsonl"
+            path_b = Path(tmpdir) / "data_b.jsonl"
+            path_a.write_text("\n".join(json.dumps(r) for r in fixture_a), encoding="utf-8")
+            path_b.write_text("\n".join(json.dumps(r) for r in fixture_b), encoding="utf-8")
+
+            # Load both fixtures.
+            records_a = [json.loads(line) for line in path_a.read_text(encoding="utf-8").splitlines() if line.strip()]
+            records_b = [json.loads(line) for line in path_b.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+            # Convert fixture A: question → prompt, answer → response.
+            kept_a, summary_a = transform_dataset(
+                records_a,
+                field_mapping={"question": "prompt", "answer": "response"},
+                sample_filter={"require_fields": ["prompt", "response"], "min_prompt_chars": 5},
+            )
+
+            # Convert fixture B: query → prompt (response already correct).
+            kept_b, summary_b = transform_dataset(
+                records_b,
+                field_mapping={"query": "prompt"},
+                sample_filter={"require_fields": ["prompt", "response"], "min_prompt_chars": 5},
+            )
+
+            # Both should produce prompt/response records.
+            all_kept = kept_a + kept_b
+            for record in all_kept:
+                self.assertIn("prompt", record)
+                self.assertIn("response", record)
+                self.assertGreaterEqual(len(record["prompt"]), 5)
+
+            # Summary counts reconcile.
+            self.assertEqual(summary_a.total_kept + summary_a.total_dropped, summary_a.total_in)
+            self.assertEqual(summary_b.total_kept + summary_b.total_dropped, summary_b.total_in)
+
+            # Source files are not modified.
+            self.assertEqual(
+                [json.loads(line) for line in path_a.read_text(encoding="utf-8").splitlines() if line.strip()],
+                fixture_a,
+            )
+            self.assertEqual(
+                [json.loads(line) for line in path_b.read_text(encoding="utf-8").splitlines() if line.strip()],
+                fixture_b,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Add three declarative CLI options for dataset transformation **after** dataset loading and **before** trainer contract conversion:

| Option | Description | Example |
|---|---|---|
| `--field-mapping` | Rename source fields to AReno-standard names | `{"question": "prompt", "answer": "response"}` |
| `--constant-fields` | Inject fixed key/value pairs without overwriting existing fields | `{"task_type": "math"}` |
| `--sample-filter` | Drop records by field presence and text-length predicates | `{"require_fields": ["prompt"], "min_prompt_chars": 5}` |

**Supported filter keys:**

- `require_fields` — all must be present (and non-empty for strings)
- `min_prompt_chars` / `max_prompt_chars` — character-length bounds on `prompt`
- `min_response_chars` — minimum character length of `response`

**Observable output** when enabled:

```
field-mapping: scanned=1024 kept=1000 dropped=24
  drop reason: prompt too short (2 < 5) (15)
  drop reason: missing field: response (9)
```

No sample text is logged — only structural counts and drop reasons.

**Backward compatibility:** when none of these options are provided, the dataset passes through unchanged. Existing commands behave identically.

## Related issue

Fixes #201

## Type of change

- [x] ✨ New feature

## How was it tested?

Ran 40+ CPU test cases (no GPU required) covering:

| Category | Tests |
|---|---|
| Core logic | Field mapping (rename, no-overwrite, identity, missing-source, preserve-unmapped) |
| Constant injection | New fields, no-overwrite, empty-constants |
| Sample filtering | Required fields, empty fields, min/max length, non-string skip |
| Malformed input | Invalid JSON, non-object JSON for CLI options |
| Boundary values | Exact min/max length, empty dataset, all-filtered-out |
| Default behavior | No options → dataset unchanged |
| Deterministic | Same input + config → same result |
| Integration | Two differently shaped JSONL → one SFT contract, source files unmodified |
| Summary assertions | Exact counts, drop-reason strings, log line content (not just exit status) |

**Bug found and fixed during testing:** field-missing records were erroneously dropped by length checks (`record.get("prompt", "")` returned empty string → `len("") < min` → false positive). Fixed: length checks now skip when the field is absent.

**Hardware:** macOS (no GPU/CUDA). Tests use only Python standard library, no torch dependency.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).