### PR TITLE
feat: add token length distribution report

### DIFF
--- a/areno/api/data.py
+++ b/areno/api/data.py
@@ -4,12 +4,19 @@
 tokenising a dataset row. `PromptBatch` groups a fixed-size set of items
 together and carries diagnostic counters so the trainer can surface how many
 records were skipped for exceeding the prompt-length budget.
+
+`TokenLengthReport` and `compute_token_length_report` provide standalone
+token-length distribution diagnostics for a list of `PromptItem` without
+requiring the full training pipeline.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import random
+from dataclasses import dataclass, field
 from typing import Any
+
+import numpy as np
 
 
 @dataclass(slots=True)
@@ -48,3 +55,176 @@ class PromptBatch:
         """Return raw prompt strings in batch order for rollout."""
 
         return [item.prompt for item in self.items]
+
+
+# ---------------------------------------------------------------------------
+# Token-length distribution report
+# ---------------------------------------------------------------------------
+
+_OVERLENGTH_POLICIES = ("drop", "truncate")
+
+
+@dataclass(slots=True)
+class LengthStats:
+    """Statistical summary of token lengths for one category."""
+
+    count: int
+    min: int
+    p50: int
+    p90: int
+    p95: int
+    p99: int
+    max: int
+    mean: float
+
+    def as_dict(self) -> dict[str, int | float]:
+        return {
+            "count": self.count,
+            "min": self.min,
+            "p50": self.p50,
+            "p90": self.p90,
+            "p95": self.p95,
+            "p99": self.p99,
+            "max": self.max,
+            "mean": round(self.mean, 2),
+        }
+
+
+@dataclass(slots=True)
+class TokenLengthReport:
+    """Full token-length distribution report for a dataset."""
+
+    total_samples: int
+    sampled: int
+    sampling_seed: int | None
+    max_context: int
+    prompt_stats: LengthStats
+    response_stats: LengthStats | None
+    total_stats: LengthStats | None
+    over_context_count: int
+    over_context_pct: float
+    retained_under_policy: dict[str, int] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "total_samples": self.total_samples,
+            "sampled": self.sampled,
+            "sampling_seed": self.sampling_seed,
+            "max_context": self.max_context,
+            "prompt_stats": self.prompt_stats.as_dict(),
+            "response_stats": self.response_stats.as_dict() if self.response_stats else None,
+            "total_stats": self.total_stats.as_dict() if self.total_stats else None,
+            "over_context_count": self.over_context_count,
+            "over_context_pct": round(self.over_context_pct, 4),
+            "retained_under_policy": dict(self.retained_under_policy),
+        }
+
+
+def _percentile_lengths(lengths: list[int]) -> LengthStats:
+    arr = np.asarray(lengths, dtype=np.int64)
+    return LengthStats(
+        count=int(arr.size),
+        min=int(arr.min()),
+        p50=int(np.percentile(arr, 50)),
+        p90=int(np.percentile(arr, 90)),
+        p95=int(np.percentile(arr, 95)),
+        p99=int(np.percentile(arr, 99)),
+        max=int(arr.max()),
+        mean=float(arr.mean()),
+    )
+
+
+def compute_token_length_report(
+    items: list[PromptItem],
+    *,
+    max_context: int = 4096,
+    sample_ratio: float = 1.0,
+    sample_seed: int | None = None,
+    response_field: str | None = None,
+    tokenizer=None,
+    overlength_policies: tuple[str, ...] = _OVERLENGTH_POLICIES,
+) -> TokenLengthReport:
+    """Compute token-length distribution statistics for a list of PromptItems.
+
+    Args:
+        items: List of PromptItem with pre-tokenized input_tokens.
+        max_context: Maximum context length for over-context calculation.
+        sample_ratio: Fraction of items to sample (1.0 = full scan).
+        sample_seed: Random seed for deterministic sampling.
+        response_field: If provided, also compute response length stats
+            by tokenizing record[response_field] with the given tokenizer.
+        tokenizer: Required when response_field is set.
+        overlength_policies: Policies to estimate retained examples.
+
+    Returns:
+        TokenLengthReport with prompt/response/total length statistics.
+
+    Raises:
+        ValueError: If items is empty, sample_ratio out of (0, 1],
+                    or response_field set without tokenizer.
+    """
+    if not items:
+        raise ValueError("items must not be empty")
+    if not 0 < sample_ratio <= 1.0:
+        raise ValueError(f"sample_ratio must be in (0, 1.0], got {sample_ratio}")
+    if response_field is not None and tokenizer is None:
+        raise ValueError("tokenizer is required when response_field is set")
+
+    total_samples = len(items)
+
+    # Deterministic sampling
+    if sample_ratio >= 1.0:
+        sampled_items = items
+        sampled_count = total_samples
+    else:
+        rng = random.Random(sample_seed)
+        sampled_count = max(1, int(total_samples * sample_ratio))
+        indices = sorted(rng.sample(range(total_samples), sampled_count))
+        sampled_items = [items[i] for i in indices]
+
+    prompt_lengths = [len(item.input_tokens) for item in sampled_items]
+
+    response_lengths: list[int] | None = None
+    total_lengths: list[int] | None = None
+    if response_field is not None:
+        response_lengths = []
+        for item in sampled_items:
+            text = item.record.get(response_field)
+            if isinstance(text, str):
+                ids = tokenizer.encode(text, add_special_tokens=False)
+                response_lengths.append(len(ids))
+            else:
+                response_lengths.append(0)
+        total_lengths = [p + r for p, r in zip(prompt_lengths, response_lengths)]
+
+    prompt_stats = _percentile_lengths(prompt_lengths)
+    response_stats = _percentile_lengths(response_lengths) if response_lengths is not None else None
+    total_stats = _percentile_lengths(total_lengths) if total_lengths is not None else None
+
+    # Over-context calculation
+    ref_lengths = total_lengths if total_lengths is not None else prompt_lengths
+    over_context_count = sum(1 for length in ref_lengths if length > max_context)
+    over_context_pct = over_context_count / len(ref_lengths) * 100 if ref_lengths else 0.0
+
+    # Retained under each policy
+    retained: dict[str, int] = {}
+    for policy in overlength_policies:
+        if policy == "drop":
+            retained[policy] = len(ref_lengths) - over_context_count
+        elif policy == "truncate":
+            retained[policy] = len(ref_lengths)
+        else:
+            retained[policy] = len(ref_lengths) - over_context_count
+
+    return TokenLengthReport(
+        total_samples=total_samples,
+        sampled=len(sampled_items),
+        sampling_seed=sample_seed if sample_ratio < 1.0 else None,
+        max_context=max_context,
+        prompt_stats=prompt_stats,
+        response_stats=response_stats,
+        total_stats=total_stats,
+        over_context_count=over_context_count,
+        over_context_pct=over_context_pct,
+        retained_under_policy=retained,
+    )

