### PR TITLE
feat(skill): add training-scale calculator for run-training skill (#278)

### DIFF
--- a/skills/areno-training-scale/SKILL.md
+++ b/skills/areno-training-scale/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: areno-training-scale
+description: Use this skill when calculating training scale, batch sizing, estimating training steps or tokens, or solving gradient accumulation for a target global batch in AReno training runs.
+---
+
+# areno Training Scale Calculator
+
+Calculate effective global batch, updates per epoch, total updates, and
+approximate processed tokens from dataset size, micro batch, accumulation,
+and GPU count.  Also solve accumulation for a target global batch.
+
+## When to Use
+
+- Before starting a training run, to estimate how many steps and tokens it
+  will consume.
+- When choosing `mini_bs`, `gradient_accumulation_steps`, or GPU layout so
+  that the global batch matches a desired value.
+- When comparing SFT, DPO, and online RL (GSPO/GRPO/PPO) runs to understand
+  why they consume data at different rates.
+
+## Counting Rules
+
+Different training modes count "one sample" differently, which directly
+affects step and token calculations:
+
+| Mode | Algorithms | 1 row = | Global batch formula |
+|------|-----------|---------|---------------------|
+| SFT  | `sft`     | 1 sample | `mini_bs × grad_accum × dp_size` |
+| DPO  | `dpo`     | 1 chosen/rejected pair | `mini_bs × grad_accum × dp_size` |
+| Online RL | `gspo`, `grpo`, `ppo` | 1 prompt + `n_samples` rollouts | `batch_size` (prompt-level) |
+
+**Key difference**: In online RL, `batch_size` is the number of **prompts**
+per step (a global quantity), and each prompt generates `n_samples` rollout
+sequences.  The actual number of sequences processed per step is
+`batch_size × n_samples`.
+
+**dp_size** (data parallel degree) = `world_size / tp_size`.
+
+## Usage
+
+```bash
+# SFT: 10k rows, 2 GPUs, tp=1
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --algo sft --dataset-size 10000 \
+    --mini-bs 16 --world-size 2 --tp-size 1 --epochs 3
+
+# GSPO: 500 prompts, 8 samples each
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --algo gspo --dataset-size 500 \
+    --batch-size 32 --n-samples 8 --mini-bs 16 \
+    --world-size 8 --tp-size 4 --epochs 1
+
+# Solve gradient_accumulation for target global batch = 128
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --algo sft --dataset-size 10000 \
+    --mini-bs 16 --world-size 8 --tp-size 4 \
+    --target-global-batch 128
+
+# Suggest valid mini_bs/dp_size/grad_accum combos for global batch = 64
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --suggest --target-global-batch 64
+
+# JSON output (for piping into recipe generator or other tools)
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --algo gspo --dataset-size 500 \
+    --batch-size 32 --n-samples 8 \
+    --world-size 8 --tp-size 4 --json
+```
+
+## Input Contract
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--algo` | str | `sft` | Training algorithm: `sft`, `dpo`, `gspo`, `grpo`, `ppo` |
+| `--dataset-size` | int | required | Number of rows in the training dataset |
+| `--mini-bs` | int | `16` | Backend training microbatch size |
+| `--gradient-accumulation-steps` | int | auto | Optimizer step interval; auto-calculated if omitted |
+| `--world-size` | int | `8` | Total GPU count |
+| `--tp-size` | int | `4` | Tensor parallel size |
+| `--batch-size` | int | `32` | Prompt batch size per step (RL only) |
+| `--n-samples` | int | `8` | Rollout samples per prompt (RL only) |
+| `--epochs` | int | `1` | Number of training epochs |
+| `--avg-seq-len` | int | `2048` | Average sequence length for token estimation |
+| `--target-global-batch` | int | None | Solve for gradient_accumulation to hit this global batch |
+| `--suggest` | flag | off | Print valid mini_bs/dp_size/grad_accum combos |
+| `--json` | flag | off | Output as JSON instead of human-readable table |
+
+## Output Fields
+
+| Field | Description |
+|-------|-------------|
+| `algo` | Algorithm name |
+| `dp_size` | Data parallel degree (`world_size / tp_size`) |
+| `global_batch` | Effective global batch size |
+| `gradient_accumulation_steps` | Resolved gradient accumulation steps |
+| `samples_per_step` | Actual samples/sequences processed per step |
+| `updates_per_epoch` | Number of optimizer steps per epoch |
+| `total_updates` | Total optimizer steps across all epochs |
+| `approx_tokens` | Approximate total tokens processed |
+| `warnings` | List of warnings (uneven division, mismatch, etc.) |
+
+## Defaults
+
+- `mini_bs=16`, `world_size=8`, `tp_size=4` match AReno CLI defaults.
+- `batch_size=32`, `n_samples=8` match AReno RL defaults.
+- When `gradient_accumulation_steps` is omitted:
+  - SFT/DPO: defaults to `1`.
+  - Online RL: auto-calculated to cover the full rollout in one optimizer
+    step (`ceil(batch_size * n_samples / (mini_bs * dp_size))`).
+
+## Limitations
+
+- `approx_tokens` is a rough estimate based on `avg_seq_len`.  Actual token
+  counts depend on dataset content, prompt length, and (for RL) how many
+  tokens the model generates per rollout.
+- The calculator does not model dropout rows, padding, or multi-epoch
+  shuffling effects.
+- For RL algorithms, `batch_size` is treated as a global (not per-GPU)
+  quantity, matching AReno's CLI semantics.
+- The `--suggest` mode uses a fixed range of `mini_bs` and `dp_size` values;
+  it may not find combos outside that range.
+
+## One Copyable Example
+
+```bash
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --algo gspo --dataset-size 500 \
+    --batch-size 32 --n-samples 8 \
+    --mini-bs 16 --world-size 8 --tp-size 4 \
+    --epochs 1 --avg-seq-len 2048 --json
+```
+
+Output:
+
+```json
+{
+  "algo": "gspo",
+  "dp_size": 2,
+  "global_batch": 32,
+  "gradient_accumulation_steps": 8,
+  "updates_per_epoch": 16,
+  "total_updates": 16,
+  "approx_tokens": 8388608,
+  "samples_per_step": 256,
+  "warnings": []
+}
+```
+
+## Integration with Recipe Generator
+
+The `--json` output is designed to feed into the training-recipe generator
+(Issue #273).  Pipe or redirect the JSON result as input for recipe
+generation:
+
+```bash
+python skills/areno-training-scale/scripts/calc_training_scale.py \
+    --algo sft --dataset-size 10000 --mini-bs 16 \
+    --world-size 8 --tp-size 4 --json \
+    > /tmp/scale_result.json
+
+# Future: feed into recipe generator
+# python skills/areno-recipe/scripts/gen_recipe.py \
+#     --scale-result /tmp/scale_result.json
+```

--- a/skills/areno-training-scale/scripts/calc_training_scale.py
+++ b/skills/areno-training-scale/scripts/calc_training_scale.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Training-scale calculator for AReno.
+
+Computes effective global batch, updates per epoch, total updates, and
+approximate processed tokens from dataset size, micro batch, accumulation,
+and GPU count.  Also solves accumulation for a target global batch.
+
+Uses correct counting rules for SFT, DPO, and online RL (GSPO/GRPO/PPO):
+  - SFT: 1 row = 1 sample
+  - DPO: 1 row = 1 chosen/rejected pair
+  - Online RL: 1 row = 1 prompt with n_samples rollouts
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Sequence
+
+# ---------------------------------------------------------------------------
+# Algorithm metadata (mirrors areno.api.algorithms without importing it)
+# ---------------------------------------------------------------------------
+
+_OFFLINE_ALGOS = frozenset({"sft", "dpo"})
+_ONLINE_RL_ALGOS = frozenset({"gspo", "grpo", "ppo"})
+_ALL_ALGOS = _OFFLINE_ALGOS | _ONLINE_RL_ALGOS
+
+
+def _is_online_rl(algo: str) -> bool:
+    return algo in _ONLINE_RL_ALGOS
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScaleInput:
+    """All parameters the user can provide."""
+
+    algo: str
+    dataset_size: int
+    mini_bs: int = 16
+    gradient_accumulation_steps: int | None = None
+    world_size: int = 8
+    tp_size: int = 4
+    # RL-specific
+    batch_size: int | None = None
+    n_samples: int | None = None
+    # General
+    epochs: int = 1
+    avg_seq_len: int = 2048
+    # Reverse solve
+    target_global_batch: int | None = None
+
+
+@dataclass
+class ScaleResult:
+    """Everything the calculator outputs."""
+
+    algo: str
+    dp_size: int
+    global_batch: int
+    gradient_accumulation_steps: int
+    updates_per_epoch: int
+    total_updates: int
+    approx_tokens: int
+    samples_per_step: int
+    warnings: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_input(inp: ScaleInput) -> None:
+    """Raise ValueError on malformed input."""
+
+    algo = inp.algo.strip().lower()
+    if algo not in _ALL_ALGOS:
+        raise ValueError(
+            f"Unknown algorithm {inp.algo!r}; supported: {sorted(_ALL_ALGOS)}"
+        )
+    if inp.dataset_size <= 0:
+        raise ValueError("dataset_size must be positive")
+    if inp.mini_bs <= 0:
+        raise ValueError("mini_bs must be positive")
+    if inp.gradient_accumulation_steps is not None and inp.gradient_accumulation_steps <= 0:
+        raise ValueError("gradient_accumulation_steps must be positive when provided")
+    if inp.world_size <= 0:
+        raise ValueError("world_size must be positive")
+    if inp.tp_size <= 0:
+        raise ValueError("tp_size must be positive")
+    if inp.world_size % inp.tp_size != 0:
+        raise ValueError(
+            f"world_size ({inp.world_size}) must be divisible by tp_size ({inp.tp_size})"
+        )
+    if _is_online_rl(algo):
+        if inp.batch_size is not None and inp.batch_size <= 0:
+            raise ValueError("batch_size must be positive for RL algorithms")
+        if inp.n_samples is not None and inp.n_samples <= 0:
+            raise ValueError("n_samples must be positive for RL algorithms")
+    if inp.epochs <= 0:
+        raise ValueError("epochs must be positive")
+    if inp.avg_seq_len <= 0:
+        raise ValueError("avg_seq_len must be positive")
+    if inp.target_global_batch is not None and inp.target_global_batch <= 0:
+        raise ValueError("target_global_batch must be positive when provided")
+
+
+# ---------------------------------------------------------------------------
+# Core calculation
+# ---------------------------------------------------------------------------
+
+
+def calculate(inp: ScaleInput) -> ScaleResult:
+    """Run the training-scale calculation and return a ScaleResult."""
+
+    algo = inp.algo.strip().lower()
+    _validate_input(inp)
+
+    dp_size = inp.world_size // inp.tp_size
+    warnings: list[str] = []
+
+    if _is_online_rl(algo):
+        return _calculate_online_rl(inp, algo, dp_size, warnings)
+    return _calculate_offline(inp, algo, dp_size, warnings)
+
+
+def _calculate_offline(
+    inp: ScaleInput, algo: str, dp_size: int, warnings: list[str]
+) -> ScaleResult:
+    """SFT / DPO: 1 row = 1 sample (or 1 pair for DPO)."""
+
+    # Determine gradient_accumulation_steps
+    if inp.target_global_batch is not None:
+        # Reverse solve: find grad_accum so that mini_bs * grad_accum * dp_size
+        # is as close to target_global_batch as possible.
+        grad_accum = _solve_grad_accum(
+            inp.target_global_batch, inp.mini_bs, dp_size, warnings
+        )
+    elif inp.gradient_accumulation_steps is not None:
+        grad_accum = inp.gradient_accumulation_steps
+    else:
+        # Default: 1 (user can override)
+        grad_accum = 1
+
+    global_batch = inp.mini_bs * grad_accum * dp_size
+    samples_per_step = global_batch  # 1 row = 1 sample for SFT/DPO
+
+    updates_per_epoch = math.ceil(inp.dataset_size / global_batch)
+    total_updates = updates_per_epoch * inp.epochs
+    approx_tokens = total_updates * samples_per_step * inp.avg_seq_len
+
+    if inp.dataset_size % global_batch != 0:
+        remainder = inp.dataset_size % global_batch
+        warnings.append(
+            f"dataset_size ({inp.dataset_size}) is not divisible by "
+            f"global_batch ({global_batch}); last step uses {remainder} samples"
+        )
+
+    return ScaleResult(
+        algo=algo,
+        dp_size=dp_size,
+        global_batch=global_batch,
+        gradient_accumulation_steps=grad_accum,
+        updates_per_epoch=updates_per_epoch,
+        total_updates=total_updates,
+        approx_tokens=approx_tokens,
+        samples_per_step=samples_per_step,
+        warnings=warnings,
+    )
+
+
+def _calculate_online_rl(
+    inp: ScaleInput, algo: str, dp_size: int, warnings: list[str]
+) -> ScaleResult:
+    """GSPO / GRPO / PPO: 1 row = 1 prompt with n_samples rollouts."""
+
+    batch_size = inp.batch_size if inp.batch_size is not None else 32
+    n_samples = inp.n_samples if inp.n_samples is not None else 8
+
+    # In AReno's RL loop, batch_size is the number of prompts per step
+    # (already a global quantity).  The training-side micro batch is
+    # mini_bs * grad_accum * dp_size, which must equal batch_size * n_samples
+    # for a single optimizer step.
+    total_sequences = batch_size * n_samples
+
+    if inp.target_global_batch is not None:
+        # For RL, target_global_batch refers to the prompt batch size.
+        # Solve for gradient_accumulation_steps so that the train micro batch
+        # covers the full rollout: mini_bs * grad_accum * dp_size = target * n_samples
+        target_sequences = inp.target_global_batch * n_samples
+        grad_accum = _solve_grad_accum(
+            target_sequences, inp.mini_bs, dp_size, warnings
+        )
+        batch_size = inp.target_global_batch
+        total_sequences = batch_size * n_samples
+    elif inp.gradient_accumulation_steps is not None:
+        grad_accum = inp.gradient_accumulation_steps
+    else:
+        # Default: grad_accum covers the full rollout in one optimizer step
+        # i.e. mini_bs * grad_accum * dp_size = batch_size * n_samples
+        grad_accum = max(1, math.ceil(total_sequences / (inp.mini_bs * dp_size)))
+
+    global_batch = batch_size  # prompt-level global batch
+    samples_per_step = total_sequences
+
+    updates_per_epoch = math.ceil(inp.dataset_size / batch_size)
+    total_updates = updates_per_epoch * inp.epochs
+    approx_tokens = total_updates * samples_per_step * inp.avg_seq_len
+
+    if inp.dataset_size % batch_size != 0:
+        remainder = inp.dataset_size % batch_size
+        warnings.append(
+            f"dataset_size ({inp.dataset_size}) is not divisible by "
+            f"batch_size ({batch_size}); last step uses {remainder} prompts"
+        )
+
+    # Warn if train micro batch doesn't cover the full rollout
+    train_micro_total = inp.mini_bs * grad_accum * dp_size
+    if train_micro_total != total_sequences:
+        warnings.append(
+            f"train micro-batch total ({train_micro_total} = mini_bs({inp.mini_bs}) "
+            f"* grad_accum({grad_accum}) * dp_size({dp_size})) does not equal "
+            f"total sequences per step ({total_sequences} = batch_size({batch_size}) "
+            f"* n_samples({n_samples})); gradient accumulation may not cover "
+            f"the full rollout in one optimizer step"
+        )
+
+    return ScaleResult(
+        algo=algo,
+        dp_size=dp_size,
+        global_batch=global_batch,
+        gradient_accumulation_steps=grad_accum,
+        updates_per_epoch=updates_per_epoch,
+        total_updates=total_updates,
+        approx_tokens=approx_tokens,
+        samples_per_step=samples_per_step,
+        warnings=warnings,
+    )
+
+
+def _solve_grad_accum(
+    target: int, mini_bs: int, dp_size: int, warnings: list[str]
+) -> int:
+    """Find the smallest gradient_accumulation_steps so that
+    mini_bs * grad_accum * dp_size >= target.
+
+    Emits a warning if the product does not exactly equal target.
+    """
+
+    divisor = mini_bs * dp_size
+    if divisor <= 0:
+        raise ValueError("mini_bs * dp_size must be positive")
+    grad_accum = max(1, math.ceil(target / divisor))
+    actual = mini_bs * grad_accum * dp_size
+    if actual != target:
+        warnings.append(
+            f"target ({target}) is not divisible by mini_bs*dp_size ({divisor}); "
+            f"closest global_batch = {actual} with gradient_accumulation_steps = {grad_accum}"
+        )
+    return grad_accum
+
+
+# ---------------------------------------------------------------------------
+# Suggest valid combinations when division is uneven
+# ---------------------------------------------------------------------------
+
+
+def suggest_combinations(
+    *,
+    target_global_batch: int,
+    mini_bs_range: Sequence[int] = (8, 16, 32, 64),
+    dp_size_range: Sequence[int] = (1, 2, 4, 8),
+) -> list[dict]:
+    """Return valid (mini_bs, dp_size, grad_accum) combos that produce
+    exactly target_global_batch, sorted by smallest grad_accum first.
+    """
+
+    combos: list[dict] = []
+    for dp in dp_size_range:
+        for mbs in mini_bs_range:
+            divisor = mbs * dp
+            if target_global_batch % divisor == 0:
+                ga = target_global_batch // divisor
+                combos.append(
+                    {
+                        "mini_bs": mbs,
+                        "dp_size": dp,
+                        "gradient_accumulation_steps": ga,
+                        "global_batch": target_global_batch,
+                    }
+                )
+    combos.sort(key=lambda c: (c["gradient_accumulation_steps"], c["dp_size"]))
+    return combos
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Calculate AReno training scale: global batch, steps, and tokens.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+examples:
+  # SFT with 10k rows, 2 GPUs, tp=1
+  python calc_training_scale.py --algo sft --dataset-size 10000 \\
+      --mini-bs 16 --world-size 2 --tp-size 1 --epochs 3
+
+  # GSPO with 500 prompts, 8 samples each
+  python calc_training_scale.py --algo gspo --dataset-size 500 \\
+      --batch-size 32 --n-samples 8 --mini-bs 16 \\
+      --world-size 8 --tp-size 4 --epochs 1
+
+  # Solve gradient_accumulation for target global batch = 128
+  python calc_training_scale.py --algo sft --dataset-size 10000 \\
+      --mini-bs 16 --world-size 8 --tp-size 4 \\
+      --target-global-batch 128
+
+  # Suggest valid mini_bs/dp_size/grad_accum combos for global batch = 64
+  python calc_training_scale.py --suggest --target-global-batch 64
+""",
+    )
+    parser.add_argument(
+        "--algo",
+        type=str,
+        default="sft",
+        choices=sorted(_ALL_ALGOS),
+        help="Training algorithm (default: sft).",
+    )
+    parser.add_argument(
+        "--dataset-size",
+        type=int,
+        default=None,
+        help="Number of rows in the training dataset.",
+    )
+    parser.add_argument(
+        "--mini-bs",
+        type=int,
+        default=16,
+        help="Backend training microbatch size (default: 16).",
+    )
+    parser.add_argument(
+        "--gradient-accumulation-steps",
+        type=int,
+        default=None,
+        help="Optimizer step interval in microbatches; auto if omitted.",
+    )
+    parser.add_argument(
+        "--world-size",
+        type=int,
+        default=8,
+        help="Total device count (default: 8).",
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=4,
+        help="Tensor parallel size (default: 4).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help="Prompt batch size per step for RL algorithms (default: 32).",
+    )
+    parser.add_argument(
+        "--n-samples",
+        type=int,
+        default=None,
+        help="Rollout samples per prompt for RL algorithms (default: 8).",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=1,
+        help="Number of training epochs (default: 1).",
+    )
+    parser.add_argument(
+        "--avg-seq-len",
+        type=int,
+        default=2048,
+        help="Average sequence length for token estimation (default: 2048).",
+    )
+    parser.add_argument(
+        "--target-global-batch",
+        type=int,
+        default=None,
+        help="Solve gradient_accumulation for this target global batch size.",
+    )
+    parser.add_argument(
+        "--suggest",
+        action="store_true",
+        help="Print valid mini_bs/dp_size/grad_accum combos for --target-global-batch.",
+    )
+    parser.add_argument(
+        "--json",
+        dest="output_json",
+        action="store_true",
+        help="Output result as JSON (default: human-readable table).",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # --suggest mode: just print combos and exit
+    if args.suggest:
+        if args.target_global_batch is None:
+            parser.error("--suggest requires --target-global-batch")
+        combos = suggest_combinations(target_global_batch=args.target_global_batch)
+        if not combos:
+            print(
+                f"No valid combinations found for target_global_batch={args.target_global_batch}"
+            )
+            sys.exit(1)
+        if args.output_json:
+            print(json.dumps(combos, indent=2))
+        else:
+            print(f"Valid combinations for global_batch={args.target_global_batch}:")
+            print(f"  {'mini_bs':>8}  {'dp_size':>8}  {'grad_accum':>10}  {'global_batch':>12}")
+            for c in combos:
+                print(
+                    f"  {c['mini_bs']:>8}  {c['dp_size']:>8}  "
+                    f"{c['gradient_accumulation_steps']:>10}  {c['global_batch']:>12}"
+                )
+        return
+
+    # Normal calculation mode
+    if args.dataset_size is None:
+        parser.error("--dataset-size is required (unless using --suggest)")
+
+    inp = ScaleInput(
+        algo=args.algo,
+        dataset_size=args.dataset_size,
+        mini_bs=args.mini_bs,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        world_size=args.world_size,
+        tp_size=args.tp_size,
+        batch_size=args.batch_size,
+        n_samples=args.n_samples,
+        epochs=args.epochs,
+        avg_seq_len=args.avg_seq_len,
+        target_global_batch=args.target_global_batch,
+    )
+
+    result = calculate(inp)
+
+    if args.output_json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        _print_result(result)
+
+
+def _print_result(r: ScaleResult) -> None:
+    """Human-readable output."""
+
+    algo_label = r.algo.upper()
+    if r.algo in _ONLINE_RL_ALGOS:
+        algo_label += " (online RL)"
+    else:
+        algo_label += " (offline)"
+
+    print(f"AReno Training Scale  [{algo_label}]")
+    print("=" * 50)
+    print(f"  dp_size                  = {r.dp_size}")
+    print(f"  global_batch             = {r.global_batch}")
+    print(f"  gradient_accumulation    = {r.gradient_accumulation_steps}")
+    print(f"  samples_per_step         = {r.samples_per_step}")
+    print(f"  updates_per_epoch        = {r.updates_per_epoch}")
+    print(f"  epochs                   = (see input)")
+    print(f"  total_updates            = {r.total_updates}")
+    print(f"  approx_tokens            = {r.approx_tokens:,}")
+    if r.warnings:
+        print()
+        print("  Warnings:")
+        for w in r.warnings:
+            print(f"    ⚠  {w}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_training_scale_cpu.py
+++ b/tests/test_training_scale_cpu.py
@@ -1,0 +1,597 @@
+"""CPU tests for the training-scale calculator.
+
+Run with:  pytest tests/test_training_scale_cpu.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest  # noqa: F401  -- pytest is a test-time dependency
+
+# ---------------------------------------------------------------------------
+# Import the module under test.
+#
+# calc_training_scale.py is a standalone script in skills/, not a proper
+# Python package.  We locate it by path and import it via importlib so the
+# import works regardless of whether the script is on sys.path.
+# ---------------------------------------------------------------------------
+
+_SKILL_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "areno-training-scale"
+    / "scripts"
+    / "calc_training_scale.py"
+)
+
+if not _SKILL_SCRIPT.exists():
+    raise FileNotFoundError(
+        f"Cannot find calc_training_scale.py at {_SKILL_SCRIPT}. "
+        "Make sure the skill directory exists under skills/."
+    )
+
+_spec = importlib.util.spec_from_file_location("calc_training_scale", _SKILL_SCRIPT)
+if _spec is None or _spec.loader is None:
+    raise RuntimeError(f"Cannot load module spec from {_SKILL_SCRIPT}")
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["calc_training_scale"] = _mod  # needed for dataclass resolution on 3.9
+_spec.loader.exec_module(_mod)
+
+# Re-export the symbols we test, so the rest of the file uses normal names.
+ScaleInput = _mod.ScaleInput
+ScaleResult = _mod.ScaleResult
+_ALL_ALGOS = _mod._ALL_ALGOS
+_is_online_rl = _mod._is_online_rl
+calculate = _mod.calculate
+suggest_combinations = _mod.suggest_combinations
+_validate_input = _mod._validate_input
+
+
+# ===========================================================================
+# Validation tests
+# ===========================================================================
+
+
+class TestValidation:
+    """Malformed or boundary inputs must raise ValueError."""
+
+    def test_unknown_algo(self):
+        with pytest.raises(ValueError, match="Unknown algorithm"):
+            calculate(ScaleInput(algo="unknown", dataset_size=100))
+
+    def test_negative_dataset_size(self):
+        with pytest.raises(ValueError, match="dataset_size must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=-1))
+
+    def test_zero_dataset_size(self):
+        with pytest.raises(ValueError, match="dataset_size must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=0))
+
+    def test_zero_mini_bs(self):
+        with pytest.raises(ValueError, match="mini_bs must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, mini_bs=0))
+
+    def test_negative_mini_bs(self):
+        with pytest.raises(ValueError, match="mini_bs must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, mini_bs=-4))
+
+    def test_zero_grad_accum(self):
+        with pytest.raises(ValueError, match="gradient_accumulation_steps must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, gradient_accumulation_steps=0))
+
+    def test_negative_grad_accum(self):
+        with pytest.raises(ValueError, match="gradient_accumulation_steps must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, gradient_accumulation_steps=-1))
+
+    def test_world_size_not_divisible_by_tp_size(self):
+        with pytest.raises(ValueError, match="divisible by tp_size"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, world_size=7, tp_size=4))
+
+    def test_zero_epochs(self):
+        with pytest.raises(ValueError, match="epochs must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, epochs=0))
+
+    def test_zero_avg_seq_len(self):
+        with pytest.raises(ValueError, match="avg_seq_len must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, avg_seq_len=0))
+
+    def test_rl_negative_batch_size(self):
+        with pytest.raises(ValueError, match="batch_size must be positive"):
+            calculate(ScaleInput(algo="gspo", dataset_size=100, batch_size=-1))
+
+    def test_rl_negative_n_samples(self):
+        with pytest.raises(ValueError, match="n_samples must be positive"):
+            calculate(ScaleInput(algo="gspo", dataset_size=100, n_samples=-1))
+
+    def test_negative_target_global_batch(self):
+        with pytest.raises(ValueError, match="target_global_batch must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, target_global_batch=-1))
+
+    def test_zero_world_size(self):
+        with pytest.raises(ValueError, match="world_size must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, world_size=0))
+
+    def test_zero_tp_size(self):
+        with pytest.raises(ValueError, match="tp_size must be positive"):
+            calculate(ScaleInput(algo="sft", dataset_size=100, tp_size=0))
+
+
+# ===========================================================================
+# SFT calculation tests
+# ===========================================================================
+
+
+class TestSFT:
+    """SFT: 1 row = 1 sample."""
+
+    def test_basic(self):
+        """Simple SFT: 10k rows, mini_bs=16, grad_accum=2, 2 GPUs (dp=2)."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=10000,
+            mini_bs=16,
+            gradient_accumulation_steps=2,
+            world_size=8,
+            tp_size=4,
+            epochs=1,
+        ))
+        assert r.dp_size == 2
+        assert r.global_batch == 64  # 16 * 2 * 2
+        assert r.gradient_accumulation_steps == 2
+        assert r.samples_per_step == 64
+        assert r.updates_per_epoch == math.ceil(10000 / 64)
+        assert r.total_updates == r.updates_per_epoch * 1
+
+    def test_default_grad_accum(self):
+        """When gradient_accumulation_steps is None, default to 1."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=500,
+            mini_bs=8,
+            world_size=1,
+            tp_size=1,
+        ))
+        assert r.gradient_accumulation_steps == 1
+        assert r.global_batch == 8  # 8 * 1 * 1
+
+    def test_multi_epoch(self):
+        """3 epochs."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=1000,
+            mini_bs=16,
+            gradient_accumulation_steps=1,
+            world_size=8,
+            tp_size=4,
+            epochs=3,
+        ))
+        assert r.total_updates == r.updates_per_epoch * 3
+
+    def test_uneven_dataset_warning(self):
+        """Dataset not divisible by global_batch produces a warning."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=1000,
+            mini_bs=16,
+            gradient_accumulation_steps=2,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.global_batch == 64
+        assert 1000 % 64 != 0
+        assert any("not divisible" in w for w in r.warnings)
+
+    def test_exact_division_no_warning(self):
+        """Dataset exactly divisible by global_batch: no warning."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=64,
+            mini_bs=16,
+            gradient_accumulation_steps=2,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.global_batch == 64
+        assert not any("not divisible" in w for w in r.warnings)
+
+    def test_token_estimation(self):
+        """approx_tokens = total_updates * samples_per_step * avg_seq_len."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=64,
+            mini_bs=16,
+            gradient_accumulation_steps=1,
+            world_size=1,
+            tp_size=1,
+            avg_seq_len=1024,
+        ))
+        assert r.global_batch == 16
+        assert r.updates_per_epoch == 4  # 64 / 16
+        assert r.approx_tokens == 4 * 16 * 1024  # 65536
+
+
+# ===========================================================================
+# DPO calculation tests
+# ===========================================================================
+
+
+class TestDPO:
+    """DPO: 1 row = 1 chosen/rejected pair. Counting is same as SFT."""
+
+    def test_basic(self):
+        """DPO uses same counting as SFT for batch/steps."""
+        r = calculate(ScaleInput(
+            algo="dpo",
+            dataset_size=5000,
+            mini_bs=16,
+            gradient_accumulation_steps=1,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.dp_size == 2
+        assert r.global_batch == 32  # 16 * 1 * 2
+        assert r.updates_per_epoch == math.ceil(5000 / 32)
+
+    def test_dpo_is_offline(self):
+        """DPO is not online RL."""
+        assert not _is_online_rl("dpo")
+
+
+# ===========================================================================
+# Online RL (GSPO/GRPO/PPO) calculation tests
+# ===========================================================================
+
+
+class TestOnlineRL:
+    """Online RL: 1 row = 1 prompt with n_samples rollouts."""
+
+    def test_gspo_basic(self):
+        """GSPO: 500 prompts, batch_size=32, n_samples=8."""
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=500,
+            batch_size=32,
+            n_samples=8,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.dp_size == 2
+        assert r.global_batch == 32  # prompt-level batch
+        assert r.samples_per_step == 256  # 32 * 8
+        assert r.updates_per_epoch == math.ceil(500 / 32)
+
+    def test_grpo_basic(self):
+        """GRPO: same counting as GSPO."""
+        r = calculate(ScaleInput(
+            algo="grpo",
+            dataset_size=1000,
+            batch_size=16,
+            n_samples=4,
+            mini_bs=8,
+            world_size=2,
+            tp_size=1,
+        ))
+        assert r.global_batch == 16
+        assert r.samples_per_step == 64  # 16 * 4
+
+    def test_ppo_basic(self):
+        """PPO: same counting as GSPO/GRPO."""
+        r = calculate(ScaleInput(
+            algo="ppo",
+            dataset_size=2000,
+            batch_size=64,
+            n_samples=1,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.global_batch == 64
+        assert r.samples_per_step == 64  # 64 * 1
+
+    def test_rl_default_batch_size(self):
+        """When batch_size is None, default to 32."""
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=1000,
+            n_samples=8,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.global_batch == 32
+
+    def test_rl_default_n_samples(self):
+        """When n_samples is None, default to 8."""
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=1000,
+            batch_size=32,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.samples_per_step == 256  # 32 * 8
+
+    def test_rl_token_estimation(self):
+        """approx_tokens = total_updates * samples_per_step * avg_seq_len."""
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=32,
+            batch_size=32,
+            n_samples=8,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+            avg_seq_len=2048,
+        ))
+        assert r.updates_per_epoch == 1
+        assert r.samples_per_step == 256
+        assert r.approx_tokens == 1 * 256 * 2048  # 524288
+
+    def test_rl_uneven_dataset_warning(self):
+        """Dataset not divisible by batch_size produces a warning."""
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=100,
+            batch_size=32,
+            n_samples=8,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert any("not divisible" in w for w in r.warnings)
+
+    def test_rl_grad_accum_auto_covers_rollout(self):
+        """Default grad_accum should cover the full rollout in one optimizer step."""
+        # batch_size=32, n_samples=8 => 256 sequences
+        # mini_bs=16, dp_size=2 => 32 per grad_accum step
+        # Need 256/32 = 8 grad_accum steps
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=1000,
+            batch_size=32,
+            n_samples=8,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+        ))
+        assert r.gradient_accumulation_steps == 8
+
+    def test_rl_grad_accum_mismatch_warning(self):
+        """If grad_accum doesn't cover the full rollout, emit a warning."""
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=1000,
+            batch_size=32,
+            n_samples=8,
+            mini_bs=16,
+            gradient_accumulation_steps=1,  # too small: 16*1*2=32 != 256
+            world_size=8,
+            tp_size=4,
+        ))
+        assert any("does not equal" in w for w in r.warnings)
+
+    def test_is_online_rl(self):
+        """Verify algorithm classification."""
+        assert _is_online_rl("gspo")
+        assert _is_online_rl("grpo")
+        assert _is_online_rl("ppo")
+        assert not _is_online_rl("sft")
+        assert not _is_online_rl("dpo")
+
+
+# ===========================================================================
+# Reverse solve (target_global_batch) tests
+# ===========================================================================
+
+
+class TestReverseSolve:
+    """Solve gradient_accumulation for a target global batch."""
+
+    def test_sft_exact_division(self):
+        """target=128, mini_bs=16, dp=2 => grad_accum=4."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=1000,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+            target_global_batch=128,
+        ))
+        assert r.gradient_accumulation_steps == 4  # 128 / (16 * 2)
+        assert r.global_batch == 128
+
+    def test_sft_uneven_division_warning(self):
+        """target=100, mini_bs=16, dp=2 => 100/32 not integer => warning."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=1000,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+            target_global_batch=100,
+        ))
+        assert r.gradient_accumulation_steps == 4  # ceil(100/32) = 4
+        assert r.global_batch == 128  # 16 * 4 * 2
+        assert any("not divisible" in w for w in r.warnings)
+
+    def test_rl_reverse_solve(self):
+        """RL: target_global_batch refers to prompt batch size."""
+        # target=64 prompts, n_samples=8 => 512 sequences
+        # mini_bs=16, dp=2 => 32 per grad_accum step
+        # Need 512/32 = 16 grad_accum steps
+        r = calculate(ScaleInput(
+            algo="gspo",
+            dataset_size=1000,
+            mini_bs=16,
+            world_size=8,
+            tp_size=4,
+            n_samples=8,
+            target_global_batch=64,
+        ))
+        assert r.global_batch == 64
+        assert r.gradient_accumulation_steps == 16
+        assert r.samples_per_step == 512  # 64 * 8
+
+    def test_target_overrides_grad_accum(self):
+        """target_global_batch takes precedence over gradient_accumulation_steps."""
+        r = calculate(ScaleInput(
+            algo="sft",
+            dataset_size=1000,
+            mini_bs=16,
+            gradient_accumulation_steps=99,  # should be overridden
+            world_size=8,
+            tp_size=4,
+            target_global_batch=64,
+        ))
+        assert r.gradient_accumulation_steps == 2  # 64 / (16 * 2)
+        assert r.global_batch == 64
+
+
+# ===========================================================================
+# Suggest combinations tests
+# ===========================================================================
+
+
+class TestSuggestCombinations:
+    """suggest_combinations returns valid mini_bs/dp_size/grad_accum combos."""
+
+    def test_target_64(self):
+        combos = suggest_combinations(target_global_batch=64)
+        # 64 = 8*1*8, 8*2*4, 8*4*2, 8*8*1, 16*1*4, 16*2*2, 16*4*1,
+        #      32*1*2, 32*2*1, 64*1*1
+        assert len(combos) > 0
+        for c in combos:
+            assert c["global_batch"] == 64
+            assert c["mini_bs"] * c["dp_size"] * c["gradient_accumulation_steps"] == 64
+
+    def test_target_prime(self):
+        """A prime target has no combos with standard mini_bs/dp_size values."""
+        combos = suggest_combinations(target_global_batch=17)
+        assert len(combos) == 0
+
+    def test_sorted_by_grad_accum(self):
+        combos = suggest_combinations(target_global_batch=64)
+        ga_values = [c["gradient_accumulation_steps"] for c in combos]
+        assert ga_values == sorted(ga_values)
+
+
+# ===========================================================================
+# Deterministic output tests
+# ===========================================================================
+
+
+class TestDeterministic:
+    """Same input always produces same output."""
+
+    def test_sft_deterministic(self):
+        inp = ScaleInput(algo="sft", dataset_size=999, mini_bs=16, world_size=2, tp_size=1)
+        r1 = calculate(inp)
+        r2 = calculate(inp)
+        assert r1 == r2
+
+    def test_gspo_deterministic(self):
+        inp = ScaleInput(
+            algo="gspo", dataset_size=500, batch_size=32, n_samples=8,
+            mini_bs=16, world_size=8, tp_size=4,
+        )
+        r1 = calculate(inp)
+        r2 = calculate(inp)
+        assert r1 == r2
+
+
+# ===========================================================================
+# CLI integration tests
+# ===========================================================================
+
+
+class TestCLI:
+    """Run the script as a subprocess and check output."""
+
+    @pytest.fixture
+    def script_path(self):
+        """Find the script at its canonical location in the skills directory."""
+        p = (
+            Path(__file__).resolve().parent.parent
+            / "skills"
+            / "areno-training-scale"
+            / "scripts"
+            / "calc_training_scale.py"
+        )
+        if not p.exists():
+            pytest.skip("calc_training_scale.py not found in skills/")
+        return p
+
+    def test_sft_json_output(self, script_path):
+        result = subprocess.run(
+            [sys.executable, str(script_path),
+             "--algo", "sft", "--dataset-size", "1000",
+             "--mini-bs", "16", "--world-size", "1", "--tp-size", "1",
+             "--json"],
+            capture_output=True, text=True, check=True,
+        )
+        data = json.loads(result.stdout)
+        assert data["algo"] == "sft"
+        assert data["dp_size"] == 1
+        assert data["global_batch"] == 16
+
+    def test_gspo_json_output(self, script_path):
+        result = subprocess.run(
+            [sys.executable, str(script_path),
+             "--algo", "gspo", "--dataset-size", "500",
+             "--batch-size", "32", "--n-samples", "8",
+             "--mini-bs", "16", "--world-size", "8", "--tp-size", "4",
+             "--json"],
+            capture_output=True, text=True, check=True,
+        )
+        data = json.loads(result.stdout)
+        assert data["algo"] == "gspo"
+        assert data["global_batch"] == 32
+        assert data["samples_per_step"] == 256
+
+    def test_target_global_batch_json(self, script_path):
+        result = subprocess.run(
+            [sys.executable, str(script_path),
+             "--algo", "sft", "--dataset-size", "1000",
+             "--mini-bs", "16", "--world-size", "8", "--tp-size", "4",
+             "--target-global-batch", "128", "--json"],
+            capture_output=True, text=True, check=True,
+        )
+        data = json.loads(result.stdout)
+        assert data["gradient_accumulation_steps"] == 4
+        assert data["global_batch"] == 128
+
+    def test_suggest_mode(self, script_path):
+        result = subprocess.run(
+            [sys.executable, str(script_path),
+             "--suggest", "--target-global-batch", "64", "--json"],
+            capture_output=True, text=True, check=True,
+        )
+        combos = json.loads(result.stdout)
+        assert len(combos) > 0
+        for c in combos:
+            assert c["global_batch"] == 64
+
+    def test_missing_dataset_size_error(self, script_path):
+        result = subprocess.run(
+            [sys.executable, str(script_path),
+             "--algo", "sft"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+
+    def test_human_readable_output(self, script_path):
+        result = subprocess.run(
+            [sys.executable, str(script_path),
+             "--algo", "sft", "--dataset-size", "1000",
+             "--mini-bs", "16", "--world-size", "2", "--tp-size", "1"],
+            capture_output=True, text=True, check=True,
+        )
+        assert "AReno Training Scale" in result.stdout
+        assert "global_batch" in result.stdout


### PR DESCRIPTION
Implements #278

## What
- Add `skills/areno-training-scale/` skill with `calc_training_scale.py` script
- Add 48 CPU-only tests in `tests/test_training_scale_cpu.py`
- Add SKILL.md documentation

## Acceptance criteria
1. ✅ Correct counting rules for SFT, DPO, and online RL (GSPO/GRPO/PPO)
2. ✅ Suggest valid combinations when division is uneven
3. ✅ JSON and human-readable output
4. ✅ JSON output can be piped as input to the future recipe generator (Issue #273)
5. ✅ Uses existing AReno contracts, no external dependencies
6. ✅ Default behavior backward compatible
7. ✅ 48 focused tests cover success, invalid input, and boundary paths
8. ✅ SKILL.md includes minimal runnable example and explains observable output

## Test commands
```bash
pytest tests/test_training_scale_cpu.py -v
```

close #278