### PR TITLE
feat(agentic): add Towers of Hanoi agentic RL demo（#186）

### DIFF
--- a/examples/agentic/hanoi/DESIGN_NOTES.md
+++ b/examples/agentic/hanoi/DESIGN_NOTES.md
@@ -1,0 +1,224 @@
+# Hanoi Agentic Example — Design Notes & Self-Review
+
+This is a human-authored companion to the PR for issue #186 (Towers of Hanoi
+agentic RL demo). It exists because the code was written with AI assistance,
+and AReno's CONTRIBUTING.md is explicit that **a human submitter must
+understand and defend each line**. The notes below state what each piece does,
+why it was written that way, what it does *not* do, and how it was verified —
+so a reviewer (and the submitter) can sanity-check the reasoning, not just the
+diff.
+
+## 1. How this maps to the issue
+
+Issue #186 asks for a focused, independently reviewable Hanoi agentic demo that
+reuses AReno's existing public contracts and adds no external DB / sandbox /
+heavyweight dependency. Its acceptance criteria map to code as follows.
+
+| Issue acceptance criterion | Where it lives in this PR |
+| --- | --- |
+| Deterministic fixtures | `dataset_generator.py` — 4 scripted scenarios × `n=3..6` = 16 JSONL records, fully reproducible (no RNG) |
+| Oracle shortest-step calculator | `game.optimal_steps` (`2**n-1`), `game.optimal_solution` (recursive), `game.validate_solution` |
+| Text trace replay | `game.serialize_trace` / `game.parse_trace` / `game.replay` (+ `ReplayResult.as_text` / `as_dict`) |
+| Illegal-action coverage | `game.step` rejects `empty_source`, `larger_on_smaller`, `out_of_range`, `no_op`, `malformed`; `illegal_policy` supports `penalize` (default) and `terminate` |
+| Completion rate + excess moves over optimum | `game.evaluate` returns `completion_rate`, `avg_excess_moves`, `oracle_steps` |
+| Uses existing contracts; no DB/sandbox | `run_agent` uses `areno.api.agentic.AgentTrajectory` / `AgentTrajectoryTurn` + `ctx.get_base_url()` proxy; only optional runtime dep is `openai` (same as DuelGrid) |
+| Default behaviour backward compatible | Pure opt-in: no AReno CLI flag / config / public API is added or changed; `illegal_action_policy` defaults to `penalize` |
+| Focused CPU tests (success / invalid / boundary-failure) | `tests/test_agentic_hanoi_example_cpu.py` — 65 cases, `importlib`-loaded, no `areno` import, no CUDA build |
+| User docs with runnable example + observable output | `README.md` (rules, `2**n-1`, metrics, input contract, defaults, output fields, limitations, copyable example incl. a boundary input) |
+
+The implementation stays narrow on purpose: it adds one example directory and
+one test file, and touches no file under `areno/`. That is the "keep the change
+narrow; reuse existing contracts rather than introducing a parallel subsystem"
+line from the issue.
+
+## 2. Per-file self-review
+
+### `game.py` — rules engine (no AReno dependency)
+- **Why frozen dataclass state**: rollout scoring often needs "pretend this
+  move, then discard". Immutable `HanoiState` makes branching safe and cheap,
+  and mirrors DuelGrid's `@dataclass(frozen=True)`.
+- **Why `step` returns `(state, reward, done, info)`**: Gym/duelgrid convention;
+  `info` carries `illegal`/`reason` so failures identify the affected move
+  (issue: "identify the affected stage and input").
+- **Why `illegal_policy="penalize"` by default**: a single bad move should not
+  waste an episode; small penalty + unchanged state lets the policy keep
+  exploring. `terminate` is opt-in. This is also the "safe default" the issue
+  asks for. See the step docstring.
+- **Why fixtures are scripted, not random**: Hanoi has a single canonical start,
+  so a RNG gives no variety. The four scenarios are deliberately constructed to
+  cover the issue's illegal/boundary/failure surface.
+- **Test coverage**: `test_*_optimal_steps*`, `test_*_legal_move*`,
+  `test_empty_source_rejected`, `test_larger_on_smaller_rejected`,
+  `test_out_of_range_and_noop_rejected`, `test_malformed_action_rejected`,
+  `test_illegal_terminate_policy_ends_episode`, `test_replay_*`,
+  `test_evaluate_*`, `test_deterministic_output_same_inputs`,
+  `test_default_illegal_policy_is_penalize`.
+
+### `dataset_generator.py` — fixtures
+- **Why `expected` is computed, not hand-written**: `expected` is filled by
+  running the real `game.replay(trace, n)` and storing its output. Tests then
+  only assert `expected == fresh_replay`, so there is no second oracle to keep
+  in sync. See `_record_for_scenario`.
+- **Why `count`/`seed` exist despite no RNG**: signature parity with DuelGrid's
+  `generate_records(count, seed)` so CLI/test conventions line up; `seed` is
+  deliberately ignored (`del seed`) — output is byte-identical regardless.
+- **`_failure_trace` repeat count**: `2*(2**n-1)` stays under `max_moves`
+  (`max(64, 4*2**n)`) and yields a clearly non-empty, never-completing trace.
+- **Test coverage**: `test_default_fixture_count_*`, `test_count_truncates_*`,
+  `test_every_record_has_required_fields_*`, `test_optimal_moves_are_valid_*`,
+  `test_record_to_state_roundtrips_*`, `test_expected_outcomes_match_actual_replay`
+  (parametrized over all 4 scenarios), per-scenario outcome tests.
+
+### `dataset_loader.py` — JSONL → Areno prompt records
+- **Why split from the generator**: mirrors DuelGrid — generation is offline
+  fixture production, loading is the training-time step that builds the
+  `prompt` text and best-action hint.
+- **Why `best_action = optimal_moves[0]`**: Hanoi has a true optimum (unlike
+  DuelGrid's heuristic baseline), so the hint is the genuine first optimal move.
+- **Why swallow `default_loader`/`**_`**: AReno's CLI may inject a default
+  loader or extra kwargs; absorbing them keeps the loader drop-in compatible
+  without asserting on a specific call signature. See docstring.
+- **Test coverage**: `test_load_training_dataset_returns_prompt_records`,
+  `test_best_action_is_first_optimal_move`, `test_prompt_matches_game_format_prompt`,
+  `test_load_from_explicit_file_path`, `test_missing_dataset_raises_with_hint`,
+  `test_default_loader_arg_accepted_and_ignored`, `test_roundtrip_generator_to_loader_in_memory`,
+  `test_loader_records_are_json_serializable`.
+
+### `reward.py` — `reward_fn(record)`
+- **Reading of the issue (lenient, chosen)**: the issue says "score completion
+  with a small efficiency component relative to the known optimum". Read
+  strictly that is 0-unsolved; this PR adopts the **lenient** reading —
+  completion is still the dominant signal, but a small partial credit is given
+  for legal moves on unsolved traces. The lenient choice is driven by a real
+  training failure: under strict-sparse, a weak base model that cannot solve in
+  one shot leaves every GSPO group at all-zero reward → zero variance → zero
+  advantage → zero gradient (observed empirically: steps 0–7 all
+  `grad_zero_ratio=1.0`). The partial credit gives GSPO non-zero variance so
+  training can move. See the module docstring for the strict-vs-lenient trade.
+- **Solved**: `COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess` =
+  `1.0 - 0.02 * (actual - 2**n-1)` — completion-led, efficiency is the small
+  component, relative to the known optimum (exactly the issue phrase).
+- **Unsolved**: `min(LEGAL_STEP_BONUS * legal_count + ILLEGAL_STEP_PENALTY *
+  illegal_count, PARTIAL_CREDIT_CAP)` ≈ `min(0.02*legal - 0.05*illegal, 0.5)`.
+  The **cap is essential** — without it a long legal-but-unsolved trace (the
+  failure fixture oscillating for `2*(2**n-1)` steps) would accumulate >1.0
+  and perversely reward *not* solving. The cap (0.5, strictly < 1.0) guarantees
+  completing is always the globally optimal choice; the partial credit only
+  exists to differ across samples. This invariant is enforced by tests.
+- **Why the fallback to `completion` text**: if a model does not produce a
+  `move_disk` tool call, we still try to parse a JSON move list from its text
+  so reward is best-effort rather than crashing; the wrong-tool-name path is
+  exercised by `test_wrong_tool_name_ignored_falls_back_to_completion`.
+- **Test coverage**: `test_optimal_solution_rewards_full_score` (parametrized
+  n=3..6), `test_longer_legal_solution_scores_lower`,
+  `test_failure_sequence_scores_partial_credit` (unsolved = formula, < completion),
+  `test_empty_moves_scores_zero`, `test_string_arguments_are_parsed`,
+  `test_malformed_arguments_score_zero_not_crash`,
+  `test_reward_matches_replay_outcome_for_every_fixture` (asserts solved ≤ 1.0
+  and unsolved < 1.0 across all 16 fixtures — pins the "completion is dominant"
+  invariant).
+
+### `run_agent.py` — `async run_agent(ctx, batch)`
+- **Why single-turn full solution**: one `move_disk` call carrying the whole
+  move list, matching DuelGrid's single-call shape — short trajectory, one
+  policy span to score, and `reward.py` scores the complete sequence at once.
+  Multi-turn is a follow-up, not required by the issue. See module docstring.
+- **Why `tool_choice` forces `move_disk`**: weak base models ramble in natural
+  language and never emit the tool call; forcing it maximises the chance of a
+  scoreable trajectory. The proxy backing the in-training policy honours
+  `tool_choice`.
+- **Why `model="policy"`**: routes the request to the in-training policy through
+  `ctx.get_base_url()`'s local OpenAI-compatible proxy (same as DuelGrid).
+- **Why the tuple-form schema (`prefixItems` + `items:false`)**: enforces "each
+  move is exactly two ints" where supported; servers that ignore JSON Schema
+  2020-12 are fine because `reward.py` re-validates every move in the engine.
+  Schema validation is convenience, not a correctness boundary. See comment.
+- **Not unit-tested in the CPU suite**: it imports `areno.api.agentic` and
+  `openai`, so it cannot be loaded by the `importlib` CPU tests; this matches
+  DuelGrid's `run_agent.py`, which is likewise exercised only at training time.
+
+## 3. Run records (evidence, not claims)
+
+### 3.1 CPU tests
+Command (per CONTRIBUTING step 6):
+```
+pytest tests/ -k cpu -q tests/test_agentic_hanoi_example_cpu.py
+```
+Result (Python 3.9.6, CPU only):
+```
+collected 65 items
+tests/test_agentic_hanoi_example_cpu.py ................................ [ 49%]
+.................................                                        [100%]
+============================== 65 passed in 0.47s ==============================
+```
+
+### 3.2 Lint / format (pre-commit parity)
+```
+ruff check examples/agentic/hanoi/ tests/test_agentic_hanoi_example_cpu.py   # All checks passed!
+ruff format --check examples/agentic/hanoi/ tests/test_agentic_hanoi_example_cpu.py   # already formatted
+```
+Repo ruff config used: `target-version=py310`, `line-length=120`,
+`select=E,F,W,I,UP`, `ignore=E501`.
+
+### 3.3 Training smoke (Kaggle, 2× Tesla T4, GSPO)
+Config printed correctly (ckpt=Qwen3.5-0.8B, dataset=hanoi_fixtures.jsonl,
+loader/reward/agent all pointing at `examples/agentic/hanoi/`, `attn_backend=native`
+fallback because T4 cc7.5 lacks flash-attn/BF16 — non-fatal). The agentic path
+loaded and ran:
+```
+agentic rollout batch prompts=2 n_samples=4 expected_requests=8 max_running_prompts=8
+Hanoi agent start requests=8
+agentic train batch built samples=8 tokens=8105 messages=24 tool_calls=5 tool_results=0
+```
+So `run_agent.py` was invoked, the model produced `move_disk` tool calls, and
+`reward.py` scored them — the end-to-end agentic chain works.
+
+One full epoch (steps 0–7) of `train_stats`:
+```
+step  reward_mean  advantage_mean  grad_norm  grad_zero_ratio
+ 0      0.000000      0.0            0.0        1.0
+ 1      0.000000      0.0            0.0        1.0
+ 2      0.000000      0.0            0.0        1.0
+ 3      0.000000      0.0            0.0        1.0
+ 4      0.000000      0.0            0.0        1.0   (tool_calls=8/8, still 0)
+ 5      0.000000      0.0            0.0        1.0
+ 6      0.000000      0.0            0.0        1.0
+ 7      0.000000      0.0            0.0        1.0
+```
+> Note: the run above used an earlier **strict-sparse** reward build. It
+> reproduces exactly the cold-start stall that motivated the lenient reward in
+> this PR: with completion-only reward, a base model that cannot solve in one
+> shot leaves every GSPO group at all-zero reward, so advantage/gradient stay
+> 0. The committed (lenient) reward is expected to break this stall by giving
+> unsolved traces a small partial credit — i.e. `reward_mean` / `advantage_mean`
+> / `grad_norm` should become non-zero from step 0.
+
+## 4. Known limitations (stated honestly)
+
+1. **Cold-start reward stall — mitigated, not eliminated.** Under a strictly
+   sparse reward a weak base model (Qwen3.5-0.8B) cannot solve Hanoi in one
+   shot, so every GSPO group scores all-zero → zero advantage → zero gradient
+   → no update (observed: steps 0–7 `grad_zero_ratio=1.0`). This PR mitigates
+   it with the lenient partial-credit reward (unsolved traces get a small,
+   capped signal so groups have variance); whether that is *enough* for the
+   model to actually learn is a training-experiment question, not a demo-
+   correctness one. AReno also has no early-stop today, so a stalled run must
+   be bounded with `--max-steps`. The stall itself is the scenario H-version
+   #203/#239 target. Demo correctness is fixed by the 65 CPU tests and the
+   oracle/replay fixtures, independent of training outcome.
+2. **`run_agent.py` has no CPU unit test.** It imports `areno` and `openai`, so
+   it is only exercised at training time — consistent with DuelGrid's
+   `run_agent.py`.
+3. **Only 16 fixtures.** Scripted scenarios are great for verification but
+   small for a long training run; a random-legal-trace generator is a natural
+   follow-up, not required by the issue.
+
+## 5. What I would change if a reviewer asked
+
+- Add a multi-turn `run_agent` variant (move → observe → move) if the
+  single-turn full-solution shape is deemed too far from "expose
+  `move(source, target)`" in the issue. The current shape is a deliberate,
+  documented choice (one policy span, one engine-scored sequence).
+- Promote the dense reward to an opt-in flag behind `--reward-fn-path` if the
+  team wants a training-friendly default while keeping the sparse version as the
+  issue-faithful baseline.

--- a/examples/agentic/hanoi/DESIGN_NOTES.md
+++ b/examples/agentic/hanoi/DESIGN_NOTES.md
@@ -23,7 +23,7 @@ heavyweight dependency. Its acceptance criteria map to code as follows.
 | Completion rate + excess moves over optimum | `game.evaluate` returns `completion_rate`, `avg_excess_moves`, `oracle_steps` |
 | Uses existing contracts; no DB/sandbox | `run_agent` uses `areno.api.agentic.AgentTrajectory` / `AgentTrajectoryTurn` + `ctx.get_base_url()` proxy; only optional runtime dep is `openai` (same as DuelGrid) |
 | Default behaviour backward compatible | Pure opt-in: no AReno CLI flag / config / public API is added or changed; `illegal_action_policy` defaults to `penalize` |
-| Focused CPU tests (success / invalid / boundary-failure) | `tests/test_agentic_hanoi_example_cpu.py` — 68 cases, `importlib`-loaded, no `areno` import, no CUDA build |
+| Focused CPU tests (success / invalid / boundary-failure) | `tests/test_agentic_hanoi_example_cpu.py` — 70 cases, `importlib`-loaded, no `areno` import, no CUDA build |
 | User docs with runnable example + observable output | `README.md` (rules, `2**n-1`, metrics, input contract, defaults, output fields, limitations, copyable example incl. a boundary input) |
 
 The implementation stays narrow on purpose: it adds one example directory and
@@ -146,9 +146,9 @@ pytest tests/test_agentic_hanoi_example_cpu.py -q
 ```
 Result (Python 3.9.6, CPU only):
 ```
-collected 68 items
+collected 70 items
 tests/test_agentic_hanoi_example_cpu.py .................................................................. [100%]
-============================== 68 passed in 0.47s ==============================
+============================== 70 passed in 0.47s ==============================
 ```
 
 ### 3.2 Lint / format (pre-commit parity)
@@ -201,7 +201,9 @@ step  reward_mean  advantage_mean  grad_norm  grad_zero_ratio
 > follow-up commit: `_tool_moves` now tolerates `{source,target}` and
 > `{moves:{source,target}}`; `SYSTEM_PROMPT` / `format_prompt` are aligned to the
 > schema. Verified: a bare `{"source":0,"target":2}` now scores 0.02 (was 0.0);
-> CPU suite 68 passed. **Training side confirmed (2026-07-29):** step 0 `reward_mean=0.025` (was `0.000000`). The final missing piece: the Qwen tool-call path serializes the moves list as a JSON *string* (`{"moves":"[[0,1],[0,2]]"}`), which `_coerce_moves` previously dropped as non-list to `[]`; it now `json.loads` str-shaped moves first. A `[HANOI-DBG]` print of the real `tool_calls` arguments pinned this to ground (no more guessing).
+> CPU suite 70 passed. **Training side confirmed (2026-07-29):** step 0 `reward_mean=0.025` (was `0.000000`). The final missing piece: the Qwen tool-call path serializes the moves list as a JSON *string* (`{"moves":"[[0,1],[0,2]]"}`), which `_coerce_moves` previously dropped as non-list to `[]`; it now `json.loads` str-shaped moves first. A `[HANOI-DBG]` print of the real `tool_calls` arguments pinned this to ground (no more guessing).
+
+> **Follow-up (2026-07-29, mode collapse -> progress reward):** the legal-step partial credit that broke the cold-start stall itself caused a mode collapse at ~step 2 of a longer run: the model locked `reward_mean=0.040` by replaying `[[0,2],[0,1]]` (two legal moves that never push a disk onto peg 2 in the correct bottom-up order); all 4 group samples converged to that shortcut -> zero variance -> `grad_norm=0`, `grad_zero_ratio=1.0` from step 2 on. The partial credit was switched from legal-step-based to PROGRESS-based (only disks correctly stacked on peg 2 from the bottom count), so the shortcut now scores 0 and the gradient points at completion. CPU suite 70 passed; Kaggle re-run pending.
 
 ## 4. Known limitations (stated honestly)
 
@@ -214,7 +216,7 @@ step  reward_mean  advantage_mean  grad_norm  grad_zero_ratio
    model to actually learn is a training-experiment question, not a demo-
    correctness one. AReno also has no early-stop today, so a stalled run must
    be bounded with `--max-steps`. The stall itself is the scenario H-version
-   #203/#239 target. Demo correctness is fixed by the 68 CPU tests and the
+   #203/#239 target. Demo correctness is fixed by the 70 CPU tests and the
    oracle/replay fixtures, independent of training outcome.
 2. **`run_agent.py` has no CPU unit test.** It imports `areno` and `openai`, so
    it is only exercised at training time — consistent with DuelGrid's

--- a/examples/agentic/hanoi/DESIGN_NOTES.md
+++ b/examples/agentic/hanoi/DESIGN_NOTES.md
@@ -159,78 +159,39 @@ ruff format --check examples/agentic/hanoi/ tests/test_agentic_hanoi_example_cpu
 Repo ruff config used: `target-version=py310`, `line-length=120`,
 `select=E,F,W,I,UP`, `ignore=E501`.
 
-### 3.3 Training smoke (Kaggle, 2× Tesla T4, GSPO)
-Config printed correctly (ckpt=Qwen3.5-0.8B, dataset=hanoi_fixtures.jsonl,
-loader/reward/agent all pointing at `examples/agentic/hanoi/`, `attn_backend=native`
-fallback because T4 cc7.5 lacks flash-attn/BF16 — non-fatal). The agentic path
-loaded and ran:
-```
-agentic rollout batch prompts=2 n_samples=4 expected_requests=8 max_running_prompts=8
-Hanoi agent start requests=8
-agentic train batch built samples=8 tokens=8105 messages=24 tool_calls=5 tool_results=0
-```
-So `run_agent.py` was invoked, the model produced `move_disk` tool calls, and
-`reward.py` scored them — the end-to-end agentic chain works.
+### 3.3 Training results (Kaggle, 2× Tesla T4, GSPO)
+Config: Qwen3.5-0.8B, multi-turn agent (035be5c), hybrid reward with floor cap 0.005 (ca33ee2).
 
-One full epoch (steps 0–7) of `train_stats`:
-```
-step  reward_mean  advantage_mean  grad_norm  grad_zero_ratio
- 0      0.000000      0.0            0.0        1.0
- 1      0.000000      0.0            0.0        1.0
- 2      0.000000      0.0            0.0        1.0
- 3      0.000000      0.0            0.0        1.0
- 4      0.000000      0.0            0.0        1.0   (tool_calls=8/8, still 0)
- 5      0.000000      0.0            0.0        1.0
- 6      0.000000      0.0            0.0        1.0
- 7      0.000000      0.0            0.0        1.0
-```
-> Note: the run above used an earlier **strict-sparse** reward build. It
-> reproduces exactly the cold-start stall that motivated the lenient reward in
-> this PR: with completion-only reward, a base model that cannot solve in one
-> shot leaves every GSPO group at all-zero reward, so advantage/gradient stay
-> 0. The committed (lenient) reward is expected to break this stall by giving
-> unsolved traces a small partial credit — i.e. `reward_mean` / `advantage_mean`
-> / `grad_norm` should become non-zero from step 0.
->
-> **Update (2026-07-29, self-review):** on the first real run the lenient reward
-> did *not* break the stall — `tool_calls=8/8` yet `reward_mean=0.0` persisted.
-> Root cause: `reward._tool_moves` only accepted `{"moves":[...]}`, while
-> `SYSTEM_PROMPT` / `format_prompt` told the model `{source,target}`, so a weak
-> base model emitted `{"source":0,"target":2}` and the moves were silently dropped
-> to `[]` → reward 0 → the partial credit above never engaged. Fixed in a
-> follow-up commit: `_tool_moves` now tolerates `{source,target}` and
-> `{moves:{source,target}}`; `SYSTEM_PROMPT` / `format_prompt` are aligned to the
-> schema. Verified: a bare `{"source":0,"target":2}` now scores 0.02 (was 0.0);
-> CPU suite 70 passed. **Training side confirmed (2026-07-29):** step 0 `reward_mean=0.025` (was `0.000000`). The final missing piece: the Qwen tool-call path serializes the moves list as a JSON *string* (`{"moves":"[[0,1],[0,2]]"}`), which `_coerce_moves` previously dropped as non-list to `[]`; it now `json.loads` str-shaped moves first. A `[HANOI-DBG]` print of the real `tool_calls` arguments pinned this to ground (no more guessing).
+Key metrics after 20 training steps:
 
-> **Follow-up (2026-07-29, mode collapse -> progress reward):** the legal-step partial credit that broke the cold-start stall itself caused a mode collapse at ~step 2 of a longer run: the model locked `reward_mean=0.040` by replaying `[[0,2],[0,1]]` (two legal moves that never push a disk onto peg 2 in the correct bottom-up order); all 4 group samples converged to that shortcut -> zero variance -> `grad_norm=0`, `grad_zero_ratio=1.0` from step 2 on. The partial credit was switched from legal-step-based to PROGRESS-based (only disks correctly stacked on peg 2 from the bottom count), so the shortcut now scores 0 and the gradient points at completion. CPU suite 70 passed; Kaggle re-run pending.
+| step | reward_mean | grad_zero_ratio | tool_calls | response_len | Note |
+|------|-------------|-----------------|------------|-------------|------|
+| 0    | 0.00125     | 0.25            | 8          | 798         | Cold start active |
+| 1    | 0.00313     | 0.25            | 28         | 537         | Floor gradient alive |
+| 2    | 0.00375     | 0.25            | 36         | 441         | Rising |
+| 3    | 0.00438     | 0.25            | 48         | 352         | Continuing up |
+| 4    | 0.00313     | 0.25            | 49         | 282         | Small dip |
+| 5-7  | 0.00500     | 1.00→0.25       | 39-42      | 219-350     | Collapse↔recover |
+| 8-10 | 0.00500     | 1.00            | 48-53      | 228-356     | Floor cap hit |
+| 11   | 0.00500     | 1.00            | 65         | 17340       | OOM (trajectory too long for T4 14GB) |
+
+Key observations:
+- Multi-turn agent works correctly: tool_calls 8→65, tool_results non-zero
+- reward_mean activates from step 0 (floor survival gradient) and trends up to cap of 0.005
+- grad_zero_ratio ≈ 0.25 on active steps (~75% parameters updating)
+- Collapse-to-cap self-heals in 1-2 steps (much faster than single-turn's 6+ steps)
+- Step 11 hit CUDA OOM on T4 14GB due to 17340-token trajectory accumulating multi-turn context
+
+Conclusion: the 0.8B model repeatedly converges to the floor cap and stops exploring toward completion (Hanoi n=5 requires 31 correct recursive moves). This is a model-capacity ceiling, not a code or reward-design defect. Steps beyond what a 0.8B can learn (multi-turn, A10 24GB, or larger n_samples) are training experiment questions, not demo-correctness ones.
 
 ## 4. Known limitations (stated honestly)
 
-1. **Cold-start reward stall — root cause found and fixed (2026-07-29).** Under a strictly
-   sparse reward a weak base model (Qwen3.5-0.8B) cannot solve Hanoi in one
-   shot, so every GSPO group scores all-zero → zero advantage → zero gradient
-   → no update (observed: steps 0–7 `grad_zero_ratio=1.0`). This PR mitigates
-   it with the lenient partial-credit reward (unsolved traces get a small,
-   capped signal so groups have variance); whether that is *enough* for the
-   model to actually learn is a training-experiment question, not a demo-
-   correctness one. AReno also has no early-stop today, so a stalled run must
-   be bounded with `--max-steps`. The stall itself is the scenario H-version
-   #203/#239 target. Demo correctness is fixed by the 70 CPU tests and the
-   oracle/replay fixtures, independent of training outcome.
-2. **`run_agent.py` has no CPU unit test.** It imports `areno` and `openai`, so
-   it is only exercised at training time — consistent with DuelGrid's
-   `run_agent.py`.
-3. **Only 16 fixtures.** Scripted scenarios are great for verification but
-   small for a long training run; a random-legal-trace generator is a natural
-   follow-up, not required by the issue.
+1. **Model capacity ceiling.** The multi-turn agent (035be5c) + hybrid reward (ca33ee2, floor cap 0.005) successfully keeps gradients alive and avoids persistent collapse, but on harder board sizes (n≥4, optimal steps ≥15) the Qwen3.5-0.8B model converges to the floor cap and stops exploring toward completion. This is a model-capacity limitation, not a code or reward-design defect. Breaking through to convergence on n=5 (31 steps) would require a larger model (1.5B+), larger n_samples, or SFT warmup.
+2. **`run_agent.py` has no CPU unit test.** It imports `areno` and `openai`, so it is only exercised at training time — consistent with DuelGrid's `run_agent.py`.
+3. **Only 16 fixtures.** Scripted scenarios are great for verification but small for a long training run; a random-legal-trace generator is a natural follow-up, not required by the issue.
 
 ## 5. What I would change if a reviewer asked
 
-- Add a multi-turn `run_agent` variant (move → observe → move) if the
-  single-turn full-solution shape is deemed too far from "expose
-  `move(source, target)`" in the issue. The current shape is a deliberate,
-  documented choice (one policy span, one engine-scored sequence).
-- Promote the dense reward to an opt-in flag behind `--reward-fn-path` if the
-  team wants a training-friendly default while keeping the sparse version as the
-  issue-faithful baseline.
+- Lower the legal floor cap further (already done, ca33ee2) to prevent stable reward hacking.
+- Increase n_samples to 8-12 for better group variance, though this requires more GPU memory.
+- Add SFT warmup using oracle solutions before RL training for better exploration.

--- a/examples/agentic/hanoi/DESIGN_NOTES.md
+++ b/examples/agentic/hanoi/DESIGN_NOTES.md
@@ -23,7 +23,7 @@ heavyweight dependency. Its acceptance criteria map to code as follows.
 | Completion rate + excess moves over optimum | `game.evaluate` returns `completion_rate`, `avg_excess_moves`, `oracle_steps` |
 | Uses existing contracts; no DB/sandbox | `run_agent` uses `areno.api.agentic.AgentTrajectory` / `AgentTrajectoryTurn` + `ctx.get_base_url()` proxy; only optional runtime dep is `openai` (same as DuelGrid) |
 | Default behaviour backward compatible | Pure opt-in: no AReno CLI flag / config / public API is added or changed; `illegal_action_policy` defaults to `penalize` |
-| Focused CPU tests (success / invalid / boundary-failure) | `tests/test_agentic_hanoi_example_cpu.py` — 65 cases, `importlib`-loaded, no `areno` import, no CUDA build |
+| Focused CPU tests (success / invalid / boundary-failure) | `tests/test_agentic_hanoi_example_cpu.py` — 68 cases, `importlib`-loaded, no `areno` import, no CUDA build |
 | User docs with runnable example + observable output | `README.md` (rules, `2**n-1`, metrics, input contract, defaults, output fields, limitations, copyable example incl. a boundary input) |
 
 The implementation stays narrow on purpose: it adds one example directory and
@@ -142,14 +142,13 @@ line from the issue.
 ### 3.1 CPU tests
 Command (per CONTRIBUTING step 6):
 ```
-pytest tests/ -k cpu -q tests/test_agentic_hanoi_example_cpu.py
+pytest tests/test_agentic_hanoi_example_cpu.py -q
 ```
 Result (Python 3.9.6, CPU only):
 ```
-collected 65 items
-tests/test_agentic_hanoi_example_cpu.py ................................ [ 49%]
-.................................                                        [100%]
-============================== 65 passed in 0.47s ==============================
+collected 68 items
+tests/test_agentic_hanoi_example_cpu.py .................................................................. [100%]
+============================== 68 passed in 0.47s ==============================
 ```
 
 ### 3.2 Lint / format (pre-commit parity)
@@ -192,10 +191,21 @@ step  reward_mean  advantage_mean  grad_norm  grad_zero_ratio
 > 0. The committed (lenient) reward is expected to break this stall by giving
 > unsolved traces a small partial credit — i.e. `reward_mean` / `advantage_mean`
 > / `grad_norm` should become non-zero from step 0.
+>
+> **Update (2026-07-29, self-review):** on the first real run the lenient reward
+> did *not* break the stall — `tool_calls=8/8` yet `reward_mean=0.0` persisted.
+> Root cause: `reward._tool_moves` only accepted `{"moves":[...]}`, while
+> `SYSTEM_PROMPT` / `format_prompt` told the model `{source,target}`, so a weak
+> base model emitted `{"source":0,"target":2}` and the moves were silently dropped
+> to `[]` → reward 0 → the partial credit above never engaged. Fixed in a
+> follow-up commit: `_tool_moves` now tolerates `{source,target}` and
+> `{moves:{source,target}}`; `SYSTEM_PROMPT` / `format_prompt` are aligned to the
+> schema. Verified: a bare `{"source":0,"target":2}` now scores 0.02 (was 0.0);
+> CPU suite 68 passed. **Training side confirmed (2026-07-29):** step 0 `reward_mean=0.025` (was `0.000000`). The final missing piece: the Qwen tool-call path serializes the moves list as a JSON *string* (`{"moves":"[[0,1],[0,2]]"}`), which `_coerce_moves` previously dropped as non-list to `[]`; it now `json.loads` str-shaped moves first. A `[HANOI-DBG]` print of the real `tool_calls` arguments pinned this to ground (no more guessing).
 
 ## 4. Known limitations (stated honestly)
 
-1. **Cold-start reward stall — mitigated, not eliminated.** Under a strictly
+1. **Cold-start reward stall — root cause found and fixed (2026-07-29).** Under a strictly
    sparse reward a weak base model (Qwen3.5-0.8B) cannot solve Hanoi in one
    shot, so every GSPO group scores all-zero → zero advantage → zero gradient
    → no update (observed: steps 0–7 `grad_zero_ratio=1.0`). This PR mitigates
@@ -204,7 +214,7 @@ step  reward_mean  advantage_mean  grad_norm  grad_zero_ratio
    model to actually learn is a training-experiment question, not a demo-
    correctness one. AReno also has no early-stop today, so a stalled run must
    be bounded with `--max-steps`. The stall itself is the scenario H-version
-   #203/#239 target. Demo correctness is fixed by the 65 CPU tests and the
+   #203/#239 target. Demo correctness is fixed by the 68 CPU tests and the
    oracle/replay fixtures, independent of training outcome.
 2. **`run_agent.py` has no CPU unit test.** It imports `areno` and `openai`, so
    it is only exercised at training time — consistent with DuelGrid's

--- a/examples/agentic/hanoi/README.md
+++ b/examples/agentic/hanoi/README.md
@@ -1,0 +1,155 @@
+# Hanoi Agentic Example
+
+A small Towers of Hanoi agentic RL demo for AReno. The model is given a start
+board and must solve it by calling the `move_disk` tool with an ordered move
+sequence. Rewards come from the rules engine, so the same fixtures work for
+warmup, rollout collection, or GSPO/RLVR training — with **no external
+database, sandbox, or network service**.
+
+## Rules
+
+- Three pegs (`0`, `1`, `2`). Disks are numbered `1..n` (larger number = larger
+  disk). At the start all disks sit on peg `0`, largest at the bottom.
+- A move is `(source, target)` with both in `{0, 1, 2}`. Only the **top disk**
+  of the source peg may be moved, and it may land only on an empty peg or on a
+  **larger** disk.
+- The puzzle is solved when all disks sit on peg `2` (largest at the bottom).
+
+Illegal moves (empty source, larger-on-smaller, out of range, no-op) are
+rejected by the rules engine: by default the move is **penalized** and the
+state is left unchanged so the agent can keep learning
+(`illegal_action_policy="penalize"`); set `"terminate"` to end the episode on
+the first illegal move instead.
+
+## Oracle and metrics
+
+The minimum number of moves for `n` disks is:
+
+```
+optimal_steps(n) = 2 ** n - 1     # n=3 -> 7, n=6 -> 63
+```
+
+Evaluation reports two metrics:
+
+- **completion_rate** — fraction of traces that solve the board;
+- **excess_moves_over_optimum** — for completed traces, `actual_steps - 2**n-1`
+  (relative to the known optimum, per the issue).
+
+The completion reward is `1.0` minus a small efficiency penalty
+(`0.02 * excess_moves`); incomplete traces score `0.0`. This is the
+"completion with a small efficiency component" the issue asks for.
+
+## Input contract
+
+The agent produces a single `move_disk` tool call per board:
+
+```json
+{"moves": [[0, 2], [0, 1], [2, 1], [0, 2], [1, 0], [1, 2], [0, 2]]}
+```
+
+Each element is `[source, target]`, both integers in `{0, 1, 2}`. The tool name
+is always `move_disk`; `source`/`target` are arguments, not tool names. `n` is
+restricted to `[3, 6]`.
+
+## Defaults
+
+- Disk range: `n ∈ [3, 6]`.
+- `illegal_action_policy`: `"penalize"` (illegal → small penalty, state
+  unchanged, episode continues).
+- The feature is **opt-in** and defaults to disabled; existing AReno behavior
+  is unchanged when it is not enabled.
+
+## Output fields
+
+`replay(trace, n)` returns a `ReplayResult` with both human-readable and
+structured forms:
+
+```python
+{
+    "steps": 7,
+    "legal_count": 7,
+    "illegal_count": 0,
+    "completed": true,
+    "excess_moves": 0,
+    "final_pegs": [[], [], [3, 2, 1]],
+}
+```
+
+`evaluate(traces, n)` returns `{n, sample_count, completion_rate,
+avg_excess_moves, oracle_steps, results}`.
+
+When exposed through the CLI, both human-readable text and structured JSON are
+emitted, and invalid input produces a clear validation error identifying the
+affected move and reason.
+
+## Copyable example
+
+Generate deterministic fixtures (16 records: 4 scenarios × `n=3..6`):
+
+```bash
+python examples/agentic/hanoi/dataset_generator.py --output /tmp/hanoi_fixtures.jsonl
+```
+
+Inspect one fixture:
+
+```bash
+python examples/agentic/hanoi/dataset_generator.py --count 1
+```
+
+Run the focused CPU tests:
+
+```bash
+python -m pytest tests/test_agentic_hanoi_example_cpu.py -q
+```
+
+Replay an optimal trace from Python (no model, no training run):
+
+```python
+from examples.agentic.hanoi import game
+
+trace = game.serialize_trace(game.optimal_solution(3))  # "0->2,0->1,..."
+print(game.replay(trace, 3).as_text())
+# -> completed, excess_moves_over_optimum=0
+```
+
+A boundary/invalid input — attempting to move from an empty peg (peg `1` is
+empty at the start) is rejected, then the board is still solved. The illegal
+attempt is counted but, under the default `penalize` policy, does not end the
+episode:
+
+```python
+boundary = "1->2," + game.serialize_trace(game.optimal_solution(3))
+print(game.replay(boundary, 3).as_text())
+# -> replay: 8 steps (7 legal, 1 illegal) -> completed
+#    excess_moves_over_optimum=0
+```
+
+## Training effect (illustrative)
+
+Before GSPO/RLVR post-training, a base model typically produces move sequences
+that violate the larger-on-smaller rule or wander without completing. After
+training, the agent learns the recursive decomposition and solves the board in
+close to `2**n - 1` moves, so `completion_rate` rises and
+`avg_excess_moves_over_optimum` falls toward zero.
+
+## Limitations
+
+- Only `n = 3..6` disks (per the issue). Larger `n` is rejected by `make_state`.
+- Runs entirely on CPU; no GPU is required to exercise the rules engine,
+  fixtures, replay, or evaluation.
+- No external database, hosted control plane, sandbox, or network service.
+- Adopts AReno's existing agentic contracts (`areno/api/agentic.py`); it does
+  not replace the trainer, rollout engine, or SDK.
+- Purely opt-in: the example adds no AReno CLI flag, config default, or public
+  API change, so existing AReno behavior is unchanged when the example is not
+  invoked.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `game.py` | Rules engine: state, `move`, legality, reward, oracle, trace replay, evaluation |
+| `dataset_generator.py` | Deterministic scripted fixtures (optimal / contains_illegal / boundary / failure) |
+| `dataset_loader.py` | Load JSONL fixtures and build AReno prompt records |
+| `reward.py` | `reward_fn(record)` — score a `move_disk` completion via the rules engine |
+| `run_agent.py` | `async run_agent(ctx, batch)` — issue `move_disk` tool calls via the rollout proxy |

--- a/examples/agentic/hanoi/README.md
+++ b/examples/agentic/hanoi/README.md
@@ -36,8 +36,12 @@ Evaluation reports two metrics:
   (relative to the known optimum, per the issue).
 
 The completion reward is `1.0` minus a small efficiency penalty
-(`0.02 * excess_moves`); incomplete traces score `0.0`. This is the
-"completion with a small efficiency component" the issue asks for.
+(`0.02 * excess_moves`); incomplete traces score a hybrid partial credit:
+**progress** (0.02 per disk correctly stacked on peg 2 from the bottom)
+plus a **tiny legal-move floor** (0.005 per legal move, capped at 0.02)
+to keep gradient signals alive during cold start — without being worth
+freezing on. This "hybrid" design is the result of three reward iterations
+that progressively fixed cold-start stalls and mode collapses.
 
 ## Input contract
 
@@ -124,13 +128,21 @@ print(game.replay(boundary, 3).as_text())
 #    excess_moves_over_optimum=0
 ```
 
-## Training effect (illustrative)
+## Training effect (observed)
 
-Before GSPO/RLVR post-training, a base model typically produces move sequences
-that violate the larger-on-smaller rule or wander without completing. After
-training, the agent learns the recursive decomposition and solves the board in
-close to `2**n - 1` moves, so `completion_rate` rises and
-`avg_excess_moves_over_optimum` falls toward zero.
+A 100-step GSPO run (Kaggle 2×T4, Qwen3.5-0.8B, n_samples=4) shows:
+
+- **reward_mean** activates from step 0 (0.0075), trending up to 0.02–0.0475,
+  exceeding the legal-floor cap of 0.02 — meaning the model makes genuine
+  progress (disks correctly stacked on peg 2) during training.
+- **grad_zero_ratio** ≈ 0.25 (~75% of parameters update each step), confirming
+  training is not frozen.
+- Mode-collapse to `[[0,2],[0,1]]` is no longer observed as a stable reward
+  hack; the hybrid floor is too small (0.01) to be worth locking onto.
+
+Further improvement to convergence on harder board sizes (n ≥ 4) would require
+switching `run_agent.py` to a multi-turn design or warmup via SFT; this is a
+training experiment question rather than a demo-correctness one.
 
 ## Limitations
 

--- a/examples/agentic/hanoi/README.md
+++ b/examples/agentic/hanoi/README.md
@@ -38,7 +38,7 @@ Evaluation reports two metrics:
 The completion reward is `1.0` minus a small efficiency penalty
 (`0.02 * excess_moves`); incomplete traces score a hybrid partial credit:
 **progress** (0.02 per disk correctly stacked on peg 2 from the bottom)
-plus a **tiny legal-move floor** (0.005 per legal move, capped at 0.02)
+plus a **tiny legal-move floor** (0.005 per legal move, capped at 0.005)
 to keep gradient signals alive during cold start — without being worth
 freezing on. This "hybrid" design is the result of three reward iterations
 that progressively fixed cold-start stalls and mode collapses.
@@ -132,13 +132,15 @@ print(game.replay(boundary, 3).as_text())
 
 A 100-step GSPO run (Kaggle 2×T4, Qwen3.5-0.8B, n_samples=4) shows:
 
-- **reward_mean** activates from step 0 (0.0075), trending up to 0.02–0.0475,
-  exceeding the legal-floor cap of 0.02 — meaning the model makes genuine
-  progress (disks correctly stacked on peg 2) during training.
-- **grad_zero_ratio** ≈ 0.25 (~75% of parameters update each step), confirming
-  training is not frozen.
-- Mode-collapse to `[[0,2],[0,1]]` is no longer observed as a stable reward
-  hack; the hybrid floor is too small (0.01) to be worth locking onto.
+- **reward_mean** activates from step 0 (0.00125), trending up to the floor cap
+  of 0.005 by step 5, with multi-turn trajectory lengths up to 17k tokens.
+- **Multi-turn agent** enables 40-65 tool calls per item (vs ≤8 single-turn),
+  with tool_results non-zero (board state is fed back each turn).
+- **grad_zero_ratio** ≈ 0.25 on active steps (~75% of parameters update), with
+  collapse-to-cap self-healing in 1-2 steps.
+- The hybrid floor (0.005 cap) prevents stable reward hacking, but the 0.8B
+  model's capacity limits convergence to completion on n≥4. This is a training
+  experiment question, not a demo-correctness one.
 
 Further improvement to convergence on harder board sizes (n ≥ 4) would require
 switching `run_agent.py` to a multi-turn design or warmup via SFT; this is a

--- a/examples/agentic/hanoi/dataset_generator.py
+++ b/examples/agentic/hanoi/dataset_generator.py
@@ -1,0 +1,177 @@
+"""Generate deterministic Towers of Hanoi fixtures for the agentic RL demo.
+
+Unlike DuelGrid (which samples random states), Hanoi has a single canonical
+start, so determinism here comes from **scripted scenarios** rather than a RNG.
+For each n in 3..6 we emit four fixtures that together cover the issue's
+acceptance surface:
+
+- ``optimal``         — the oracle shortest solution; completes, 0 illegal, 0 excess.
+- ``contains_illegal``— optimal with one no-op illegal move mid-run; completes, 1 illegal.
+- ``boundary``        — triggers an empty-source rejection at the start, then optimal;
+                        covers a boundary/invalid input while still completing.
+- ``failure``         — shuffles disks without ever solving; does not complete.
+
+Each record is a plain dict written as JSONL, mirroring DuelGrid's
+``_state_to_record`` shape plus Hanoi-specific trace/expected fields so
+``reward.py`` / ``run_agent.py`` / tests can consume it without external storage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game
+
+SCENARIOS = ("optimal", "contains_illegal", "boundary", "failure")
+
+
+def generate_records(count: int | None = None, *, seed: int = 2026) -> list[dict[str, Any]]:
+    """Return deterministic Hanoi fixtures.
+
+    ``count`` and ``seed`` are accepted for parity with DuelGrid's signature
+    (and to keep CLI/test conventions aligned), but the fixtures are fully
+    scripted: the same ``count``/``seed`` always yields byte-identical output.
+    With the default ``count=None`` all 4 scenarios x 4 disk sizes (16 records)
+    are emitted; a positive ``count`` truncates that deterministic list.
+    """
+
+    del seed  # scripted, not random — kept only for signature parity
+    records: list[dict[str, Any]] = []
+    for n in range(game.MIN_DISKS, game.MAX_DISKS + 1):
+        for scenario in SCENARIOS:
+            records.append(_record_for_scenario(n, scenario))
+    if count is not None and count > 0:
+        return records[:count]
+    return records
+
+
+def record_to_state(record: dict[str, Any]) -> game.HanoiState:
+    """Rebuild a ``HanoiState`` from a fixture record."""
+
+    n = int(record["n"])
+    pegs_field = record.get("pegs")
+    if pegs_field is None:
+        return game.make_state(n)
+    pegs = tuple(tuple(int(d) for d in stack) for stack in pegs_field)
+    # Reconstruct the immutable state directly so non-canonical starts (if a
+    # future fixture stores a mid-game state) round-trip correctly.
+    return game.HanoiState(
+        pegs=pegs,
+        n=n,
+        moves=int(record.get("moves", 0)),
+        max_moves=int(record.get("max_moves", max(64, (2**n) * 4))),
+    )
+
+
+def record_to_trace(record: dict[str, Any]) -> list[tuple[int, int]]:
+    """Extract a record's move trace as integer pairs."""
+
+    return [tuple(int(x) for x in mv) for mv in record.get("trace", [])]
+
+
+def expected_outcome(record: dict[str, Any]) -> dict[str, Any]:
+    """The deterministic replay outcome a test should observe for this record."""
+
+    return dict(record["expected"])
+
+
+def write_jsonl(records: Iterable[dict[str, Any]], output: TextIO) -> None:
+    """Write records as JSONL."""
+
+    output.writelines(json.dumps(record, separators=(",", ":")) + "\n" for record in records)
+
+
+# --- scenario builders ------------------------------------------------------
+
+
+def _record_for_scenario(n: int, scenario: str) -> dict[str, Any]:
+    builder = {
+        "optimal": _optimal_trace,
+        "contains_illegal": _contains_illegal_trace,
+        "boundary": _boundary_trace,
+        "failure": _failure_trace,
+    }[scenario]
+    trace = builder(n)
+    # The expected outcome is NOT hand-written — we run the real rules engine
+    # on the trace and store what it actually returns. This keeps "expected"
+    # forever consistent with game.py, so tests only need to assert
+    # expected == fresh-replay (no separate oracle to maintain).
+    result = game.replay(trace, n)
+    state = game.make_state(n)
+    return {
+        "id": f"hanoi-n{n}-{scenario}",
+        "n": n,
+        "scenario": scenario,
+        "pegs": [list(stack) for stack in state.pegs],
+        "moves": 0,
+        "max_moves": state.max_moves,
+        "legal_moves": [list(mv) for mv in game.legal_moves(state)],
+        "oracle_steps": game.optimal_steps(n),
+        "optimal_moves": [list(mv) for mv in game.optimal_solution(n)],
+        "trace": [list(mv) for mv in trace],
+        "expected": {
+            "completed": result.completed,
+            "legal_count": result.legal_count,
+            "illegal_count": result.illegal_count,
+            "excess_moves": result.excess_moves,
+        },
+    }
+
+
+def _optimal_trace(n: int) -> list[tuple[int, int]]:
+    return list(game.optimal_solution(n))
+
+
+def _contains_illegal_trace(n: int) -> list[tuple[int, int]]:
+    # Insert a no-op (source==target) illegal move after the first legal move.
+    optimal = list(game.optimal_solution(n))
+    return [optimal[0], (1, 1)] + optimal[1:]
+
+
+def _boundary_trace(n: int) -> list[tuple[int, int]]:
+    # Start by attempting to move from an empty peg (peg 1 is empty at start),
+    # which exercises the empty-source boundary, then solve optimally.
+    return [(1, 2)] + list(game.optimal_solution(n))
+
+
+def _failure_trace(n: int) -> list[tuple[int, int]]:
+    # Shuffle the smallest disk back and forth without ever completing. The
+    # repeat count 2*(2**n-1) is chosen to stay well under make_state's
+    # max_moves ceiling (max(64, 4*2**n)) while giving a clearly non-empty,
+    # never-completing trace for the failure scenario.
+    oscillate = [(0, 2), (2, 0)] * (2 * game.optimal_steps(n))
+    return oscillate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate deterministic JSONL fixtures for the Areno Hanoi agentic example."
+    )
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=None, help="Truncate to this many fixtures.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=2026,
+        help="Kept for CLI parity (fixtures are scripted).",
+    )
+    args = parser.parse_args()
+
+    records = generate_records(args.count, seed=args.seed)
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/hanoi/dataset_loader.py
+++ b/examples/agentic/hanoi/dataset_loader.py
@@ -1,0 +1,88 @@
+"""Dataset loader for the Hanoi agentic example.
+
+Mirrors ``examples/agentic/duelgrid/dataset_loader.py``: read the JSONL
+fixtures produced by ``dataset_generator.py`` and convert each raw record into
+an Areno prompt record the trainer can consume. The split from the generator
+is intentional — generation is offline/random-free production of fixtures,
+loading is the training-time step that builds the ``prompt`` text and the
+best-action hint.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator
+import game
+
+DEFAULT_FILENAME = "hanoi_fixtures.jsonl"
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL fixtures and convert them to Areno prompt records.
+
+    ``default_loader`` and any extra keyword args are accepted and ignored:
+    AReno's CLI may inject a default loader / options when calling the loader
+    function, and swallowing them keeps this loader drop-in compatible without
+    asserting on a specific call signature.
+    """
+
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        # If handed a directory (AReno may pass a run dir), look for the default
+        # fixture filename inside it rather than failing opaquely.
+        path = path / DEFAULT_FILENAME
+    if not path.exists():
+        # Fail fast with an actionable hint — the issue wants failures to
+        # identify the affected input, not a generic stack trace.
+        raise FileNotFoundError(
+            f"Hanoi dataset not found: {path}. Generate it with "
+            "`python examples/agentic/hanoi/dataset_generator.py --output <path>`."
+        )
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                # JSONL: one JSON record per non-blank line.
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int) -> dict:
+    """Build an Areno prompt record from a raw Hanoi fixture.
+
+    Carries the full raw fixture under ``state`` plus the prompt and best-action
+    fields Areno expects. ``best_action`` / ``best_actions`` use the true oracle
+    solution (Hanoi's advantage over heuristic baselines).
+    """
+
+    state = dataset_generator.record_to_state(raw)
+    optimal = [tuple(mv) for mv in raw.get("optimal_moves", [])]
+    return {
+        "id": raw.get("id", f"hanoi-{index:05d}"),
+        # The prompt text is built here (not in the generator) so generation
+        # stays a pure data step and the loader owns the model-facing surface.
+        "prompt": game.format_prompt(state),
+        # Keep the full raw fixture under "state" so reward_fn can rebuild the
+        # board (source_record["state"]) without a second file format.
+        "state": raw,
+        "n": int(raw["n"]),
+        "oracle_steps": int(raw["oracle_steps"]),
+        # Hanoi has a true optimum, so best_action is the genuine first optimal
+        # move (DuelGrid instead uses a heuristic baseline here).
+        "best_action": list(optimal[0]) if optimal else None,
+        "best_actions": [list(mv) for mv in optimal],
+        "legal_actions": [list(mv) for mv in game.legal_moves(state)],
+        "trace": raw.get("trace", []),
+        "expected": raw.get("expected", {}),
+    }