--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -490,7 +490,7 @@ def _print_env_report(report: dict[str, Any]) -> None:
 
 
 @click.command(name="token-report", context_settings={"help_option_names": ["-h", "--help"]})
-@click.option("--dataset-path", required=True, help="Path or HuggingFace ID of the dataset (JSONL file).")
+@click.option("--dataset-path", required=True, help="Path to a local JSONL dataset file (one JSON object per line).")
 @click.option("--tokenizer", "tokenizer_path", required=True, help="Model path for tokenizer loading.")
 @click.option("--max-context", default=4096, type=int, help="Maximum context length for over-context stats.")
 @click.option("--sample-ratio", default=1.0, type=float, help="Fraction to sample (1.0 = full scan).")

--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -482,3 +482,149 @@ def _print_env_report(report: dict[str, Any]) -> None:
     click.echo("  Environment variables:")
     for name, value in report["env"].items():
         click.echo(f"    {name}={value if value is not None else '<unset>'}")
+
+
+# ---------------------------------------------------------------------------
+# token-report command
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="token-report", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--dataset-path", required=True, help="Path or HuggingFace ID of the dataset (JSONL file).")
+@click.option("--tokenizer", "tokenizer_path", required=True, help="Model path for tokenizer loading.")
+@click.option("--max-context", default=4096, type=int, help="Maximum context length for over-context stats.")
+@click.option("--sample-ratio", default=1.0, type=float, help="Fraction to sample (1.0 = full scan).")
+@click.option("--sample-seed", default=None, type=int, help="Random seed for deterministic sampling.")
+@click.option("--response-field", default=None, help="Dataset field to measure response length.")
+@click.option("--prompt-field", default="prompt", help="Dataset field containing prompt text.")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON output.")
+def token_report_command(
+    dataset_path: str,
+    tokenizer_path: str,
+    max_context: int,
+    sample_ratio: float,
+    sample_seed: int | None,
+    response_field: str | None,
+    prompt_field: str,
+    as_json: bool,
+) -> None:
+    """Report token-length distributions and context capacity."""
+
+    report = _run_token_report(
+        dataset_path=dataset_path,
+        tokenizer_path=tokenizer_path,
+        max_context=max_context,
+        sample_ratio=sample_ratio,
+        sample_seed=sample_seed,
+        response_field=response_field,
+        prompt_field=prompt_field,
+    )
+    if as_json:
+        click.echo(json.dumps(report.as_dict(), indent=2, sort_keys=True))
+    else:
+        _print_token_report(report, dataset_path, tokenizer_path)
+
+
+def _run_token_report(
+    *,
+    dataset_path: str,
+    tokenizer_path: str,
+    max_context: int,
+    sample_ratio: float,
+    sample_seed: int | None,
+    response_field: str | None,
+    prompt_field: str,
+):
+    """Load data and compute the token-length report."""
+
+    from areno.api.data import PromptItem, compute_token_length_report
+    from areno.api.tokenizer import encode_generation_prompt, load_tokenizer
+
+    # Validate inputs before expensive operations
+    if sample_ratio <= 0 or sample_ratio > 1.0:
+        raise click.UsageError(f"sample_ratio must be in (0, 1.0], got {sample_ratio}")
+
+    path = Path(dataset_path)
+    if not path.exists():
+        raise click.UsageError(f"dataset file not found: {dataset_path}")
+
+    # Load tokenizer
+    tokenizer = load_tokenizer(tokenizer_path)
+
+    # Load JSONL dataset
+    items: list[PromptItem] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            prompt_text = record.get(prompt_field, "")
+            if not isinstance(prompt_text, str):
+                raise click.UsageError(
+                    f"line {line_num}: field '{prompt_field}' is not a string, got {type(prompt_text).__name__}"
+                )
+            input_tokens = encode_generation_prompt(tokenizer, prompt_text)
+            items.append(
+                PromptItem(
+                    prompt=prompt_text,
+                    solutions=None,
+                    input_tokens=input_tokens,
+                    record=record,
+                )
+            )
+
+    if not items:
+        raise click.UsageError(f"dataset is empty: {dataset_path}")
+
+    return compute_token_length_report(
+        items,
+        max_context=max_context,
+        sample_ratio=sample_ratio,
+        sample_seed=sample_seed,
+        response_field=response_field,
+        tokenizer=tokenizer,
+    )
+
+
+def _print_token_report(report, dataset_path: str, tokenizer_path: str) -> None:
+    """Print a human-readable token-length report."""
+
+    click.echo("Token Length Distribution Report")
+    click.echo("=" * 40)
+    click.echo(f"Dataset:         {dataset_path}")
+    click.echo(f"Tokenizer:       {tokenizer_path}")
+    click.echo(f"Max context:     {report.max_context}")
+    if report.sampling_seed is not None:
+        click.echo(f"Sampled:         {report.sampled} / {report.total_samples}  seed={report.sampling_seed}")
+    else:
+        click.echo(f"Sampled:         {report.sampled} / {report.total_samples}  (full scan)")
+    click.echo()
+
+    def _print_section(title: str, stats):
+        if stats is None:
+            return
+        click.echo(f"  {title}")
+        click.echo(f"  {'-' * 36}")
+        click.echo(
+            f"  {'count':>6}  {'min':>4}  {'p50':>4}  {'p90':>4}  {'p95':>4}  {'p99':>4}  {'max':>5}  {'mean':>6}"
+        )
+        click.echo(
+            f"  {stats.count:>6}  {stats.min:>4}  {stats.p50:>4}  {stats.p90:>4}  {stats.p95:>4}  {stats.p99:>4}"
+            f"  {stats.max:>5}  {stats.mean:>6.1f}"
+        )
+        click.echo()
+
+    _print_section("Prompt Length", report.prompt_stats)
+    _print_section("Response Length", report.response_stats)
+    _print_section("Total Length", report.total_stats)
+
+    click.echo(f"  Over-context (max={report.max_context})")
+    click.echo(f"  {'-' * 36}")
+    click.echo(f"  count:  {report.over_context_count} / {report.sampled} ({report.over_context_pct:.1f}%)")
+    click.echo()
+
+    click.echo("  Retained under policy")
+    click.echo(f"  {'-' * 36}")
+    for policy, count in report.retained_under_policy.items():
+        click.echo(f"  {policy:>10}:  {count} / {report.sampled}")

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -17,6 +17,11 @@ class ArenoCli(click.Group):
     _COMMANDS = {
         "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
+        "token-report": (
+            "areno.cli.diagnostics",
+            "token_report_command",
+            "Report token-length distributions and context capacity.",
+        ),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),

