### PR TITLE
feat(api): add loss mask explanation feature

### DIFF
--- a/areno/api/__init__.py
+++ b/areno/api/__init__.py
@@ -17,8 +17,10 @@ from areno.api.agentic import (
 )
 from areno.api.algorithms import AlgorithmSpec, get_algorithm, list_algorithms, register_algorithm
 from areno.api.config import ArenoConfig
-from areno.api.data import PromptBatch, PromptItem
+from areno.api.data import LossMaskExplanation, LossSpan, PromptBatch, PromptItem
+from areno.api.data_utils import spans_from_prompt_mask
 from areno.api.loss_fns import dpo_loss_fn, grpo_loss_fn, gspo_loss_fn, ppo_loss_fn, sft_loss_fn
+from areno.api.loss_mask_explainer import explain_loss_mask
 from areno.api.models import (
     BackendType,
     RolloutResult,
@@ -40,6 +42,8 @@ __all__ = [
     "ArenoConfig",
     "PromptBatch",
     "PromptItem",
+    "LossSpan",
+    "LossMaskExplanation",
     "AgentBatch",
     "AgentItem",
     "AgentTrainBatch",
@@ -63,4 +67,6 @@ __all__ = [
     "grpo_loss_fn",
     "ppo_loss_fn",
     "sft_loss_fn",
+    "explain_loss_mask",
+    "spans_from_prompt_mask",
 ]

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -665,13 +665,15 @@ class RolloutSession:
                 if span.end <= prefix_len:
                     continue
                 clipped_start = max(span.start, prefix_len)
-                existing.spans.append(LossSpan(
-                    role=span.role,
-                    start=old_row_len + clipped_start - prefix_len,
-                    end=old_row_len + span.end - prefix_len,
-                    loss=span.loss,
-                    turn=next_turn,
-                ))
+                existing.spans.append(
+                    LossSpan(
+                        role=span.role,
+                        start=old_row_len + clipped_start - prefix_len,
+                        end=old_row_len + span.end - prefix_len,
+                        loss=span.loss,
+                        turn=next_turn,
+                    )
+                )
         elif not existing.token_row:
             existing.token_row = list(existing.item.input_tokens) + list(existing.response_tokens)
             prompt_len = len(existing.item.input_tokens)
@@ -713,7 +715,9 @@ class RolloutSession:
                 start = i
                 current = loss_mask[i]
         role = sample.response_kind if current else ("tool_result" if has_override else sample.response_kind)
-        spans.append(LossSpan(role=role, start=prompt_len + start, end=prompt_len + len(loss_mask), loss=current, turn=turn))
+        spans.append(
+            LossSpan(role=role, start=prompt_len + start, end=prompt_len + len(loss_mask), loss=current, turn=turn)
+        )
         return spans
 
     def _set_sample_training_row(self, sample: _AgentSample, prompt_tokens: list[int]) -> None:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -26,6 +26,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from areno.api.data import LossSpan
 from areno.api.openai_chat import (
     build_chat_completion_response,
     first_user_text,
@@ -116,6 +117,7 @@ class AgentTrainBatch:
     rewards: list[float] | None
     records: list[dict[str, Any]]
     reward_records: list[RewardRecord]
+    spans: list[list[LossSpan]] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -164,6 +166,7 @@ class _AgentSample:
     response_mask_row: list[bool] = field(default_factory=list)
     loss_mask_row: list[bool] = field(default_factory=list)
     rollout_logprobs_row: list[float] = field(default_factory=list)
+    spans: list[LossSpan] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -179,6 +182,7 @@ class _AgentTrainRows:
     loss_masks: list[list[bool]]
     rollout_logprobs: list[list[float]]
     total_tokens: int
+    spans: list[list[LossSpan]] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -389,6 +393,7 @@ class RolloutSession:
         response_masks: list[list[bool]] = []
         loss_masks: list[list[bool]] = []
         rollout_logprobs: list[list[float]] = []
+        all_spans: list[list[LossSpan]] = []
         total_tokens = 0
         for sample in samples:
             if sample.token_row:
@@ -396,6 +401,7 @@ class RolloutSession:
                 response_masks.append(list(sample.response_mask_row))
                 loss_masks.append(list(sample.loss_mask_row))
                 rollout_logprobs.append(list(sample.rollout_logprobs_row))
+                all_spans.append(list(sample.spans))
                 total_tokens += len(sample.token_row)
                 continue
             prompt_len = len(sample.item.input_tokens)
@@ -405,6 +411,7 @@ class RolloutSession:
             response_masks.append([False] * prompt_len + [True] * response_len)
             loss_masks.append([False] * prompt_len + self._response_loss_mask(sample))
             rollout_logprobs.append([0.0] * prompt_len + list(sample.response_logprobs))
+            all_spans.append(self._build_sample_spans(sample, prompt_len, turn=0))
             total_tokens += len(token_row)
         return _AgentTrainRows(
             token_rows=token_rows,
@@ -412,6 +419,7 @@ class RolloutSession:
             loss_masks=loss_masks,
             rollout_logprobs=rollout_logprobs,
             total_tokens=total_tokens,
+            spans=all_spans,
         )
 
     def _handler_cls(self):
@@ -645,17 +653,32 @@ class RolloutSession:
         # Append only the suffix so the training row becomes one trajectory
         # instead of duplicating the shared prefix for every tool call.
         prefix_len = _common_prefix_len(existing.token_row, new_sample.token_row)
+        old_row_len = len(existing.token_row)
+        next_turn = max((s.turn for s in existing.spans), default=-1) + 1
         if prefix_len < len(new_sample.token_row):
             existing.token_row.extend(new_sample.token_row[prefix_len:])
             existing.response_mask_row.extend(new_sample.response_mask_row[prefix_len:])
             existing.loss_mask_row.extend(new_sample.loss_mask_row[prefix_len:])
             existing.rollout_logprobs_row.extend(new_sample.rollout_logprobs_row[prefix_len:])
+            # Clip and re-offset the new sample's spans to the appended suffix.
+            for span in new_sample.spans:
+                if span.end <= prefix_len:
+                    continue
+                clipped_start = max(span.start, prefix_len)
+                existing.spans.append(LossSpan(
+                    role=span.role,
+                    start=old_row_len + clipped_start - prefix_len,
+                    end=old_row_len + span.end - prefix_len,
+                    loss=span.loss,
+                    turn=next_turn,
+                ))
         elif not existing.token_row:
             existing.token_row = list(existing.item.input_tokens) + list(existing.response_tokens)
             prompt_len = len(existing.item.input_tokens)
             existing.response_mask_row = [False] * prompt_len + [True] * len(existing.response_tokens)
             existing.loss_mask_row = [False] * prompt_len + self._response_loss_mask(existing)
             existing.rollout_logprobs_row = [0.0] * prompt_len + list(existing.response_logprobs)
+            existing.spans = self._build_sample_spans(existing, prompt_len, turn=0)
         old_mask = existing.loss_mask_override
         if old_mask is None:
             old_mask = self._response_loss_mask_for_span(old_response_kind, old_response_len)
@@ -665,15 +688,45 @@ class RolloutSession:
         existing.loss_mask_override = list(old_mask) + list(new_mask)
         existing.response_kind = new_sample.response_kind
 
+    def _build_sample_spans(self, sample: _AgentSample, prompt_len: int, *, turn: int) -> list[LossSpan]:
+        """Build ``LossSpan`` annotations for one sample's training row.
+
+        The prompt portion is a single ``"prompt"`` span with ``loss=False``.
+        The response portion is split at loss-mask boundaries: segments with
+        ``loss=True`` use ``sample.response_kind`` as role; segments with
+        ``loss=False`` use ``"tool_result"`` when a ``loss_mask_override`` is
+        present (indicating ``_tool_call_loss_mask`` suppressed tool-result
+        sentinels), otherwise the role stays ``response_kind``.
+        """
+
+        spans = [LossSpan(role="prompt", start=0, end=prompt_len, loss=False, turn=turn)]
+        loss_mask = self._response_loss_mask(sample)
+        has_override = sample.loss_mask_override is not None
+        if not loss_mask:
+            return spans
+        start = 0
+        current = loss_mask[0]
+        for i in range(1, len(loss_mask)):
+            if loss_mask[i] != current:
+                role = sample.response_kind if current else ("tool_result" if has_override else sample.response_kind)
+                spans.append(LossSpan(role=role, start=prompt_len + start, end=prompt_len + i, loss=current, turn=turn))
+                start = i
+                current = loss_mask[i]
+        role = sample.response_kind if current else ("tool_result" if has_override else sample.response_kind)
+        spans.append(LossSpan(role=role, start=prompt_len + start, end=prompt_len + len(loss_mask), loss=current, turn=turn))
+        return spans
+
     def _set_sample_training_row(self, sample: _AgentSample, prompt_tokens: list[int]) -> None:
         response_mask = [True] * len(sample.response_tokens)
         loss_mask = self._response_loss_mask(sample)
         # response_mask marks generated tokens; loss_mask is stricter and can
         # suppress tool-result or other non-policy spans.
+        prompt_len = len(prompt_tokens)
         sample.token_row = list(prompt_tokens) + list(sample.response_tokens)
-        sample.response_mask_row = [False] * len(prompt_tokens) + response_mask
-        sample.loss_mask_row = [False] * len(prompt_tokens) + loss_mask
-        sample.rollout_logprobs_row = [0.0] * len(prompt_tokens) + list(sample.response_logprobs)
+        sample.response_mask_row = [False] * prompt_len + response_mask
+        sample.loss_mask_row = [False] * prompt_len + loss_mask
+        sample.rollout_logprobs_row = [0.0] * prompt_len + list(sample.response_logprobs)
+        sample.spans = self._build_sample_spans(sample, prompt_len, turn=0)
 
     def _build_pending_chat_response(
         self,

--- a/areno/api/data.py
+++ b/areno/api/data.py
@@ -4,6 +4,11 @@
 tokenising a dataset row. `PromptBatch` groups a fixed-size set of items
 together and carries diagnostic counters so the trainer can surface how many
 records were skipped for exceeding the prompt-length budget.
+
+`LossSpan` and `LossMaskExplanation` support the human-readable loss-mask
+explainer: they annotate contiguous token spans with role labels and loss
+flags so users can inspect which parts of a packed sequence contribute to
+training loss.
 """
 
 from __future__ import annotations
@@ -48,3 +53,46 @@ class PromptBatch:
         """Return raw prompt strings in batch order for rollout."""
 
         return [item.prompt for item in self.items]
+
+
+@dataclass(slots=True)
+class LossSpan:
+    """One contiguous token span with a role label and loss flag.
+
+    ``role`` is a free-form string using one of the known values:
+
+    * SFT packer: ``"prompt"``, ``"response"``
+    * Agentic packer: ``"system_prompt"``, ``"user_prompt"``,
+      ``"assistant_text"``, ``"assistant_tool_call"``, ``"tool_result"``
+
+    ``start`` / ``end`` are half-open token offsets within the packed
+    sequence.  ``loss`` indicates whether this span contributes to the
+    training loss (i.e. the packer's effective mask is ``True`` here).
+    ``turn`` is the zero-based conversation turn index; SFT spans always
+    use turn 0.
+    """
+
+    role: str
+    start: int
+    end: int
+    loss: bool
+    turn: int = 0
+
+
+@dataclass(slots=True)
+class LossMaskExplanation:
+    """Structured loss-mask report built from packer output.
+
+    ``spans`` is the per-span annotation list.  ``total_tokens`` and
+    ``loss_tokens`` are computed from the span boundaries.  ``summary``
+    contains per-role statistics as a list of dicts with keys ``role``,
+    ``token_count``, and ``loss_tokens``.  ``text_preview`` maps span
+    indices to decoded text and is only populated when text display is
+    explicitly requested.
+    """
+
+    spans: list[LossSpan]
+    total_tokens: int
+    loss_tokens: int
+    summary: list[dict[str, Any]]
+    text_preview: dict[int, str] | None = None

--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -70,7 +70,9 @@ def spans_from_prompt_mask(prompt_mask: list[bool]) -> list[LossSpan]:
             spans.append(LossSpan(role="prompt" if current else "response", start=start, end=i, loss=not current))
             start = i
             current = prompt_mask[i]
-    spans.append(LossSpan(role="prompt" if current else "response", start=start, end=len(prompt_mask), loss=not current))
+    spans.append(
+        LossSpan(role="prompt" if current else "response", start=start, end=len(prompt_mask), loss=not current)
+    )
     return spans
 
 

--- a/areno/api/data_utils.py
+++ b/areno/api/data_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from areno.api.data import LossSpan
 from areno.api.tokenizer import apply_chat_template_with_options, encode_generation_prompt, normalize_token_ids
 
 
@@ -49,6 +50,28 @@ def response_to_tokens_and_mask(
     if eos_token_id is not None and (not response_ids or response_ids[-1] != eos_token_id):
         response_ids.append(eos_token_id)
     return prompt_ids + response_ids, [True] * len(prompt_ids) + [False] * len(response_ids)
+
+
+def spans_from_prompt_mask(prompt_mask: list[bool]) -> list[LossSpan]:
+    """Derive minimal ``LossSpan`` annotations from an SFT ``prompt_mask``.
+
+    Consecutive ``True`` values become a ``"prompt"`` span (``loss=False``);
+    consecutive ``False`` values become a ``"response"`` span (``loss=True``).
+    All spans use turn 0 because SFT packs a single prompt-response pair.
+    """
+
+    if not prompt_mask:
+        return []
+    spans: list[LossSpan] = []
+    start = 0
+    current = prompt_mask[0]
+    for i in range(1, len(prompt_mask)):
+        if prompt_mask[i] != current:
+            spans.append(LossSpan(role="prompt" if current else "response", start=start, end=i, loss=not current))
+            start = i
+            current = prompt_mask[i]
+    spans.append(LossSpan(role="prompt" if current else "response", start=start, end=len(prompt_mask), loss=not current))
+    return spans
 
 
 def has_any(record: dict[str, Any], keys: tuple[str, ...]) -> bool:

--- a/areno/api/loss_mask_explainer.py
+++ b/areno/api/loss_mask_explainer.py
@@ -1,0 +1,130 @@
+"""Human-readable loss-mask explainer.
+
+Consumes packer output — token sequences, effective loss masks, and per-span
+role annotations — and produces a structured ``LossMaskExplanation`` that maps
+each contiguous token span back to its role (prompt, response, assistant text,
+tool call, tool result) and reports whether it contributes to training loss.
+
+The explainer does **not** re-implement mask rules; it only interprets the masks
+and span metadata already produced by the SFT or Agentic packer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from areno.api.data import LossMaskExplanation, LossSpan
+
+
+def explain_loss_mask(
+    tokens: list[int],
+    loss_mask: list[bool],
+    spans: list[LossSpan],
+    *,
+    tokenizer=None,
+    show_text: bool = False,
+) -> LossMaskExplanation:
+    """Build a human-readable + structured loss-mask report from packer output.
+
+    Parameters
+    ----------
+    tokens
+        Packer-produced token sequence.
+    loss_mask
+        Effective loss mask (``True`` = token contributes to loss).
+
+        * SFT: ``[not m for m in prompt_mask]``
+        * Agentic: ``AgentTrainBatch.loss_masks[i]``
+    spans
+        Packer-produced per-span role annotations.
+
+        * SFT: ``spans_from_prompt_mask(prompt_mask)``
+        * Agentic: ``AgentTrainBatch.spans[i]``
+    tokenizer
+        Optional tokenizer; required when ``show_text=True``.
+    show_text
+        Whether to decode and include span text in the explanation.
+
+    Returns
+    -------
+    LossMaskExplanation
+        Structured report with spans, token counts, per-role summary, and
+        optional text preview.
+
+    Raises
+    ------
+    ValueError
+        If ``tokens`` and ``loss_mask`` lengths differ, or if spans have gaps
+        or overlaps after truncation clipping.
+    """
+
+    n = len(tokens)
+    if n != len(loss_mask):
+        raise ValueError(
+            f"tokens and loss_mask length mismatch: tokens={n}, loss_mask={len(loss_mask)}"
+        )
+
+    # Clip spans to the actual token range (handles right-truncated sequences).
+    clipped: list[LossSpan] = []
+    for span in spans:
+        if span.start >= n:
+            continue
+        end = min(span.end, n)
+        if end <= span.start:
+            continue
+        clipped.append(LossSpan(role=span.role, start=span.start, end=end, loss=span.loss, turn=span.turn))
+
+    # Validate coverage: spans should cover [0, n) without gaps or overlaps.
+    pos = 0
+    for span in clipped:
+        if span.start > pos:
+            raise ValueError(
+                f"span gap: expected coverage at position {pos}, but next span "
+                f"'{span.role}' starts at {span.start}"
+            )
+        if span.start < pos:
+            raise ValueError(
+                f"span overlap: span '{span.role}' starts at {span.start} "
+                f"but previous span ended at {pos}"
+            )
+        pos = span.end
+    if pos < n:
+        raise ValueError(
+            f"span coverage incomplete: spans end at {pos} but tokens has {n} positions"
+        )
+
+    # Compute statistics.
+    loss_tokens = sum(1 for m in loss_mask if m)
+    summary: list[dict[str, Any]] = []
+    role_stats: dict[str, dict[str, int]] = {}
+    for span in clipped:
+        token_count = span.end - span.start
+        span_loss_tokens = token_count if span.loss else 0
+        if span.role not in role_stats:
+            role_stats[span.role] = {"token_count": 0, "loss_tokens": 0}
+        role_stats[span.role]["token_count"] += token_count
+        role_stats[span.role]["loss_tokens"] += span_loss_tokens
+    for role, stats in role_stats.items():
+        summary.append({"role": role, **stats})
+
+    # Optional text preview.
+    text_preview: dict[int, str] | None = None
+    if show_text and tokenizer is not None:
+        text_preview = {}
+        for idx, span in enumerate(clipped):
+            span_tokens = tokens[span.start : span.end]
+            try:
+                text_preview[idx] = tokenizer.decode(span_tokens)
+            except Exception:
+                text_preview[idx] = "<decode-error>"
+
+    return LossMaskExplanation(
+        spans=clipped,
+        total_tokens=n,
+        loss_tokens=loss_tokens,
+        summary=summary,
+        text_preview=text_preview,
+    )
+
+
+__all__ = ["explain_loss_mask"]

--- a/areno/api/loss_mask_explainer.py
+++ b/areno/api/loss_mask_explainer.py
@@ -60,9 +60,7 @@ def explain_loss_mask(
 
     n = len(tokens)
     if n != len(loss_mask):
-        raise ValueError(
-            f"tokens and loss_mask length mismatch: tokens={n}, loss_mask={len(loss_mask)}"
-        )
+        raise ValueError(f"tokens and loss_mask length mismatch: tokens={n}, loss_mask={len(loss_mask)}")
 
     # Clip spans to the actual token range (handles right-truncated sequences).
     clipped: list[LossSpan] = []
@@ -79,19 +77,15 @@ def explain_loss_mask(
     for span in clipped:
         if span.start > pos:
             raise ValueError(
-                f"span gap: expected coverage at position {pos}, but next span "
-                f"'{span.role}' starts at {span.start}"
+                f"span gap: expected coverage at position {pos}, but next span '{span.role}' starts at {span.start}"
             )
         if span.start < pos:
             raise ValueError(
-                f"span overlap: span '{span.role}' starts at {span.start} "
-                f"but previous span ended at {pos}"
+                f"span overlap: span '{span.role}' starts at {span.start} but previous span ended at {pos}"
             )
         pos = span.end
     if pos < n:
-        raise ValueError(
-            f"span coverage incomplete: spans end at {pos} but tokens has {n} positions"
-        )
+        raise ValueError(f"span coverage incomplete: spans end at {pos} but tokens has {n} positions")
 
     # Compute statistics.
     loss_tokens = sum(1 for m in loss_mask if m)

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -263,6 +263,7 @@ class PolicyOnlyTrainer:
                 rewards=rewards,
                 records=[sample.item.record for sample in samples],
                 reward_records=reward_records,
+                spans=rows.spans,
             )
 
     def _filter_overlong_agent_samples(self, ctx, samples, sampling_params):

--- a/areno/cli/explain_mask.py
+++ b/areno/cli/explain_mask.py
@@ -1,0 +1,148 @@
+"""CLI command for explaining SFT packer loss-mask output.
+
+Produces a human-readable or JSON report that maps token-level training masks
+back to roles (prompt / response) and reports per-span token counts and loss
+flags.  Runs entirely on CPU — no model weights or GPU workers are loaded.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from areno.api.data import LossMaskExplanation
+from areno.api.data_utils import prompt_response_to_tokens_and_mask, spans_from_prompt_mask
+from areno.api.loss_mask_explainer import explain_loss_mask
+
+
+@click.command(name="explain-mask", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--ckpt", required=True, help="Tokenizer / model checkpoint path (loaded on CPU only).")
+@click.option("--dataset-path", required=True, help="Dataset path (same format as `areno train`).")
+@click.option(
+    "--dataset-loader-fn",
+    required=True,
+    help="Python file with a loader function (same format as `areno train --dataset-loader-fn`).",
+)
+@click.option("--max-rows", default=5, help="Number of dataset rows to process (default 5).")
+@click.option("--show-text", is_flag=True, help="Decode and show span text (default: hidden).")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON output.")
+def explain_mask_command(
+    ckpt: str,
+    dataset_path: str,
+    dataset_loader_fn: str,
+    max_rows: int,
+    show_text: bool,
+    as_json: bool,
+) -> None:
+    """Explain SFT packer loss-mask: map tokens back to roles and counts."""
+
+    # 1. Validate inputs before loading anything expensive.
+    if max_rows <= 0:
+        raise click.UsageError("--max-rows must be positive")
+    loader_file = Path(dataset_loader_fn.split(":")[0] if ":" in dataset_loader_fn else dataset_loader_fn)
+    if not loader_file.exists():
+        raise click.UsageError(f"--dataset-loader-fn file does not exist: {loader_file}")
+
+    # 2. Load tokenizer (CPU-only).
+    from areno.api.tokenizer import load_tokenizer
+
+    tokenizer = load_tokenizer(ckpt)
+    eos_token_id = tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 0
+
+    # 3. Load dataset and apply loader function (same flow as `areno train`).
+    from areno.cli.train import _load_dataset_for_training
+
+    try:
+        from datasets import load_dataset as hf_load_dataset, load_from_disk as hf_load_from_disk
+    except ImportError:
+        raise click.UsageError("The `datasets` package is required to load datasets. Install it with `pip install datasets`.")
+
+    dataset = _load_dataset_for_training(
+        dataset_path,
+        dataset_loader_fn=dataset_loader_fn,
+        load_dataset=hf_load_dataset,
+        load_from_disk=hf_load_from_disk,
+    )
+
+    # 4. Process rows.
+    explanations: list[tuple[int, LossMaskExplanation]] = []
+    row_idx = 0
+    for record in dataset:
+        if row_idx >= max_rows:
+            break
+        record = dict(record) if not isinstance(record, dict) else record
+        if "prompt" not in record or "response" not in record:
+            continue
+        prompt = str(record["prompt"]) if record["prompt"] is not None else ""
+        response = str(record["response"]) if record["response"] is not None else ""
+        if not response:
+            continue
+        tokens, prompt_mask = prompt_response_to_tokens_and_mask(prompt, response, tokenizer, eos_token_id)
+        if len(tokens) < 2:
+            continue
+        spans = spans_from_prompt_mask(prompt_mask)
+        loss_mask = [not m for m in prompt_mask]
+        explanation = explain_loss_mask(tokens, loss_mask, spans, tokenizer=tokenizer if show_text else None, show_text=show_text)
+        explanations.append((row_idx, explanation))
+        row_idx += 1
+
+    if not explanations:
+        click.echo("No valid rows found in the dataset.", err=True)
+        raise click.exceptions.Exit(1)
+
+    # 5. Output.
+    if as_json:
+        _emit_json(explanations)
+    else:
+        _emit_terminal(explanations, show_text)
+
+
+def _emit_json(explanations: list[tuple[int, LossMaskExplanation]]) -> None:
+    rows = []
+    for row_idx, exp in explanations:
+        rows.append({
+            "row": row_idx,
+            "total_tokens": exp.total_tokens,
+            "loss_tokens": exp.loss_tokens,
+            "spans": [
+                {
+                    "role": s.role,
+                    "start": s.start,
+                    "end": s.end,
+                    "loss": s.loss,
+                    "turn": s.turn,
+                    "token_count": s.end - s.start,
+                }
+                for s in exp.spans
+            ],
+            "summary": exp.summary,
+            "text_preview": exp.text_preview,
+        })
+    click.echo(json.dumps({"rows": rows}, indent=2))
+
+
+def _emit_terminal(explanations: list[tuple[int, LossMaskExplanation]], show_text: bool) -> None:
+    for row_idx, exp in explanations:
+        click.echo(f"\nRow {row_idx}: total={exp.total_tokens} tokens, loss={exp.loss_tokens} tokens")
+        click.echo("")
+        header = "  Span  Role      Start  End  Tokens  Loss"
+        if show_text:
+            header += "  Text"
+        click.echo(header)
+        click.echo(f"  {'─' * (len(header) - 2)}")
+        for i, span in enumerate(exp.spans):
+            line = (
+                f"  {i:<5}  {span.role:<9} {span.start:<5}  {span.end:<3}  "
+                f"{span.end - span.start:<6}  {'Yes' if span.loss else 'No'}"
+            )
+            if show_text and exp.text_preview and i in exp.text_preview:
+                text = exp.text_preview[i].replace("\n", " ")[:40]
+                line += f"  {text}"
+            click.echo(line)
+        click.echo("")
+        click.echo("  Summary:")
+        for entry in exp.summary:
+            click.echo(f"    {entry['role']}: {entry['token_count']} tokens, {entry['loss_tokens']} loss tokens")

--- a/areno/cli/explain_mask.py
+++ b/areno/cli/explain_mask.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
 import click
 
@@ -56,9 +55,12 @@ def explain_mask_command(
     from areno.cli.train import _load_dataset_for_training
 
     try:
-        from datasets import load_dataset as hf_load_dataset, load_from_disk as hf_load_from_disk
+        from datasets import load_dataset as hf_load_dataset
+        from datasets import load_from_disk as hf_load_from_disk
     except ImportError:
-        raise click.UsageError("The `datasets` package is required to load datasets. Install it with `pip install datasets`.")
+        raise click.UsageError(
+            "The `datasets` package is required to load datasets. Install it with `pip install datasets`."
+        )
 
     dataset = _load_dataset_for_training(
         dataset_path,
@@ -85,7 +87,9 @@ def explain_mask_command(
             continue
         spans = spans_from_prompt_mask(prompt_mask)
         loss_mask = [not m for m in prompt_mask]
-        explanation = explain_loss_mask(tokens, loss_mask, spans, tokenizer=tokenizer if show_text else None, show_text=show_text)
+        explanation = explain_loss_mask(
+            tokens, loss_mask, spans, tokenizer=tokenizer if show_text else None, show_text=show_text
+        )
         explanations.append((row_idx, explanation))
         row_idx += 1
 
@@ -103,24 +107,26 @@ def explain_mask_command(
 def _emit_json(explanations: list[tuple[int, LossMaskExplanation]]) -> None:
     rows = []
     for row_idx, exp in explanations:
-        rows.append({
-            "row": row_idx,
-            "total_tokens": exp.total_tokens,
-            "loss_tokens": exp.loss_tokens,
-            "spans": [
-                {
-                    "role": s.role,
-                    "start": s.start,
-                    "end": s.end,
-                    "loss": s.loss,
-                    "turn": s.turn,
-                    "token_count": s.end - s.start,
-                }
-                for s in exp.spans
-            ],
-            "summary": exp.summary,
-            "text_preview": exp.text_preview,
-        })
+        rows.append(
+            {
+                "row": row_idx,
+                "total_tokens": exp.total_tokens,
+                "loss_tokens": exp.loss_tokens,
+                "spans": [
+                    {
+                        "role": s.role,
+                        "start": s.start,
+                        "end": s.end,
+                        "loss": s.loss,
+                        "turn": s.turn,
+                        "token_count": s.end - s.start,
+                    }
+                    for s in exp.spans
+                ],
+                "summary": exp.summary,
+                "text_preview": exp.text_preview,
+            }
+        )
     click.echo(json.dumps({"rows": rows}, indent=2))
 
 

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -17,7 +17,11 @@ class ArenoCli(click.Group):
     _COMMANDS = {
         "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
-        "explain-mask": ("areno.cli.explain_mask", "explain_mask_command", "Explain SFT packer loss-mask: map tokens back to roles and counts."),
+        "explain-mask": (
+            "areno.cli.explain_mask",
+            "explain_mask_command",
+            "Explain SFT packer loss-mask: map tokens back to roles and counts.",
+        ),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -17,6 +17,7 @@ class ArenoCli(click.Group):
     _COMMANDS = {
         "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
+        "explain-mask": ("areno.cli.explain_mask", "explain_mask_command", "Explain SFT packer loss-mask: map tokens back to roles and counts."),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),

--- a/docs/cli/explain-mask.rst
+++ b/docs/cli/explain-mask.rst
@@ -1,0 +1,165 @@
+:orphan:
+
+Loss-mask explainer CLI reference
+==================================
+
+``areno explain-mask`` maps the token-level training mask produced by the SFT
+packer back to human-readable roles and statistics. It runs entirely on
+CPU — no model weights or GPU workers are loaded.
+
+Use it to inspect which parts of a packed sequence contribute to training loss
+before starting an expensive training run.
+
+.. code-block:: bash
+
+   areno explain-mask \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path /path/to/data.jsonl \
+     --dataset-loader-fn examples/sft/loader.py \
+     --max-rows 5
+
+Example output:
+
+.. code-block:: text
+
+   Row 0: total=52 tokens, loss=12 tokens
+
+     Span  Role      Start  End  Tokens  Loss
+     ─────────────────────────────────────────
+     0     prompt    0      40   40      No
+     1     response  40     52   12      Yes
+
+     Summary:
+       prompt:   40 tokens, 0 loss tokens
+       response: 12 tokens, 12 loss tokens
+
+Options
+-------
+
+``--ckpt`` (required)
+    Tokenizer or model checkpoint path. Loaded on CPU only; no CUDA or model
+    weights are initialized.
+
+``--dataset-path`` (required)
+    Dataset path in the same format as ``areno train``. Supports local JSONL,
+    JSON, Parquet, CSV, and HuggingFace ``save_to_disk`` directories, as well as
+    remote dataset references like ``gsm8k:main``.
+
+``--dataset-loader-fn`` (required)
+    Python file containing a loader function, same format as
+    ``areno train --dataset-loader-fn``. The function receives the raw dataset
+    and must return an iterable of records with ``prompt`` and ``response``
+    string fields.
+
+``--max-rows`` (default: 5)
+    Number of dataset rows to process.
+
+``--show-text``
+    Decode and display the text of each span. By default, span text is hidden
+    to avoid exposing full training samples.
+
+``--json``
+    Emit machine-readable JSON output instead of a terminal table.
+
+Output fields
+-------------
+
+Terminal output
+~~~~~~~~~~~~~~~
+
+Each row produces a table with one line per span:
+
+* **Span** — zero-based span index
+* **Role** — ``prompt`` or ``response`` (SFT packer)
+* **Start / End** — half-open token offsets within the packed sequence
+* **Tokens** — number of tokens in this span
+* **Loss** — ``Yes`` if the span contributes to training loss, ``No`` otherwise
+* **Text** — decoded span text (only when ``--show-text`` is passed)
+
+A summary section lists per-role token counts and loss token counts.
+
+JSON output
+~~~~~~~~~~~~
+
+When ``--json`` is passed, the output is a JSON object with a ``rows`` array.
+Each row contains:
+
+* ``row`` — zero-based row index
+* ``total_tokens`` — total number of tokens in the packed sequence
+* ``loss_tokens`` — number of tokens that contribute to loss
+* ``spans`` — array of span objects with ``role``, ``start``, ``end``,
+  ``loss``, ``turn``, and ``token_count``
+* ``summary`` — array of per-role statistics with ``role``, ``token_count``,
+  and ``loss_tokens``
+* ``text_preview`` — dictionary mapping span indices to decoded text, or
+  ``null`` when ``--show-text`` is not passed
+
+Minimal example
+---------------
+
+1. Create a small JSONL dataset:
+
+.. code-block:: bash
+
+   cat > /tmp/sft_demo.jsonl << 'EOF'
+   {"prompt": "What is 2+2?", "response": "4"}
+   {"prompt": "What is 3+3?", "response": "6"}
+   EOF
+
+2. Create a loader function:
+
+.. code-block:: bash
+
+   cat > /tmp/loader.py << 'EOF'
+   def load_training_dataset(dataset):
+       return dataset
+   EOF
+
+3. Run the explainer:
+
+.. code-block:: bash
+
+   areno explain-mask \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path /tmp/sft_demo.jsonl \
+     --dataset-loader-fn /tmp/loader.py
+
+SDK API
+-------
+
+For programmatic use, including Agentic packer output that cannot be run from
+the CLI without a model, use the SDK API:
+
+.. code-block:: python
+
+   from areno.api import explain_loss_mask, spans_from_prompt_mask, LossSpan
+
+   # SFT path: derive spans from prompt_mask
+   prompt_mask = [True, True, True, True, False, False, False]
+   tokens = [101, 102, 103, 104, 105, 106, 107]
+   loss_mask = [not m for m in prompt_mask]
+   spans = spans_from_prompt_mask(prompt_mask)
+
+   explanation = explain_loss_mask(tokens, loss_mask, spans)
+   print(f"total={explanation.total_tokens}, loss={explanation.loss_tokens}")
+   for span in explanation.spans:
+       print(f"  {span.role}: [{span.start}:{span.end}] loss={span.loss}")
+
+   # Agentic path: spans come from AgentTrainBatch.spans
+   # (populated by the agentic packer during rollout)
+   explanation = explain_loss_mask(
+       batch.token_rows[0],
+       batch.loss_masks[0],
+       batch.spans[0],
+   )
+
+Limitations
+-----------
+
+* The CLI supports **SFT packer** output only. Agentic packer output requires
+  model rollout and is accessible via the SDK API.
+* SFT prompt spans are labeled ``"prompt"`` as a whole. The SFT packer receives
+  plain text, so system-prompt vs. user-prompt segmentation is not available.
+* Agentic prompt spans are labeled ``"prompt"`` by default. Finer-grained
+  ``system_prompt`` / ``user_prompt`` segmentation requires per-message
+  tokenization and is not performed by default.

--- a/tests/test_loss_mask_explainer_cpu.py
+++ b/tests/test_loss_mask_explainer_cpu.py
@@ -1,0 +1,384 @@
+"""CPU tests for the human-readable loss-mask explainer (Issue #221).
+
+Covers:
+- SFT packer span derivation from prompt_mask
+- Agentic packer span construction with tool call / tool result splitting
+- Token-level equivalence between spans and masks
+- Boundary cases: all-masked, truncated
+- Invalid inputs: length mismatch, span gaps
+- show_text behaviour
+- Backward compatibility (AgentTrainBatch without spans)
+- CLI end-to-end (terminal + JSON)
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.api.data import LossMaskExplanation, LossSpan
+from areno.api.data_utils import spans_from_prompt_mask
+from areno.api.loss_mask_explainer import explain_loss_mask
+from areno.api.agentic import AgentTrainBatch, LossMaskPolicy
+
+
+class TestSpansFromPromptMask(unittest.TestCase):
+    """SFT span derivation from prompt_mask."""
+
+    def test_basic_prompt_then_response(self):
+        """Consecutive same values produce two spans."""
+        prompt_mask = [True, True, True, False, False]
+        spans = spans_from_prompt_mask(prompt_mask)
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(spans[0].role, "prompt")
+        self.assertEqual(spans[0].start, 0)
+        self.assertEqual(spans[0].end, 3)
+        self.assertFalse(spans[0].loss)
+        self.assertEqual(spans[1].role, "response")
+        self.assertEqual(spans[1].start, 3)
+        self.assertEqual(spans[1].end, 5)
+        self.assertTrue(spans[1].loss)
+
+    def test_all_prompt(self):
+        """All-prompt mask produces one span with loss=False."""
+        spans = spans_from_prompt_mask([True, True, True])
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].role, "prompt")
+        self.assertEqual(spans[0].start, 0)
+        self.assertEqual(spans[0].end, 3)
+        self.assertFalse(spans[0].loss)
+
+    def test_all_response(self):
+        """All-response mask produces one span with loss=True."""
+        spans = spans_from_prompt_mask([False, False])
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].role, "response")
+        self.assertEqual(spans[0].start, 0)
+        self.assertEqual(spans[0].end, 2)
+        self.assertTrue(spans[0].loss)
+
+    def test_empty_mask(self):
+        """Empty prompt_mask produces empty span list."""
+        self.assertEqual(spans_from_prompt_mask([]), [])
+
+
+class TestExplainSftEquivalence(unittest.TestCase):
+    """Token-level equivalence: span loss flags must match ~prompt_mask."""
+
+    def test_sft_equivalence(self):
+        """For each token position, span.loss == (not prompt_mask[i])."""
+        prompt_mask = [True, True, True, True, False, False, False, False, False]
+        tokens = list(range(9))
+        loss_mask = [not m for m in prompt_mask]
+        spans = spans_from_prompt_mask(prompt_mask)
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        # Reconstruct mask from spans and compare.
+        reconstructed = [False] * len(tokens)
+        for span in exp.spans:
+            for i in range(span.start, span.end):
+                reconstructed[i] = span.loss
+        self.assertEqual(reconstructed, loss_mask)
+        self.assertEqual(exp.total_tokens, 9)
+        self.assertEqual(exp.loss_tokens, 5)
+
+    def test_sft_summary(self):
+        """Summary contains per-role token and loss counts."""
+        prompt_mask = [True] * 4 + [False] * 6
+        tokens = list(range(10))
+        loss_mask = [not m for m in prompt_mask]
+        spans = spans_from_prompt_mask(prompt_mask)
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        roles = {e["role"]: e for e in exp.summary}
+        self.assertEqual(roles["prompt"]["token_count"], 4)
+        self.assertEqual(roles["prompt"]["loss_tokens"], 0)
+        self.assertEqual(roles["response"]["token_count"], 6)
+        self.assertEqual(roles["response"]["loss_tokens"], 6)
+
+
+class TestExplainAgenticEquivalence(unittest.TestCase):
+    """Agentic packer: span loss flags must match loss_masks."""
+
+    def test_agentic_single_turn_text(self):
+        """Single-turn assistant_text: prompt (loss=False) + response (loss=True)."""
+        tokens = list(range(20))
+        loss_mask = [False] * 8 + [True] * 12
+        spans = [
+            LossSpan(role="prompt", start=0, end=8, loss=False),
+            LossSpan(role="assistant_text", start=8, end=20, loss=True),
+        ]
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        reconstructed = [False] * len(tokens)
+        for span in exp.spans:
+            for i in range(span.start, span.end):
+                reconstructed[i] = span.loss
+        self.assertEqual(reconstructed, loss_mask)
+        self.assertEqual(exp.loss_tokens, 12)
+
+    def test_agentic_tool_call_with_tool_result(self):
+        """Tool call (loss=True) + tool result sentinel (loss=False) in one response."""
+        tokens = list(range(15))
+        # prompt=5, tool_call=4, tool_result=6
+        loss_mask = [False] * 5 + [True, True, True, True] + [False] * 6
+        spans = [
+            LossSpan(role="prompt", start=0, end=5, loss=False),
+            LossSpan(role="assistant_tool_call", start=5, end=9, loss=True),
+            LossSpan(role="tool_result", start=9, end=15, loss=False),
+        ]
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        reconstructed = [False] * len(tokens)
+        for span in exp.spans:
+            for i in range(span.start, span.end):
+                reconstructed[i] = span.loss
+        self.assertEqual(reconstructed, loss_mask)
+        roles = {e["role"]: e for e in exp.summary}
+        self.assertIn("assistant_tool_call", roles)
+        self.assertIn("tool_result", roles)
+        self.assertEqual(roles["tool_result"]["loss_tokens"], 0)
+
+    def test_agentic_multi_turn(self):
+        """Multi-turn: 2 assistant turns + 1 tool call + 1 tool result."""
+        tokens = list(range(30))
+        # turn 0: prompt(0-5), assistant_text(5-12)
+        # turn 1: assistant_tool_call(12-16), tool_result(16-22)
+        # turn 2: assistant_text(22-30)
+        loss_mask = (
+            [False] * 5          # prompt
+            + [True] * 7         # assistant_text turn 0
+            + [True] * 4         # assistant_tool_call turn 1
+            + [False] * 6        # tool_result turn 1
+            + [True] * 8         # assistant_text turn 2
+        )
+        spans = [
+            LossSpan(role="prompt", start=0, end=5, loss=False, turn=0),
+            LossSpan(role="assistant_text", start=5, end=12, loss=True, turn=0),
+            LossSpan(role="assistant_tool_call", start=12, end=16, loss=True, turn=1),
+            LossSpan(role="tool_result", start=16, end=22, loss=False, turn=1),
+            LossSpan(role="assistant_text", start=22, end=30, loss=True, turn=2),
+        ]
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        # Verify token-level equivalence.
+        reconstructed = [False] * len(tokens)
+        for span in exp.spans:
+            for i in range(span.start, span.end):
+                reconstructed[i] = span.loss
+        self.assertEqual(reconstructed, loss_mask)
+        # Verify all 4 roles appear (prompt + 3 response roles).
+        roles = {e["role"] for e in exp.summary}
+        self.assertIn("prompt", roles)
+        self.assertIn("assistant_text", roles)
+        self.assertIn("assistant_tool_call", roles)
+        self.assertIn("tool_result", roles)
+        # Verify turn numbers.
+        turns = {s.turn for s in exp.spans}
+        self.assertEqual(turns, {0, 1, 2})
+
+
+class TestBoundaryCases(unittest.TestCase):
+
+    def test_all_masked_sample(self):
+        """All loss=False: correct report of 0 loss tokens."""
+        tokens = list(range(10))
+        loss_mask = [False] * 10
+        spans = [LossSpan(role="prompt", start=0, end=10, loss=False)]
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        self.assertEqual(exp.loss_tokens, 0)
+        self.assertEqual(exp.total_tokens, 10)
+
+    def test_truncated_sample(self):
+        """Right-truncated sequence: spans clipped to token length."""
+        # Original 10 tokens, truncated to 6.
+        tokens = list(range(6))
+        loss_mask = [False, False, False, True, True, False]  # truncated loss_mask too
+        # Spans that would cover the original 10-token range.
+        spans = [
+            LossSpan(role="prompt", start=0, end=3, loss=False),
+            LossSpan(role="response", start=3, end=10, loss=True),  # extends beyond truncation
+        ]
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        # The response span should be clipped to end=6.
+        self.assertEqual(exp.spans[1].end, 6)
+        self.assertEqual(exp.total_tokens, 6)
+        # Token-level equivalence within the truncated range.
+        reconstructed = [False] * 6
+        for span in exp.spans:
+            for i in range(span.start, span.end):
+                reconstructed[i] = span.loss
+        # Spans say response is loss=True, but loss_mask says position 5 is False.
+        # The explainer reports spans, not masks — len(loss_mask)==len(tokens) is the invariant.
+        self.assertEqual(len(exp.spans), 2)
+
+
+class TestInvalidInputs(unittest.TestCase):
+
+    def test_length_mismatch(self):
+        """tokens and loss_mask with different lengths raise ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            explain_loss_mask([1, 2, 3], [True, False], [])
+        self.assertIn("length mismatch", str(ctx.exception))
+
+    def test_span_gap(self):
+        """Spans that don't cover [0, n) raise ValueError."""
+        tokens = list(range(5))
+        loss_mask = [True] * 5
+        spans = [
+            LossSpan(role="response", start=0, end=2, loss=True),
+            # Gap at positions 2-3.
+            LossSpan(role="response", start=4, end=5, loss=True),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            explain_loss_mask(tokens, loss_mask, spans)
+        self.assertIn("gap", str(ctx.exception))
+
+    def test_span_overlap(self):
+        """Overlapping spans raise ValueError."""
+        tokens = list(range(5))
+        loss_mask = [True] * 5
+        spans = [
+            LossSpan(role="response", start=0, end=3, loss=True),
+            LossSpan(role="response", start=2, end=5, loss=True),  # overlaps at 2
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            explain_loss_mask(tokens, loss_mask, spans)
+        self.assertIn("overlap", str(ctx.exception))
+
+
+class TestShowText(unittest.TestCase):
+
+    def test_show_text_false_omits_content(self):
+        """Default behaviour: text_preview is None."""
+        tokens = list(range(5))
+        loss_mask = [True] * 5
+        spans = [LossSpan(role="response", start=0, end=5, loss=True)]
+        exp = explain_loss_mask(tokens, loss_mask, spans)
+        self.assertIsNone(exp.text_preview)
+
+    def test_show_text_true_with_tokenizer(self):
+        """show_text=True with a tokenizer decodes span text."""
+        class FakeTokenizer:
+            def decode(self, token_ids):
+                return f"<decoded {len(token_ids)} tokens>"
+
+        tokens = list(range(8))
+        loss_mask = [False] * 3 + [True] * 5
+        spans = [
+            LossSpan(role="prompt", start=0, end=3, loss=False),
+            LossSpan(role="response", start=3, end=8, loss=True),
+        ]
+        exp = explain_loss_mask(tokens, loss_mask, spans, tokenizer=FakeTokenizer(), show_text=True)
+        self.assertIsNotNone(exp.text_preview)
+        self.assertIn(0, exp.text_preview)
+        self.assertIn(1, exp.text_preview)
+        self.assertEqual(exp.text_preview[0], "<decoded 3 tokens>")
+        self.assertEqual(exp.text_preview[1], "<decoded 5 tokens>")
+
+
+class TestBackwardCompatibility(unittest.TestCase):
+    """AgentTrainBatch must work without passing spans."""
+
+    def test_agent_train_batch_no_spans(self):
+        """Constructing AgentTrainBatch without spans yields empty list."""
+        batch = AgentTrainBatch(
+            token_rows=[[1, 2, 3]],
+            response_masks=[[False, True, True]],
+            loss_masks=[[False, True, True]],
+            rollout_logprobs=[[0.0, 0.1, 0.2]],
+            rewards=[1.0],
+            records=[{"id": 0}],
+            reward_records=[],
+        )
+        self.assertEqual(batch.spans, [])
+
+
+class TestCliExplainMask(unittest.TestCase):
+    """CLI end-to-end tests using CliRunner."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.dataset_path = None
+        self.loader_path = None
+
+    def _setup_fixture(self, tmp_path):
+        """Create a minimal local JSON dataset and loader."""
+        import json as json_mod
+
+        data = [
+            {"prompt": "What is 2+2?", "response": "4"},
+            {"prompt": "What is 3+3?", "response": "6"},
+        ]
+        dataset_file = tmp_path / "data.jsonl"
+        with dataset_file.open("w") as f:
+            for row in data:
+                f.write(json_mod.dumps(row) + "\n")
+
+        loader_file = tmp_path / "loader.py"
+        loader_file.write_text(
+            "def load_training_dataset(dataset):\n"
+            "    return dataset\n"
+        )
+        return str(dataset_file), str(loader_file)
+
+    @patch("areno.cli.explain_mask.load_tokenizer", create=True)
+    def test_cli_help(self, *args):
+        """--help produces output without error."""
+        from areno.cli.explain_mask import explain_mask_command
+        result = self.runner.invoke(explain_mask_command, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("explain-mask", result.output)
+
+    @patch("areno.cli.explain_mask.load_tokenizer", create=True)
+    def test_cli_missing_args(self, *args):
+        """Missing required args produces error."""
+        from areno.cli.explain_mask import explain_mask_command
+        result = self.runner.invoke(explain_mask_command, [])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_cli_json_output(self):
+        """CLI with --json produces valid JSON with expected structure."""
+        import tempfile
+
+        from areno.cli.explain_mask import explain_mask_command
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = __import__("pathlib").Path(tmp)
+            dataset_path, loader_path = self._setup_fixture(tmp_path)
+
+            # Mock the tokenizer and dataset loading.
+            class FakeTokenizer:
+                eos_token_id = 0
+                chat_template = None
+
+                def encode(self, text, add_special_tokens=False):
+                    return [ord(c) for c in text[:5]]
+
+            class FakeDataset:
+                def __iter__(self):
+                    return iter([
+                        {"prompt": "Hello", "response": "World"},
+                    ])
+
+            with patch("areno.cli.explain_mask.load_tokenizer", return_value=FakeTokenizer()), \
+                 patch("areno.cli.train._load_dataset_from_path", return_value=FakeDataset()):
+                from areno.cli.train import _load_dataset_loader_fn
+                with patch.object(_load_dataset_loader_fn, "__call__", return_value=lambda ds: ds):
+                    result = self.runner.invoke(explain_mask_command, [
+                        "--ckpt", "/fake/path",
+                        "--dataset-path", dataset_path,
+                        "--dataset-loader-fn", loader_path,
+                        "--json",
+                        "--max-rows", "1",
+                    ])
+            if result.exception:
+                import traceback
+                traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+            # The CLI may fail on the fake tokenizer, but we check for JSON structure.
+            # If it succeeds, validate JSON.
+            if result.exit_code == 0:
+                data = json.loads(result.output)
+                self.assertIn("rows", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_loss_mask_explainer_cpu.py
+++ b/tests/test_loss_mask_explainer_cpu.py
@@ -353,31 +353,31 @@ class TestCliExplainMask(unittest.TestCase):
                 def encode(self, text, add_special_tokens=False):
                     return [ord(c) for c in text[:5]]
 
-            class FakeDataset:
-                def __iter__(self):
-                    return iter([
-                        {"prompt": "Hello", "response": "World"},
-                    ])
+            fake_dataset = [
+                {"prompt": "Hello", "response": "World"},
+            ]
 
-            with patch("areno.cli.explain_mask.load_tokenizer", return_value=FakeTokenizer()), \
-                 patch("areno.cli.train._load_dataset_from_path", return_value=FakeDataset()):
-                from areno.cli.train import _load_dataset_loader_fn
-                with patch.object(_load_dataset_loader_fn, "__call__", return_value=lambda ds: ds):
-                    result = self.runner.invoke(explain_mask_command, [
-                        "--ckpt", "/fake/path",
-                        "--dataset-path", dataset_path,
-                        "--dataset-loader-fn", loader_path,
-                        "--json",
-                        "--max-rows", "1",
-                    ])
+            with patch("areno.api.tokenizer.load_tokenizer", return_value=FakeTokenizer()), \
+                 patch("areno.cli.train._load_dataset_for_training", return_value=fake_dataset):
+                result = self.runner.invoke(explain_mask_command, [
+                    "--ckpt", "/fake/path",
+                    "--dataset-path", dataset_path,
+                    "--dataset-loader-fn", loader_path,
+                    "--json",
+                    "--max-rows", "1",
+                ])
             if result.exception:
                 import traceback
                 traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
-            # The CLI may fail on the fake tokenizer, but we check for JSON structure.
-            # If it succeeds, validate JSON.
-            if result.exit_code == 0:
-                data = json.loads(result.output)
-                self.assertIn("rows", data)
+            self.assertEqual(result.exit_code, 0, f"CLI failed: {result.output}")
+            data = json.loads(result.output)
+            self.assertIn("rows", data)
+            self.assertEqual(len(data["rows"]), 1)
+            row = data["rows"][0]
+            self.assertIn("total_tokens", row)
+            self.assertIn("loss_tokens", row)
+            self.assertIn("spans", row)
+            self.assertIn("summary", row)
 
 
 if __name__ == "__main__":

--- a/tests/test_loss_mask_explainer_cpu.py
+++ b/tests/test_loss_mask_explainer_cpu.py
@@ -19,10 +19,10 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from areno.api.data import LossMaskExplanation, LossSpan
+from areno.api.agentic import AgentTrainBatch
+from areno.api.data import LossSpan
 from areno.api.data_utils import spans_from_prompt_mask
 from areno.api.loss_mask_explainer import explain_loss_mask
-from areno.api.agentic import AgentTrainBatch, LossMaskPolicy
 
 
 class TestSpansFromPromptMask(unittest.TestCase):
@@ -145,11 +145,11 @@ class TestExplainAgenticEquivalence(unittest.TestCase):
         # turn 1: assistant_tool_call(12-16), tool_result(16-22)
         # turn 2: assistant_text(22-30)
         loss_mask = (
-            [False] * 5          # prompt
-            + [True] * 7         # assistant_text turn 0
-            + [True] * 4         # assistant_tool_call turn 1
-            + [False] * 6        # tool_result turn 1
-            + [True] * 8         # assistant_text turn 2
+            [False] * 5  # prompt
+            + [True] * 7  # assistant_text turn 0
+            + [True] * 4  # assistant_tool_call turn 1
+            + [False] * 6  # tool_result turn 1
+            + [True] * 8  # assistant_text turn 2
         )
         spans = [
             LossSpan(role="prompt", start=0, end=5, loss=False, turn=0),
@@ -177,7 +177,6 @@ class TestExplainAgenticEquivalence(unittest.TestCase):
 
 
 class TestBoundaryCases(unittest.TestCase):
-
     def test_all_masked_sample(self):
         """All loss=False: correct report of 0 loss tokens."""
         tokens = list(range(10))
@@ -212,7 +211,6 @@ class TestBoundaryCases(unittest.TestCase):
 
 
 class TestInvalidInputs(unittest.TestCase):
-
     def test_length_mismatch(self):
         """tokens and loss_mask with different lengths raise ValueError."""
         with self.assertRaises(ValueError) as ctx:
@@ -246,7 +244,6 @@ class TestInvalidInputs(unittest.TestCase):
 
 
 class TestShowText(unittest.TestCase):
-
     def test_show_text_false_omits_content(self):
         """Default behaviour: text_preview is None."""
         tokens = list(range(5))
@@ -257,6 +254,7 @@ class TestShowText(unittest.TestCase):
 
     def test_show_text_true_with_tokenizer(self):
         """show_text=True with a tokenizer decodes span text."""
+
         class FakeTokenizer:
             def decode(self, token_ids):
                 return f"<decoded {len(token_ids)} tokens>"
@@ -314,16 +312,14 @@ class TestCliExplainMask(unittest.TestCase):
                 f.write(json_mod.dumps(row) + "\n")
 
         loader_file = tmp_path / "loader.py"
-        loader_file.write_text(
-            "def load_training_dataset(dataset):\n"
-            "    return dataset\n"
-        )
+        loader_file.write_text("def load_training_dataset(dataset):\n    return dataset\n")
         return str(dataset_file), str(loader_file)
 
     @patch("areno.cli.explain_mask.load_tokenizer", create=True)
     def test_cli_help(self, *args):
         """--help produces output without error."""
         from areno.cli.explain_mask import explain_mask_command
+
         result = self.runner.invoke(explain_mask_command, ["--help"])
         self.assertEqual(result.exit_code, 0)
         self.assertIn("explain-mask", result.output)
@@ -332,6 +328,7 @@ class TestCliExplainMask(unittest.TestCase):
     def test_cli_missing_args(self, *args):
         """Missing required args produces error."""
         from areno.cli.explain_mask import explain_mask_command
+
         result = self.runner.invoke(explain_mask_command, [])
         self.assertNotEqual(result.exit_code, 0)
 
@@ -357,17 +354,27 @@ class TestCliExplainMask(unittest.TestCase):
                 {"prompt": "Hello", "response": "World"},
             ]
 
-            with patch("areno.api.tokenizer.load_tokenizer", return_value=FakeTokenizer()), \
-                 patch("areno.cli.train._load_dataset_for_training", return_value=fake_dataset):
-                result = self.runner.invoke(explain_mask_command, [
-                    "--ckpt", "/fake/path",
-                    "--dataset-path", dataset_path,
-                    "--dataset-loader-fn", loader_path,
-                    "--json",
-                    "--max-rows", "1",
-                ])
+            with (
+                patch("areno.api.tokenizer.load_tokenizer", return_value=FakeTokenizer()),
+                patch("areno.cli.train._load_dataset_for_training", return_value=fake_dataset),
+            ):
+                result = self.runner.invoke(
+                    explain_mask_command,
+                    [
+                        "--ckpt",
+                        "/fake/path",
+                        "--dataset-path",
+                        dataset_path,
+                        "--dataset-loader-fn",
+                        loader_path,
+                        "--json",
+                        "--max-rows",
+                        "1",
+                    ],
+                )
             if result.exception:
                 import traceback
+
                 traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
             self.assertEqual(result.exit_code, 0, f"CLI failed: {result.output}")
             data = json.loads(result.output)


### PR DESCRIPTION
## What does this PR do?
- Add `LossSpan` and `LossMaskExplanation` data structures in `areno/api/data.py` for annotating token spans with role labels and loss flags
- Implement `explain_loss_mask` explainer in `areno/api/loss_mask_explainer.py` — consumes packer output (tokens, loss_mask, spans), produces structured report with per-role statistics, optional text preview
- Implement `spans_from_prompt_mask` in `areno/api/data_utils.py` — derives SFT spans directly from existing `prompt_mask`, zero changes to SFT packer
- Integrate span metadata into Agentic packer: add `spans` field to `AgentTrainBatch`, `_AgentTrainRows`, `_AgentSample`; add `_build_sample_spans` method that records span info alongside mask generation without modifying mask logic; handle multi-turn span offset in `_append_sample_response`
- Add `areno explain-mask` CLI command (SFT path, CPU-only, supports `--show-text` and `--json`)
- Add documentation in `docs/cli/explain-mask.rst`

## Related issue
Fixes #221

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?
Ran on Google Colab (Python 3.12.13, CPU-only, no GPU required):

```
pytest tests/test_loss_mask_explainer_cpu.py -v
```

Result: **20 passed in 5.45s**

Tests cover: SFT span derivation (4), SFT token-level equivalence (2), Agentic token-level equivalence including single-turn / tool-result split / multi-turn (3), boundary cases — all-masked and truncated (2), invalid inputs — length mismatch / span gap / span overlap (3), show_text privacy control (2), backward compatibility (1), CLI end-to-end — help / missing args / JSON output (3).

Also manually verified CLI with real tokenizer (`Qwen/Qwen3-0.6B`) producing both terminal table and JSON output, and SDK API for both SFT and Agentic paths.

## Checklist
- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).