### PR TITLE
feat(hanoi): add Towers of Hanoi agentic RL demo (#186)

### DIFF
--- a/examples/agentic/hanoi/README.md
+++ b/examples/agentic/hanoi/README.md
@@ -1,0 +1,91 @@
+# Agentic Towers of Hanoi Example
+
+This example trains a policy to solve the Towers of Hanoi puzzle for 3 to 6
+disks. The policy repeatedly calls a single tool, `move(source, target)`, to
+transfer every disk from peg `A` to peg `C`. The environment is fully
+deterministic, CPU-only, and self-contained: no network services, sandboxes, or
+external databases are required.
+
+## Files
+
+- `game.py` -- state, legality, the optimal-move oracle, rendering, and
+  `score_episode` (completion + excess-over-optimum efficiency).
+- `dataset_generator.py` -- reproducible `n in {3..6}` tasks written as JSONL.
+- `dataset_loader.py` -- validates each task and attaches the per-task prompt.
+- `run_agent.py` -- the bounded multi-turn episode loop (one `move` call/turn).
+- `reward.py` -- replays emitted `move` calls through `score_episode`.
+
+## Task contract
+
+Each task record stores the disk count `n` and a generous move cap `max_moves`
+(twice the optimum plus slack). The optimum `2**n - 1` is **not** stored on the
+record; the reward path recomputes it via `game.optimal_steps`, so a record
+cannot leak the answer to the model.
+
+The only tool is:
+
+```python
+move(source: "A" | "B" | "C", target: "A" | "B" | "C")
+```
+
+An episode ends when the puzzle is solved, the move cap is reached, or the model
+emits an **illegal move** (empty source peg, source equals target, or a larger
+disk placed on a smaller disk). Illegal moves terminate the rollout.
+
+## Scoring
+
+`score_episode(n, moves)` replays the move sequence against a fresh start state
+and returns:
+
+| Field         | Meaning                                                    |
+| ------------- | ---------------------------------------------------------- |
+| `completed`   | All disks reached peg `C`.                                 |
+| `illegal`     | An illegal move was encountered before completion.         |
+| `num_moves`   | Moves replayed until termination.                          |
+| `excess`      | `max(0, num_moves - optimal)` when completed, else `None`. |
+| `efficiency`  | `max(0, 1 - excess / optimal)` when completed, else `0`.   |
+| `reward`      | `0.5 * completed + 0.5 * efficiency`; illegal/incomplete = `0.0`. |
+
+`COMPLETION_WEIGHT` and `EFFICIENCY_WEIGHT` in `game.py` tune the split without
+changing the scoring contract. A solved optimal run scores `1.0`; a solved run
+with extra moves scores less but still rewards completion; any illegal or
+incomplete run scores `0.0`.
+
+## Generate tasks
+
+```bash
+python examples/agentic/hanoi/dataset_generator.py \
+  --output /tmp/areno-hanoi-tasks.jsonl \
+  --count 128 --seed 2026 --min-disks 3 --max-disks 6
+```
+
+## Train
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path /tmp/areno-hanoi-tasks.jsonl \
+  --dataset-loader-fn examples/agentic/hanoi/dataset_loader.py \
+  --reward-fn-path examples/agentic/hanoi/reward.py \
+  --agent-fn examples/agentic/hanoi/run_agent.py \
+  --algo gspo \
+  --batch-size 1 \
+  --n-samples 2 \
+  --max-new-tokens 64
+```
+
+## Observable output
+
+During rollout the trainer logs per-step agentic diagnostics: number of
+samples, total tokens, message/tool-call/tool-result counts, and the share of
+trajectories filtered for exceeding the context length. The reward records
+expose `completed`, `excess`, and `efficiency`, so a completed-but-inefficient
+rollout is distinguishable from a failed one.
+
+## Reproducible oracle and trace replay
+
+`game.optimal_moves(n)` returns the recursive shortest solution and
+`game.optimal_steps(n)` returns `2**n - 1`. Replaying `optimal_moves(n)` against
+`score_episode(n, ...)` yields `completed=True`, `excess=0`, `reward=1.0` for
+every supported `n`; this is covered by the CPU tests and gives a deterministic
+fixture independent of any model.

--- a/examples/agentic/hanoi/dataset_generator.py
+++ b/examples/agentic/hanoi/dataset_generator.py
@@ -1,0 +1,89 @@
+"""Generate reproducible Towers of Hanoi tasks for the agentic example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = game.DEFAULT_COUNT
+DEFAULT_SEED = game.DEFAULT_SEED
+MIN_DISKS = game.MIN_DISKS
+MAX_DISKS = game.MAX_DISKS
+
+
+def generate_records(
+    count: int = DEFAULT_COUNT,
+    *,
+    seed: int = DEFAULT_SEED,
+    min_disks: int = MIN_DISKS,
+    max_disks: int = MAX_DISKS,
+) -> list[dict]:
+    """Return deterministic Towers of Hanoi tasks spread across the disk range.
+
+    Each task records the disk count ``n`` and a generous move cap derived from
+    the known optimum. The optimum itself is never stored on the record so the
+    reward path must independently recompute it via ``game.optimal_steps``.
+    """
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+    min_disks = game.validate_disks(min_disks)
+    max_disks = game.validate_disks(max_disks)
+    if min_disks > max_disks:
+        raise ValueError("min_disks must be <= max_disks")
+    rng = random.Random(seed)
+    records: list[dict] = []
+    for index in range(count):
+        n = rng.randint(min_disks, max_disks)
+        records.append(
+            {
+                "id": f"hanoi-{index + 1:05d}",
+                "n": n,
+                "max_moves": game.default_max_moves(n),
+            }
+        )
+    return records
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write generated records as JSONL."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate JSONL tasks for the Areno Towers of Hanoi agentic example."
+    )
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of tasks to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    parser.add_argument("--min-disks", type=int, default=MIN_DISKS, help="Smallest number of disks per task.")
+    parser.add_argument("--max-disks", type=int, default=MAX_DISKS, help="Largest number of disks per task.")
+    args = parser.parse_args()
+
+    records = generate_records(
+        args.count,
+        seed=args.seed,
+        min_disks=args.min_disks,
+        max_disks=args.max_disks,
+    )
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/hanoi/dataset_loader.py
+++ b/examples/agentic/hanoi/dataset_loader.py
@@ -1,0 +1,50 @@
+"""Dataset loader for the Towers of Hanoi agentic example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL Hanoi tasks and convert them to Areno prompt records."""
+
+    records = _load_records(dataset_path, default_loader=default_loader)
+    return [_format_record(raw, index) for index, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str, *, default_loader=None) -> list[dict]:
+    if default_loader is not None:
+        rows = default_loader(dataset_path)
+        if rows:
+            return list(rows)
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "tasks.jsonl"
+    if not path.exists():
+        return dataset_generator.generate_records()
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int) -> dict:
+    n = game.validate_disks(int(raw["n"]))
+    record = {
+        "id": str(raw.get("id", f"hanoi-{index:05d}")),
+        "n": n,
+        "max_moves": int(raw.get("max_moves", game.default_max_moves(n))),
+    }
+    if record["max_moves"] <= 0:
+        raise ValueError(f"max_moves must be positive for task {record['id']}")
+    record["prompt"] = game.make_prompt(record)
+    return record

--- a/examples/agentic/hanoi/game.py
+++ b/examples/agentic/hanoi/game.py
@@ -1,0 +1,275 @@
+"""Deterministic Towers of Hanoi rules for the agentic example."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+PEGS = ("A", "B", "C")
+MIN_DISKS = 3
+MAX_DISKS = 6
+DEFAULT_SEED = 2026
+DEFAULT_COUNT = 128
+
+# Reward weighting: completion is the dominant signal; efficiency is a small
+# component relative to the known optimum. Tune these in call sites (and reward
+# consumers) without changing the scoring contract.
+COMPLETION_WEIGHT = 0.5
+EFFICIENCY_WEIGHT = 0.5
+
+MOVE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "move",
+        "description": "Move the top disk of the source peg onto the target peg.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "enum": list(PEGS),
+                    "description": "The peg to take the top disk from (A, B, or C).",
+                },
+                "target": {
+                    "type": "string",
+                    "enum": list(PEGS),
+                    "description": "The peg to place the disk onto (A, B, or C).",
+                },
+            },
+            "required": ["source", "target"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def initial_state(n: int) -> dict[str, list[int]]:
+    """Return the canonical start state: all disks on peg A, largest on the bottom."""
+
+    n = _validate_disk_count(n)
+    return {"A": list(range(n, 0, -1)), "B": [], "C": []}
+
+
+def validate_disks(n: int) -> int:
+    """Validate and return a disk count in the supported range."""
+
+    return _validate_disk_count(n)
+
+
+def _validate_disk_count(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise ValueError("disk count must be an integer")
+    if n < MIN_DISKS or n > MAX_DISKS:
+        raise ValueError(f"disk count must be in [{MIN_DISKS}, {MAX_DISKS}]")
+    return n
+
+
+def normalize_state(state: dict[str, Iterable[int]], *, n: int) -> dict[str, list[int]]:
+    """Return a validated state with integer stacks and canonical peg keys."""
+
+    n = _validate_disk_count(n)
+    if not isinstance(state, dict) or set(state.keys()) != set(PEGS):
+        raise ValueError(f"state must expose exactly pegs {PEGS}")
+    normalized: dict[str, list[int]] = {}
+    for peg in PEGS:
+        stack = [int(disk) for disk in state[peg]]
+        if any(disk < 1 or disk > n for disk in stack):
+            raise ValueError(f"peg {peg} contains a disk outside [1, {n}]")
+        if len(stack) != len(set(stack)):
+            raise ValueError(f"peg {peg} contains duplicate disks")
+        normalized[peg] = stack
+    seen = sorted(disk for peg in PEGS for disk in normalized[peg])
+    if seen != list(range(1, n + 1)):
+        raise ValueError(f"state does not contain each disk 1..{n} exactly once")
+    return normalized
+
+
+def top_disk(state: dict[str, list[int]], peg: str) -> int | None:
+    """Return the top disk of ``peg`` (last list element) or None if empty."""
+
+    stack = state.get(peg)
+    if not stack:
+        return None
+    return stack[-1]
+
+
+def is_legal_move(state: dict[str, list[int]], source: Any, target: Any) -> bool:
+    """Reject empty-source moves, larger-on-smaller moves, and invalid pegs."""
+
+    try:
+        state = normalize_state(state, n=_infer_n(state))
+    except ValueError:
+        return False
+    if source not in PEGS or target not in PEGS:
+        return False
+    if source == target:
+        return False
+    source_top = top_disk(state, source)
+    if source_top is None:
+        return False
+    target_top = top_disk(state, target)
+    if target_top is not None and source_top > target_top:
+        return False
+    return True
+
+
+def illegal_reason(state: dict[str, list[int]], source: Any, target: Any) -> str:
+    """Return a human-readable reason for an illegal move."""
+
+    if source not in PEGS or target not in PEGS:
+        return f"peg names must be one of {PEGS}"
+    if source == target:
+        return "source and target are the same peg"
+    if top_disk(state, source) is None:
+        return f"peg {source} is empty"
+    source_top = top_disk(state, source)
+    target_top = top_disk(state, target)
+    return f"cannot place disk {source_top} on smaller disk {target_top}"
+
+
+def legal_moves(state: dict[str, list[int]]) -> list[tuple[str, str]]:
+    """Return every legal (source, target) peg pair for ``state``."""
+
+    result: list[tuple[str, str]] = []
+    for source in PEGS:
+        for target in PEGS:
+            if is_legal_move(state, source, target):
+                result.append((source, target))
+    return result
+
+
+def apply_move(state: dict[str, list[int]], source: str, target: str) -> dict[str, list[int]]:
+    """Apply a legal move and return a new state. Raise on illegal moves."""
+
+    n = _infer_n(state)
+    state = normalize_state(state, n=n)
+    if source not in PEGS or target not in PEGS:
+        raise ValueError(f"peg names must be one of {PEGS}")
+    if not is_legal_move(state, source, target):
+        raise ValueError(illegal_reason(state, source, target))
+    next_state = {peg: list(stack) for peg, stack in state.items()}
+    next_state[target].append(next_state[source].pop())
+    return next_state
+
+
+def is_terminal(state: dict[str, list[int]], n: int) -> bool:
+    """Return True when every disk is stacked on peg C in the solved order."""
+
+    normalize_state(state, n=n)
+    return list(state["C"]) == list(range(n, 0, -1))
+
+
+def optimal_steps(n: int) -> int:
+    """Return the closed-form minimum number of moves: 2**n - 1."""
+
+    return 2 ** _validate_disk_count(n) - 1
+
+
+def optimal_moves(n: int, *, source: str = "A", target: str = "C", auxiliary: str = "B") -> list[tuple[str, str]]:
+    """Return the recursive optimal move sequence solving the puzzle."""
+
+    _validate_disk_count(n)
+    return _optimal_moves(n, source, target, auxiliary)
+
+
+def _optimal_moves(n: int, source: str, target: str, auxiliary: str) -> list[tuple[str, str]]:
+    if n == 0:
+        return []
+    moves: list[tuple[str, str]] = []
+    moves.extend(_optimal_moves(n - 1, source, auxiliary, target))
+    moves.append((source, target))
+    moves.extend(_optimal_moves(n - 1, auxiliary, target, source))
+    return moves
+
+
+def default_max_moves(n: int) -> int:
+    """Return a generous per-task move cap, twice the optimum plus a little slack."""
+
+    return optimal_steps(n) * 2 + 2
+
+
+def state_to_text(state: dict[str, list[int]]) -> str:
+    """Render pegs bottom-up so the model can read the top disk at a glance."""
+
+    lines = []
+    for peg in PEGS:
+        stack = state.get(peg, [])
+        rendered = " ".join(str(disk) for disk in stack) if stack else "(empty)"
+        lines.append(f"Peg {peg} (bottom->top): {rendered}")
+    return "\n".join(lines)
+
+
+def make_prompt(record: dict[str, Any]) -> str:
+    """Build the per-task task prompt without leaking any solution."""
+
+    n = int(record["n"])
+    max_moves = int(record.get("max_moves", default_max_moves(n)))
+    return (
+        f"Solve the Towers of Hanoi puzzle with {n} disks. All disks start on peg A "
+        "(largest on the bottom, smallest on top) and must end on peg C in the same order.\n\n"
+        "Rules:\n"
+        "- Move exactly one disk per turn by calling the move(source, target) tool.\n"
+        "- source/target are peg names A, B, or C.\n"
+        "- You may only move the top disk of a peg. Never place a larger disk on a smaller one.\n"
+        "- An empty-source move or a larger-on-smaller move is illegal and ends the episode.\n"
+        f"- You have at most {max_moves} moves.\n\n"
+        f"Start state:\n{state_to_text(initial_state(n))}\n\nMove:"
+    )
+
+
+def score_episode(n: int, moves: list[tuple[Any, Any]]) -> dict[str, Any]:
+    """Replay ``moves`` and score completion plus efficiency over the optimum.
+
+    Illegal moves terminate the replay and score 0.0 exactly (per the design:
+    an illegal action ends the rollout). Completion earns the full completion
+    weight; the efficiency component decays as moves exceed the known optimum.
+    """
+
+    n = _validate_disk_count(n)
+    optimum = optimal_steps(n)
+    state = initial_state(n)
+    for index, move in enumerate(moves):
+        source, target = _move_pair(move)
+        if not is_legal_move(state, source, target):
+            return {
+                "completed": False,
+                "illegal": True,
+                "num_moves": index,
+                "excess": None,
+                "efficiency": 0.0,
+                "reward": 0.0,
+            }
+        state = apply_move(state, source, target)
+        if is_terminal(state, n):
+            num_moves = index + 1
+            excess = max(0, num_moves - optimum)
+            efficiency = max(0.0, 1.0 - excess / optimum)
+            reward = COMPLETION_WEIGHT + EFFICIENCY_WEIGHT * efficiency
+            return {
+                "completed": True,
+                "illegal": False,
+                "num_moves": num_moves,
+                "excess": excess,
+                "efficiency": efficiency,
+                "reward": reward,
+            }
+    return {
+        "completed": False,
+        "illegal": False,
+        "num_moves": len(moves),
+        "excess": None,
+        "efficiency": 0.0,
+        "reward": 0.0,
+    }
+
+
+def _move_pair(move: Any) -> tuple[Any, Any]:
+    if isinstance(move, (tuple, list)) and len(move) == 2:
+        return move[0], move[1]
+    return None, None
+
+
+def _infer_n(state: dict[str, Iterable[int]]) -> int:
+    disks = [int(disk) for peg in PEGS for disk in state.get(peg, [])]
+    if not disks:
+        raise ValueError("state has no disks; pass n explicitly via normalize_state")
+    return max(disks)

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -1,0 +1,43 @@
+"""Outcome and efficiency reward for Towers of Hanoi trajectories."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def reward_fn(record) -> float:
+    """Score one episode by replaying the emitted ``move`` tool calls.
+
+    The reward is shared between completion and a small efficiency component
+    relative to the known optimum. Any illegal move terminates the replay and
+    scores 0.0 exactly.
+    """
+
+    source = dict(record.source_record)
+    n = int(source["n"])
+    moves = _extract_moves(record.tool_calls)
+    return float(game.score_episode(n, moves)["reward"])
+
+
+def _extract_moves(tool_calls) -> list[tuple[object, object]]:
+    moves: list[tuple[object, object]] = []
+    for call in tool_calls:
+        if call.get("name") != "move":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                moves.append((None, None))
+                continue
+        if not isinstance(arguments, dict):
+            moves.append((None, None))
+            continue
+        moves.append((arguments.get("source"), arguments.get("target")))
+    return moves

--- a/examples/agentic/hanoi/run_agent.py
+++ b/examples/agentic/hanoi/run_agent.py
@@ -1,0 +1,194 @@
+"""Bounded multi-turn agent loop for the Towers of Hanoi example."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import (  # noqa: E402
+    MOVE_TOOL,
+    apply_move,
+    default_max_moves,
+    illegal_reason,
+    initial_state,
+    is_legal_move,
+    is_terminal,
+    state_to_text,
+)
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are a careful Towers of Hanoi solver. On every turn call the move(source, target) "
+    "tool exactly once with peg names A, B, or C. Only move the top disk of a peg and never "
+    "place a larger disk on a smaller one. Use peg B as the auxiliary. After the puzzle is "
+    "solved or an illegal move ends the episode, summarize the outcome without a tool call."
+)
+
+
+async def run_agent(ctx, batch):
+    """Run bounded concurrent Hanoi episodes while preserving exact model outputs."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "Towers of Hanoi requires `openai` and `httpx`. Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+    try:
+        grouped = await asyncio.gather(*(_run_episode(item, client) for item in items))
+        return AgentTrajectory(turns=[turn for episode in grouped for turn in episode])
+    finally:
+        await client.close()
+
+
+async def _run_episode(item, client) -> list[AgentTrajectoryTurn]:
+    n = int(item.record["n"])
+    max_moves = int(item.record.get("max_moves", default_max_moves(n)))
+    state = initial_state(n)
+    messages: list[dict] = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": item.prompt},
+    ]
+    turns: list[AgentTrajectoryTurn] = []
+    for step in range(1, max_moves + 1):
+        turn_messages = [
+            *messages,
+            {
+                "role": "user",
+                "content": f"Move {step} of {max_moves}. Current state:\n{state_to_text(state)}\nCall move now.",
+            },
+        ]
+        tool_choice = {"type": "function", "function": {"name": "move"}}
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=turn_messages,
+            tools=[MOVE_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        turns.append(
+            AgentTrajectoryTurn(
+                item=item,
+                messages=turn_messages,
+                response=response,
+                tools=[MOVE_TOOL],
+                tool_choice=tool_choice,
+            )
+        )
+        assistant_message = _assistant_message(response)
+        move = _parse_move(assistant_message)
+        if move is None:
+            logger.warning("Hanoi model returned no executable move call")
+            break
+        source, target = move
+        if not is_legal_move(state, source, target):
+            tool_result = {
+                "ok": False,
+                "completed": False,
+                "move": [source, target],
+                "error": illegal_reason(state, source, target),
+                "state": state_to_text(state),
+            }
+            messages.extend(_tool_messages(assistant_message, tool_result))
+            await _finish_episode(item, client, messages, turns)
+            break
+        state = apply_move(state, source, target)
+        completed = is_terminal(state, n)
+        tool_result = {
+            "ok": True,
+            "completed": completed,
+            "move": [source, target],
+            "state": state_to_text(state),
+        }
+        messages.extend(_tool_messages(assistant_message, tool_result))
+        if completed or step == max_moves:
+            await _finish_episode(item, client, messages, turns, completed=completed)
+            break
+    return turns
+
+
+async def _finish_episode(item, client, messages, turns, *, completed: bool = False) -> None:
+    """Append one final non-tool summary turn so the episode has a clean stop."""
+
+    if completed:
+        content = "All disks are on peg C. Briefly summarize the solution without calling a tool."
+    else:
+        content = "The episode is over. Briefly summarize the outcome without calling a tool."
+    finish_messages = [*messages, {"role": "user", "content": content}]
+    finish_response = await client.chat.completions.create(
+        model="policy",
+        messages=finish_messages,
+        stream=False,
+    )
+    turns.append(AgentTrajectoryTurn(item=item, messages=finish_messages, response=finish_response))
+
+
+def _assistant_message(response: dict) -> dict:
+    message = response.choices[0].message
+    return {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": call.type,
+                "function": {"name": call.function.name, "arguments": call.function.arguments},
+            }
+            for call in (message.tool_calls or [])
+        ],
+    }
+
+
+def _parse_move(message: dict) -> tuple[str, str] | None:
+    """Return the single move arguments, or None if the call is not executable.
+
+    A move is executable when the model emitted exactly one ``move`` call with a
+    JSON ``source``/``target`` pair drawn from the supported pegs. Moves that are
+    parseable but illegal (empty source, larger on smaller) still return here so
+    the episode can record the rejection and terminate.
+    """
+
+    calls = message.get("tool_calls") or []
+    if len(calls) != 1 or calls[0].get("function", {}).get("name") != "move":
+        return None
+    try:
+        arguments = json.loads(calls[0]["function"].get("arguments") or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(arguments, dict):
+        return None
+    source = arguments.get("source")
+    target = arguments.get("target")
+    if source not in ("A", "B", "C") or target not in ("A", "B", "C"):
+        return None
+    return source, target
+
+
+def _tool_messages(assistant_message: dict, tool_result: dict) -> list[dict]:
+    call = assistant_message["tool_calls"][0]
+    return [
+        assistant_message,
+        {
+            "role": "tool",
+            "tool_call_id": call["id"],
+            "name": "move",
+            "content": json.dumps(tool_result, ensure_ascii=False),
+        },
+    ]

--- a/tests/test_agentic_hanoi_example_cpu.py
+++ b/tests/test_agentic_hanoi_example_cpu.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "hanoi"
+
+
+def _load_module(name: str):
+    path = EXAMPLE_DIR / f"{name}.py"
+    previous_game = sys.modules.pop("game", None)
+    previous_agentic = sys.modules.get("areno.api.agentic")
+    if name == "run_agent":
+        sys.modules["areno.api.agentic"] = SimpleNamespace(
+            AgentTrajectory=type("AgentTrajectory", (), {}),
+            AgentTrajectoryTurn=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(f"agentic_hanoi_{name}_for_tests", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+        if name == "run_agent":
+            sys.modules.pop("areno.api.agentic", None)
+            if previous_agentic is not None:
+                sys.modules["areno.api.agentic"] = previous_agentic
+
+
+def test_optimal_calculator_and_trace_replay_complete_every_disk_count():
+    game = _load_module("game")
+
+    for n in (3, 4, 5, 6):
+        assert game.optimal_steps(n) == 2 ** n - 1
+        moves = game.optimal_moves(n)
+        assert len(moves) == game.optimal_steps(n)
+        result = game.score_episode(n, moves)
+        assert result["completed"] is True
+        assert result["illegal"] is False
+        assert result["excess"] == 0
+        assert result["efficiency"] == 1.0
+        assert result["reward"] == 1.0
+
+
+def test_legal_moves_reject_empty_source_and_larger_on_smaller():
+    game = _load_module("game")
+    state = game.initial_state(3)
+
+    # Pegs B and C are empty at the start: B -> C is an empty-source move.
+    assert game.is_legal_move(state, "B", "C") is False
+    assert game.is_legal_move(state, "A", "B") is True
+
+    # A -> C moves disk 1, then A -> B moves disk 2. State: A=[3], B=[2], C=[1].
+    state = game.apply_move(state, "A", "C")
+    assert game.top_disk(state, "A") == 2
+    state = game.apply_move(state, "A", "B")
+    assert game.top_disk(state, "C") == 1
+    # Placing disk 1 (C) on disk 2 (B) is legal (smaller on larger).
+    assert game.is_legal_move(state, "C", "B") is True
+    # Placing disk 2 (B) on disk 1 (C) is illegal (larger on smaller).
+    assert game.is_legal_move(state, "B", "C") is False
+    assert "smaller disk" in game.illegal_reason(state, "B", "C")
+    with pytest.raises(ValueError):
+        game.apply_move(state, "B", "C")
+
+
+def test_score_completion_efficiency_and_illegal_termination():
+    game = _load_module("game")
+    n = 3
+    optimal = game.optimal_moves(n)
+
+    # Illegal move before completion terminates and scores 0.0.
+    assert game.score_episode(n, [("B", "C")])["reward"] == 0.0
+    assert game.score_episode(n, [("B", "C")])["illegal"] is True
+
+    # One move short of completion: completed=False, reward 0.0, not illegal.
+    short = game.score_episode(n, optimal[: len(optimal) - 1])
+    assert short["completed"] is False
+    assert short["illegal"] is False
+    assert short["reward"] == 0.0
+
+    # Optimal path scores 1.0; one extra redundant move still completes but scores less.
+    assert game.score_episode(n, optimal)["reward"] == 1.0
+    # Insert a legal redundant cycle A->B, B->A after the first optimal move.
+    extended = [optimal[0], ("A", "B"), ("B", "A"), *optimal[1:]]
+    result = game.score_episode(n, extended)
+    assert result["completed"] is True
+    assert result["excess"] == 2
+    assert 0.5 < result["reward"] < 1.0
+
+
+def test_generator_is_reproducible_and_within_disk_range():
+    generator = _load_module("dataset_generator")
+
+    records = generator.generate_records(32, seed=7)
+    assert records == generator.generate_records(32, seed=7)
+    assert len(records) == 32
+    for record in records:
+        assert record["n"] in (3, 4, 5, 6)
+        assert record["max_moves"] >= game_optimal_steps(record["n"]) * 2
+        assert "optimal" not in record  # the answer must not live on the record
+
+
+def game_optimal_steps(n: int) -> int:
+    game = _load_module("game")
+    return game.optimal_steps(n)
+
+
+def test_loader_validates_disks_and_attaches_prompt_without_leaking_solution():
+    loader = _load_module("dataset_loader")
+    game = _load_module("game")
+
+    raw = [{"id": "t1", "n": 3}, {"id": "t2", "n": 5}]
+    records = loader.load_training_dataset("unused", default_loader=lambda _: raw)
+    assert [r["id"] for r in records] == ["t1", "t2"]
+    for record in records:
+        assert record["n"] in (3, 5)
+        assert record["max_moves"] > 0
+        assert f"{record['n']} disks" in record["prompt"]
+        assert "Peg A" in record["prompt"]
+        assert "2 ** n - 1" not in record["prompt"]
+
+    # Out-of-range disk counts are rejected before any backend work.
+    with pytest.raises(ValueError):
+        loader.load_training_dataset("unused", default_loader=lambda _: [{"n": 2}])
+    with pytest.raises(ValueError):
+        loader.load_training_dataset("unused", default_loader=lambda _: [{"n": 7}])
+
+
+def test_reward_replays_tool_calls_and_scores_illegal_and_malformed():
+    reward = _load_module("reward")
+    game = _load_module("game")
+    n = 3
+    optimal = game.optimal_moves(n)
+
+    def score(moves):
+        calls = [
+            {"name": "move", "arguments": json.dumps({"source": src, "target": tgt})}
+            for src, tgt in moves
+        ]
+        return reward.reward_fn(
+            SimpleNamespace(source_record={"n": n}, tool_calls=calls)
+        )
+
+    assert score([]) == 0.0
+    assert score(optimal) == 1.0
+    assert score([("B", "C")]) == 0.0  # empty source is illegal
+    assert score(optimal[:2]) == 0.0  # incomplete without illegal
+
+    malformed = reward.reward_fn(
+        SimpleNamespace(
+            source_record={"n": n},
+            tool_calls=[{"name": "move", "arguments": "not-json"}],
+        )
+    )
+    assert malformed == 0.0
+
+
+def test_tool_schema_is_closed_and_bounded_to_three_pegs():
+    game = _load_module("game")
+    parameters = game.MOVE_TOOL["function"]["parameters"]
+
+    assert parameters["additionalProperties"] is False
+    assert parameters["required"] == ["source", "target"]
+    assert parameters["properties"]["source"]["enum"] == ["A", "B", "C"]
+    assert parameters["properties"]["target"]["enum"] == ["A", "B", "C"]
+
+
+def _move_response(source: str, target: str):
+    call = SimpleNamespace(
+        id=f"call-{source}{target}",
+        type="function",
+        function=SimpleNamespace(
+            name="move", arguments=json.dumps({"source": source, "target": target})
+        ),
+    )
+    message = SimpleNamespace(content=None, tool_calls=[call])
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _summary_response():
+    message = SimpleNamespace(content="solved", tool_calls=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class _FakeCompletions:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs["messages"])
+        return next(self.responses)
+
+
+def test_episode_replays_optimal_path_and_appends_clean_summary():
+    run_agent = _load_module("run_agent")
+    game = _load_module("game")
+    n = 3
+    optimal = game.optimal_moves(n)
+
+    responses = [_move_response(src, tgt) for src, tgt in optimal]
+    responses.append(_summary_response())
+    completions = _FakeCompletions(responses)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    item = SimpleNamespace(
+        prompt="solve it",
+        record={"n": n, "max_moves": game.default_max_moves(n)},
+    )
+
+    turns = asyncio.run(run_agent._run_episode(item, client))
+
+    # One turn per optimal move, plus the final non-tool summary turn.
+    assert len(turns) == len(optimal) + 1
+    assert all(getattr(turn, "tool_choice", None) is not None for turn in turns[:-1])
+    assert getattr(turns[-1], "tool_choice", None) is None  # summary turn carries no tool
+    assert getattr(turns[-1], "tools", None) in (None, [])
+
+    finish_messages = completions.calls[-1]
+    tool_results = [m for m in finish_messages if m.get("role") == "tool"]
+    assert '"ok": true' in tool_results[-1]["content"]
+    assert '"completed": true' in tool_results[-1]["content"]
+    # The model was asked for exactly one move per turn plus the summary.
+    assert len(completions.calls) == len(optimal) + 1
+
+
+def test_episode_terminates_on_illegal_move_with_rejection_message():
+    run_agent = _load_module("run_agent")
+    game = _load_module("game")
+    n = 3
+
+    # From the start state, B is empty: move(B, C) is an illegal empty-source move.
+    responses = [_move_response("B", "C"), _summary_response()]
+    completions = _FakeCompletions(responses)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    item = SimpleNamespace(
+        prompt="solve it",
+        record={"n": n, "max_moves": game.default_max_moves(n)},
+    )
+
+    turns = asyncio.run(run_agent._run_episode(item, client))
+    assert len(turns) == 2  # illegal move turn + summary turn
+    tool_results = [m for m in completions.calls[-1] if m.get("role") == "tool"]
+    assert '"ok": false' in tool_results[-1]["content"]
+    assert "empty" in tool_results[-1]["content"]
+    # Replaying the single emitted move through the reward scores 0.0.
+    reward = _load_module("reward")
+    score = reward.reward_fn(
+        SimpleNamespace(
+            source_record={"n": n},
+            tool_calls=[{"name": "move", "arguments": json.dumps({"source": "B", "target": "C"})}],
+        )
+    )
+    assert score == 0.0
+
+
+def test_episode_breaks_when_model_returns_no_tool_call():
+    run_agent = _load_module("run_agent")
+    game = _load_module("game")
+    n = 3
+
+    completions = _FakeCompletions([_summary_response()])
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    item = SimpleNamespace(
+        prompt="solve it",
+        record={"n": n, "max_moves": game.default_max_moves(n)},
+    )
+
+    turns = asyncio.run(run_agent._run_episode(item, client))
+    assert len(turns) == 1  # no executable move -> stop without a summary turn
+
+
+def test_state_text_is_deterministic_and_reads_top_at_glance():
+    game = _load_module("game")
+    text = game.state_to_text(game.initial_state(3))
+    assert text == "Peg A (bottom->top): 3 2 1\nPeg B (bottom->top): (empty)\nPeg C (bottom->top): (empty)"


### PR DESCRIPTION
## Summary

Adds a focused, self-contained **Towers of Hanoi agentic RL demo** under `examples/agentic/hanoi/`, implementing #186. The policy repeatedly calls a single `move(source, target)` tool to transfer 3–6 disks from peg A to peg C. It mirrors AReno's existing agentic contracts (tictactoe / codebreaker) and introduces **no external database, no mandatory sandbox, and no new dependency**.

Closes #186.

## What's added (purely additive — 7 new files, 0 existing files modified)

| File | Role |
|---|---|
| `examples/agentic/hanoi/game.py` | Peg state, legal-move validation (empty source / larger-on-smaller), recursive optimal-move oracle (`2^n-1`), state rendering, and `score_episode` (completion + excess-over-optimum efficiency) |
| `examples/agentic/hanoi/dataset_generator.py` | Reproducible `n ∈ {3..6}` task JSONL generator |
| `examples/agentic/hanoi/dataset_loader.py` | Tokenizer-independent loader; the optimum is **never** stored on the record (no answer leakage) |
| `examples/agentic/hanoi/run_agent.py` | Bounded multi-turn episode loop (one `move` call/turn), terminating on completion / illegal move / move cap |
| `examples/agentic/hanoi/reward.py` | Replays emitted `move` calls through `score_episode` |
| `examples/agentic/hanoi/README.md` | Input contract, defaults, output fields, copyable example |
| `tests/test_agentic_hanoi_example_cpu.py` | CPU tests covering the oracle, trace replay, illegal-action paths, excess metric, and the multi-turn episode loop |

## Contract alignment

- Reuses existing public contracts only: `run_agent(ctx, batch)` → `AgentTrajectory(turns=[AgentTrajectoryTurn])`, `reward_fn(record)`, `load_training_dataset(dataset_path, *, default_loader=None, **_)`, `generate_records(count, *, seed)`.
- Multi-turn turns for the same `(prompt_index, sample_index)` accumulate through AReno's existing `_append_sample_response`; the reward replays the full `record.tool_calls` from the initial state.
- Legal-move semantics: empty-source and larger-on-smaller moves are rejected and **terminate the rollout** (reward `0.0`), per the design in #186.
- `reward = 0.5 · completion + 0.5 · efficiency`, where `efficiency = max(0, 1 − excess / optimum)`. Weights are constants in `game.py` (tunable without changing the scoring contract). Optimal run scores `1.0`.

## Acceptance criteria vs. #186

- ✅ Deterministic fixtures + oracle shortest-step calculator (`optimal_steps`/`optimal_moves`) + text trace replay (`state_to_text` + `score_episode` replay) + illegal-action coverage + completion-rate and excess-over-optimum metrics
- ✅ Uses existing AReno contracts; no external database or mandatory sandbox
- ✅ Default behavior unchanged (purely additive; no existing file modified)
- ✅ Focused CPU tests cover success, invalid input, and a boundary/failure path (illegal move, malformed tool args, out-of-range disk counts, no-tool-call early stop)
- ✅ User documentation in `examples/agentic/hanoi/README.md` with a minimal runnable example and an explicit "Observable output" section

## Verification

Ran on CPU (Python 3.9 system interpreter for our example modules; the full repo `pytest tests/ -k cpu` runs under 3.10+ in CI):
```
tests/test_agentic_hanoi_example_cpu.py ...........  11 passed
tests/test_agentic_tictactoe_example_cpu.py .....   5 passed   (no regression)
```
End-to-end smoke (generate → load → reward replay) gives `reward=1.0` on optimal `optimal_moves(n)` for every `n ∈ {3,4,5,6}`, `reward≈0.857` for an excess-of-2 path, and `reward=0.0` for an illegal first move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)