--- a/docs/cli/diagnostics.rst
+++ b/docs/cli/diagnostics.rst
@@ -78,3 +78,78 @@ Checks include:
 
 ``WARN`` items usually indicate degraded or incomplete setup. ``FAIL`` items
 mean AReno is not ready to run the CUDA training/inference engine.
+
+areno token-report
+------------------
+
+``areno token-report`` computes token-length distributions and context capacity
+for a JSONL dataset using the selected tokenizer. It reports min, p50, p90, p95,
+p99, and max for prompt, response, and total token lengths, along with the
+percentage of examples that exceed a configurable maximum context length.
+
+.. code-block:: bash
+
+   areno token-report --dataset-path ./data.jsonl --tokenizer Qwen/Qwen3-0.6B
+
+For machine-readable output (e.g. piping to a script):
+
+.. code-block:: bash
+
+   areno token-report --dataset-path ./data.jsonl --tokenizer Qwen/Qwen3-0.6B --json
+
+Options:
+
+* ``--dataset-path`` (required): Path to a JSONL file. Each line must be a JSON
+  object with at least a ``prompt`` field.
+* ``--tokenizer`` (required): HuggingFace model path for tokenizer loading.
+* ``--max-context`` (default: 4096): Maximum context length for over-context
+  percentage calculation.
+* ``--sample-ratio`` (default: 1.0): Fraction of examples to sample. Use a value
+  between 0 and 1.0. ``1.0`` performs a full scan.
+* ``--sample-seed`` (default: None): Random seed for deterministic sampling.
+  Required for reproducible results when ``--sample-ratio`` is less than 1.0.
+* ``--response-field`` (default: None): Dataset field to also measure response
+  token length. When provided, ``--tokenizer`` is used to encode the response
+  text.
+* ``--prompt-field`` (default: "prompt"): Dataset field containing the prompt
+  text.
+* ``--json``: Emit machine-readable JSON instead of a human-readable table.
+
+Output fields (JSON mode):
+
+* ``total_samples``: Total number of records in the dataset.
+* ``sampled``: Number of records actually analyzed (after sampling).
+* ``sampling_seed``: The random seed used, or ``null`` for full scans.
+* ``max_context``: The configured maximum context length.
+* ``prompt_stats``: Object with ``count``, ``min``, ``p50``, ``p90``, ``p95``,
+  ``p99``, ``max``, and ``mean`` for prompt token lengths.
+* ``response_stats``: Same structure as ``prompt_stats`` for response lengths,
+  or ``null`` when ``--response-field`` is not provided.
+* ``total_stats``: Same structure for ``prompt + response`` total lengths, or
+  ``null`` when ``--response-field`` is not provided.
+* ``over_context_count``: Number of examples exceeding ``max_context``.
+* ``over_context_pct``: Percentage of examples exceeding ``max_context``.
+* ``retained_under_policy``: Object mapping each overlength policy to the
+  number of retained examples. ``drop`` discards over-context examples;
+  ``truncate`` keeps all examples (with truncation).
+
+Limitations:
+
+* The dataset must be a local JSONL file. HuggingFace dataset IDs are not
+  supported by the CLI command directly.
+* The tokenizer must be loadable by HuggingFace ``transformers``.
+* The command loads the tokenizer but does not initialize the AReno engine or
+  any GPU resources.
+
+Example with deterministic sampling and response length:
+
+.. code-block:: bash
+
+   areno token-report \
+     --dataset-path ./train.jsonl \
+     --tokenizer Qwen/Qwen3-0.6B \
+     --max-context 2048 \
+     --sample-ratio 0.1 \
+     --sample-seed 42 \
+     --response-field answer \
+     --json

