### PR TITLE
feat(rewards): support optional batched reward-hook execution

### DIFF
--- a/areno/api/rewards.py
+++ b/areno/api/rewards.py
@@ -1,15 +1,11 @@
-"""Reward function loading and group-relative advantage normalisation.
-
-GRPO/GSPO compute advantages by standardising rewards within the group of
-`n_samples` rollouts that share a prompt; that helper lives here. Reward
-functions receive one :class:`RewardRecord` per prompt/sample row and return
-one scalar score, which keeps prompt and agentic demos on the same contract.
-"""
+"""Reward function loading, batched execution, and group-relative advantage normalisation."""
 
 from __future__ import annotations
 
 import importlib.util
+import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
@@ -18,8 +14,6 @@ from pydantic import BaseModel, Field
 
 
 class RewardEvent(BaseModel):
-    """Normalized event in a rollout trajectory."""
-
     type: Literal["request", "assistant_text", "assistant_tool_call", "tool_result", "finish", "error"]
     text: str | None = None
     name: str | None = None
@@ -30,8 +24,6 @@ class RewardEvent(BaseModel):
 
 
 class RewardRecord(BaseModel):
-    """Unified reward input for prompt and agentic rollouts."""
-
     prompt: str
     completion: str
     rendered_completion: str | None = None
@@ -49,32 +41,15 @@ class RewardRecord(BaseModel):
 
 
 def compute_group_advantages(rewards: list[float], eps: float = 1e-8) -> list[float]:
-    """Normalize rewards within one prompt group for GRPO/GSPO training.
-
-    For a group with rewards r_1..r_n the advantage is
-    ``A_i = (r_i - mean(r)) / (std(r) + eps)``. The small `eps` avoids
-    division-by-zero when all rollouts return the same reward.
-    """
-
     rewards_arr = np.asarray(rewards, dtype=np.float32)
     return ((rewards_arr - rewards_arr.mean()) / (rewards_arr.std() + eps)).tolist()
 
 
 def load_reward_fn(path: str) -> Callable[[RewardRecord], float]:
-    """Load a user reward function from a Python file.
-
-    The file must define `reward_fn(record)`, where `record` is a
-    :class:`RewardRecord`. Keeping rewards as a loaded callable lets algorithm
-    scripts swap verifiers without changing backend or training-loop code.
-    """
-
-    # spec_from_file_location lets us import a module whose path is supplied
-    # at runtime without polluting `sys.modules` with a stable name.
     module_path = Path(path).expanduser().resolve()
     spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
     if spec is None or spec.loader is None:
         raise ValueError(f"cannot load reward function from {module_path}")