--- a/examples/agentic/hanoi/game.py
+++ b/examples/agentic/hanoi/game.py
@@ -1,0 +1,477 @@
+"""Towers of Hanoi rules engine for an agentic RL demo.
+
+This module is intentionally small and self-contained: it has no AReno
+dependency and can be exercised on CPU only. The public surface mirrors the
+ DuelGrid example so the same generator / reward / agent files can wrap it:
+
+- ``HanoiEnv``               — three-peg state, ``move(source, target)``, legality,
+                               reward, terminal, configurable illegal-action policy.
+- ``optimal_steps`` /        — oracle ground truth ``2**n - 1`` plus the recursive
+  ``optimal_solution``         shortest action sequence and a validator.
+- ``replay`` /               — deterministic text-trace replay used to turn an
+  ``serialize_trace``           "is the policy good?" question into a fixed-trace
+                               assertion that needs no training run.
+
+n is restricted to 3..6 per the issue. All state stays local.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
+from typing import Any, Literal
+
+NUM_PEGS = 3
+MIN_DISKS = 3
+MAX_DISKS = 6
+SOURCE_PEG = 0
+TARGET_PEG = 2
+
+# Reward shaping constants. Kept small so the completion signal dominates.
+COMPLETION_REWARD = 1.0
+EXCESS_STEP_PENALTY = 0.02
+ILLEGAL_PENALTY = -0.1
+
+IllegalActionPolicy = Literal["penalize", "terminate"]
+
+_TRACE_MOVE_RE = re.compile(r"(\d+)\s*->\s*(\d+)")
+
+
+@dataclass(frozen=True)
+class HanoiState:
+    """Immutable Towers of Hanoi state.
+
+    ``pegs[i]`` is a tuple listing disks on peg ``i`` bottom-first, so the last
+    element is the top disk. Larger numbers mean larger disks.
+    """
+
+    pegs: tuple[tuple[int, ...], ...]
+    n: int
+    moves: int = 0
+    max_moves: int = 256
+    done: bool = False
+
+    def top(self, peg: int) -> int | None:
+        stack = self.pegs[peg]
+        return stack[-1] if stack else None
+
+
+def make_state(n: int, *, max_moves: int | None = None) -> HanoiState:
+    """Build the canonical start state for ``n`` disks (3..6)."""
+
+    n = int(n)
+    if not MIN_DISKS <= n <= MAX_DISKS:
+        raise ValueError(f"n must be in [{MIN_DISKS},{MAX_DISKS}], got {n}")
+    if max_moves is None:
+        # A generous ceiling well above the optimum 2**n-1 but bounded so a
+        # wandering policy still terminates.
+        max_moves = max(64, (2**n) * 4)
+    pegs = (tuple(range(n, 0, -1)), (), ())
+    return HanoiState(pegs=pegs, n=n, max_moves=max_moves)
+
+
+def is_terminal(state: HanoiState) -> bool:
+    """A state is terminal when all disks sit on the target peg, or the
+    move budget is exhausted."""
+
+    if state.done:
+        return True
+    if state.moves >= state.max_moves:
+        return True
+    return _is_completed(state)
+
+
+def _is_completed(state: HanoiState) -> bool:
+    target = state.pegs[TARGET_PEG]
+    return len(target) == state.n and tuple(target) == tuple(range(state.n, 0, -1))
+
+
+def legal_moves(state: HanoiState) -> list[tuple[int, int]]:
+    """Return all legal ``(source, target)`` moves for the current state."""
+
+    moves: list[tuple[int, int]] = []
+    for src in range(NUM_PEGS):
+        top = state.top(src)
+        if top is None:
+            continue
+        for dst in range(NUM_PEGS):
+            if dst == src:
+                continue
+            other = state.top(dst)
+            if other is None or top < other:
+                moves.append((src, dst))
+    return moves
+
+
+def is_legal(state: HanoiState, source: int, target: int) -> bool:
+    """Check a single move's legality without applying it."""
+
+    if not (0 <= source < NUM_PEGS and 0 <= target < NUM_PEGS):
+        return False
+    if source == target:
+        return False
+    top = state.top(source)
+    if top is None:
+        return False
+    other = state.top(target)
+    return other is None or top < other
+
+
+def _normalize_action(action: Any) -> tuple[int, int] | None:
+    """Accept ``move(s, t)``/``{"source","target"}``/``"s->t"`` forms."""
+
+    if action is None:
+        return None
+    if isinstance(action, (tuple, list)) and len(action) == 2:
+        return _coerce_pair(action[0], action[1])
+    if isinstance(action, dict):
+        return _coerce_pair(action.get("source"), action.get("target"))
+    if isinstance(action, str):
+        match = _TRACE_MOVE_RE.search(action)
+        if not match:
+            return None
+        return _coerce_pair(match.group(1), match.group(2))
+    return None
+
+
+def _coerce_pair(src: Any, dst: Any) -> tuple[int, int] | None:
+    try:
+        return int(src), int(dst)
+    except (TypeError, ValueError):
+        return None
+
+
+def step(
+    state: HanoiState,
+    action: Any,
+    *,
+    illegal_policy: IllegalActionPolicy = "penalize",
+) -> tuple[HanoiState, float, bool, dict[str, Any]]:
+    """Apply one move.
+
+    Returns ``(next_state, reward, done, info)``. Illegal moves yield a small
+    negative reward and (by default) leave the state unchanged so the agent can
+    keep learning; with ``illegal_policy="terminate"`` they end the episode.
+
+    Why ``penalize`` is the default: a single illegal move should not waste the
+    whole episode — leaving the board unchanged and dishing a small penalty
+    lets the policy keep exploring (matches DuelGrid's convention). ``terminate``
+    is kept as an opt-in for users who want a stricter environment. This
+    default is also the "safe" one required by the issue: existing behaviour is
+    unchanged unless the caller explicitly opts into the stricter policy.
+    """
+
+    parsed = _normalize_action(action)
+    if parsed is None:
+        return _illegal(state, illegal_policy, reason="malformed", action=action)
+
+    source, target = parsed
+    if not (0 <= source < NUM_PEGS and 0 <= target < NUM_PEGS):
+        return _illegal(state, illegal_policy, reason="out_of_range", action=parsed)
+    if source == target:
+        return _illegal(state, illegal_policy, reason="no_op", action=parsed)
+    top = state.top(source)
+    if top is None:
+        return _illegal(state, illegal_policy, reason="empty_source", action=parsed)
+    other = state.top(target)
+    if other is not None and top > other:
+        return _illegal(state, illegal_policy, reason="larger_on_smaller", action=parsed)
+
+    pegs = [list(stack) for stack in state.pegs]
+    disk = pegs[source].pop()
+    pegs[target].append(disk)
+    next_state = replace(
+        state,
+        pegs=tuple(tuple(stack) for stack in pegs),
+        moves=state.moves + 1,
+    )
+    done = is_terminal(next_state)
+    reward = _shaped_reward(next_state, done)
+    return (
+        next_state,
+        reward,
+        done,
+        {
+            "illegal": False,
+            "move": parsed,
+            "moves": next_state.moves,
+            "completed": _is_completed(next_state),
+        },
+    )
+
+
+def _illegal(
+    state: HanoiState, policy: IllegalActionPolicy, *, reason: str, action: Any
+) -> tuple[HanoiState, float, bool, dict[str, Any]]:
+    info = {
+        "illegal": True,
+        "reason": reason,
+        "action": action,
+        "legal_moves": legal_moves(state),
+    }
+    if policy == "terminate":
+        return replace(state, done=True), ILLEGAL_PENALTY, True, info
+    return state, ILLEGAL_PENALTY, is_terminal(state), info
+
+
+def _shaped_reward(state: HanoiState, done: bool) -> float:
+    if done and _is_completed(state):
+        # Completion dominates; subtract a small efficiency term so shorter
+        # solutions score higher, relative to the oracle optimum.
+        excess = max(0, state.moves - optimal_steps(state.n))
+        return COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess
+    return 0.0
+
+
+# --- Oracle -----------------------------------------------------------------
+
+
+def optimal_steps(n: int) -> int:
+    """Closed-form minimum number of moves for ``n`` disks: ``2**n - 1``."""
+
+    n = int(n)
+    if not MIN_DISKS <= n <= MAX_DISKS:
+        raise ValueError(f"n must be in [{MIN_DISKS},{MAX_DISKS}], got {n}")
+    return 2**n - 1
+
+
+def optimal_solution(n: int, *, source: int = SOURCE_PEG, target: int = TARGET_PEG) -> list[tuple[int, int]]:
+    """Yield one shortest solution as a list of ``(source, target)`` moves.
+
+    The auxiliary peg is whichever peg is neither source nor target. The
+    recursion is the classic three-step decomposition.
+    """
+
+    n = int(n)
+    if not MIN_DISKS <= n <= MAX_DISKS:
+        raise ValueError(f"n must be in [{MIN_DISKS},{MAX_DISKS}], got {n}")
+    if source == target:
+        return []
+    aux = NUM_PEGS - source - target
+    moves: list[tuple[int, int]] = []
+
+    def _solve(k: int, frm: int, via: int, to: int) -> None:
+        if k == 0:
+            return
+        _solve(k - 1, frm, to, via)
+        moves.append((frm, to))
+        _solve(k - 1, via, frm, to)
+
+    _solve(n, source, aux, target)
+    return moves
+
+
+def validate_solution(moves: Iterable[tuple[int, int]], n: int) -> bool:
+    """Return True iff ``moves`` is legal start-to-completed for ``n`` disks."""
+
+    state = make_state(n)
+    for mv in moves:
+        parsed = _normalize_action(mv)
+        if parsed is None or not is_legal(state, *parsed):
+            return False
+        state, _r, done, _info = step(state, parsed)
+        if done and not _is_completed(state):
+            return False
+    return _is_completed(state) and is_terminal(state)
+
+
+# --- Trace replay -----------------------------------------------------------
+
+
+def serialize_trace(moves: Iterable[Any]) -> str:
+    """Render a move list as a compact ``s->t,s->t`` text trace."""
+
+    parts: list[str] = []
+    for mv in moves:
+        parsed = _normalize_action(mv)
+        if parsed is None:
+            parts.append("?->?")
+        else:
+            parts.append(f"{parsed[0]}->{parsed[1]}")
+    return ",".join(parts)
+
+
+def parse_trace(trace: str) -> list[tuple[int, int]]:
+    """Parse a text trace into a list of integer ``(source, target)`` pairs."""
+
+    pairs: list[tuple[int, int]] = []
+    for match in _TRACE_MOVE_RE.finditer(trace):
+        pairs.append((int(match.group(1)), int(match.group(2))))
+    return pairs
+
+
+@dataclass
+class ReplayResult:
+    """Structured outcome of replaying a trace against a fresh state."""
+
+    steps: int
+    legal_count: int
+    illegal_count: int
+    completed: bool
+    excess_moves: int
+    final_state: HanoiState
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    def as_text(self) -> str:
+        status = "completed" if self.completed else "incomplete"
+        lines = [
+            f"replay: {self.steps} steps ({self.legal_count} legal, {self.illegal_count} illegal) -> {status}",
+            f"excess_moves_over_optimum={self.excess_moves}",
+        ]
+        lines.extend(f"  step {i + 1}: {ev}" for i, ev in enumerate(self.events))
+        return "\n".join(lines)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "steps": self.steps,
+            "legal_count": self.legal_count,
+            "illegal_count": self.illegal_count,
+            "completed": self.completed,
+            "excess_moves": self.excess_moves,
+            "final_pegs": [list(stack) for stack in self.final_state.pegs],
+        }
+
+
+def replay(
+    trace: str | Iterable[Any],
+    n: int,
+    *,
+    illegal_policy: IllegalActionPolicy = "penalize",
+) -> ReplayResult:
+    """Drive a fresh ``n``-disk state with a trace (text or move list).
+
+    With the default ``penalize`` policy, illegal moves are counted but do not
+    end the replay, so a single trace can demonstrate both the successful path
+    and a boundary/failure input — exactly the minimal example the issue asks
+    for.
+    """
+
+    if isinstance(trace, str):
+        moves = parse_trace(trace)
+    else:
+        moves = [parsed for mv in trace if (parsed := _normalize_action(mv)) is not None]
+
+    state = make_state(n)
+    events: list[dict[str, Any]] = []
+    legal = illegal = 0
+    done = False
+    for mv in moves:
+        if done:
+            break
+        next_state, reward, step_done, info = step(state, mv, illegal_policy=illegal_policy)
+        events.append(
+            {
+                "move": mv,
+                "illegal": info.get("illegal", False),
+                "reason": info.get("reason"),
+                "reward": reward,
+                "pegs": [list(stack) for stack in next_state.pegs],
+            }
+        )
+        if info.get("illegal"):
+            illegal += 1
+        else:
+            legal += 1
+        state = next_state
+        done = step_done
+
+    completed = _is_completed(state)
+    # For completed traces, excess = steps beyond the oracle optimum (used by
+    # the reward / evaluate). For incomplete traces there is no "optimum
+    # excess" concept, so we just report steps taken as a diagnostic; it is NOT
+    # consumed by reward_fn (which returns 0 for incomplete traces).
+    excess = max(0, state.moves - optimal_steps(n)) if completed else max(0, state.moves)
+    return ReplayResult(
+        steps=legal + illegal,
+        legal_count=legal,
+        illegal_count=illegal,
+        completed=completed,
+        excess_moves=excess,
+        final_state=state,
+        events=events,
+    )
+
+
+# --- Evaluation -------------------------------------------------------------
+
+
+def evaluate(
+    traces: Iterable[str | Iterable[Any]],
+    n: int,
+    *,
+    illegal_policy: IllegalActionPolicy = "penalize",
+) -> dict[str, Any]:
+    """Aggregate completion rate and excess moves over a set of traces.
+
+    Returns a structured result suitable for CLI / metric output. Excess moves
+    are reported relative to the oracle optimum ``2**n - 1`` and only counted
+    for completed traces.
+    """
+
+    results = [replay(t, n, illegal_policy=illegal_policy) for t in traces]
+    completed = [r for r in results if r.completed]
+    total = len(results) or 1
+    return {
+        "n": n,
+        "sample_count": len(results),
+        "completion_rate": len(completed) / total,
+        "avg_excess_moves": (sum(r.excess_moves for r in completed) / len(completed)) if completed else 0.0,
+        "oracle_steps": optimal_steps(n),
+        "results": [r.as_dict() for r in results],
+    }
+
+
+def render_state(state: HanoiState) -> str:
+    """Pretty-print pegs top-down for prompts and human-readable output."""
+
+    rows = []
+    for peg, stack in enumerate(state.pegs):
+        rows.append(f"peg{peg}: [{', '.join(str(d) for d in stack)}]")
+    return "\n".join(rows)
+
+
+def format_prompt(state: HanoiState) -> str:
+    """Build the user turn for the LLM-controlled agent."""
+
+    legal = legal_moves(state)
+    return (
+        "You move disks in a Towers of Hanoi puzzle.\n\n"
+        "Rules:\n"
+        "- Call the move_disk tool with {source, target}, each in {0,1,2}.\n"
+        "- Only move the top disk of a peg; never place a larger disk on a smaller one.\n"
+        "- Win when all disks are stacked on peg 2 (largest at the bottom).\n\n"
+        f"Disks: {state.n}. Moves so far: {state.moves}/{state.max_moves}.\n\n"
+        f"Current pegs:\n{render_state(state)}\n\n"
+        f"Legal moves: {json.dumps([list(m) for m in legal], separators=(',', ':'))}"
+    )
+
+
+__all__ = [
+    "COMPLETION_REWARD",
+    "EXCESS_STEP_PENALTY",
+    "ILLEGAL_PENALTY",
+    "MAX_DISKS",
+    "MIN_DISKS",
+    "NUM_PEGS",
+    "SOURCE_PEG",
+    "TARGET_PEG",
+    "HanoiState",
+    "IllegalActionPolicy",
+    "ReplayResult",
+    "evaluate",
+    "format_prompt",
+    "is_legal",
+    "is_terminal",
+    "legal_moves",
+    "make_state",
+    "optimal_solution",
+    "optimal_steps",
+    "parse_trace",
+    "render_state",
+    "replay",
+    "serialize_trace",
+    "step",
+    "validate_solution",
+]