--- a/tests/test_token_length_report_cpu.py
+++ b/tests/test_token_length_report_cpu.py
@@ -295,5 +295,147 @@ class BackwardCompatibilityTest(unittest.TestCase):
         self.assertEqual(batch.prompts, [item.prompt for item in items])
 
 
+class TokenLengthReportIntegrationTest(unittest.TestCase):
+    """Integration test: load JSONL fixture → tokenize with mock → compute → assert.
+
+    Exercises the full compute pipeline (PromptItem construction →
+    compute_token_length_report → as_dict → JSON serialize) with a tiny
+    deterministic fixture and a mock tokenizer. No real HuggingFace model
+    or GPU required.
+    """
+
+    def _load_fixture(self) -> list[PromptItem]:
+        """Build PromptItems from hand-crafted records with known token lengths.
+
+        Using _MockTokenizer (word-count encoding), the prompt and response
+        token lengths are deterministic:
+
+            prompt tokens:   [2, 4, 6, 8, 3]
+            response tokens: [2, 3, 4, 2, 1]
+            total tokens:    [4, 7, 10, 10, 4]
+        """
+        records = [
+            ("hello world", "yes no"),
+            ("the quick brown fox", "a b c"),
+            ("a b c d e f", "foo bar baz qux"),
+            ("one two three four five six seven eight", "alpha beta"),
+            ("x y z", "p"),
+        ]
+        items = []
+        for prompt_text, answer_text in records:
+            prompt_ids = list(range(len(prompt_text.split())))
+            items.append(
+                PromptItem(
+                    prompt=prompt_text,
+                    solutions=None,
+                    input_tokens=prompt_ids,
+                    record={"answer": answer_text},
+                )
+            )
+        return items
+
+    def test_integration_prompt_and_response_stats(self):
+        """Verify prompt, response, and total length stats with known values."""
+        items = self._load_fixture()
+        tok = _MockTokenizer()
+        report = compute_token_length_report(items, max_context=5, response_field="answer", tokenizer=tok)
+        d = report.as_dict()
+
+        # Prompt lengths: [2, 4, 6, 8, 3]
+        self.assertEqual(d["prompt_stats"]["count"], 5)
+        self.assertEqual(d["prompt_stats"]["min"], 2)
+        self.assertEqual(d["prompt_stats"]["max"], 8)
+
+        # Response lengths: [2, 3, 4, 2, 1]
+        self.assertEqual(d["response_stats"]["min"], 1)
+        self.assertEqual(d["response_stats"]["max"], 4)
+
+        # Total lengths: [4, 7, 10, 10, 4]
+        self.assertEqual(d["total_stats"]["min"], 4)
+        self.assertEqual(d["total_stats"]["max"], 10)
+
+        # Over-context (total > 5): 7, 10, 10 → 3 out of 5 = 60%
+        self.assertEqual(d["over_context_count"], 3)
+        self.assertAlmostEqual(d["over_context_pct"], 60.0, places=1)
+        self.assertEqual(d["retained_under_policy"]["drop"], 2)
+        self.assertEqual(d["retained_under_policy"]["truncate"], 5)
+
+        # Must be JSON-serializable end-to-end
+        json.dumps(d)
+
+    def test_integration_jsonl_file_to_report(self):
+        """Read a real JSONL file, build PromptItems, compute, and verify."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "fixture.jsonl"
+            records = [
+                {"prompt": "hello world", "answer": "yes no"},
+                {"prompt": "the quick brown fox", "answer": "a b c"},
+                {"prompt": "x y z", "answer": "p"},
+            ]
+            with path.open("w", encoding="utf-8") as f:
+                for rec in records:
+                    f.write(json.dumps(rec) + "\n")
+
+            # Load JSONL the same way _run_token_report does
+            tok = _MockTokenizer()
+            items = []
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    prompt_text = record.get("prompt", "")
+                    items.append(
+                        PromptItem(
+                            prompt=prompt_text,
+                            solutions=None,
+                            input_tokens=list(range(len(prompt_text.split()))),
+                            record=record,
+                        )
+                    )
+
+            report = compute_token_length_report(items, max_context=100, response_field="answer", tokenizer=tok)
+            d = report.as_dict()
+
+            self.assertEqual(d["total_samples"], 3)
+            self.assertEqual(d["prompt_stats"]["count"], 3)
+            # prompt lengths: [2, 4, 3]
+            self.assertEqual(d["prompt_stats"]["min"], 2)
+            self.assertEqual(d["prompt_stats"]["max"], 4)
+            # response lengths: [2, 3, 1]
+            self.assertEqual(d["response_stats"]["min"], 1)
+            self.assertEqual(d["response_stats"]["max"], 3)
+
+    def test_integration_boundary_empty_file(self):
+        """An empty JSONL file should produce zero items and raise ValueError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "empty.jsonl"
+            path.write_text("\n\n\n", encoding="utf-8")
+
+            items = []
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    items.append(json.loads(line))
+
+            self.assertEqual(len(items), 0)
+            with self.assertRaisesRegex(ValueError, "empty"):
+                compute_token_length_report(items)
+
+    def test_integration_disabled_by_default(self):
+        """The feature is opt-in — compute_token_length_report is never called
+        unless the user explicitly invokes it. Verify that PromptItem and
+        PromptBatch work normally without the report."""
+        items = self._load_fixture()
+        # Normal usage without report — just build a PromptBatch
+        batch = PromptBatch(items=items, scanned=5, skipped_long=0, total_skipped_long=0)
+        self.assertEqual(len(batch.items), 5)
+        self.assertEqual(batch.prompts[0], "hello world")
+        self.assertEqual(batch.scanned, 5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_token_length_report_cpu.py
+++ b/tests/test_token_length_report_cpu.py
@@ -1,0 +1,299 @@
+"""CPU tests for token-length distribution report.
+
+These tests run without torch, CUDA, or transformers installed by loading
+the data module directly via importlib, bypassing the heavy areno.api.__init__
+import chain.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# Load areno.api.data without triggering areno.api.__init__ (which imports torch).
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DATA_PY = _REPO_ROOT / "areno" / "api" / "data.py"
+
+# Ensure numpy is importable (it's a dependency of data.py).
+_spec = importlib.util.spec_from_file_location("areno.api.data", _DATA_PY)
+_data_mod = importlib.util.module_from_spec(_spec)
+sys.modules["areno.api.data"] = _data_mod
+_spec.loader.exec_module(_data_mod)
+
+# Re-export the symbols we need.
+LengthStats = _data_mod.LengthStats
+PromptItem = _data_mod.PromptItem
+PromptBatch = _data_mod.PromptBatch
+TokenLengthReport = _data_mod.TokenLengthReport
+compute_token_length_report = _data_mod.compute_token_length_report
+
+# Load areno.cli.diagnostics and areno.cli.main for CLI tests.
+# These also avoid importing heavy modules at load time.
+_DIAG_PY = _REPO_ROOT / "areno" / "cli" / "diagnostics.py"
+_spec_diag = importlib.util.spec_from_file_location("areno.cli.diagnostics", _DIAG_PY)
+diag_mod = importlib.util.module_from_spec(_spec_diag)
+sys.modules["areno.cli.diagnostics"] = diag_mod
+_spec_diag.loader.exec_module(diag_mod)
+
+_MAIN_PY = _REPO_ROOT / "areno" / "cli" / "main.py"
+_spec_main = importlib.util.spec_from_file_location("areno.cli.main", _MAIN_PY)
+main_mod = importlib.util.module_from_spec(_spec_main)
+sys.modules["areno.cli.main"] = main_mod
+_spec_main.loader.exec_module(main_mod)
+
+
+class _MockTokenizer:
+    """Minimal tokenizer stub for CPU tests — encodes by splitting on words."""
+
+    chat_template = None
+
+    def encode(self, text, add_special_tokens=True):
+        return list(range(len(text.split())))
+
+
+def _make_item(prompt_len: int, response: str | None = None) -> PromptItem:
+    return PromptItem(
+        prompt="word " * prompt_len,
+        solutions=None,
+        input_tokens=list(range(prompt_len)),
+        record={"answer": response} if response is not None else {},
+    )
+
+
+class TokenLengthReportCoreTest(unittest.TestCase):
+    """Core logic tests — no GPU, no real tokenizer."""
+
+    def test_basic_stats_match_handcalc(self):
+        items = [_make_item(n) for n in [10, 20, 30, 40, 50]]
+        report = compute_token_length_report(items, max_context=100)
+
+        self.assertEqual(report.prompt_stats.count, 5)
+        self.assertEqual(report.prompt_stats.min, 10)
+        self.assertEqual(report.prompt_stats.max, 50)
+        self.assertEqual(report.prompt_stats.p50, 30)
+
+    def test_empty_dataset_raises(self):
+        with self.assertRaisesRegex(ValueError, "empty"):
+            compute_token_length_report([])
+
+    def test_invalid_sample_ratio_zero_raises(self):
+        items = [_make_item(10)]
+        with self.assertRaisesRegex(ValueError, "sample_ratio"):
+            compute_token_length_report(items, sample_ratio=0.0)
+
+    def test_invalid_sample_ratio_above_one_raises(self):
+        items = [_make_item(10)]
+        with self.assertRaisesRegex(ValueError, "sample_ratio"):
+            compute_token_length_report(items, sample_ratio=1.5)
+
+    def test_sampling_determinism(self):
+        items = [_make_item(n) for n in range(100)]
+        r1 = compute_token_length_report(items, sample_ratio=0.1, sample_seed=42)
+        r2 = compute_token_length_report(items, sample_ratio=0.1, sample_seed=42)
+        self.assertEqual(r1.prompt_stats.as_dict(), r2.prompt_stats.as_dict())
+        self.assertEqual(r1.sampled, r2.sampled)
+
+    def test_full_scan_no_seed(self):
+        items = [_make_item(n) for n in range(50)]
+        report = compute_token_length_report(items, sample_ratio=1.0)
+        self.assertEqual(report.sampled, 50)
+        self.assertEqual(report.total_samples, 50)
+        self.assertIsNone(report.sampling_seed)
+
+    def test_over_context_pct(self):
+        items = [_make_item(n) for n in [5, 10, 15, 20, 25]]
+        report = compute_token_length_report(items, max_context=10)
+        self.assertEqual(report.over_context_count, 3)
+        self.assertAlmostEqual(report.over_context_pct, 60.0, places=1)
+
+    def test_retained_under_drop_policy(self):
+        items = [_make_item(n) for n in [5, 10, 15, 20, 25]]
+        report = compute_token_length_report(items, max_context=10)
+        self.assertEqual(report.retained_under_policy["drop"], 2)
+
+    def test_retained_under_truncate_policy(self):
+        items = [_make_item(n) for n in [5, 10, 15, 20, 25]]
+        report = compute_token_length_report(items, max_context=10)
+        self.assertEqual(report.retained_under_policy["truncate"], 5)
+
+    def test_response_stats_with_tokenizer(self):
+        items = [
+            PromptItem(
+                prompt="hello world",
+                solutions=None,
+                input_tokens=[0, 1],
+                record={"answer": "foo bar baz"},
+            )
+        ]
+        tok = _MockTokenizer()
+        report = compute_token_length_report(items, response_field="answer", tokenizer=tok, max_context=100)
+        self.assertIsNotNone(report.response_stats)
+        self.assertEqual(report.response_stats.count, 1)
+        self.assertEqual(report.response_stats.min, 3)
+        self.assertIsNotNone(report.total_stats)
+        self.assertEqual(report.total_stats.min, 5)
+
+    def test_response_stats_none_without_field(self):
+        items = [_make_item(10)]
+        report = compute_token_length_report(items)
+        self.assertIsNone(report.response_stats)
+        self.assertIsNone(report.total_stats)
+
+    def test_response_field_without_tokenizer_raises(self):
+        items = [_make_item(10)]
+        with self.assertRaisesRegex(ValueError, "tokenizer"):
+            compute_token_length_report(items, response_field="answer")
+
+    def test_single_sample(self):
+        items = [_make_item(42)]
+        report = compute_token_length_report(items, max_context=100)
+        self.assertEqual(report.prompt_stats.min, 42)
+        self.assertEqual(report.prompt_stats.p50, 42)
+        self.assertEqual(report.prompt_stats.max, 42)
+
+    def test_all_same_length(self):
+        items = [_make_item(30) for _ in range(10)]
+        report = compute_token_length_report(items, max_context=100)
+        self.assertEqual(report.prompt_stats.min, 30)
+        self.assertEqual(report.prompt_stats.p50, 30)
+        self.assertEqual(report.prompt_stats.p99, 30)
+        self.assertEqual(report.prompt_stats.max, 30)
+
+    def test_sampling_seed_recorded(self):
+        items = [_make_item(n) for n in range(100)]
+        report = compute_token_length_report(items, sample_ratio=0.5, sample_seed=123)
+        self.assertEqual(report.sampling_seed, 123)
+
+    def test_as_dict_serializable(self):
+        items = [_make_item(10), _make_item(20)]
+        report = compute_token_length_report(items, max_context=100)
+        d = report.as_dict()
+        json.dumps(d)
+        self.assertIn("prompt_stats", d)
+        self.assertIn("over_context_pct", d)
+
+
+class TokenLengthReportCLITest(unittest.TestCase):
+    """CLI tests using CliRunner with mocked internals."""
+
+    def _make_jsonl(self, tmp: str) -> str:
+        path = Path(tmp) / "data.jsonl"
+        with path.open("w", encoding="utf-8") as f:
+            for lengths in [2, 4, 6, 8, 10]:
+                f.write(json.dumps({"prompt": "word " * lengths, "answer": "a " * lengths}) + "\n")
+        return str(path)
+
+    def test_cli_json_output(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = self._make_jsonl(tmp)
+            with patch.object(diag_mod, "_run_token_report") as mock_run:
+                mock_run.return_value = TokenLengthReport(
+                    total_samples=5,
+                    sampled=5,
+                    sampling_seed=None,
+                    max_context=4096,
+                    prompt_stats=LengthStats(5, 2, 6, 10, 10, 10, 10, 6.0),
+                    response_stats=LengthStats(5, 2, 6, 10, 10, 10, 10, 6.0),
+                    total_stats=LengthStats(5, 4, 12, 20, 20, 20, 20, 12.0),
+                    over_context_count=0,
+                    over_context_pct=0.0,
+                    retained_under_policy={"drop": 5, "truncate": 5},
+                )
+                result = runner.invoke(
+                    diag_mod.token_report_command,
+                    ["--dataset-path", dataset, "--tokenizer", "fake", "--json"],
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["total_samples"], 5)
+        self.assertEqual(parsed["prompt_stats"]["p50"], 6)
+        self.assertEqual(parsed["over_context_pct"], 0.0)
+
+    def test_cli_human_output(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = self._make_jsonl(tmp)
+            with patch.object(diag_mod, "_run_token_report") as mock_run:
+                mock_run.return_value = TokenLengthReport(
+                    total_samples=5,
+                    sampled=5,
+                    sampling_seed=None,
+                    max_context=4096,
+                    prompt_stats=LengthStats(5, 2, 6, 10, 10, 10, 10, 6.0),
+                    response_stats=None,
+                    total_stats=None,
+                    over_context_count=0,
+                    over_context_pct=0.0,
+                    retained_under_policy={"drop": 5, "truncate": 5},
+                )
+                result = runner.invoke(
+                    diag_mod.token_report_command,
+                    ["--dataset-path", dataset, "--tokenizer", "fake"],
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Token Length Distribution Report", result.output)
+        self.assertIn("Prompt Length", result.output)
+        self.assertIn("Over-context", result.output)
+        self.assertIn("Retained under policy", result.output)
+
+    def test_cli_registered_in_main(self):
+        result = CliRunner().invoke(main_mod.main, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("token-report", result.output)
+
+    def test_cli_invalid_sample_ratio(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            dataset = self._make_jsonl(tmp)
+            result = runner.invoke(
+                diag_mod.token_report_command,
+                ["--dataset-path", dataset, "--tokenizer", "fake", "--sample-ratio", "0"],
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("sample_ratio", result.output)
+
+    def test_cli_missing_dataset_file(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            diag_mod.token_report_command,
+            ["--dataset-path", "/nonexistent/path.jsonl", "--tokenizer", "fake"],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("not found", result.output)
+
+
+class BackwardCompatibilityTest(unittest.TestCase):
+    """Existing PromptItem and PromptBatch behavior must not change."""
+
+    def test_prompt_item_fields_unchanged(self):
+        item = PromptItem(
+            prompt="test",
+            solutions=["a"],
+            input_tokens=[1, 2, 3],
+            record={"key": "value"},
+        )
+        self.assertEqual(item.prompt, "test")
+        self.assertEqual(item.input_tokens, [1, 2, 3])
+        self.assertEqual(item.record["key"], "value")
+
+    def test_prompt_batch_prompts_property_unchanged(self):
+        items = [_make_item(5), _make_item(10)]
+        batch = PromptBatch(items=items, scanned=2, skipped_long=0, total_skipped_long=0)
+        self.assertEqual(batch.prompts, [item.prompt for item in items])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_token_length_report_cpu.py
+++ b/tests/test_token_length_report_cpu.py
@@ -19,16 +19,28 @@ from click.testing import CliRunner
 
 # ---------------------------------------------------------------------------
 # Load areno.api.data without triggering areno.api.__init__ (which imports torch).
+# Module names use a `_for_tests` suffix and are registered under those names
+# only, so the real `areno.api.data` / `areno.cli.*` slots in sys.modules stay
+# untouched -- this avoids cross-test module-identity pollution when the full
+# CPU suite runs side by side with tests that import those modules normally.
 # ---------------------------------------------------------------------------
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_DATA_PY = _REPO_ROOT / "areno" / "api" / "data.py"
 
-# Ensure numpy is importable (it's a dependency of data.py).
-_spec = importlib.util.spec_from_file_location("areno.api.data", _DATA_PY)
-_data_mod = importlib.util.module_from_spec(_spec)
-sys.modules["areno.api.data"] = _data_mod
-_spec.loader.exec_module(_data_mod)
+
+def _load_module_for_tests(path: Path, name: str):
+    """Load a source file under a tests-only module name, isolated from sys.modules global slots."""
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_DATA_PY = _REPO_ROOT / "areno" / "api" / "data.py"
+_data_mod = _load_module_for_tests(_DATA_PY, "_areno_token_report_data_for_tests")
 
 # Re-export the symbols we need.
 LengthStats = _data_mod.LengthStats
@@ -40,16 +52,10 @@ compute_token_length_report = _data_mod.compute_token_length_report
 # Load areno.cli.diagnostics and areno.cli.main for CLI tests.
 # These also avoid importing heavy modules at load time.
 _DIAG_PY = _REPO_ROOT / "areno" / "cli" / "diagnostics.py"
-_spec_diag = importlib.util.spec_from_file_location("areno.cli.diagnostics", _DIAG_PY)
-diag_mod = importlib.util.module_from_spec(_spec_diag)
-sys.modules["areno.cli.diagnostics"] = diag_mod
-_spec_diag.loader.exec_module(diag_mod)
+diag_mod = _load_module_for_tests(_DIAG_PY, "_areno_token_report_diagnostics_for_tests")
 
 _MAIN_PY = _REPO_ROOT / "areno" / "cli" / "main.py"
-_spec_main = importlib.util.spec_from_file_location("areno.cli.main", _MAIN_PY)
-main_mod = importlib.util.module_from_spec(_spec_main)
-sys.modules["areno.cli.main"] = main_mod
-_spec_main.loader.exec_module(main_mod)
+main_mod = _load_module_for_tests(_MAIN_PY, "_areno_token_report_main_for_tests")
 
 
 class _MockTokenizer:


### PR DESCRIPTION
## Summary

Add a standalone token-length distribution report capability for AReno, as requested in #215.

## Changes

- **`areno/api/data.py`**: New `LengthStats`, `TokenLengthReport` dataclasses and `compute_token_length_report()` function that computes min/p50/p90/p95/p99/max for prompt, response, and total token lengths, plus over-context percentage and retained-example estimates under drop/truncate policies. Supports deterministic sampling with seed.
- **`areno/cli/diagnostics.py`**: New `areno token-report` CLI command with human-readable table and `--json` structured output.
- **`areno/cli/main.py`**: Register `token-report` command.
- **`tests/test_token_length_report_cpu.py`**: 27 CPU tests covering core logic, CLI, integration, and backward compatibility.
- **`docs/cli/diagnostics.rst`**: Full CLI reference for `areno token-report` with options, output fields, limitations, and examples.

## Usage

```bash
# Full scan
areno token-report --dataset-path ./data.jsonl --tokenizer Qwen/Qwen3-0.6B --max-context 4096

# 10% deterministic sampling with response length
areno token-report --dataset-path ./data.jsonl --tokenizer Qwen/Qwen3-0.6B \
  --sample-ratio 0.1 --sample-seed 42 --response-field answer

# JSON output for scripting
areno token-report --dataset-path ./data.jsonl --tokenizer Qwen/Qwen3-0.6B --json

```

## Test Results
27 passed in 2.27s
Test coverage:

16 core logic tests (stats, sampling, over-context, policies, boundary values)
5 CLI tests (JSON output, human output, registration, invalid input, missing file)
4 integration tests (end-to-end JSONL fixture, prompt+response stats, empty file boundary, disabled-by-default)
2 backward compatibility tests (PromptItem and PromptBatch unchanged)
All tests run on CPU without GPU/CUDA. The feature is opt-in — existing behavior is unchanged when not invoked.

Closes #215