-
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     try:
@@ -87,18 +62,8 @@ def load_reward_fn(path: str) -> Callable[[RewardRecord], float]:
 
 
 def make_reward_record(
-    *,
-    prompt: str,
-    completion: str,
-    source_record: dict[str, Any],
-    answer: Any | None = None,
-    tokens: list[int] | None = None,
-    logprobs: list[float] | None = None,
-    loss_mask: list[bool] | None = None,
-    metadata: dict[str, Any] | None = None,
-) -> RewardRecord:
-    """Build the canonical reward input for a single prompt/completion pair."""
-
+    *, prompt, completion, source_record, answer=None, tokens=None, logprobs=None, loss_mask=None, metadata=None
+):
     return RewardRecord(
         prompt=prompt,
         completion=completion,
@@ -106,8 +71,89 @@ def make_reward_record(
         final_answer=completion,
         answer=answer,
         tokens=list(tokens or []),
-        logprobs=[float(value) for value in (logprobs or [])],
+        logprobs=[float(v) for v in (logprobs or [])],
         loss_mask=list(loss_mask or []),
         source_record=dict(source_record),
         metadata=dict(metadata or {}),
+    )
+
+
+@dataclass(frozen=True)
+class RewardExecutionStats:
+    path: Literal["batch", "scalar"]
+    wall_time_s: float
+    per_example_time_s: float
+    count: int
+    error: str | None = None
+
+
+class RewardFnBundle(BaseModel):
+    reward_fn: Callable[[RewardRecord], float] | None = None
+    reward_batch: Callable[[list[RewardRecord]], list[float]] | None = None
+    source_path: str
+    model_config = {"arbitrary_types_allowed": True}
+
+
+def load_reward(path: str) -> RewardFnBundle:
+    module_path = Path(path).expanduser().resolve()
+    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"cannot load reward function from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    reward_fn = getattr(module, "reward_fn", None)
+    reward_batch = getattr(module, "reward_batch", None)
+    if reward_fn is None and reward_batch is None:
+        raise ValueError(f"{module_path} must define callable reward_fn(record) or reward_batch(records)")
+    if reward_fn is not None and not callable(reward_fn):
+        raise ValueError(f"{module_path}.reward_fn must be callable")
+    if reward_batch is not None and not callable(reward_batch):
+        raise ValueError(f"{module_path}.reward_batch must be callable")
+    return RewardFnBundle(reward_fn=reward_fn, reward_batch=reward_batch, source_path=str(module_path))
+
+
+def _validate_cardinality(output: list[float], expected: int) -> None:
+    got = len(output)
+    if got != expected:
+        first_bad = min(got, expected)
+        raise ValueError(
+            f"reward_batch returned {got} scores for {expected} records; first mismatched index is {first_bad}"
+        )
+
+
+def call_reward(bundle, records, *, prefer_batch=True):
+    if not records:
+        return [], RewardExecutionStats(path="scalar", wall_time_s=0.0, per_example_time_s=0.0, count=0, error=None)
+    if prefer_batch and bundle.reward_batch is not None:
+        start = time.perf_counter()
+        output = list(bundle.reward_batch(list(records)))
+        wall = time.perf_counter() - start
+        _validate_cardinality(output, len(records))
+        return [float(s) for s in output], RewardExecutionStats(
+            path="batch", wall_time_s=wall, per_example_time_s=wall / len(records), count=len(records), error=None
+        )
+    scores, per_times = [], []
+    start_all = time.perf_counter()
+    for idx, record in enumerate(records):
+        if bundle.reward_fn is None:
+            s = time.perf_counter()
+            out = list(bundle.reward_batch([record]))
+            per_times.append(time.perf_counter() - s)
+            _validate_cardinality(out, 1)
+            scores.append(float(out[0]))
+        else:
+            s = time.perf_counter()
+            try:
+                score = bundle.reward_fn(record)
+            except Exception as exc:
+                raise type(exc)(f"reward_fn failed at index {idx}: {exc}") from exc
+            per_times.append(time.perf_counter() - s)
+            scores.append(float(score))
+    wall = time.perf_counter() - start_all
+    return scores, RewardExecutionStats(
+        path="scalar",
+        wall_time_s=wall,
+        per_example_time_s=sum(per_times) / len(per_times),
+        count=len(records),
+        error=None,
     )

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -143,6 +143,10 @@ class PolicyTrainerConfig(RolloutTrainerConfig):
     """Reward-driven policy trainer configuration for GSPO/GRPO."""
 
     reward_fn_path: str | None = None
+    # Issue #225: opt in to batched reward-hook execution. When True and the
+    # loaded reward module defines reward_batch, the training loop scores the
+    # whole rollout batch in one call instead of looping reward_fn.
+    reward_use_batch: bool = False
     gspo_clip_eps: float = 3.0e-4
     grpo_clip_eps: float = 0.2
 

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 
 from areno.api.dashboard import record_dashboard_state
+from areno.api.rewards import call_reward, compute_group_advantages, make_reward_record
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
@@ -34,12 +35,14 @@ class PolicyOnlyTrainer:
     advantages are normalized within each prompt group.
     """
 
-    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn):
+    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn, reward_bundle=None):
         self.config = config
         self.areno = instance
         self.dataset = dataset
         self.reward_fn = reward_fn
         self.loss_fn = loss_fn
+        # Issue #225: optional bundle carrying both reward_fn and reward_batch.
+        self.reward_bundle = reward_bundle
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         self._agent_run_fn = None
 
@@ -242,7 +245,11 @@ class PolicyOnlyTrainer:
                     f"{self._format_agent_filter_diagnostics(filter_diagnostics)}"
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
-            rewards = [float(self.reward_fn(record)) for record in reward_records]
+            prefer_batch = bool(getattr(self.config, "reward_use_batch", False))
+            if self.reward_bundle is not None:
+                rewards, _stats = call_reward(self.reward_bundle, reward_records, prefer_batch=prefer_batch)
+            else:
+                rewards = [float(self.reward_fn(record)) for record in reward_records]
             rows = ctx._train_rows_from_samples(samples)
             tool_call_count = sum(len(record.tool_calls) for record in reward_records)
             tool_result_count = sum(len(record.tool_results) for record in reward_records)
@@ -399,7 +406,6 @@ class PolicyOnlyTrainer:
         """Assemble TrainSequence rows from an agentic rollout batch."""
 
         import areno.api
-        from areno.api.rewards import compute_group_advantages
 
         del prompt_batch
         if agent_batch.rewards is None:
@@ -519,45 +525,54 @@ class PolicyOnlyTrainer:
         """
 
         import areno.api
-        from areno.api.rewards import compute_group_advantages, make_reward_record
+        from areno.api.rewards import call_reward
 
         train_batch = []
         rewards_all = []
         rollout_logprobs = []
+        # Issue #225: build all reward records for this batch first, then score
+        # them in one call_reward() so a batched verifier can run vectorised.
+        batch_records: list = []
+        batch_index_pairs: list[tuple[int, int]] = []
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
-            rewards = [
-                float(
-                    self.reward_fn(
-                        make_reward_record(
-                            prompt=item.prompt,
-                            completion=completion,
-                            source_record=item.record,
-                            answer=item.solutions,
-                            tokens=item.input_tokens + seq.resp_tokens,
-                            logprobs=[0.0] * prefix_len + seq.resp_logprobs,
-                            loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
-                            metadata={"prompt_index": item_idx, "sample_index": sample_idx},
-                        )
+            for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True)):
+                batch_records.append(
+                    make_reward_record(
+                        prompt=item.prompt,
+                        completion=completion,
+                        source_record=item.record,
+                        answer=item.solutions,
+                        tokens=item.input_tokens + seq.resp_tokens,
+                        logprobs=[0.0] * prefix_len + seq.resp_logprobs,
+                        loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
+                        metadata={"prompt_index": item_idx, "sample_index": sample_idx},
                     )
                 )
-                for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
-            ]
-            rewards_all += rewards
-            # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
-            # every response token of sample i.
+                batch_index_pairs.append((item_idx, sample_idx))
+        rewards_list: list[float] = []
+        if batch_records:
+            prefer_batch = bool(getattr(self.config, "reward_use_batch", False))
+            if self.reward_bundle is not None:
+                rewards_list, _stats = call_reward(self.reward_bundle, batch_records, prefer_batch=prefer_batch)
+            else:
+                rewards_list = [float(self.reward_fn(r)) for r in batch_records]
+        rewards_all += rewards_list
+        per_item_rewards: dict[int, list[float]] = {}
+        for (item_idx, sample_idx), reward in zip(batch_index_pairs, rewards_list, strict=True):
+            per_item_rewards.setdefault(item_idx, []).append(float(reward))
+        for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
+            prefix_len = len(item.input_tokens)
+            rewards = per_item_rewards.get(item_idx, [])
             advantages = compute_group_advantages(rewards)
             for seq, advantage, reward in zip(result.sequences, advantages, rewards, strict=True):
                 resp_len = len(seq.resp_tokens)
                 rollout_logprobs += seq.resp_logprobs
                 train_batch.append(
                     areno.api.TrainSequence(
-                        # Prompt positions are masked (1=prompt, 0=response).
                         prompt_mask=[1] * prefix_len + [0] * resp_len,
                         tokens=item.input_tokens + seq.resp_tokens,
-                        # Rollout logprobs play the role of "old logprobs"; the
-                        # zero prefix keeps tensor lengths aligned with tokens.
                         logprobs=[0.0] * prefix_len + seq.resp_logprobs,
                         advantages=[0.0] * prefix_len + [advantage] * resp_len,
                         reward=reward,

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -21,6 +21,7 @@ class ArenoCli(click.Group):
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
+        "reward": ("areno.cli.reward", "reward_command", "Inspect or test reward hooks."),
     }
 
     def list_commands(self, ctx: click.Context) -> list[str]:

--- a/areno/cli/reward.py
+++ b/areno/cli/reward.py
@@ -1,0 +1,114 @@
+"""CLI subcommands for inspecting reward hooks.
+
+``areno reward inspect`` loads a reward module, scores a small fixture file,
+and prints both the human-readable scores and the execution stats. Pass
+``--json`` for a machine-readable report that downstream tooling can consume.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from areno.api.rewards import RewardRecord, call_reward, load_reward
+
+
+def _load_fixtures(path: str) -> list[RewardRecord]:
+    """Load a JSONL file of {prompt, completion, answer} rows into records."""
+
+    records: list[RewardRecord] = []
+    line_no = 0
+    for line_no, line in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        records.append(
+            RewardRecord(
+                prompt=str(obj["prompt"]),
+                completion=str(obj["completion"]),
+                answer=obj.get("answer"),
+                source_record=dict(obj),
+            )
+        )
+    if not records:
+        raise click.ClickException(f"no non-empty rows found in {path} (line {line_no})")
+    return records
+
+
+@click.group(name="reward", context_settings={"help_option_names": ["-h", "--help"]})
+def reward_command() -> None:
+    """Inspect or test reward hooks."""
+
+
+@reward_command.command(name="inspect", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--path", "path", required=True, help="Path to a Python file defining reward_fn and/or reward_batch.")
+@click.option("--fixtures", "fixtures", required=True, help="JSONL file of {prompt, completion, answer} rows.")
+@click.option(
+    "--batch-size", "batch_size", default=0, help="Slice fixtures into batches of this size (0 = all at once)."
+)
+@click.option(
+    "--scalar-only", "scalar_only", is_flag=True, help="Force the per-example path even if reward_batch exists."
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON report.")
+def inspect_command(path: str, fixtures: str, batch_size: int, scalar_only: bool, as_json: bool) -> None:
+    """Load a reward module, score fixtures, and print scores + execution stats."""
+
+    bundle = load_reward(path)
+    records = _load_fixtures(fixtures)
+    prefer_batch = not scalar_only
+
+    if batch_size <= 0:
+        batch_size = len(records)
+
+    all_scores: list[float] = []
+    all_stats: list[dict[str, Any]] = []
+    for start in range(0, len(records), batch_size):
+        chunk = records[start : start + batch_size]
+        scores, stats = call_reward(bundle, chunk, prefer_batch=prefer_batch)
+        all_scores.extend(scores)
+        all_stats.append(
+            {
+                "path": stats.path,
+                "wall_time_s": stats.wall_time_s,
+                "per_example_time_s": stats.per_example_time_s,
+                "count": stats.count,
+                "error": stats.error,
+            }
+        )
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "source": bundle.source_path,
+                    "has_reward_fn": bundle.reward_fn is not None,
+                    "has_reward_batch": bundle.reward_batch is not None,
+                    "prefer_batch": prefer_batch,
+                    "scores": all_scores,
+                    "stats": all_stats,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    click.echo(f"source: {bundle.source_path}")
+    click.echo(
+        f"hooks:  reward_fn={'yes' if bundle.reward_fn else 'no'} reward_batch={'yes' if bundle.reward_batch else 'no'}"
+    )
+    click.echo(f"prefer_batch: {prefer_batch}")
+    click.echo("")
+    for idx, (record, score) in enumerate(zip(records, all_scores, strict=True)):
+        click.echo(f"  [{idx}] prompt={record.prompt[:40]!r} -> score={score:.4f}")
+    click.echo("")
+    click.echo("stats per chunk:")
+    for chunk_stats in all_stats:
+        click.echo(
+            f"  path={chunk_stats['path']} count={chunk_stats['count']} "
+            f"wall={chunk_stats['wall_time_s']:.6f}s "
+            f"per_example={chunk_stats['per_example_time_s']:.6f}s"
+        )

--- a/docs/reward_hooks.md
+++ b/docs/reward_hooks.md
@@ -1,0 +1,27 @@
+# Reward Hooks
+
+AReno reward functions score each rollout completion against its prompt. This
+page describes the single-record contract, the optional batched contract, and
+the CLI for inspecting both.
+
+## Input contract
+
+Every reward hook receives a `RewardRecord` with at least these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prompt` | `str` | The prompt text fed to the rollout. |
+| `completion` | `str` | The decoded model response. |
+| `answer` | `Any \| None` | Gold answer from the dataset, if any. |
+| `messages` | `list[dict]` | Full chat messages (agentic mode). |
+| `tool_calls` | `list[dict]` | Tool calls made during rollout. |
+| `tool_results` | `list[dict]` | Tool results returned to the model. |
+| `tokens` / `logprobs` / `loss_mask` | `list[...]` | Per-token tensors for the full sequence. |
+| `source_record` | `dict` | The original dataset row. |
+| `metadata` | `dict` | Free-form metadata (e.g. prompt_index). |
+
+## Single-record hook (default)
+
+```python
+def reward_fn(record: RewardRecord) -> float:
+    return 1.0 if record.completion.strip() == str(record.answer) else 0.0

--- a/examples/reward/batch_reward_example.py
+++ b/examples/reward/batch_reward_example.py
@@ -1,0 +1,17 @@
+"""Minimal reward module defining both reward_fn and reward_batch.
+
+Run with:
+    areno reward inspect --path examples/reward/batch_reward_example.py --fixtures examples/reward/fixtures.jsonl
+"""
+
+from areno.api.rewards import RewardRecord
+
+
+def reward_fn(record: RewardRecord) -> float:
+    """Per-example path: 1.0 if the completion matches the gold answer."""
+    return 1.0 if record.completion.strip() == str(record.answer).strip() else 0.0
+
+
+def reward_batch(records: list[RewardRecord]) -> list[float]:
+    """Batched path: same contract, one pass over the list."""
+    return [1.0 if r.completion.strip() == str(r.answer).strip() else 0.0 for r in records]

--- a/examples/reward/fixtures.jsonl
+++ b/examples/reward/fixtures.jsonl
@@ -1,0 +1,3 @@
+{"prompt": "What is 2+2?", "completion": "4", "answer": 4}
+{"prompt": "What is 3*3?", "completion": "9", "answer": 9}
+{"prompt": "What is 10-7?", "completion": "4", "answer": 3}

--- a/tests/api/test_rewards_batch.py
+++ b/tests/api/test_rewards_batch.py
@@ -1,0 +1,357 @@
+"""CPU tests for batched reward-hook execution (Issue #225).
+
+These tests run without GPU, without external services, and without real model
+rollouts. They cover:
+
+- :func:`load_reward` discovering reward_fn, reward_batch, or both
+- :func:`call_reward` batch path, scalar path, and fallback paths
+- Cardinality validation pointing at the first mismatched index
+- Error isolation in the scalar path (one bad sample surfaces its index)
+- Deterministic agreement between batch and scalar paths
+- CLI ``areno reward inspect`` with --json and human-readable output
+- Default behavior (reward_use_batch=False) keeps the scalar path
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from areno.api.rewards import (
+    RewardRecord,
+    call_reward,
+    load_reward,
+    load_reward_fn,
+)
+from areno.cli.reward import reward_command
+
+
+def _write_reward_module(tmp_path: Path, body: str) -> Path:
+    """Write a Python reward module to tmp_path and return its path."""
+
+    path = tmp_path / "reward_mod.py"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def _make_records(n: int) -> list[RewardRecord]:
+    return [RewardRecord(prompt=f"p{i}", completion=str(i), answer=int(i)) for i in range(n)]
+
+
+# --- TestLoadReward --------------------------------------------------------
+
+
+class TestLoadReward:
+    def test_loads_reward_fn_only(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+        """,
+        )
+        bundle = load_reward(str(path))
+        assert bundle.reward_fn is not None
+        assert bundle.reward_batch is None
+        assert bundle.source_path.endswith("reward_mod.py")
+
+    def test_loads_reward_batch_only(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_batch(records):
+                return [float(r.answer) for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        assert bundle.reward_fn is None
+        assert bundle.reward_batch is not None
+
+    def test_loads_both_hooks(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+            def reward_batch(records):
+                return [float(r.answer) for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        assert bundle.reward_fn is not None
+        assert bundle.reward_batch is not None
+
+    def test_raises_when_no_hook_defined(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            # intentionally empty
+        """,
+        )
+        with pytest.raises(ValueError, match="must define callable"):
+            load_reward(str(path))
+
+
+# --- TestCallReward --------------------------------------------------------
+
+
+class TestCallReward:
+    def test_batch_path_used_when_preferred(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+            def reward_batch(records):
+                return [float(r.answer) + 100 for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(3)
+        scores, stats = call_reward(bundle, records, prefer_batch=True)
+        assert scores == [100.0, 101.0, 102.0]
+        assert stats.path == "batch"
+        assert stats.count == 3
+        assert stats.error is None
+        assert stats.wall_time_s >= 0.0
+        assert stats.per_example_time_s > 0.0
+
+    def test_scalar_path_used_when_preferred_false(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+            def reward_batch(records):
+                return [float(r.answer) + 100 for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(3)
+        scores, stats = call_reward(bundle, records, prefer_batch=False)
+        assert scores == [0.0, 1.0, 2.0]
+        assert stats.path == "scalar"
+
+    def test_scalar_path_falls_back_when_only_batch_defined(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_batch(records):
+                return [float(r.answer) for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(2)
+        scores, stats = call_reward(bundle, records, prefer_batch=False)
+        assert scores == [0.0, 1.0]
+        assert stats.path == "scalar"
+
+    def test_batch_scalar_agree(self, tmp_path):
+        """Acceptance criterion: deterministic hook proves both paths agree."""
+
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer) * 2
+            def reward_batch(records):
+                return [float(r.answer) * 2 for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(5)
+        batch_scores, batch_stats = call_reward(bundle, records, prefer_batch=True)
+        scalar_scores, scalar_stats = call_reward(bundle, records, prefer_batch=False)
+        assert batch_scores == scalar_scores == [0.0, 2.0, 4.0, 6.0, 8.0]
+        assert batch_stats.path == "batch"
+        assert scalar_stats.path == "scalar"
+
+    def test_cardinality_mismatch_reports_index(self, tmp_path):
+        """Acceptance criterion: diagnose exact bad batch on length mismatch."""
+
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_batch(records):
+                # Drop the last score to trigger a cardinality mismatch.
+                return [float(r.answer) for r in records[:-1]]
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(4)
+        with pytest.raises(ValueError) as excinfo:
+            call_reward(bundle, records, prefer_batch=True)
+        msg = str(excinfo.value)
+        # Error message must include the count and the first mismatched index,
+        # but must NOT include any prompt or completion content.
+        assert "3" in msg  # got 3, expected 4
+        assert "4" in msg  # expected 4
+        assert "first mismatched index" in msg
+        assert "p0" not in msg and "p1" not in msg
+
+    def test_scalar_path_isolates_bad_sample(self, tmp_path):
+        """Acceptance criterion: scalar path surfaces the failing index."""
+
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                if record.answer == 2:
+                    raise RuntimeError("bad sample")
+                return float(record.answer)
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(4)
+        with pytest.raises(RuntimeError) as excinfo:
+            call_reward(bundle, records, prefer_batch=False)
+        assert "index 2" in str(excinfo.value)
+
+    def test_empty_records_returns_empty(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return 0.0
+        """,
+        )
+        bundle = load_reward(str(path))
+        scores, stats = call_reward(bundle, [], prefer_batch=True)
+        assert scores == []
+        assert stats.count == 0
+        assert stats.path == "scalar"
+
+    def test_order_preserved(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_batch(records):
+                return [float(r.answer) for r in records]
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(5)
+        scores, _ = call_reward(bundle, records, prefer_batch=True)
+        assert scores == [0.0, 1.0, 2.0, 3.0, 4.0]
+
+
+# --- TestBackwardCompat ----------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_load_reward_fn_still_works(self, tmp_path):
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+        """,
+        )
+        fn = load_reward_fn(str(path))
+        record = RewardRecord(prompt="p", completion="c", answer=42)
+        assert fn(record) == 42.0
+
+    def test_default_prefer_batch_true_but_no_batch_hook(self, tmp_path):
+        """Default behavior unchanged when only reward_fn is defined."""
+
+        path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+        """,
+        )
+        bundle = load_reward(str(path))
+        records = _make_records(3)
+        scores, stats = call_reward(bundle, records, prefer_batch=True)
+        # Falls back to scalar because reward_batch is None.
+        assert scores == [0.0, 1.0, 2.0]
+        assert stats.path == "scalar"
+
+
+# --- TestCli ---------------------------------------------------------------
+
+
+class TestCli:
+    def _write_fixtures(self, tmp_path: Path) -> Path:
+        fixtures = tmp_path / "fixtures.jsonl"
+        fixtures.write_text(
+            "\n".join(json.dumps({"prompt": f"p{i}", "completion": str(i), "answer": i}) for i in range(3)) + "\n",
+            encoding="utf-8",
+        )
+        return fixtures
+
+    def test_inspect_human_readable(self, tmp_path):
+        reward_path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+            def reward_batch(records):
+                return [float(r.answer) for r in records]
+        """,
+        )
+        fixtures_path = self._write_fixtures(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            reward_command,
+            ["inspect", "--path", str(reward_path), "--fixtures", str(fixtures_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "reward_fn=yes" in result.output
+        assert "reward_batch=yes" in result.output
+        assert "score=0.0000" in result.output
+        assert "score=2.0000" in result.output
+        assert "path=batch" in result.output  # prefer_batch defaults to True
+
+    def test_inspect_json_output(self, tmp_path):
+        reward_path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+            def reward_batch(records):
+                return [float(r.answer) for r in records]
+        """,
+        )
+        fixtures_path = self._write_fixtures(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            reward_command,
+            ["inspect", "--path", str(reward_path), "--fixtures", str(fixtures_path), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output)
+        assert report["has_reward_fn"] is True
+        assert report["has_reward_batch"] is True
+        assert report["prefer_batch"] is True
+        assert report["scores"] == [0.0, 1.0, 2.0]
+        assert len(report["stats"]) == 1
+        assert report["stats"][0]["path"] == "batch"
+        assert report["stats"][0]["count"] == 3
+
+    def test_inspect_scalar_only_flag(self, tmp_path):
+        reward_path = _write_reward_module(
+            tmp_path,
+            """
+            def reward_fn(record):
+                return float(record.answer)
+            def reward_batch(records):
+                return [float(r.answer) + 100 for r in records]
+        """,
+        )
+        fixtures_path = self._write_fixtures(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            reward_command,
+            ["inspect", "--path", str(reward_path), "--fixtures", str(fixtures_path), "--scalar-only", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output)
+        assert report["prefer_batch"] is False
+        assert report["scores"] == [0.0, 1.0, 2.0]
+        assert report["stats"][0]["path"] == "scalar"


### PR DESCRIPTION
Add RewardFnBundle and call_reward() so a reward module can define both reward_fn (per-example) and reward_batch (whole-batch) hooks. The training loop opts in via reward_use_batch=True; default behavior is unchanged.

- Validate output cardinality; error names the first mismatched index
- Preserve input order; record wall/per-example time on both paths
- Reuse RewardRecord; no external database or sandbox required
- Add `areno reward inspect` CLI with --json and --scalar-only flags
- Add CPU tests covering success, cardinality mismatch, error isolation, batch/scalar agreement, and backward compatibility
- Add docs/reward_hooks.md and a runnable example with fixtures

Closes #225

<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?

<!-- A clear and concise description of the change and its motivation. -->

## Related issue

<!-- Link the issue this PR addresses so GitHub closes it on merge, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

<!-- Select ONE that best describes this PR. -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

<!-- Note the test commands you ran (e.g. `pytest tests/ -k cpu`) and any hardware limitations. New behavior must be covered by tests — no testing, no merge. -->

## Checklist

- [ ] The PR title summarizes the contribution.
- [ ] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [ ] New behavior is covered by tests.
- [ ] Described the test commands run and any hardware limitations.
- [ ] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Breaking change details

<!-- If this is a breaking change, describe what breaks and how users should migrate. Otherwise delete this section. -->