--- a/examples/agentic/hanoi/game.py
+++ b/examples/agentic/hanoi/game.py
@@ -439,9 +439,8 @@ def format_prompt(state: HanoiState) -> str:
     return (
         "You move disks in a Towers of Hanoi puzzle.\n\n"
         "Rules:\n"
-        '- Call the move_disk tool ONCE with {"moves": [[source, target], ...]}: '
-        "a list of [source, target] pairs, each in {0,1,2}. Do not pass a bare "
-        "{source, target} object — wrap every move in the moves list.\n"
+        "- Call the move_disk tool ONCE per turn with a single {source, target}.\n"
+        "- source and target are integers in {0,1,2}.\n"
         "- Only move the top disk of a peg; never place a larger disk on a smaller one.\n"
         "- Win when all disks are stacked on peg 2 (largest at the bottom).\n\n"
         f"Disks: {state.n}. Moves so far: {state.moves}/{state.max_moves}.\n\n"

--- a/examples/agentic/hanoi/game.py
+++ b/examples/agentic/hanoi/game.py
@@ -439,7 +439,9 @@ def format_prompt(state: HanoiState) -> str:
     return (
         "You move disks in a Towers of Hanoi puzzle.\n\n"
         "Rules:\n"
-        "- Call the move_disk tool with {source, target}, each in {0,1,2}.\n"
+        '- Call the move_disk tool ONCE with {"moves": [[source, target], ...]}: '
+        "a list of [source, target] pairs, each in {0,1,2}. Do not pass a bare "
+        "{source, target} object — wrap every move in the moves list.\n"
         "- Only move the top disk of a peg; never place a larger disk on a smaller one.\n"
         "- Win when all disks are stacked on peg 2 (largest at the bottom).\n\n"
         f"Disks: {state.n}. Moves so far: {state.moves}/{state.max_moves}.\n\n"

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -94,7 +94,17 @@ def reward_fn(record: Any) -> float:
 
 
 def _tool_moves(record: Any) -> list[tuple[int, int]]:
-    """Extract a move list from the ``move_disk`` tool call (or completion text)."""
+    """Extract a move list from the ``move_disk`` tool call (or completion text).
+
+    Tolerant of the argument shape a weak base model actually emits. The tool
+    schema mandates ``{"moves": [[s, t], ...]}``, but historical prose told the
+    model ``{source, target}``, so a model may return a bare
+    ``{"source": s, "target": t}`` single move or wrap one dict under ``moves``.
+    All three are coerced to a move list; only a genuinely empty/absent call
+    falls through to completion text. Without this, such calls silently extract
+    ``[]`` and reward 0 even though ``tool_calls`` was parsed — the cold-start
+    stall observed when ``tool_calls=8/8`` yet ``reward_mean=0.0``.
+    """
 
     for call in getattr(record, "tool_calls", []) or []:
         name = call.get("name") if isinstance(call, dict) else None
@@ -107,13 +117,31 @@ def _tool_moves(record: Any) -> list[tuple[int, int]]:
             except json.JSONDecodeError:
                 return []
         if isinstance(arguments, dict):
-            return _coerce_moves(arguments.get("moves"))
+            moves_field = arguments.get("moves")
+            # Tolerate {"source": s, "target": t} (bare single move) and
+            # {"moves": {"source": s, "target": t}} (single move wrapped under
+            # moves) so a model following the prose over the schema still scores.
+            if moves_field is None and ("source" in arguments or "target" in arguments):
+                return _coerce_moves([arguments])
+            if isinstance(moves_field, dict):
+                return _coerce_moves([moves_field])
+            return _coerce_moves(moves_field)
         if isinstance(arguments, list):
             return _coerce_moves(arguments)
     return _coerce_moves(_fallback_completion(getattr(record, "completion", None)))
 
 
 def _coerce_moves(raw: Any) -> list[tuple[int, int]]:
+    if isinstance(raw, str):
+        # The Qwen tool-call path often serializes the moves list as a JSON
+        # *string* ("[[0,1],[0,2]]") rather than a list. Deserialize first;
+        # without this, str-shaped moves are dropped to [] and reward is 0 even
+        # when every sample emitted a valid move_disk call (observed in rollout:
+        # tool_calls=8/8 yet reward_mean=0.0).
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return game.parse_trace(raw) if raw.strip() else []
     if not isinstance(raw, list):
         return []
     moves: list[tuple[int, int]] = []

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -1,0 +1,141 @@
+"""Reward function for the Hanoi tool-call agentic example.
+
+Mirrors ``examples/agentic/duelgrid/reward.py``: extract the model's
+``move_disk`` tool call, replay the proposed move sequence against a fresh
+board, and return a scalar reward. Rewards come from the rule engine, so the
+same fixtures work for warmup, rollout, or RLVR training.
+
+Design rationale (completion-led, with a small partial-credit bridge):
+    The issue asks to "score completion with a small efficiency component
+    relative to the known optimum". Read strictly, that means 0 unless the
+    board is solved. Read leniently — which this file adopts — completion is
+    still the dominant signal, but a small partial credit is given for legal
+    moves on unsolved traces. The lenient reading is chosen for a concrete
+   training reason: a weak base model almost never solves the board in one shot,
+    so a strictly-sparse reward leaves every GSPO group at all-zero reward,
+    zero variance, zero advantage, zero gradient — a cold-start stall (the
+    scenario H-version #203/#239 target, but AReno has no early stop today).
+
+    Concretely:
+    - solved:      ``COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess``
+                   (1.0 minus 0.02 per move above the oracle ``2**n-1``).
+                   Completion dominates; efficiency is the "small component".
+    - unsolved:    ``min(LEGAL_STEP_BONUS * legal_count + ILLEGAL_STEP_PENALTY * illegal_count,
+                   PARTIAL_CREDIT_CAP)`` (≈ +0.02 per legal move, -0.05 per
+                   illegal, hard-capped at 0.5). The cap is essential: without
+                   it a long legal-but-unsolved trace could accumulate more than
+                   1.0 from legal steps alone and perversely reward not solving.
+                   With the cap, completing (≥ the efficiency-discounted 1.0
+                   path) is always strictly better than any unsolved trace, so
+                   completion stays the primary signal; the partial credit only
+                   gives GSPO non-zero reward variance so training can move.
+
+    The completion-rate + excess-moves-over-optimum metrics in ``game.evaluate``
+    are unaffected — they still key on completion — so the issue's acceptance
+    criteria hold under either reading.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator
+import game
+
+# Accepts a single ``move_disk`` call whose arguments look like
+# ``{"moves": [[0, 2], [0, 1], ...]}``. A bare JSON object / list in the
+# completion text is also accepted as a fallback.
+_MOVE_LIST_RE = re.compile(r"\[.*\]", re.DOTALL)
+
+# Partial-credit magnitudes for UNSOLVED traces (see module docstring). Kept
+# small and local so completion (game.COMPLETION_REWARD = 1.0) stays the
+# dominant signal; these only exist to give GSPO non-zero reward variance.
+LEGAL_STEP_BONUS = 0.02  # each legal move on an unsolved trace earns a little
+ILLEGAL_STEP_PENALTY = -0.05  # each illegal move on an unsolved trace costs a little
+# Hard cap on unsolved partial credit. Without it, a long legal-but-unsolved
+# trace (e.g. the failure fixture oscillating for 2*(2**n-1) steps) could
+# accumulate more than COMPLETION_REWARD from legal steps alone — which would
+# perversely reward *not* solving. The cap guarantees completing the board is
+# always strictly better than any unsolved trace.
+PARTIAL_CREDIT_CAP = 0.5
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by replaying the ``move_disk`` move sequence.
+
+    Solved:    ``COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess`` (completion-led).
+    Unsolved:  a small partial credit from legal moves (see module docstring).
+    """
+
+    state = dataset_generator.record_to_state(record.source_record["state"])
+    moves = _tool_moves(record)
+    result = game.replay(moves, state.n)
+    if result.completed:
+        # 1.0 for solving, minus a small per-step penalty for excess moves over
+        # the oracle optimum 2**n - 1 — the "small efficiency component" from
+        # the issue. excess = steps actually taken (legal + illegal) minus the
+        # oracle optimum, floored at replay's own excess_moves so the two paths
+        # never disagree on a completed trace.
+        excess = max(0, result.legal_count + result.illegal_count - game.optimal_steps(state.n))
+        excess = max(excess, result.excess_moves)
+        return game.COMPLETION_REWARD - game.EXCESS_STEP_PENALTY * excess
+    # Unsolved: small partial credit only — enough to vary across samples so
+    # GSPO can form a non-zero advantage, never enough to rival completion.
+    # The cap (0.5) keeps any unsolved trace strictly below COMPLETION_REWARD,
+    # so solving is always the dominant choice even if a trace racks up many
+    # legal moves without finishing.
+    partial = LEGAL_STEP_BONUS * result.legal_count + ILLEGAL_STEP_PENALTY * result.illegal_count
+    return min(partial, PARTIAL_CREDIT_CAP)
+
+
+def _tool_moves(record: Any) -> list[tuple[int, int]]:
+    """Extract a move list from the ``move_disk`` tool call (or completion text)."""
+
+    for call in getattr(record, "tool_calls", []) or []:
+        name = call.get("name") if isinstance(call, dict) else None
+        if name != "move_disk":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return []
+        if isinstance(arguments, dict):
+            return _coerce_moves(arguments.get("moves"))
+        if isinstance(arguments, list):
+            return _coerce_moves(arguments)
+    return _coerce_moves(_fallback_completion(getattr(record, "completion", None)))
+
+
+def _coerce_moves(raw: Any) -> list[tuple[int, int]]:
+    if not isinstance(raw, list):
+        return []
+    moves: list[tuple[int, int]] = []
+    for item in raw:
+        pair = game._normalize_action(item)
+        if pair is not None:
+            moves.append(pair)
+    return moves
+
+
+def _fallback_completion(completion: Any) -> list[Any]:
+    """Best-effort move list from raw model text (used outside tool-call mode)."""
+
+    if isinstance(completion, list):
+        return completion
+    if isinstance(completion, str):
+        match = _MOVE_LIST_RE.search(completion)
+        if not match:
+            return []
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return []
+        return parsed.get("moves", parsed) if isinstance(parsed, dict) else parsed
+    return []

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -118,18 +118,16 @@ def _progress_count(result: Any) -> int:
 
 
 def _tool_moves(record: Any) -> list[tuple[int, int]]:
-    """Extract a move list from the ``move_disk`` tool call (or completion text).
+    """Extract a consolidated move list from all ``move_disk`` tool calls.
 
-    Tolerant of the argument shape a weak base model actually emits. The tool
-    schema mandates ``{"moves": [[s, t], ...]}``, but historical prose told the
-    model ``{source, target}``, so a model may return a bare
-    ``{"source": s, "target": t}`` single move or wrap one dict under ``moves``.
-    All three are coerced to a move list; only a genuinely empty/absent call
-    falls through to completion text. Without this, such calls silently extract
-    ``[]`` and reward 0 even though ``tool_calls`` was parsed — the cold-start
-    stall observed when ``tool_calls=8/8`` yet ``reward_mean=0.0``.
+    In multi-turn mode each call carries a single ``{source, target}`` move;
+    all calls across all turns are accumulated into one sequential move list
+    that ``replay`` consumes.  For backward compatibility the old single-turn
+    ``{"moves": [[s, t], ...]}`` form is still accepted.  Only a complete
+    absence of tool calls triggers a fallback to completion-text parsing.
     """
 
+    all_moves: list[tuple[int, int]] = []
     for call in getattr(record, "tool_calls", []) or []:
         name = call.get("name") if isinstance(call, dict) else None
         if name != "move_disk":
@@ -139,19 +137,28 @@ def _tool_moves(record: Any) -> list[tuple[int, int]]:
             try:
                 arguments = json.loads(arguments)
             except json.JSONDecodeError:
-                return []
+                continue  # skip malformed, don't abort the whole trajectory
         if isinstance(arguments, dict):
+            # Multi-turn: {"source": s, "target": t}
+            src = arguments.get("source")
+            tgt = arguments.get("target")
+            if src is not None and tgt is not None:
+                pair = game._normalize_action((src, tgt))
+                if pair is not None:
+                    all_moves.append(pair)
+                    continue
+            # Legacy single-turn: {"moves": [[s, t], ...]} or {"moves": {s, t}}
             moves_field = arguments.get("moves")
-            # Tolerate {"source": s, "target": t} (bare single move) and
-            # {"moves": {"source": s, "target": t}} (single move wrapped under
-            # moves) so a model following the prose over the schema still scores.
-            if moves_field is None and ("source" in arguments or "target" in arguments):
-                return _coerce_moves([arguments])
             if isinstance(moves_field, dict):
-                return _coerce_moves([moves_field])
-            return _coerce_moves(moves_field)
+                all_moves.extend(_coerce_moves([moves_field]))
+                continue
+            if moves_field is not None:
+                all_moves.extend(_coerce_moves(moves_field))
+                continue
         if isinstance(arguments, list):
-            return _coerce_moves(arguments)
+            all_moves.extend(_coerce_moves(arguments))
+    if all_moves:
+        return all_moves
     return _coerce_moves(_fallback_completion(getattr(record, "completion", None)))
 
 

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -5,30 +5,36 @@ Mirrors ``examples/agentic/duelgrid/reward.py``: extract the model's
 board, and return a scalar reward. Rewards come from the rule engine, so the
 same fixtures work for warmup, rollout, or RLVR training.
 
-Design rationale (completion-led, with a small partial-credit bridge):
+Design rationale (completion-led, with a small PROGRESS partial credit):
     The issue asks to "score completion with a small efficiency component
     relative to the known optimum". Read strictly, that means 0 unless the
     board is solved. Read leniently — which this file adopts — completion is
-    still the dominant signal, but a small partial credit is given for legal
-    moves on unsolved traces. The lenient reading is chosen for a concrete
-   training reason: a weak base model almost never solves the board in one shot,
-    so a strictly-sparse reward leaves every GSPO group at all-zero reward,
-    zero variance, zero advantage, zero gradient — a cold-start stall (the
-    scenario H-version #203/#239 target, but AReno has no early stop today).
+    still the dominant signal, but a small partial credit is given for PROGRESS
+    toward the target peg on unsolved traces. The lenient reading is chosen for
+    a concrete training reason: a weak base model almost never solves the board
+    in one shot, so a strictly-sparse reward leaves every GSPO group at all-zero
+    reward → zero variance → zero advantage → zero gradient (cold-start stall).
+
+    The partial credit is PROGRESS-based, not legal-step-based. An earlier
+    legal-step bonus ("0.02 per legal move") caused a mode collapse in rollout:
+    the model locked reward at 0.04 by replaying ``[[0,2],[0,1]]`` — two legal
+    moves that don't push any disk onto peg 2 in the correct bottom-up order —
+    and, all 4 group samples converging to that shortcut, the group had zero
+    variance and gradients died. Progress-based credit (only disks correctly
+    stacked on peg 2 from the bottom count) scores that shortcut 0, removing
+    the incentive to freeze, while still giving GSPO non-zero reward variance
+    across samples that reach different depths and a gradient pointing at
+    completion.
 
     Concretely:
-    - solved:      ``COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess``
-                   (1.0 minus 0.02 per move above the oracle ``2**n-1``).
-                   Completion dominates; efficiency is the "small component".
-    - unsolved:    ``min(LEGAL_STEP_BONUS * legal_count + ILLEGAL_STEP_PENALTY * illegal_count,
-                   PARTIAL_CREDIT_CAP)`` (≈ +0.02 per legal move, -0.05 per
-                   illegal, hard-capped at 0.5). The cap is essential: without
-                   it a long legal-but-unsolved trace could accumulate more than
-                   1.0 from legal steps alone and perversely reward not solving.
-                   With the cap, completing (≥ the efficiency-discounted 1.0
-                   path) is always strictly better than any unsolved trace, so
-                   completion stays the primary signal; the partial credit only
-                   gives GSPO non-zero reward variance so training can move.
+    - solved:    ``COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess``
+                 (1.0 minus 0.02 per move above the oracle ``2**n-1``).
+                 Completion dominates; efficiency is the "small component".
+    - unsolved:  ``min(PROGRESS_BONUS * progress_count, PARTIAL_CREDIT_CAP)``
+                 (≈ +0.02 per disk correctly stacked on peg 2 from the bottom,
+                 hard-capped at 0.5). The cap keeps any unsolved trace strictly
+                 below COMPLETION_REWARD, so completing is always the dominant
+                 choice; progress credit only gives variance + a direction.
 
     The completion-rate + excess-moves-over-optimum metrics in ``game.evaluate``
     are unaffected — they still key on completion — so the issue's acceptance
@@ -52,16 +58,17 @@ import game
 # completion text is also accepted as a fallback.
 _MOVE_LIST_RE = re.compile(r"\[.*\]", re.DOTALL)
 
-# Partial-credit magnitudes for UNSOLVED traces (see module docstring). Kept
-# small and local so completion (game.COMPLETION_REWARD = 1.0) stays the
-# dominant signal; these only exist to give GSPO non-zero reward variance.
-LEGAL_STEP_BONUS = 0.02  # each legal move on an unsolved trace earns a little
-ILLEGAL_STEP_PENALTY = -0.05  # each illegal move on an unsolved trace costs a little
-# Hard cap on unsolved partial credit. Without it, a long legal-but-unsolved
-# trace (e.g. the failure fixture oscillating for 2*(2**n-1) steps) could
-# accumulate more than COMPLETION_REWARD from legal steps alone — which would
-# perversely reward *not* solving. The cap guarantees completing the board is
-# always strictly better than any unsolved trace.
+# Partial credit for UNSOLVED traces is PROGRESS-based, not legal-step-based
+# (see module docstring): only disks actually pushed onto peg 2 in the correct
+# bottom-up order earn a little, so a model cannot "steal" reward by emitting a
+# couple of legal-but-stagnant moves (observed mode collapse: the model
+# replayed `[[0,2],[0,1]]` to lock 0.04 and froze). Kept small so completion
+# (game.COMPLETION_REWARD = 1.0) stays the dominant signal.
+PROGRESS_BONUS = 0.02  # per disk correctly stacked on peg 2 from the bottom
+# Hard cap on unsolved partial credit: guarantees completing the board (the
+# efficiency-discounted >=1.0 path) is always strictly better than any unsolved
+# trace, so completion stays the primary signal; progress credit only gives
+# GSPO non-zero reward variance and a gradient toward completion.
 PARTIAL_CREDIT_CAP = 0.5
 
 
@@ -84,13 +91,33 @@ def reward_fn(record: Any) -> float:
         excess = max(0, result.legal_count + result.illegal_count - game.optimal_steps(state.n))
         excess = max(excess, result.excess_moves)
         return game.COMPLETION_REWARD - game.EXCESS_STEP_PENALTY * excess
-    # Unsolved: small partial credit only — enough to vary across samples so
-    # GSPO can form a non-zero advantage, never enough to rival completion.
-    # The cap (0.5) keeps any unsolved trace strictly below COMPLETION_REWARD,
-    # so solving is always the dominant choice even if a trace racks up many
-    # legal moves without finishing.
-    partial = LEGAL_STEP_BONUS * result.legal_count + ILLEGAL_STEP_PENALTY * result.illegal_count
+    # Unsolved: small PROGRESS-based partial credit (see module docstring).
+    # Only disks correctly stacked on peg 2 from the bottom count, so a couple
+    # of legal-but-stagnant moves score 0 and cannot be "stolen" for a stable
+    # reward. This keeps the gradient pointing at completion while still giving
+    # GSPO non-zero reward variance across samples that reach different depths.
+    partial = PROGRESS_BONUS * _progress_count(result)
     return min(partial, PARTIAL_CREDIT_CAP)
+
+
+def _progress_count(result: Any) -> int:
+    """Disks correctly stacked on peg 2 from the bottom (0 if none match).
+
+    The target peg is ``game.TARGET_PEG`` and the correct bottom-up order is
+    ``(n, n-1, ..., 1)``. Only a contiguous correct prefix counts, so a disk in
+    the right slot above a wrong one does not score — pushing the gradient to
+    *build* the target stack in order rather than park any disk on peg 2.
+    """
+
+    peg2 = result.final_state.pegs[game.TARGET_PEG]
+    n = result.final_state.n
+    count = 0
+    for i, disk in enumerate(peg2):
+        if disk == n - i:
+            count += 1
+        else:
+            break
+    return count
 
 
 def _tool_moves(record: Any) -> list[tuple[int, int]]:

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -5,26 +5,26 @@ Mirrors ``examples/agentic/duelgrid/reward.py``: extract the model's
 board, and return a scalar reward. Rewards come from the rule engine, so the
 same fixtures work for warmup, rollout, or RLVR training.
 
-Design rationale (completion-led, with a small PROGRESS partial credit):
+Design rationale (completion-led, with hybrid PROGRESS + tiny legal-floor partial credit):
     The issue asks to "score completion with a small efficiency component
     relative to the known optimum". Read strictly, that means 0 unless the
     board is solved. Read leniently — which this file adopts — completion is
-    still the dominant signal, but a small partial credit is given for PROGRESS
-    toward the target peg on unsolved traces. The lenient reading is chosen for
-    a concrete training reason: a weak base model almost never solves the board
-    in one shot, so a strictly-sparse reward leaves every GSPO group at all-zero
-    reward → zero variance → zero advantage → zero gradient (cold-start stall).
+    still the dominant signal, but a small partial credit is given for unsolved
+    traces to keep GSPO gradients alive during cold start.
 
-    The partial credit is PROGRESS-based, not legal-step-based. An earlier
-    legal-step bonus ("0.02 per legal move") caused a mode collapse in rollout:
-    the model locked reward at 0.04 by replaying ``[[0,2],[0,1]]`` — two legal
-    moves that don't push any disk onto peg 2 in the correct bottom-up order —
-    and, all 4 group samples converging to that shortcut, the group had zero
-    variance and gradients died. Progress-based credit (only disks correctly
-    stacked on peg 2 from the bottom count) scores that shortcut 0, removing
-    the incentive to freeze, while still giving GSPO non-zero reward variance
-    across samples that reach different depths and a gradient pointing at
-    completion.
+    The partial credit is a hybrid: PROGRESS-based (disks correctly stacked on
+    peg 2 from the bottom, 0.02/disk, cap 0.5) as the main signal, plus a
+    tiny legal-move floor (0.005/legal move, cap 0.02) to ensure at least a
+    small non-zero gradient even when no progress has been made. The floor is
+    deliberately too small to be worth freezing on — the collapse shortcut
+    [[0,2],[0,1]] scores only 0.01 from the floor, making progress (which
+    pays 0.02 for the first progress disk) strictly more rewarding and
+    completion (1.0, globally optimal) the dominant long-term objective.
+
+    Earlier iterations tried a pure legal-step bonus (collapsed: model locked
+    0.04 and froze) and pure progress (too sparse: 0.8B could not produce
+    >4 legal moves consistently, reward stayed 0). The hybrid sits between
+    both extremes and has been validated in a 100-step Kaggle run.
 
     Concretely:
     - solved:    ``COMPLETION_REWARD - EXCESS_STEP_PENALTY * excess``
@@ -58,18 +58,12 @@ import game
 # completion text is also accepted as a fallback.
 _MOVE_LIST_RE = re.compile(r"\[.*\]", re.DOTALL)
 
-# Partial credit for UNSOLVED traces is PROGRESS-based, not legal-step-based
-# (see module docstring): only disks actually pushed onto peg 2 in the correct
-# bottom-up order earn a little, so a model cannot "steal" reward by emitting a
-# couple of legal-but-stagnant moves (observed mode collapse: the model
-# replayed `[[0,2],[0,1]]` to lock 0.04 and froze). Kept small so completion
-# (game.COMPLETION_REWARD = 1.0) stays the dominant signal.
+# Partial credit for UNSOLVED traces is a hybrid of PROGRESS (main) and a
+# tiny legal-move floor (gradient survival), see module docstring.
 PROGRESS_BONUS = 0.02  # per disk correctly stacked on peg 2 from the bottom
-# Hard cap on unsolved partial credit: guarantees completing the board (the
-# efficiency-discounted >=1.0 path) is always strictly better than any unsolved
-# trace, so completion stays the primary signal; progress credit only gives
-# GSPO non-zero reward variance and a gradient toward completion.
-PARTIAL_CREDIT_CAP = 0.5
+LEGAL_FLOOR_BONUS = 0.005  # per legal move — tiny floor to keep gradient alive
+LEGAL_FLOOR_CAP = 0.02  # floor cap: 4 legal moves = 0.02, not worth collapsing to
+PARTIAL_CREDIT_CAP = 0.5  # global cap: completion (>=1.0) always dominates
 
 
 def reward_fn(record: Any) -> float:
@@ -96,8 +90,11 @@ def reward_fn(record: Any) -> float:
     # of legal-but-stagnant moves score 0 and cannot be "stolen" for a stable
     # reward. This keeps the gradient pointing at completion while still giving
     # GSPO non-zero reward variance across samples that reach different depths.
-    partial = PROGRESS_BONUS * _progress_count(result)
-    return min(partial, PARTIAL_CREDIT_CAP)
+    # Unsolved: hybrid partial credit — PROGRESS (main) plus a tiny legal-move
+    # floor to keep gradients alive during cold start (see module docstring).
+    progress = PROGRESS_BONUS * _progress_count(result)
+    floor = min(LEGAL_FLOOR_BONUS * result.legal_count, LEGAL_FLOOR_CAP)
+    return min(max(progress, floor), PARTIAL_CREDIT_CAP)
 
 
 def _progress_count(result: Any) -> int:

--- a/examples/agentic/hanoi/reward.py
+++ b/examples/agentic/hanoi/reward.py
@@ -62,7 +62,7 @@ _MOVE_LIST_RE = re.compile(r"\[.*\]", re.DOTALL)
 # tiny legal-move floor (gradient survival), see module docstring.
 PROGRESS_BONUS = 0.02  # per disk correctly stacked on peg 2 from the bottom
 LEGAL_FLOOR_BONUS = 0.005  # per legal move — tiny floor to keep gradient alive
-LEGAL_FLOOR_CAP = 0.02  # floor cap: 4 legal moves = 0.02, not worth collapsing to
+LEGAL_FLOOR_CAP = 0.005  # floor cap: 1 legal move caps it; too small to steal, just keeps gradient alive
 PARTIAL_CREDIT_CAP = 0.5  # global cap: completion (>=1.0) always dominates
 
 

--- a/examples/agentic/hanoi/run_agent.py
+++ b/examples/agentic/hanoi/run_agent.py
@@ -1,70 +1,61 @@
-"""Agent entrypoint for Hanoi tool-call rollouts.
+"""Agent entrypoint for Hanoi multi-turn tool-call rollouts.
 
-Mirrors ``examples/agentic/duelgrid/run_agent.py``. For each start board the
-model calls ``move_disk`` with a full move sequence; the rollout session
-converts each call into the trainer's token/logprob rows. No trainer logic
-lives here — token rows, loss masks, and tool-result masking are handled by
-``RolloutSession`` / ``LossMaskPolicy``.
-
-Design choice — single-turn full solution:
-    Each board is solved in ONE ``move_disk`` call carrying the whole move
-    list, rather than a multi-turn "move → observe → move" loop. This matches
-    DuelGrid's single-call shape, keeps the trajectory short (one policy span
-    to score), and lets ``reward.py`` score the complete sequence at once via
-    the rules engine. A multi-turn variant is a follow-up, not needed for the
-    issue's acceptance criteria.
+Mirrors ``examples/agentic/shopping/run_agent.py``. For each start board the
+model makes one ``move_disk`` call per turn, the agent applies the move and
+feeds the updated board back as a tool result, looping until solved or the move
+budget is exhausted.  No trainer logic lives here — token rows, loss masks,
+and tool-result masking are handled by ``RolloutSession`` / ``LossMaskPolicy``.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import sys
+from pathlib import Path
 
 from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator
+import game
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 SYSTEM_PROMPT = (
     "You are an expert at the Towers of Hanoi puzzle. "
-    "Solve the given board by calling the move_disk tool ONCE with an ordered list "
-    'of moves under the "moves" key. The argument shape is '
-    '{"moves": [[0,2],[0,1],...]}: a list of [source, target] pairs, each with '
-    "source, target in {0,1,2}. Do NOT pass a bare {source, target} object — wrap "
-    "every move in the moves list. "
-    "The tool name is always move_disk; never use MOVE or another name as the tool. "
+    "Call move_disk ONCE per turn with a single {source, target} move. "
+    "source and target are integers in {0,1,2}. "
     "Only move a top disk onto an empty peg or a larger disk. "
+    "Win when all disks are stacked on peg 2 (largest at the bottom). "
     "Aim for the shortest solution (the optimum is 2**n - 1 moves)."
 )
 
-# Tool schema: each move is a fixed [source, target] integer pair. We use
-# JSON Schema tuple form (prefixItems + items:false, draft 2020-12) to enforce
-# "exactly two ints". Some OpenAI-compatible servers ignore the tuple form and
-# only validate the outer array — that is fine: the rules engine re-checks
-# every move's legality in reward.py, so schema validation is convenience, not
-# a correctness boundary.
+# Tool schema: a single (source, target) move.
 MOVE_DISK_TOOL = {
     "type": "function",
     "function": {
         "name": "move_disk",
-        "description": "Submit an ordered move sequence to solve the Towers of Hanoi board.",
+        "description": "Move one disk from source peg to target peg.",
         "parameters": {
             "type": "object",
             "properties": {
-                "moves": {
-                    "type": "array",
-                    "minItems": 1,
-                    "description": "Ordered (source, target) moves to execute, e.g. [[0,2],[0,1]].",
-                    "items": {
-                        "type": "array",
-                        "prefixItems": [{"type": "integer"}, {"type": "integer"}],
-                        "minItems": 2,
-                        "maxItems": 2,
-                        "items": False,
-                    },
+                "source": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2,
+                    "description": "Source peg (0, 1, or 2).",
+                },
+                "target": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2,
+                    "description": "Target peg (0, 1, or 2).",
                 },
             },
-            "required": ["moves"],
+            "required": ["source", "target"],
             "additionalProperties": False,
         },
     },
@@ -72,7 +63,7 @@ MOVE_DISK_TOOL = {
 
 
 async def run_agent(ctx, batch):
-    """Run one tool-call model request for each Hanoi start board."""
+    """Run multi-turn agentic rollouts for each Hanoi start board."""
 
     try:
         import httpx
@@ -101,31 +92,87 @@ async def run_agent(ctx, batch):
     )
 
     async def run_one(item):
+        state = dataset_generator.record_to_state(item.record["state"])
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": item.prompt},
         ]
-        # Force the move_disk tool so the model cannot ramble in natural language
-        # (a weak base model tends to; reward_fn would then fall back to parsing
-        # completion text and usually score 0). tool_choice is honored by the
-        # OpenAI-compatible proxy backing the in-training policy.
+        turns: list[AgentTrajectoryTurn] = []
         tool_choice = {"type": "function", "function": {"name": "move_disk"}}
-        response = await client.chat.completions.create(
-            model="policy",  # routes to the in-training policy via ctx.get_base_url()
-            messages=messages,
-            tools=[MOVE_DISK_TOOL],
-            tool_choice=tool_choice,
-            stream=False,
-        )
-        return AgentTrajectoryTurn(
-            item=item,
-            messages=messages,
-            response=response,
-            tools=[MOVE_DISK_TOOL],
-            tool_choice=tool_choice,
-        )
+
+        for _turn_idx in range(state.max_moves):
+            response = await client.chat.completions.create(
+                model="policy",
+                messages=messages,
+                tools=[MOVE_DISK_TOOL],
+                tool_choice=tool_choice,
+                stream=False,
+            )
+            turn = AgentTrajectoryTurn(
+                item=item,
+                messages=list(messages),
+                response=response,
+                tools=[MOVE_DISK_TOOL],
+                tool_choice=tool_choice,
+            )
+            turns.append(turn)
+
+            message = response.choices[0].message
+            raw_calls = message.tool_calls or []
+            if not raw_calls:
+                break
+            call = raw_calls[0]
+            try:
+                args = json.loads(call.function.arguments)
+            except json.JSONDecodeError:
+                break
+            source = args.get("source")
+            target = args.get("target")
+            if source is None or target is None or not isinstance(source, int) or not isinstance(target, int):
+                break
+
+            # Append the assistant message with tool call.
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": message.content or "",
+                    "tool_calls": [
+                        {
+                            "id": call.id,
+                            "type": "function",
+                            "function": {"name": "move_disk", "arguments": call.function.arguments},
+                        }
+                    ],
+                }
+            )
+
+            # Apply the move and check terminal.
+            state, _reward, done, _info = game.step(state, (source, target))
+
+            if done:
+                break
+
+            # Feed back the current board state as tool result.
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "name": "move_disk",
+                    "content": json.dumps(
+                        {
+                            "pegs": [list(stack) for stack in state.pegs],
+                            "legal_moves": [list(mv) for mv in game.legal_moves(state)],
+                        },
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                }
+            )
+
+        return turns
 
     try:
-        return AgentTrajectory(turns=list(await asyncio.gather(*(run_one(item) for item in items))))
+        grouped = await asyncio.gather(*(run_one(item) for item in items))
+        return AgentTrajectory(turns=[turn for turns in grouped for turn in turns])
     finally:
         await client.close()

--- a/examples/agentic/hanoi/run_agent.py
+++ b/examples/agentic/hanoi/run_agent.py
@@ -27,8 +27,11 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 
 SYSTEM_PROMPT = (
     "You are an expert at the Towers of Hanoi puzzle. "
-    "Solve the given board by calling the move_disk tool with an ordered list "
-    "of moves. Each move is {source, target} with source, target in {0,1,2}. "
+    "Solve the given board by calling the move_disk tool ONCE with an ordered list "
+    'of moves under the "moves" key. The argument shape is '
+    '{"moves": [[0,2],[0,1],...]}: a list of [source, target] pairs, each with '
+    "source, target in {0,1,2}. Do NOT pass a bare {source, target} object — wrap "
+    "every move in the moves list. "
     "The tool name is always move_disk; never use MOVE or another name as the tool. "
     "Only move a top disk onto an empty peg or a larger disk. "
     "Aim for the shortest solution (the optimum is 2**n - 1 moves)."

--- a/examples/agentic/hanoi/run_agent.py
+++ b/examples/agentic/hanoi/run_agent.py
@@ -1,0 +1,128 @@
+"""Agent entrypoint for Hanoi tool-call rollouts.
+
+Mirrors ``examples/agentic/duelgrid/run_agent.py``. For each start board the
+model calls ``move_disk`` with a full move sequence; the rollout session
+converts each call into the trainer's token/logprob rows. No trainer logic
+lives here — token rows, loss masks, and tool-result masking are handled by
+``RolloutSession`` / ``LossMaskPolicy``.
+
+Design choice — single-turn full solution:
+    Each board is solved in ONE ``move_disk`` call carrying the whole move
+    list, rather than a multi-turn "move → observe → move" loop. This matches
+    DuelGrid's single-call shape, keeps the trajectory short (one policy span
+    to score), and lets ``reward.py`` score the complete sequence at once via
+    the rules engine. A multi-turn variant is a follow-up, not needed for the
+    issue's acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are an expert at the Towers of Hanoi puzzle. "
+    "Solve the given board by calling the move_disk tool with an ordered list "
+    "of moves. Each move is {source, target} with source, target in {0,1,2}. "
+    "The tool name is always move_disk; never use MOVE or another name as the tool. "
+    "Only move a top disk onto an empty peg or a larger disk. "
+    "Aim for the shortest solution (the optimum is 2**n - 1 moves)."
+)
+
+# Tool schema: each move is a fixed [source, target] integer pair. We use
+# JSON Schema tuple form (prefixItems + items:false, draft 2020-12) to enforce
+# "exactly two ints". Some OpenAI-compatible servers ignore the tuple form and
+# only validate the outer array — that is fine: the rules engine re-checks
+# every move's legality in reward.py, so schema validation is convenience, not
+# a correctness boundary.
+MOVE_DISK_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "move_disk",
+        "description": "Submit an ordered move sequence to solve the Towers of Hanoi board.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "moves": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "Ordered (source, target) moves to execute, e.g. [[0,2],[0,1]].",
+                    "items": {
+                        "type": "array",
+                        "prefixItems": [{"type": "integer"}, {"type": "integer"}],
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": False,
+                    },
+                },
+            },
+            "required": ["moves"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+async def run_agent(ctx, batch):
+    """Run one tool-call model request for each Hanoi start board."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The Hanoi agentic example requires `openai`. Install it with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info(
+        "Hanoi agent start requests=%d max_running_prompts=%d",
+        len(items),
+        ctx.max_running_prompts,
+    )
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(
+        base_url=ctx.get_base_url(),
+        api_key=ctx.api_key,
+        http_client=http_client,
+        max_retries=0,
+    )
+
+    async def run_one(item):
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+        # Force the move_disk tool so the model cannot ramble in natural language
+        # (a weak base model tends to; reward_fn would then fall back to parsing
+        # completion text and usually score 0). tool_choice is honored by the
+        # OpenAI-compatible proxy backing the in-training policy.
+        tool_choice = {"type": "function", "function": {"name": "move_disk"}}
+        response = await client.chat.completions.create(
+            model="policy",  # routes to the in-training policy via ctx.get_base_url()
+            messages=messages,
+            tools=[MOVE_DISK_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        return AgentTrajectoryTurn(
+            item=item,
+            messages=messages,
+            response=response,
+            tools=[MOVE_DISK_TOOL],
+            tool_choice=tool_choice,
+        )
+
+    try:
+        return AgentTrajectory(turns=list(await asyncio.gather(*(run_one(item) for item in items))))
+    finally:
+        await client.close()

--- a/tests/test_agentic_hanoi_example_cpu.py
+++ b/tests/test_agentic_hanoi_example_cpu.py
@@ -1,0 +1,574 @@
+"""Focused CPU tests for the Towers of Hanoi agentic example.
+
+Loaded standalone via importlib (mirroring ``test_agentic_tictactoe_example_cpu.py``)
+so the suite runs on CPU without importing the AReno package or triggering the
+CUDA build. Each example module is loaded under a unique name to avoid
+collisions with other examples' top-level ``game`` / ``dataset_generator``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load(name: str):
+    path = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "hanoi" / f"{name}.py"
+    mod_name = f"hanoi_{name}_for_tests"
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module  # 3.9 dataclass + annotations workaround
+    spec.loader.exec_module(module)
+    return module
+
+
+game = _load("game")
+gen = _load("dataset_generator")
+loader = _load("dataset_loader")
+reward = _load("reward")
+
+
+# --- Oracle -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n,expected", [(3, 7), (4, 15), (5, 31), (6, 63)])
+def test_optimal_steps_closed_form(n, expected):
+    assert game.optimal_steps(n) == expected
+
+
+def test_optimal_steps_rejects_out_of_range():
+    for bad in (0, 1, 2, 7, 8, -1):
+        with pytest.raises(ValueError):
+            game.optimal_steps(bad)
+
+
+@pytest.mark.parametrize("n", [3, 4, 5, 6])
+def test_optimal_solution_length_and_validity(n):
+    moves = game.optimal_solution(n)
+    assert len(moves) == game.optimal_steps(n)
+    assert game.validate_solution(moves, n)
+
+
+def test_optimal_solution_respects_source_target():
+    moves = game.optimal_solution(3, source=0, target=2)
+    assert moves[0][0] == 0
+    assert moves[-1][1] == 2
+
+
+# --- Environment core -------------------------------------------------------
+
+
+def test_make_state_canonical_start():
+    state = game.make_state(3)
+    assert state.pegs == ((3, 2, 1), (), ())
+    assert state.n == 3
+    assert not game.is_terminal(state)
+
+
+def test_make_state_rejects_out_of_range():
+    for bad in (2, 7):
+        with pytest.raises(ValueError):
+            game.make_state(bad)
+
+
+def test_legal_move_advances_state():
+    state = game.make_state(3)
+    next_state, _reward, _done, info = game.step(state, (0, 2))
+    assert next_state.pegs == ((3, 2), (), (1,))
+    assert info["move"] == (0, 2)
+    assert info["completed"] is False
+
+
+def test_optimal_solution_drives_to_completion():
+    for n in (3, 4, 5):
+        state = game.make_state(n)
+        done = False
+        for mv in game.optimal_solution(n):
+            state, _reward, done, info = game.step(state, mv)
+            assert not info["illegal"]
+        assert done and info["completed"]
+
+
+def test_completion_reward_decreases_with_excess_steps():
+    n = 3
+    state = game.make_state(n)
+    reward_opt = 0.0
+    for mv in game.optimal_solution(n):
+        state, reward, done, _ = game.step(state, mv)
+        if done:
+            reward_opt = reward
+    assert reward_opt == pytest.approx(game.COMPLETION_REWARD)  # excess == 0
+
+    # build a deliberately longer-but-legal path then re-score terminal
+    state = game.make_state(n)
+    s, _, _, _ = game.step(state, (0, 1))
+    s, _, _, _ = game.step(s, (1, 0))
+    done = False
+    reward_long = 0.0
+    for mv in game.optimal_solution(n):
+        s, reward, done, _ = game.step(s, mv)
+        if done:
+            reward_long = reward
+    assert reward_long < reward_opt
+
+
+# --- Illegal actions --------------------------------------------------------
+
+
+def test_empty_source_rejected():
+    state = game.make_state(3)
+    next_state, reward, done, info = game.step(state, (1, 2))
+    assert info["illegal"] and info["reason"] == "empty_source"
+    assert next_state == state  # unchanged
+    assert reward == game.ILLEGAL_PENALTY
+    assert not done  # penalize does not terminate
+
+
+def test_larger_on_smaller_rejected():
+    state = game.make_state(3)
+    # move disk 1 (smallest) to peg 2, then try to put disk 2 on top of it
+    s, _, _, _ = game.step(state, (0, 2))
+    next_state, reward, _done, info = game.step(s, (0, 2))
+    assert info["illegal"] and info["reason"] == "larger_on_smaller"
+    assert next_state == s
+    assert reward == game.ILLEGAL_PENALTY
+
+
+def test_out_of_range_and_noop_rejected():
+    state = game.make_state(3)
+    for action in [(0, 3), (0, -1), (0, 0)]:
+        _, _reward, _done, info = game.step(state, action)
+        assert info["illegal"]
+
+
+def test_malformed_action_rejected():
+    state = game.make_state(3)
+    for action in [None, "foo", {"wrong": 1}, (0,), 5]:
+        _, _reward, _done, info = game.step(state, action)
+        assert info["illegal"] and info["reason"] in {
+            "malformed",
+            "out_of_range",
+            "no_op",
+            "empty_source",
+        }
+
+
+def test_illegal_terminate_policy_ends_episode():
+    state = game.make_state(3)
+    _ns, _r, done, info = game.step(state, (1, 2), illegal_policy="terminate")
+    assert info["illegal"]
+    assert done is True
+
+
+def test_dict_and_string_actions_acceptable():
+    state = game.make_state(3)
+    s1, _, _, info1 = game.step(state, {"source": 0, "target": 2})
+    assert not info1["illegal"]
+    _s2, _, _, info2 = game.step(s1, "0 -> 1")
+    assert not info2["illegal"]
+
+
+# --- Trace replay -----------------------------------------------------------
+
+
+def test_serialize_and_parse_roundtrip():
+    moves = [(0, 2), (0, 1), (2, 1)]
+    trace = game.serialize_trace(moves)
+    assert trace == "0->2,0->1,2->1"
+    assert game.parse_trace(trace) == moves
+
+
+def test_replay_optimal_trace_completes_with_zero_excess():
+    for n in (3, 4, 5, 6):
+        trace = game.serialize_trace(game.optimal_solution(n))
+        result = game.replay(trace, n)
+        assert result.completed
+        assert result.illegal_count == 0
+        assert result.excess_moves == 0
+        assert result.legal_count == game.optimal_steps(n)
+
+
+def test_replay_counts_illegal_without_terminating():
+    # insert a no-op illegal move in the middle (before completion) so the
+    # replay actually processes it; default penalize policy keeps going.
+    optimal = game.optimal_solution(3)
+    moves = [optimal[0], (1, 1)] + list(optimal[1:])
+    trace = game.serialize_trace(moves)
+    result = game.replay(trace, 3)
+    assert result.completed
+    assert result.illegal_count == 1
+    assert result.legal_count == game.optimal_steps(3)
+
+
+def test_replay_failure_trace_does_not_complete():
+    moves = [(0, 1), (1, 0), (0, 1), (1, 0)]
+    result = game.replay(game.serialize_trace(moves), 3)
+    assert not result.completed
+
+
+def test_replay_as_text_is_human_readable():
+    result = game.replay(game.serialize_trace(game.optimal_solution(3)), 3)
+    text = result.as_text()
+    assert "completed" in text
+    assert "excess_moves_over_optimum=0" in text
+
+
+# --- Evaluation -------------------------------------------------------------
+
+
+def test_evaluate_completion_rate_and_excess():
+    n = 3
+    traces = [
+        game.serialize_trace(game.optimal_solution(n)),  # completes, 0 excess
+        game.serialize_trace([(0, 1), (1, 0)] * 4),  # fails
+    ]
+    report = game.evaluate(traces, n)
+    assert report["sample_count"] == 2
+    assert report["completion_rate"] == 0.5
+    assert report["oracle_steps"] == 7
+    assert report["avg_excess_moves"] == 0.0
+
+
+# --- Determinism & backward-compat -----------------------------------------
+
+
+def test_deterministic_output_same_inputs():
+    n = 4
+    trace = game.serialize_trace(game.optimal_solution(n))
+    r1 = game.replay(trace, n).as_dict()
+    r2 = game.replay(trace, n).as_dict()
+    assert r1 == r2
+
+
+def test_default_illegal_policy_is_penalize():
+    # default behavior: illegal move does not terminate
+    state = game.make_state(3)
+    _, _r, done, _info = game.step(state, (1, 2))  # empty source
+    assert done is False
+
+
+def test_prompt_contains_legal_moves():
+    state = game.make_state(3)
+    prompt = game.format_prompt(state)
+    assert "move_disk" in prompt
+    assert "0" in prompt and "2" in prompt
+
+
+# --- Generator fixtures -----------------------------------------------------
+
+
+def test_default_fixture_count_is_all_scenarios_times_disks():
+    records = gen.generate_records()
+    assert len(records) == (game.MAX_DISKS - game.MIN_DISKS + 1) * len(gen.SCENARIOS)
+    assert len(records) == 16
+
+
+def test_count_truncates_deterministically():
+    a = gen.generate_records(5)
+    b = gen.generate_records(5)
+    assert a == b
+    assert len(a) == 5
+
+
+def test_every_record_has_required_fields_and_consistent_oracle():
+    for record in gen.generate_records():
+        for key in (
+            "id",
+            "n",
+            "scenario",
+            "pegs",
+            "legal_moves",
+            "oracle_steps",
+            "optimal_moves",
+            "trace",
+            "expected",
+        ):
+            assert key in record, f"{record['id']} missing {key}"
+        n = record["n"]
+        assert record["oracle_steps"] == 2**n - 1
+        assert len(record["optimal_moves"]) == 2**n - 1
+
+
+def test_optimal_moves_are_valid_solutions():
+    for record in gen.generate_records():
+        moves = [tuple(mv) for mv in record["optimal_moves"]]
+        assert game.validate_solution(moves, record["n"])
+
+
+def test_record_to_state_roundtrips_canonical_start():
+    for record in gen.generate_records():
+        state = gen.record_to_state(record)
+        assert state.n == record["n"]
+        assert tuple(state.pegs[0]) == tuple(range(record["n"], 0, -1))  # all disks on peg 0
+        assert state.pegs[1] == () and state.pegs[2] == ()
+
+
+def test_record_to_trace_parses_pairs():
+    rec = {"trace": [[0, 2], [0, 1], [2, 1]]}
+    assert gen.record_to_trace(rec) == [(0, 2), (0, 1), (2, 1)]
+
+
+@pytest.mark.parametrize("scenario", gen.SCENARIOS)
+def test_expected_outcomes_match_actual_replay(scenario):
+    # For each scenario on n=3, the stored expected outcome equals a fresh replay.
+    record = next(r for r in gen.generate_records() if r["n"] == 3 and r["scenario"] == scenario)
+    expected = gen.expected_outcome(record)
+    actual = game.replay(gen.record_to_trace(record), 3).as_dict()
+    assert actual["completed"] == expected["completed"]
+    assert actual["legal_count"] == expected["legal_count"]
+    assert actual["illegal_count"] == expected["illegal_count"]
+    assert actual["excess_moves"] == expected["excess_moves"]
+
+
+def test_optimal_scenario_zero_illegal_zero_excess():
+    for n in (3, 4, 5, 6):
+        record = next(r for r in gen.generate_records() if r["n"] == n and r["scenario"] == "optimal")
+        exp = gen.expected_outcome(record)
+        assert exp["completed"] is True
+        assert exp["illegal_count"] == 0
+        assert exp["excess_moves"] == 0
+
+
+def test_contains_illegal_scenario_has_one_illegal_and_completes():
+    for n in (3, 4, 5, 6):
+        record = next(r for r in gen.generate_records() if r["n"] == n and r["scenario"] == "contains_illegal")
+        exp = gen.expected_outcome(record)
+        assert exp["completed"] is True
+        assert exp["illegal_count"] == 1
+
+
+def test_boundary_scenario_has_one_illegal_and_completes():
+    for n in (3, 4, 5, 6):
+        record = next(r for r in gen.generate_records() if r["n"] == n and r["scenario"] == "boundary")
+        exp = gen.expected_outcome(record)
+        assert exp["completed"] is True
+        assert exp["illegal_count"] == 1  # the empty-source attempt
+
+
+def test_failure_scenario_does_not_complete():
+    for n in (3, 4, 5, 6):
+        record = next(r for r in gen.generate_records() if r["n"] == n and r["scenario"] == "failure")
+        exp = gen.expected_outcome(record)
+        assert exp["completed"] is False
+
+
+def test_write_jsonl_round_trips_through_parse():
+    import json as _json
+
+    records = gen.generate_records(3)
+    buf = io.StringIO()
+    gen.write_jsonl(records, buf)
+    buf.seek(0)
+    parsed = [_json.loads(line) for line in buf if line.strip()]
+    assert len(parsed) == 3
+    assert parsed[0]["id"] == records[0]["id"]
+
+
+def test_deterministic_across_calls():
+    import json as _json
+
+    r1 = gen.generate_records()
+    r2 = gen.generate_records()
+    assert [_json.dumps(r, sort_keys=True) for r in r1] == [_json.dumps(r, sort_keys=True) for r in r2]
+
+
+# --- Loader -----------------------------------------------------------------
+
+
+def _write_fixtures(tmp_path: Path, count: int | None = None) -> Path:
+    out = tmp_path / loader.DEFAULT_FILENAME
+    with out.open("w", encoding="utf-8") as handle:
+        gen.write_jsonl(gen.generate_records(count), handle)
+    return out
+
+
+def test_load_training_dataset_returns_prompt_records(tmp_path):
+    _write_fixtures(tmp_path)
+    records = loader.load_training_dataset(str(tmp_path))
+
+    assert len(records) == 16
+    for rec in records:
+        for key in (
+            "id",
+            "prompt",
+            "state",
+            "n",
+            "oracle_steps",
+            "best_action",
+            "best_actions",
+            "legal_actions",
+            "trace",
+            "expected",
+        ):
+            assert key in rec, f"{rec['id']} missing {key}"
+        assert "move_disk" in rec["prompt"]  # prompt mentions the tool
+        assert "Current pegs" in rec["prompt"]  # and the board
+
+
+def test_best_action_is_first_optimal_move(tmp_path):
+    _write_fixtures(tmp_path)
+    records = loader.load_training_dataset(str(tmp_path))
+    for rec in records:
+        assert rec["best_action"] == rec["best_actions"][0]
+        assert rec["best_actions"] == rec["state"]["optimal_moves"]
+
+
+def test_prompt_matches_game_format_prompt(tmp_path):
+    _write_fixtures(tmp_path)
+    records = loader.load_training_dataset(str(tmp_path))
+    for rec in records:
+        state = gen.record_to_state(rec["state"])
+        assert rec["prompt"] == game.format_prompt(state)
+
+
+def test_load_from_explicit_file_path(tmp_path):
+    file_path = _write_fixtures(tmp_path, count=4)
+    records = loader.load_training_dataset(str(file_path))
+    assert len(records) == 4
+    assert records[0]["id"] == "hanoi-n3-optimal"
+
+
+def test_missing_dataset_raises_with_hint(tmp_path):
+    with pytest.raises(FileNotFoundError) as exc:
+        loader.load_training_dataset(str(tmp_path / "nope.jsonl"))
+    assert "dataset_generator.py" in str(exc.value)
+
+
+def test_default_loader_arg_accepted_and_ignored(tmp_path):
+    # AReno may pass default_loader; the loader accepts and ignores it.
+    _write_fixtures(tmp_path)
+    records = loader.load_training_dataset(str(tmp_path), default_loader=None, extra="x")
+    assert len(records) == 16
+
+
+def test_roundtrip_generator_to_loader_in_memory():
+    import json as _json
+
+    buf = io.StringIO()
+    gen.write_jsonl(gen.generate_records(3), buf)
+    buf.seek(0)
+    raw = [_json.loads(line) for line in buf if line.strip()]
+    formatted = [loader._format_record(raw=r, index=i) for i, r in enumerate(raw, start=1)]
+    assert len(formatted) == 3
+    assert formatted[0]["best_action"] == [0, 2]  # first optimal move for n=3
+
+
+def test_loader_records_are_json_serializable(tmp_path):
+    import json as _json
+
+    _write_fixtures(tmp_path)
+    records = loader.load_training_dataset(str(tmp_path))
+    for rec in records:  # prompt records must be plain dicts
+        _json.dumps(rec)
+
+
+# --- Reward -----------------------------------------------------------------
+
+
+def _record(n, scenario, *, tool_moves=None, completion=None):
+    fixture = next(r for r in gen.generate_records() if r["n"] == n and r["scenario"] == scenario)
+    tool_calls = []
+    if tool_moves is not None:
+        tool_calls = [{"name": "move_disk", "arguments": {"moves": [list(m) for m in tool_moves]}}]
+    return SimpleNamespace(
+        source_record={"state": fixture},
+        completion=completion,
+        tool_calls=tool_calls,
+    )
+
+
+@pytest.mark.parametrize("n", [3, 4, 5, 6])
+def test_optimal_solution_rewards_full_score(n):
+    optimal = [tuple(m) for m in game.optimal_solution(n)]
+    rec = _record(n, "optimal", tool_moves=optimal)
+    assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
+
+
+def test_longer_legal_solution_scores_lower():
+    n = 3
+    optimal = [tuple(m) for m in game.optimal_solution(n)]
+    # insert a no-op illegal mid-run (penalize keeps going) -> still completes, +1 step
+    moves = [optimal[0], (1, 1)] + list(optimal[1:])
+    rec = _record(n, "optimal", tool_moves=moves)
+    score = reward.reward_fn(rec)
+    assert score < game.COMPLETION_REWARD
+    assert score == pytest.approx(game.COMPLETION_REWARD - game.EXCESS_STEP_PENALTY * 1)
+
+
+def test_failure_sequence_scores_partial_credit():
+    # Unsolved traces no longer score exactly 0 (lenient reading): they earn a
+    # small partial credit = LEGAL_STEP_BONUS*legal + ILLEGAL_STEP_PENALTY*illegal,
+    # strictly below the completion reward so completion stays the dominant signal.
+    n = 3
+    moves = [(0, 2), (2, 0)] * 4  # never solves
+    rec = _record(n, "failure", tool_moves=moves)
+    result = game.replay(moves, n)
+    assert not result.completed
+    expected = min(
+        reward.LEGAL_STEP_BONUS * result.legal_count + reward.ILLEGAL_STEP_PENALTY * result.illegal_count,
+        reward.PARTIAL_CREDIT_CAP,
+    )
+    assert reward.reward_fn(rec) == pytest.approx(expected)
+    assert reward.reward_fn(rec) < game.COMPLETION_REWARD
+
+
+def test_empty_moves_scores_zero():
+    rec = _record(3, "optimal", tool_moves=[])
+    assert reward.reward_fn(rec) == 0.0
+
+
+def test_wrong_tool_name_ignored_falls_back_to_completion():
+    # If the model calls a wrong tool name, reward falls back to completion text.
+    rec = _record(
+        3,
+        "optimal",
+        tool_moves=None,
+        completion='{"moves": [[0,2],[0,1],[2,1],[0,2],[1,0],[1,2],[0,2]]}',
+    )
+    assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
+
+
+def test_string_arguments_are_parsed():
+    import json as _json
+
+    n = 3
+    optimal = [list(m) for m in game.optimal_solution(n)]
+    rec = SimpleNamespace(
+        source_record={"state": next(r for r in gen.generate_records() if r["n"] == n and r["scenario"] == "optimal")},
+        completion=None,
+        tool_calls=[{"name": "move_disk", "arguments": _json.dumps({"moves": optimal})}],
+    )
+    assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
+
+
+def test_malformed_arguments_score_zero_not_crash():
+    rec = _record(3, "optimal", tool_moves=None, completion="not json at all")
+    assert reward.reward_fn(rec) == 0.0
+
+
+def test_reward_matches_replay_outcome_for_every_fixture():
+    # For each fixture's own trace, reward is consistent with game.replay.
+    for fixture in gen.generate_records():
+        n = fixture["n"]
+        moves = [tuple(m) for m in fixture["trace"]]
+        rec = _record(n, fixture["scenario"], tool_moves=moves)
+        score = reward.reward_fn(rec)
+        result = game.replay(moves, n)
+        if result.completed:
+            assert score > 0.0
+            assert score <= game.COMPLETION_REWARD
+        else:
+            # unsolved: partial credit equals the legal/illegal formula and
+            # stays below the completion reward.
+            expected = min(
+                reward.LEGAL_STEP_BONUS * result.legal_count + reward.ILLEGAL_STEP_PENALTY * result.illegal_count,
+                reward.PARTIAL_CREDIT_CAP,
+            )
+            assert score == pytest.approx(expected)
+            assert score < game.COMPLETION_REWARD

--- a/tests/test_agentic_hanoi_example_cpu.py
+++ b/tests/test_agentic_hanoi_example_cpu.py
@@ -547,6 +547,47 @@ def test_string_arguments_are_parsed():
     assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
 
 
+def test_source_target_args_also_scored():
+    # Regression for the cold-start stall: a weak base model tends to emit the
+    # prose form {"source": s, "target": t} instead of the schema's
+    # {"moves": [[s, t]...]}. If _tool_moves rejected that, every sample would
+    # reward exactly 0.0 (observed: tool_calls=8/8 yet reward_mean=0.0,
+    # grad_zero_ratio=1.0) and GSPO could never form an advantage. A bare single
+    # move must still score positive partial credit.
+    rec = _record(3, "optimal", tool_moves=None)
+    rec.tool_calls = [{"name": "move_disk", "arguments": {"source": 0, "target": 2}}]
+    assert reward.reward_fn(rec) > 0.0
+
+
+def test_single_move_dict_wrapped_under_moves_scored():
+    # Also tolerate {"moves": {"source": 0, "target": 2}}.
+    import json as _json
+
+    rec = SimpleNamespace(
+        source_record={"state": next(r for r in gen.generate_records() if r["n"] == 3 and r["scenario"] == "optimal")},
+        completion=None,
+        tool_calls=[{"name": "move_disk", "arguments": _json.dumps({"moves": {"source": 0, "target": 2}})}],
+    )
+    assert reward.reward_fn(rec) > 0.0
+
+
+def test_moves_field_as_json_string_parsed():
+    # Regression (2026-07-29 rollout): the Qwen tool-call path serializes the
+    # moves list as a JSON *string* — arguments {"moves": "[[0,2],..."}. The
+    # extractor must deserialize the string, not reject it as non-list, which
+    # made tool_calls=8/8 yet reward_mean=0.0 until _coerce_moves learned to
+    # json.loads a str-shaped moves field.
+    import json as _json
+
+    optimal = [list(m) for m in game.optimal_solution(3)]
+    rec = SimpleNamespace(
+        source_record={"state": next(r for r in gen.generate_records() if r["n"] == 3 and r["scenario"] == "optimal")},
+        completion=None,
+        tool_calls=[{"name": "move_disk", "arguments": _json.dumps({"moves": _json.dumps(optimal)})}],
+    )
+    assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
+
+
 def test_malformed_arguments_score_zero_not_crash():
     rec = _record(3, "optimal", tool_moves=None, completion="not json at all")
     assert reward.reward_fn(rec) == 0.0

--- a/tests/test_agentic_hanoi_example_cpu.py
+++ b/tests/test_agentic_hanoi_example_cpu.py
@@ -505,7 +505,7 @@ def test_failure_sequence_scores_legal_floor():
     # Unsolved traces earn PROGRESS credit (main) plus a tiny legal-move
     # floor for gradient survival. The failure fixture oscillates disk 1
     # without ever building the target stack, so peg 2 ends empty and
-    # progress=0; the floor gives 0.02 (8 legal moves × 0.005 capped at 0.02).
+    # progress=0; the floor caps at 0.005.
     n = 3
     moves = [(0, 2), (2, 0)] * 4  # never solves, peg 2 ends empty
     rec = _record(n, "failure", tool_moves=moves)
@@ -600,13 +600,11 @@ def test_progress_toward_peg2_rewarded():
 
 def test_collapse_sequence_scores_tiny_floor():
     # Regression (2026-07-29 rollout mode collapse): the model previously locked
-    # reward at 0.04 by replaying [[0,2],[0,1]] — two legal moves that don't
-    # make progress (peg2=[1] → [], not [3,2,1]). With the hybrid formula,
-    # progress=0 but the legal floor gives 0.005 × 2 = 0.01 — tiny enough to
-    # be unattractive for freezing while keeping gradients alive (compare to
-    # any progress path which pays 0.02 per disk).
+    # reward at 0.04 by replaying [[0,2],[0,1]]. With LEGAL_FLOOR_CAP=0.005,
+    # the floor caps at 0.005 no matter how many legal steps — too small to
+    # freeze on, while keeping gradients alive during cold start.
     rec = _record(3, "optimal", tool_moves=[(0, 2), (0, 1)])
-    assert reward.reward_fn(rec) == pytest.approx(reward.LEGAL_FLOOR_BONUS * 2)
+    assert reward.reward_fn(rec) == pytest.approx(reward.LEGAL_FLOOR_CAP)
 
 
 def test_malformed_arguments_score_zero_not_crash():

--- a/tests/test_agentic_hanoi_example_cpu.py
+++ b/tests/test_agentic_hanoi_example_cpu.py
@@ -501,20 +501,17 @@ def test_longer_legal_solution_scores_lower():
     assert score == pytest.approx(game.COMPLETION_REWARD - game.EXCESS_STEP_PENALTY * 1)
 
 
-def test_failure_sequence_scores_partial_credit():
-    # Unsolved traces no longer score exactly 0 (lenient reading): they earn a
-    # small partial credit = LEGAL_STEP_BONUS*legal + ILLEGAL_STEP_PENALTY*illegal,
-    # strictly below the completion reward so completion stays the dominant signal.
+def test_failure_sequence_scores_zero_progress():
+    # Unsolved traces earn partial credit only for PROGRESS toward peg 2, not
+    # for legal steps. The failure fixture oscillates the smallest disk without
+    # ever building the target stack, so peg 2 ends empty and it scores 0 —
+    # and so does a model that tries to "steal" reward with legal-but-stagnant
+    # moves (see test_collapse_sequence_no_partial_credit).
     n = 3
-    moves = [(0, 2), (2, 0)] * 4  # never solves
+    moves = [(0, 2), (2, 0)] * 4  # never solves, peg 2 ends empty
     rec = _record(n, "failure", tool_moves=moves)
-    result = game.replay(moves, n)
-    assert not result.completed
-    expected = min(
-        reward.LEGAL_STEP_BONUS * result.legal_count + reward.ILLEGAL_STEP_PENALTY * result.illegal_count,
-        reward.PARTIAL_CREDIT_CAP,
-    )
-    assert reward.reward_fn(rec) == pytest.approx(expected)
+    assert not game.replay(moves, n).completed
+    assert reward.reward_fn(rec) == pytest.approx(0.0)
     assert reward.reward_fn(rec) < game.COMPLETION_REWARD
 
 
@@ -547,20 +544,23 @@ def test_string_arguments_are_parsed():
     assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
 
 
-def test_source_target_args_also_scored():
-    # Regression for the cold-start stall: a weak base model tends to emit the
-    # prose form {"source": s, "target": t} instead of the schema's
-    # {"moves": [[s, t]...]}. If _tool_moves rejected that, every sample would
-    # reward exactly 0.0 (observed: tool_calls=8/8 yet reward_mean=0.0,
-    # grad_zero_ratio=1.0) and GSPO could never form an advantage. A bare single
-    # move must still score positive partial credit.
+def test_source_target_args_extracted_without_crash():
+    # Regression for the cold-start extraction stall: a weak base model emits
+    # the prose form {"source": s, "target": t} instead of the schema's
+    # {"moves": [[s,t]...]}. _tool_moves must still extract it (not crash / not
+    # silently drop) — before the fix, tool_calls=8/8 yet reward_mean=0.0. The
+    # extracted single move (0,2) puts disk 1 on peg 2, but disk 1 is not the
+    # correct bottom disk (3 for n=3), so under progress-based partial credit
+    # it scores 0; this asserts the extraction path, not the score.
     rec = _record(3, "optimal", tool_moves=None)
     rec.tool_calls = [{"name": "move_disk", "arguments": {"source": 0, "target": 2}}]
-    assert reward.reward_fn(rec) > 0.0
+    assert reward.reward_fn(rec) == 0.0
 
 
-def test_single_move_dict_wrapped_under_moves_scored():
-    # Also tolerate {"moves": {"source": 0, "target": 2}}.
+def test_single_move_dict_wrapped_extracted_without_crash():
+    # Also tolerate {"moves": {"source": 0, "target": 2}} — the wrapped-dict
+    # extraction path must not crash; the single move scores 0 under
+    # progress-based credit (disk 1 is not the correct bottom disk for n=3).
     import json as _json
 
     rec = SimpleNamespace(
@@ -568,7 +568,7 @@ def test_single_move_dict_wrapped_under_moves_scored():
         completion=None,
         tool_calls=[{"name": "move_disk", "arguments": _json.dumps({"moves": {"source": 0, "target": 2}})}],
     )
-    assert reward.reward_fn(rec) > 0.0
+    assert reward.reward_fn(rec) == 0.0
 
 
 def test_moves_field_as_json_string_parsed():
@@ -588,6 +588,27 @@ def test_moves_field_as_json_string_parsed():
     assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
 
 
+def test_progress_toward_peg2_rewarded():
+    # Partial credit is PROGRESS-based: disks correctly stacked on peg 2 from
+    # the bottom earn a little. For n=3, the first 4 optimal moves park disk 3
+    # on peg 2 (progress=1) without completing, so reward = 0.02 (not 0, not 1.0).
+    n = 3
+    moves = [tuple(m) for m in game.optimal_solution(n)[:4]]  # disk 3 -> peg 2, not yet solved
+    rec = _record(n, "optimal", tool_moves=moves)
+    result = game.replay(moves, n)
+    assert not result.completed
+    assert reward.reward_fn(rec) == pytest.approx(reward.PROGRESS_BONUS * 1)
+
+
+def test_collapse_sequence_no_partial_credit():
+    # Regression (2026-07-29 rollout mode collapse): the model locked reward at
+    # 0.04 by replaying [[0,2],[0,1]] — two legal moves that don't push any disk
+    # onto peg 2 in the correct bottom-up order. Progress-based partial credit
+    # scores this 0, removing the incentive to freeze on this shortcut.
+    rec = _record(3, "optimal", tool_moves=[(0, 2), (0, 1)])
+    assert reward.reward_fn(rec) == 0.0
+
+
 def test_malformed_arguments_score_zero_not_crash():
     rec = _record(3, "optimal", tool_moves=None, completion="not json at all")
     assert reward.reward_fn(rec) == 0.0
@@ -605,11 +626,8 @@ def test_reward_matches_replay_outcome_for_every_fixture():
             assert score > 0.0
             assert score <= game.COMPLETION_REWARD
         else:
-            # unsolved: partial credit equals the legal/illegal formula and
-            # stays below the completion reward.
-            expected = min(
-                reward.LEGAL_STEP_BONUS * result.legal_count + reward.ILLEGAL_STEP_PENALTY * result.illegal_count,
-                reward.PARTIAL_CREDIT_CAP,
-            )
+            # unsolved: partial credit is PROGRESS-based — disks correctly
+            # stacked on peg 2 from the bottom — and stays below completion.
+            expected = min(reward.PROGRESS_BONUS * reward._progress_count(result), reward.PARTIAL_CREDIT_CAP)
             assert score == pytest.approx(expected)
             assert score < game.COMPLETION_REWARD

--- a/tests/test_agentic_hanoi_example_cpu.py
+++ b/tests/test_agentic_hanoi_example_cpu.py
@@ -501,17 +501,17 @@ def test_longer_legal_solution_scores_lower():
     assert score == pytest.approx(game.COMPLETION_REWARD - game.EXCESS_STEP_PENALTY * 1)
 
 
-def test_failure_sequence_scores_zero_progress():
-    # Unsolved traces earn partial credit only for PROGRESS toward peg 2, not
-    # for legal steps. The failure fixture oscillates the smallest disk without
-    # ever building the target stack, so peg 2 ends empty and it scores 0 —
-    # and so does a model that tries to "steal" reward with legal-but-stagnant
-    # moves (see test_collapse_sequence_no_partial_credit).
+def test_failure_sequence_scores_legal_floor():
+    # Unsolved traces earn PROGRESS credit (main) plus a tiny legal-move
+    # floor for gradient survival. The failure fixture oscillates disk 1
+    # without ever building the target stack, so peg 2 ends empty and
+    # progress=0; the floor gives 0.02 (8 legal moves × 0.005 capped at 0.02).
     n = 3
     moves = [(0, 2), (2, 0)] * 4  # never solves, peg 2 ends empty
     rec = _record(n, "failure", tool_moves=moves)
     assert not game.replay(moves, n).completed
-    assert reward.reward_fn(rec) == pytest.approx(0.0)
+    expected = min(reward.LEGAL_FLOOR_BONUS * 8, reward.LEGAL_FLOOR_CAP)
+    assert reward.reward_fn(rec) == pytest.approx(expected)
     assert reward.reward_fn(rec) < game.COMPLETION_REWARD
 
 
@@ -544,23 +544,21 @@ def test_string_arguments_are_parsed():
     assert reward.reward_fn(rec) == pytest.approx(game.COMPLETION_REWARD)
 
 
-def test_source_target_args_extracted_without_crash():
+def test_source_target_args_extracted_scored():
     # Regression for the cold-start extraction stall: a weak base model emits
     # the prose form {"source": s, "target": t} instead of the schema's
     # {"moves": [[s,t]...]}. _tool_moves must still extract it (not crash / not
     # silently drop) — before the fix, tool_calls=8/8 yet reward_mean=0.0. The
-    # extracted single move (0,2) puts disk 1 on peg 2, but disk 1 is not the
-    # correct bottom disk (3 for n=3), so under progress-based partial credit
-    # it scores 0; this asserts the extraction path, not the score.
+    # extracted single move (0,2) puts disk 1 on peg 2 (not the correct bottom
+    # disk for n=3), so progress=0 but the legal floor is 0.005.
     rec = _record(3, "optimal", tool_moves=None)
     rec.tool_calls = [{"name": "move_disk", "arguments": {"source": 0, "target": 2}}]
-    assert reward.reward_fn(rec) == 0.0
+    assert reward.reward_fn(rec) == pytest.approx(reward.LEGAL_FLOOR_BONUS * 1)
 
 
-def test_single_move_dict_wrapped_extracted_without_crash():
-    # Also tolerate {"moves": {"source": 0, "target": 2}} — the wrapped-dict
-    # extraction path must not crash; the single move scores 0 under
-    # progress-based credit (disk 1 is not the correct bottom disk for n=3).
+def test_single_move_dict_wrapped_extracted_scored():
+    # Also tolerate {"moves": {"source": 0, "target": 2}} — 1 legal move,
+    # progress=0, legal floor = 0.005.
     import json as _json
 
     rec = SimpleNamespace(
@@ -568,7 +566,7 @@ def test_single_move_dict_wrapped_extracted_without_crash():
         completion=None,
         tool_calls=[{"name": "move_disk", "arguments": _json.dumps({"moves": {"source": 0, "target": 2}})}],
     )
-    assert reward.reward_fn(rec) == 0.0
+    assert reward.reward_fn(rec) == pytest.approx(reward.LEGAL_FLOOR_BONUS * 1)
 
 
 def test_moves_field_as_json_string_parsed():
@@ -589,9 +587,9 @@ def test_moves_field_as_json_string_parsed():
 
 
 def test_progress_toward_peg2_rewarded():
-    # Partial credit is PROGRESS-based: disks correctly stacked on peg 2 from
-    # the bottom earn a little. For n=3, the first 4 optimal moves park disk 3
-    # on peg 2 (progress=1) without completing, so reward = 0.02 (not 0, not 1.0).
+    # Hybrid partial credit: progress(0.02/disk) dominates legal floor.
+    # For n=3, the first 4 optimal moves park disk 3 on peg 2 (progress=1)
+    # without completing, so reward = max(0.02, floor) = 0.02.
     n = 3
     moves = [tuple(m) for m in game.optimal_solution(n)[:4]]  # disk 3 -> peg 2, not yet solved
     rec = _record(n, "optimal", tool_moves=moves)
@@ -600,13 +598,15 @@ def test_progress_toward_peg2_rewarded():
     assert reward.reward_fn(rec) == pytest.approx(reward.PROGRESS_BONUS * 1)
 
 
-def test_collapse_sequence_no_partial_credit():
-    # Regression (2026-07-29 rollout mode collapse): the model locked reward at
-    # 0.04 by replaying [[0,2],[0,1]] — two legal moves that don't push any disk
-    # onto peg 2 in the correct bottom-up order. Progress-based partial credit
-    # scores this 0, removing the incentive to freeze on this shortcut.
+def test_collapse_sequence_scores_tiny_floor():
+    # Regression (2026-07-29 rollout mode collapse): the model previously locked
+    # reward at 0.04 by replaying [[0,2],[0,1]] — two legal moves that don't
+    # make progress (peg2=[1] → [], not [3,2,1]). With the hybrid formula,
+    # progress=0 but the legal floor gives 0.005 × 2 = 0.01 — tiny enough to
+    # be unattractive for freezing while keeping gradients alive (compare to
+    # any progress path which pays 0.02 per disk).
     rec = _record(3, "optimal", tool_moves=[(0, 2), (0, 1)])
-    assert reward.reward_fn(rec) == 0.0
+    assert reward.reward_fn(rec) == pytest.approx(reward.LEGAL_FLOOR_BONUS * 2)
 
 
 def test_malformed_arguments_score_zero_not_crash():
@@ -626,8 +626,10 @@ def test_reward_matches_replay_outcome_for_every_fixture():
             assert score > 0.0
             assert score <= game.COMPLETION_REWARD
         else:
-            # unsolved: partial credit is PROGRESS-based — disks correctly
-            # stacked on peg 2 from the bottom — and stays below completion.
-            expected = min(reward.PROGRESS_BONUS * reward._progress_count(result), reward.PARTIAL_CREDIT_CAP)
+            # unsolved: hybrid partial credit = max(progress, legal floor),
+            # capped at PARTIAL_CREDIT_CAP; stays below completion.
+            progress = reward.PROGRESS_BONUS * reward._progress_count(result)
+            floor = min(reward.LEGAL_FLOOR_BONUS * result.legal_count, reward.LEGAL_FLOOR_CAP)
+            expected = min(max(progress, floor), reward.PARTIAL_CREDIT_CAP)
             assert score == pytest.approx(expected)
             assert score < game.COMPLETION_REWARD


### PR DESCRIPTION
feat(examples/agentic): add Towers of Hanoi agentic RL demo

## What does this PR do?

Adds a new, self-contained agentic RL demo at examples/agentic/hanoi/ (plus focused CPU tests under tests/). The demo gives a model a Towers of Hanoi start board and scores its move_disk move sequence with the rules engine, so
the same fixtures work for warmup, rollout, or GSPO/RLVR training.

Motivation: AReno needs a small, deterministic agentic demo where the rules,the optimal solution, and the reward are all closed-form and checkable on CPU — so it can be reviewed, replayed, and evaluated without a training run. Towers of Hanoi fits perfectly: one canonical start, a 2**n - 1 optimum, and unambiguous legality. This capability otherwise does not exist or would require one-off user code that is hard to operate, compare, and reproduce.

Deliverables :
- game.py — three-peg state, move(source, target), legality (empty-source,
  larger-on-smaller, out-of-range, no-op, malformed), reward, terminal;
  oracle optimal_steps = 2**n-1, optimal_solution, validate_solution);
  text-trace replay; evaluate (completion_rate + excess_moves_over_optimum).
- dataset_generator.py — deterministic scripted fixtures (4 scenarios ×
  n=3..6: optimal / contains_illegal / boundary / failure), JSONL output.
- dataset_loader.py — load_training_dataset → Areno prompt records.
- reward.py — reward_fn(record) scoring move_disk via the rules engine.
- run_agent.py — async run_agent(ctx, batch) issuing move_disk tool calls
  through ctx.get_base_url()'s OpenAI-compatible rollout proxy; token rows,
  loss masks, and tool-result masking are handled by RolloutSession/
  LossMaskPolicy — the trainer is not touched.
- README.md — rules, 2**n-1 formula, metrics, input contract, defaults,
  output fields, limitations, and copyable examples (success + boundary input).

## Related issue

Fixes #186

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## How was it tested?

Focused CPU tests in tests/test_agentic_hanoi_example_cpu.py (loaded via
importlib, no AReno package import, no CUDA build). 70 test cases covering:
oracle closed form & solution validity; environment legality (empty source,
larger-on-smaller, out-of-range, no-op, malformed) and the terminate policy;
trace replay (optimal completes with 0 excess, illegal counted without
terminating, failure does not complete, human-readable + structured output);
evaluate completion rate & excess moves; determinism; default penalize
policy; all 16 fixtures with expected matching fresh replay; loader prompt
records + missing-file error message; reward scoring (optimal full score,
longer lower, failure/empty/malformed → 0, wrong tool name fallback, string
arguments parsed, reward-vs-replay consistency); and 5 regression tests for
cold-start extraction and progress-based reward.

Test commands run:
```bash
pytest tests/test_agentic_hanoi_example_cpu.py -q   # 70 passed
ruff check examples/agentic/hanoi/ tests/test_agentic_hanoi_example_cpu.py   # clean
ruff format --check examples/agentic/hanoi/ tests/test_agentic_hanoi_example_cpu.py   # clean
