### PR TITLE
feat: add completion-summary command for terminal completion quality reporting

### DIFF
--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -116,6 +116,7 @@ class AgentTrainBatch:
     rewards: list[float] | None
     records: list[dict[str, Any]]
     reward_records: list[RewardRecord]
+    filtered_count: int = 0
 
 
 @dataclass(slots=True)

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -218,6 +218,7 @@ class ArenoBackend(Backend):
                         RolloutSequence(
                             resp_tokens=tokens,
                             resp_logprobs=rollout.logprobs[i, : len(tokens)].tolist(),
+                            finish_reason=rollout.finish_reason[i] if i < len(rollout.finish_reason) else "",
                         )
                         for i, tokens in enumerate(rollout.response_ids[start:end], start=start)
                     ]
@@ -320,6 +321,7 @@ class ArenoBackend(Backend):
                         RolloutSequence(
                             resp_tokens=tokens,
                             resp_logprobs=rollout.logprobs[i, : len(tokens)].tolist(),
+                            finish_reason=rollout.finish_reason[i] if i < len(rollout.finish_reason) else "",
                         )
                         for i, tokens in enumerate(rollout.response_ids[start:end], start=start)
                     ]

--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -29,6 +29,7 @@ class MetricsRecorder:
         self._writer = create_tensorboard_writer(log_dir)
         self._state_file = self._log_dir / f"dashboard_state.{os.getpid()}.json"
         self._sample_file = self._log_dir / f"rollout_samples.{os.getpid()}.jsonl"
+        self._completion_summary_file = self._log_dir / f"completion_summary.{os.getpid()}.jsonl"
         self._closed = False
 
     def record_train_step(self, *, step: int, train_result, train_batch, timings: dict[str, float] | None = None):
@@ -47,6 +48,14 @@ class MetricsRecorder:
         sample.setdefault("pid", os.getpid())
         with self._sample_file.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    def record_completion_summary(self, summary: dict) -> None:
+        """Record a per-step completion quality summary as JSONL."""
+
+        summary = dict(summary)
+        summary.setdefault("pid", os.getpid())
+        with self._completion_summary_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(summary, ensure_ascii=False) + "\n")
 
     def record_dashboard_state(
         self,
@@ -219,3 +228,24 @@ def record_training_stats(writer, stats, step, train_res, train_batch, timings: 
         if key in metric_timings:
             writer.add_scalar(f"time/{key}", metric_timings[key], step)
     writer.flush()
+
+
+def compute_percentile(sorted_values: list[float] | list[int], fraction: float) -> float:
+    """Compute the *fraction*-th percentile from a pre-sorted list.
+
+    ``fraction`` uses the [0, 1] convention (0.50 = median).  Returns 0.0
+    for an empty list so callers don't have to guard against empty inputs
+    separately.
+    """
+
+    if not sorted_values:
+        return 0.0
+    n = len(sorted_values)
+    if n == 1:
+        return float(sorted_values[0])
+    # Linear-interpolation rank (same convention as numpy's default).
+    rank = fraction * (n - 1)
+    lo = int(rank)
+    hi = min(lo + 1, n - 1)
+    frac = rank - lo
+    return float(sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac)

--- a/areno/api/models.py
+++ b/areno/api/models.py
@@ -55,6 +55,7 @@ class RolloutSequence(BaseModel):
 
     resp_tokens: list[int] = Field(default_factory=list)
     resp_logprobs: list[float] = Field(default_factory=list)
+    finish_reason: str = Field(default="")
 
 
 class RolloutResult(BaseModel):

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -362,6 +362,12 @@ class Trainer:
         if self._metrics is not None:
             self._metrics.record_rollout_sample(sample)
 
+    def record_completion_summary(self, summary: dict[str, Any]) -> None:
+        """Persist a per-step completion quality summary when metrics recording is enabled."""
+
+        if self._metrics is not None:
+            self._metrics.record_completion_summary(summary)
+
     def record_dashboard_state(
         self,
         *,

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -82,20 +82,28 @@ class PolicyOnlyTrainer:
                 self._dashboard_epoch = epoch
                 self._dashboard_step = step
                 if self._agentic_enabled():
+                    rollout_start = time.perf_counter()
                     agent_batch = asyncio.run(self._run_agentic_rollout(sampling_params, prompt_batch))
+                    rollout_time_s = time.perf_counter() - rollout_start
                     self.logger.info("epoch=%d step=%d role=%s stage=rollout_end", epoch, step, role)
                     record_dashboard_state(self.areno, stage="rollout_end", epoch=epoch, step=step, role=role)
                     self._log_agentic_sample_completions(epoch, step, agent_batch)
+                    summary = self._compute_agentic_completion_summary(epoch, step, agent_batch, rollout_time_s)
+                    self.areno.record_completion_summary(summary)
                     train_batch, rewards_all, rollout_logprobs = self._materialize_agentic_train_batch(
                         tokenizer, prompt_batch, agent_batch
                     )
                 else:
                     # 1) Sample n_samples completions per prompt; ordering
                     #    matches `prompt_batch.items` so we can zip downstream.
+                    rollout_start = time.perf_counter()
                     rollout_results = asyncio.run(self._run_prompt_rollout(sampling_params, prompt_batch))
+                    rollout_time_s = time.perf_counter() - rollout_start
                     self.logger.info("epoch=%d step=%d role=%s stage=rollout_end", epoch, step, role)
                     record_dashboard_state(self.areno, stage="rollout_end", epoch=epoch, step=step, role=role)
                     self._record_sample_completions(tokenizer, epoch, step, prompt_batch, rollout_results)
+                    summary = self._compute_single_turn_completion_summary(epoch, step, rollout_results, rollout_time_s)
+                    self.areno.record_completion_summary(summary)
 
                     # 2+3) Score rewards and broadcast group-normalised
                     #      advantages down to per-token tensors.
@@ -263,6 +271,7 @@ class PolicyOnlyTrainer:
                 rewards=rewards,
                 records=[sample.item.record for sample in samples],
                 reward_records=reward_records,
+                filtered_count=filtered_count,
             )
 
     def _filter_overlong_agent_samples(self, ctx, samples, sampling_params):
@@ -444,6 +453,89 @@ class PolicyOnlyTrainer:
                 )
             )
         return train_batch, rewards_all, rollout_logprobs
+
+    def _compute_single_turn_completion_summary(
+        self, epoch: int, step: int, rollout_results, rollout_time_s: float
+    ) -> dict:
+        """Compute per-step completion quality stats for single-turn rollouts."""
+
+        completion_lengths: list[int] = []
+        finish_reasons: list[str] = []
+        for result in rollout_results:
+            for seq in result.sequences:
+                completion_lengths.append(len(seq.resp_tokens))
+                finish_reasons.append(seq.finish_reason or "unknown")
+        total_completions = len(completion_lengths)
+        total_generated_tokens = sum(completion_lengths)
+        empty_count = sum(1 for length in completion_lengths if length == 0)
+        length_limit_count = sum(1 for fr in finish_reasons if fr == "length")
+        stop_count = sum(1 for fr in finish_reasons if fr == "stop")
+        tool_calls_count = sum(1 for fr in finish_reasons if fr == "tool_calls")
+        sorted_lengths = sorted(completion_lengths)
+        tokens_per_second = total_generated_tokens / rollout_time_s if rollout_time_s > 0 else 0.0
+        return {
+            "epoch": epoch,
+            "step": step,
+            "kind": "rollout",
+            "total_completions": total_completions,
+            "total_generated_tokens": total_generated_tokens,
+            "empty_count": empty_count,
+            "length_limit_count": length_limit_count,
+            "stop_count": stop_count,
+            "tool_calls_count": tool_calls_count,
+            "filtered_count": 0,
+            "completion_length_min": min(completion_lengths) if completion_lengths else 0,
+            "completion_length_max": max(completion_lengths) if completion_lengths else 0,
+            "completion_length_mean": float(np.mean(completion_lengths)) if completion_lengths else 0.0,
+            "completion_length_p50": self._percentile_value(sorted_lengths, 0.50),
+            "completion_length_p90": self._percentile_value(sorted_lengths, 0.90),
+            "completion_lengths": completion_lengths,
+            "rollout_time_s": rollout_time_s,
+            "tokens_per_second": tokens_per_second,
+        }
+
+    def _compute_agentic_completion_summary(
+        self, epoch: int, step: int, agent_batch, rollout_time_s: float
+    ) -> dict:
+        """Compute per-step completion quality stats for agentic rollouts."""
+
+        completion_lengths: list[int] = []
+        for loss_mask in agent_batch.loss_masks:
+            completion_lengths.append(sum(1 for enabled in loss_mask if enabled))
+        total_completions = len(completion_lengths)
+        total_generated_tokens = sum(completion_lengths)
+        empty_count = sum(1 for length in completion_lengths if length == 0)
+        filtered_count = getattr(agent_batch, "filtered_count", 0)
+        # Approximate length-limit detection: compare trajectory token length
+        # to the configured max context length.
+        max_ctx = self._agent_model_context_len()
+        length_limit_count = 0
+        if max_ctx is not None:
+            for token_row in agent_batch.token_rows:
+                if len(token_row) >= max_ctx:
+                    length_limit_count += 1
+        sorted_lengths = sorted(completion_lengths)
+        tokens_per_second = total_generated_tokens / rollout_time_s if rollout_time_s > 0 else 0.0
+        return {
+            "epoch": epoch,
+            "step": step,
+            "kind": "agentic",
+            "total_completions": total_completions,
+            "total_generated_tokens": total_generated_tokens,
+            "empty_count": empty_count,
+            "length_limit_count": length_limit_count,
+            "stop_count": -1,
+            "tool_calls_count": -1,
+            "filtered_count": filtered_count,
+            "completion_length_min": min(completion_lengths) if completion_lengths else 0,
+            "completion_length_max": max(completion_lengths) if completion_lengths else 0,
+            "completion_length_mean": float(np.mean(completion_lengths)) if completion_lengths else 0.0,
+            "completion_length_p50": self._percentile_value(sorted_lengths, 0.50),
+            "completion_length_p90": self._percentile_value(sorted_lengths, 0.90),
+            "completion_lengths": completion_lengths,
+            "rollout_time_s": rollout_time_s,
+            "tokens_per_second": tokens_per_second,
+        }
 
     def _record_sample_completions(self, tokenizer, epoch: int, step: int, prompt_batch, rollout_results) -> None:
         # Diagnostics knob: setting ARENO_LOG_COMPLETIONS=N records up to N

--- a/areno/cli/completion_summary.py
+++ b/areno/cli/completion_summary.py
@@ -1,0 +1,358 @@
+"""CLI command for summarising completion quality from metrics artifacts.
+
+Reads ``completion_summary.{pid}.jsonl`` (primary) or ``rollout_samples.{pid}.jsonl``
+(fallback) from a metrics log directory and reports completion-length
+distribution, empty count, length-limit count, filtered count, and generated
+tokens per second, distinguishing single-turn and agentic generation.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import click
+
+from areno.api.metrics import compute_percentile
+
+
+# ---------------------------------------------------------------------------
+# Loading helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FIELDS = {
+    "total_completions": 0,
+    "total_generated_tokens": 0,
+    "empty_count": 0,
+    "length_limit_count": 0,
+    "stop_count": -1,
+    "tool_calls_count": -1,
+    "filtered_count": 0,
+    "completion_length_min": 0,
+    "completion_length_max": 0,
+    "completion_length_mean": 0.0,
+    "completion_length_p50": 0,
+    "completion_length_p90": 0,
+    "completion_lengths": [],
+    "rollout_time_s": 0.0,
+    "tokens_per_second": 0.0,
+}
+
+
+def _fill_defaults(record: dict) -> dict:
+    """Fill missing fields with safe defaults so old records don't crash."""
+    filled = dict(_DEFAULT_FIELDS)
+    filled.update(record)
+    return filled
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return records
+
+
+def _load_completion_summary_files(log_dir: Path, pid: int | None) -> tuple[list[dict], str]:
+    """Load per-step completion quality summaries.
+
+    Returns ``(records, source_type)`` where *source_type* is either
+    ``"completion_summary"`` or ``"rollout_samples"`` (fallback).
+    """
+
+    if pid is not None:
+        candidate = log_dir / f"completion_summary.{pid}.jsonl"
+        files = [candidate] if candidate.exists() else []
+    else:
+        files = sorted(log_dir.glob("completion_summary.*.jsonl"))
+    if files:
+        records = []
+        for f in files:
+            records.extend(_fill_defaults(r) for r in _load_jsonl(f))
+        return records, "completion_summary"
+
+    # Fallback: aggregate from rollout_samples JSONL.
+    if pid is not None:
+        candidate = log_dir / f"rollout_samples.{pid}.jsonl"
+        files = [candidate] if candidate.exists() else []
+    else:
+        files = sorted(log_dir.glob("rollout_samples.*.jsonl"))
+    if files:
+        records = []
+        for f in files:
+            records.extend(_rollout_samples_to_summaries(_load_jsonl(f)))
+        return records, "rollout_samples"
+
+    return [], "none"
+
+
+def _rollout_samples_to_summaries(samples: list[dict]) -> list[dict]:
+    """Aggregate raw rollout_samples entries into per-step summaries.
+
+    This is a *fallback* path for runs that pre-date
+    ``completion_summary`` files.  Because ``response_tokens`` is truncated
+    to 64 in the sample log and only a limited number of samples are
+    recorded per step, the numbers are approximate.
+    """
+
+    by_step: dict[tuple[int, int, str], list[dict]] = {}
+    for sample in samples:
+        kind = sample.get("kind", "rollout")
+        epoch = int(sample.get("epoch", 0))
+        step = int(sample.get("step", 0))
+        key = (epoch, step, kind)
+        by_step.setdefault(key, []).append(sample)
+
+    records = []
+    for (epoch, step, kind), group in sorted(by_step.items(), key=lambda kv: (kv[0][0], kv[0][1])):
+        completion_lengths = []
+        empty_count = 0
+        length_limit_count = 0
+        for s in group:
+            # Prefer response_len (new field); fall back to response_tokens
+            # length (truncated to 64, hence approximate).
+            if "response_len" in s:
+                rlen = int(s["response_len"])
+            else:
+                rlen = len(s.get("response_tokens", []))
+            completion_lengths.append(rlen)
+            if rlen == 0:
+                empty_count += 1
+            fr = s.get("finish_reason", "")
+            if fr == "length":
+                length_limit_count += 1
+        sorted_lengths = sorted(completion_lengths)
+        records.append(
+            {
+                "epoch": epoch,
+                "step": step,
+                "kind": kind,
+                "total_completions": len(group),
+                "total_generated_tokens": sum(completion_lengths),
+                "empty_count": empty_count,
+                "length_limit_count": length_limit_count,
+                "stop_count": -1,
+                "tool_calls_count": -1,
+                "filtered_count": 0,
+                "completion_length_min": min(completion_lengths) if completion_lengths else 0,
+                "completion_length_max": max(completion_lengths) if completion_lengths else 0,
+                "completion_length_mean": float(sum(completion_lengths) / len(completion_lengths))
+                if completion_lengths
+                else 0.0,
+                "completion_length_p50": int(compute_percentile(sorted_lengths, 0.50)),
+                "completion_length_p90": int(compute_percentile(sorted_lengths, 0.90)),
+                "completion_lengths": completion_lengths,
+                "rollout_time_s": 0.0,
+                "tokens_per_second": 0.0,
+            }
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_kind(records: list[dict]) -> dict | None:
+    """Aggregate all per-step records of one kind into an overall summary."""
+    if not records:
+        return None
+    total_completions = sum(r.get("total_completions", 0) for r in records)
+    total_generated_tokens = sum(r.get("total_generated_tokens", 0) for r in records)
+    empty_count = sum(r.get("empty_count", 0) for r in records)
+    length_limit_count = sum(r.get("length_limit_count", 0) for r in records)
+    stop_count = sum(max(r.get("stop_count", -1), 0) for r in records)
+    tool_calls_count = sum(max(r.get("tool_calls_count", -1), 0) for r in records)
+    filtered_count = sum(r.get("filtered_count", 0) for r in records)
+
+    all_lengths: list[int] = []
+    total_rollout_time = 0.0
+    for r in records:
+        lengths = r.get("completion_lengths", [])
+        all_lengths.extend(l for l in lengths if isinstance(l, (int, float)))
+        total_rollout_time += float(r.get("rollout_time_s", 0.0))
+
+    sorted_lengths = sorted(all_lengths)
+    tokens_per_second = total_generated_tokens / total_rollout_time if total_rollout_time > 0 else 0.0
+
+    return {
+        "num_steps": len(records),
+        "total_completions": total_completions,
+        "total_generated_tokens": total_generated_tokens,
+        "empty_count": empty_count,
+        "length_limit_count": length_limit_count,
+        "stop_count": stop_count,
+        "tool_calls_count": tool_calls_count,
+        "filtered_count": filtered_count,
+        "completion_length": {
+            "min": min(sorted_lengths) if sorted_lengths else 0,
+            "max": max(sorted_lengths) if sorted_lengths else 0,
+            "mean": float(sum(sorted_lengths) / len(sorted_lengths)) if sorted_lengths else 0.0,
+            "p50": int(compute_percentile(sorted_lengths, 0.50)),
+            "p90": int(compute_percentile(sorted_lengths, 0.90)),
+        },
+        "tokens_per_second": round(tokens_per_second, 1),
+        "total_rollout_time_s": round(total_rollout_time, 3),
+    }
+
+
+def _aggregate_overall(records: list[dict]) -> dict:
+    rollout_records = [r for r in records if r.get("kind") == "rollout"]
+    agentic_records = [r for r in records if r.get("kind") == "agentic"]
+    return {
+        "rollout": _aggregate_kind(rollout_records),
+        "agentic": _aggregate_kind(agentic_records),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Human-readable formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_overall_section(label: str, overall: dict, *, color: bool = True) -> str:
+    if overall is None:
+        line = f"  {label}: (none)"
+        return click.style(line, fg="white", dim=True) if color else line
+
+    lines = [click.style(f"{label}", fg="cyan", bold=True) if color else f"{label}"]
+    metrics = [
+        ("Steps", overall["num_steps"]),
+        ("Total completions", overall["total_completions"]),
+        ("Total generated tokens", f"{overall['total_generated_tokens']:,}"),
+        ("Empty count", overall["empty_count"]),
+        ("Length-limit count", overall["length_limit_count"]),
+        ("Stop count", overall["stop_count"] if overall["stop_count"] >= 0 else "N/A"),
+        ("Tool-calls count", overall["tool_calls_count"] if overall["tool_calls_count"] >= 0 else "N/A"),
+        ("Filtered count", overall["filtered_count"]),
+    ]
+    cl = overall["completion_length"]
+    metrics.append(("Length (min/p50/p90/max)", f"{cl['min']}/{cl['p50']}/{cl['p90']}/{cl['max']}"))
+    metrics.append(("Mean length", f"{cl['mean']:.1f}"))
+    if overall["tokens_per_second"] > 0:
+        metrics.append(("Tokens per second", f"{overall['tokens_per_second']:.1f}"))
+    else:
+        metrics.append(("Tokens per second", "N/A"))
+    for key, value in metrics:
+        lines.append(f"  {key:<24} {value}")
+    return "\n".join(lines)
+
+
+def _format_completion_summary_table(records: list[dict], *, color: bool = True) -> str:
+    if not records:
+        line = "  (no per-step records)"
+        return click.style(line, fg="white", dim=True) if color else line
+
+    header = f"  {'Step':<6} {'Kind':<9} {'Comps':<6} {'Empty':<7} {'Len-Lim':<8} {'Filt':<6} {'Mean':<7} {'P50':<5} {'P90':<5} {'Tok/s':<7}"
+    sep = f"  {'-' * 6} {'-' * 9} {'-' * 6} {'-' * 7} {'-' * 8} {'-' * 6} {'-' * 7} {'-' * 5} {'-' * 5} {'-' * 7}"
+    lines = [header, sep]
+    for r in records:
+        tps = f"{r.get('tokens_per_second', 0.0):.1f}" if r.get("tokens_per_second", 0.0) > 0 else "N/A"
+        stop = "N/A" if r.get("stop_count", -1) < 0 else r.get("stop_count", 0)
+        row = (
+            f"  {r.get('step', 0):<6} {r.get('kind', '?'):<9} "
+            f"{r.get('total_completions', 0):<6} {r.get('empty_count', 0):<7} "
+            f"{r.get('length_limit_count', 0):<8} {r.get('filtered_count', 0):<6} "
+            f"{r.get('completion_length_mean', 0.0):<7.1f} "
+            f"{r.get('completion_length_p50', 0):<5} "
+            f"{r.get('completion_length_p90', 0):<5} {tps:<7}"
+        )
+        lines.append(row)
+
+    # Truncate to terminal width if necessary.
+    term_width = shutil.get_terminal_size((120, 24)).columns
+    if term_width < 120:
+        return "\n".join(lines)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Click command
+# ---------------------------------------------------------------------------
+
+@click.command(
+    name="completion-summary",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--metrics-log-dir",
+    "log_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    required=True,
+    help="Directory containing AReno metrics artifacts.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit machine-readable JSON instead of a human-readable table.",
+)
+@click.option(
+    "--pid",
+    type=int,
+    default=None,
+    help="Filter by process ID. If omitted, reads all matching files.",
+)
+def completion_summary_command(log_dir: Path, as_json: bool, pid: int | None) -> None:
+    """Summarise completion quality from a metrics log directory.
+
+    Reports completion-length distribution, empty count, length-limit count,
+    filtered count, and generated tokens per second per update, distinguishing
+    single-turn (rollout) and agentic generation.
+
+    Primary data source is ``completion_summary.{pid}.jsonl``. If that file is
+    absent, the command falls back to ``rollout_samples.{pid}.jsonl`` with
+    reduced fidelity (response tokens are truncated to 64 in samples and only
+    a limited number of completions are logged per step).
+    """
+
+    records, source = _load_completion_summary_files(log_dir, pid)
+    if not records:
+        raise click.UsageError(
+            f"No completion_summary or rollout_samples files found in {log_dir}."
+            " Run a training job with AReno first."
+        )
+
+    overall = _aggregate_overall(records)
+
+    if as_json:
+        output = {
+            "overall": overall,
+            "per_step": records,
+            "source": source,
+        }
+        click.echo(json.dumps(output, indent=2, sort_keys=True, default=str))
+        return
+
+    # Human-readable output.
+    rollout_summary = overall.get("rollout")
+    agentic_summary = overall.get("agentic")
+    num_rollout_steps = rollout_summary["num_steps"] if rollout_summary else 0
+    num_agentic_steps = agentic_summary["num_steps"] if agentic_summary else 0
+
+    click.echo()
+    click.echo(click.style("Completion Quality Summary", bold=True))
+    click.echo(f"  Metrics directory: {log_dir}")
+    click.echo(f"  Source: {source}")
+    click.echo(f"  Steps: {len(records)} (rollout: {num_rollout_steps}, agentic: {num_agentic_steps})")
+    click.echo()
+
+    if rollout_summary:
+        click.echo(_format_overall_section("Single-turn (rollout)", rollout_summary, color=True))
+        click.echo()
+    if agentic_summary:
+        click.echo(_format_overall_section("Agentic", agentic_summary, color=True))
+        click.echo()
+
+    click.echo("Per-step detail")
+    click.echo(_format_completion_summary_table(records, color=True))
+    click.echo()

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -17,6 +17,7 @@ class ArenoCli(click.Group):
     _COMMANDS = {
         "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
+        "completion-summary": ("areno.cli.completion_summary", "completion_summary_command", "Summarize completion quality from a metrics log directory."),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),

--- a/docs/cli/observability.rst
+++ b/docs/cli/observability.rst
@@ -175,3 +175,86 @@ When a trajectory is dropped for exceeding the model context window,
 counts, message counts, assistant turn counts, tool-result counts, and a short
 prompt preview. This is the fastest way to debug overlong agentic examples
 without dumping every token in every trajectory.
+
+Completion quality summary
+--------------------------
+
+After a training run, use ``areno completion-summary`` to report
+completion-length distribution, empty count, length-limit count, filtered
+count, and generated tokens per second per update, distinguishing single-turn
+(``rollout``) and agentic generation.
+
+.. code-block:: bash
+
+   areno completion-summary --metrics-log-dir /tmp/areno/tfevent
+
+Add ``--json`` for machine-readable output:
+
+.. code-block:: bash
+
+   areno completion-summary --metrics-log-dir /tmp/areno/tfevent --json
+
+Use ``--pid`` to filter by process ID when multiple runs share the same
+metrics directory:
+
+.. code-block:: bash
+
+   areno completion-summary --metrics-log-dir /tmp/areno/tfevent --pid 12345
+
+The primary data source is ``completion_summary.{pid}.jsonl``, written by
+``MetricsRecorder.record_completion_summary()`` after each rollout step.
+Each line is a JSON object with the following fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - ``epoch`` / ``step``
+     - Epoch and global step index.
+   * - ``kind``
+     - ``"rollout"`` (single-turn) or ``"agentic"``.
+   * - ``total_completions``
+     - Number of completions generated in this step.
+   * - ``total_generated_tokens``
+     - Sum of all completion token lengths.
+   * - ``empty_count``
+     - Completions with zero response tokens.
+   * - ``length_limit_count``
+     - Completions whose ``finish_reason`` is ``"length"`` (hit
+       ``max_new_tokens`` without a stop token). For agentic, this is an
+       approximate count based on trajectory context length.
+   * - ``stop_count``
+     - Completions with ``finish_reason == "stop"``. Set to ``-1`` for
+       agentic (per-turn finish reasons are not tracked in v1).
+   * - ``tool_calls_count``
+     - Completions with ``finish_reason == "tool_calls"``. Set to ``-1``
+       for agentic.
+   * - ``filtered_count``
+     - Agentic samples dropped for exceeding ``max_context_len``. Always
+       ``0`` for single-turn.
+   * - ``completion_length_min`` / ``_max`` / ``_mean`` / ``_p50`` / ``_p90``
+     - Distribution of completion lengths.
+   * - ``completion_lengths``
+     - Full per-completion length list (for cross-step aggregation).
+   * - ``rollout_time_s``
+     - Wall-clock time for the rollout phase of this step.
+   * - ``tokens_per_second``
+     - ``total_generated_tokens / rollout_time_s``.
+
+**Fallback mode.** If ``completion_summary.*.jsonl`` is absent (e.g. from
+runs before this feature was added), the command falls back to
+``rollout_samples.{pid}.jsonl`` and computes partial statistics. Because
+``response_tokens`` is truncated to 64 in the sample log and only a limited
+number of completions are recorded per step, length numbers are approximate
+and unavailable fields are reported as ``N/A``.
+
+**Limitations.**
+
+- Agentic ``stop_count`` and ``tool_calls_count`` are not tracked in v1
+  because per-turn ``finish_reason`` is not propagated through the agentic
+  rollout path.
+- The command reads from local JSONL files only; no external database or
+  sandbox is required.
+- Completion text is never printed — only counts and length distributions.

--- a/tests/test_completion_summary_cpu.py
+++ b/tests/test_completion_summary_cpu.py
@@ -1,0 +1,511 @@
+"""CPU tests for the completion-quality summary feature.
+
+Covers:
+- Data model changes (RolloutSequence.finish_reason, AgentTrainBatch.filtered_count).
+- Trainer-side stat computation (_compute_single_turn / _compute_agentic).
+- CLI loading, aggregation, fallback, and output formatting.
+- MetricsRecorder.record_completion_summary file I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from areno.api import metrics as metrics_mod
+from areno.api.metrics import MetricsRecorder, compute_percentile
+from areno.api.models import RolloutSequence, RolloutResult
+from areno.cli import completion_summary as cs_mod
+from areno.cli.completion_summary import completion_summary_command
+from areno.cli.main import main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_rollout_result(num_seqs: int, lengths: list[int], finish_reasons: list[str]) -> RolloutResult:
+    seqs = []
+    for i in range(num_seqs):
+        seqs.append(
+            RolloutSequence(
+                resp_tokens=list(range(lengths[i])),
+                resp_logprobs=[0.0] * lengths[i],
+                finish_reason=finish_reasons[i],
+            )
+        )
+    return RolloutResult(sequences=seqs)
+
+
+class _AgentBatchStub:
+    """Minimal stand-in for AgentTrainBatch."""
+
+    def __init__(self, loss_masks, token_rows=None, filtered_count=0):
+        self.loss_masks = loss_masks
+        self.token_rows = token_rows or ([[]] * len(loss_masks))
+        self.filtered_count = filtered_count
+        self.reward_records = []
+
+
+class _TrainerStub:
+    """Minimal object exposing _percentile_value and _agent_model_context_len."""
+
+    def _percentile_value(self, sorted_values, fraction):
+        if not sorted_values:
+            return 0
+        index = min(int(round((len(sorted_values) - 1) * fraction)), len(sorted_values) - 1)
+        return int(sorted_values[index])
+
+    def _agent_model_context_len(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Data model tests
+# ---------------------------------------------------------------------------
+
+class FinishReasonModelTest(unittest.TestCase):
+
+    def test_rollout_sequence_has_finish_reason_field(self):
+        seq = RolloutSequence(resp_tokens=[1, 2], resp_logprobs=[0.0, 0.0], finish_reason="length")
+        self.assertEqual(seq.finish_reason, "length")
+
+    def test_rollout_sequence_finish_reason_defaults_empty(self):
+        seq = RolloutSequence(resp_tokens=[1])
+        self.assertEqual(seq.finish_reason, "")
+
+
+class AgentTrainBatchFilteredCountTest(unittest.TestCase):
+
+    def test_default_filtered_count_is_zero(self):
+        from areno.api.agentic import AgentTrainBatch
+
+        batch = AgentTrainBatch(
+            token_rows=[],
+            response_masks=[],
+            loss_masks=[],
+            rollout_logprobs=[],
+            rewards=[],
+            records=[],
+            reward_records=[],
+        )
+        self.assertEqual(batch.filtered_count, 0)
+
+    def test_filtered_count_set(self):
+        from areno.api.agentic import AgentTrainBatch
+
+        batch = AgentTrainBatch(
+            token_rows=[],
+            response_masks=[],
+            loss_masks=[],
+            rollout_logprobs=[],
+            rewards=[],
+            records=[],
+            reward_records=[],
+            filtered_count=5,
+        )
+        self.assertEqual(batch.filtered_count, 5)
+
+
+# ---------------------------------------------------------------------------
+# Trainer-side computation tests
+# ---------------------------------------------------------------------------
+
+class SingleTurnSummaryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.stub = _TrainerStub()
+        # Bind the real method from PolicyOnlyTrainer.
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        self._compute = PolicyOnlyTrainer._compute_single_turn_completion_summary.__get__(self.stub)
+
+    def test_counts_finish_reasons(self):
+        result = _make_rollout_result(
+            6,
+            lengths=[0, 10, 20, 30, 0, 40],
+            finish_reasons=["stop", "stop", "length", "stop", "length", "tool_calls"],
+        )
+        summary = self._compute(epoch=0, step=0, rollout_results=[result], rollout_time_s=10.0)
+        self.assertEqual(summary["total_completions"], 6)
+        self.assertEqual(summary["empty_count"], 2)
+        self.assertEqual(summary["length_limit_count"], 2)
+        self.assertEqual(summary["stop_count"], 3)
+        self.assertEqual(summary["tool_calls_count"], 1)
+        self.assertEqual(summary["filtered_count"], 0)
+
+    def test_all_empty_completions(self):
+        result = _make_rollout_result(
+            4, lengths=[0, 0, 0, 0], finish_reasons=["length", "length", "length", "length"]
+        )
+        summary = self._compute(epoch=0, step=0, rollout_results=[result], rollout_time_s=5.0)
+        self.assertEqual(summary["empty_count"], 4)
+        self.assertEqual(summary["total_generated_tokens"], 0)
+
+    def test_tokens_per_second(self):
+        result = _make_rollout_result(2, lengths=[100, 200], finish_reasons=["stop", "stop"])
+        summary = self._compute(epoch=0, step=0, rollout_results=[result], rollout_time_s=10.0)
+        self.assertAlmostEqual(summary["tokens_per_second"], 30.0, places=1)
+
+    def test_tokens_per_second_zero_rollout_time(self):
+        result = _make_rollout_result(2, lengths=[100, 200], finish_reasons=["stop", "stop"])
+        summary = self._compute(epoch=0, step=0, rollout_results=[result], rollout_time_s=0.0)
+        self.assertEqual(summary["tokens_per_second"], 0.0)
+
+    def test_length_distribution(self):
+        result = _make_rollout_result(3, lengths=[10, 50, 100], finish_reasons=["stop", "stop", "stop"])
+        summary = self._compute(epoch=0, step=0, rollout_results=[result], rollout_time_s=1.0)
+        self.assertEqual(summary["completion_length_min"], 10)
+        self.assertEqual(summary["completion_length_max"], 100)
+        self.assertAlmostEqual(summary["completion_length_mean"], 53.333, places=1)
+        self.assertEqual(summary["completion_lengths"], [10, 50, 100])
+
+
+class AgenticSummaryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.stub = _TrainerStub()
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        self._compute = PolicyOnlyTrainer._compute_agentic_completion_summary.__get__(self.stub)
+
+    def test_counts_loss_mask_tokens(self):
+        batch = _AgentBatchStub(
+            loss_masks=[
+                [False, True, True, True, False, True],  # 4 trainable
+                [False, False, True, True],  # 2 trainable
+            ],
+        )
+        summary = self._compute(epoch=0, step=0, agent_batch=batch, rollout_time_s=8.0)
+        self.assertEqual(summary["total_completions"], 2)
+        self.assertEqual(summary["total_generated_tokens"], 6)
+        self.assertEqual(summary["completion_lengths"], [4, 2])
+
+    def test_includes_filtered_count(self):
+        batch = _AgentBatchStub(loss_masks=[[True, True]], filtered_count=3)
+        summary = self._compute(epoch=0, step=0, agent_batch=batch, rollout_time_s=1.0)
+        self.assertEqual(summary["filtered_count"], 3)
+
+    def test_empty_completion_detected(self):
+        batch = _AgentBatchStub(loss_masks=[[False, False, False], [True, True]])
+        summary = self._compute(epoch=0, step=0, agent_batch=batch, rollout_time_s=2.0)
+        self.assertEqual(summary["empty_count"], 1)
+
+    def test_stop_and_tool_calls_are_negative_one(self):
+        batch = _AgentBatchStub(loss_masks=[[True]])
+        summary = self._compute(epoch=0, step=0, agent_batch=batch, rollout_time_s=1.0)
+        self.assertEqual(summary["stop_count"], -1)
+        self.assertEqual(summary["tool_calls_count"], -1)
+
+
+# ---------------------------------------------------------------------------
+# compute_percentile helper tests
+# ---------------------------------------------------------------------------
+
+class ComputePercentileTest(unittest.TestCase):
+
+    def test_median(self):
+        self.assertAlmostEqual(compute_percentile([1, 2, 3, 4, 5], 0.5), 3.0)
+
+    def test_p90(self):
+        result = compute_percentile(list(range(1, 11)), 0.9)
+        self.assertAlmostEqual(result, 9.1, places=1)
+
+    def test_empty_list(self):
+        self.assertEqual(compute_percentile([], 0.5), 0.0)
+
+    def test_single_element(self):
+        self.assertAlmostEqual(compute_percentile([42], 0.5), 42.0)
+
+
+# ---------------------------------------------------------------------------
+# CLI loading & aggregation tests
+# ---------------------------------------------------------------------------
+
+class CompletionSummaryLoadingTest(unittest.TestCase):
+
+    def test_load_completion_summary_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "completion_summary.12345.jsonl"
+            records = [
+                {"step": 0, "kind": "rollout", "total_completions": 8},
+                {"step": 1, "kind": "rollout", "total_completions": 8},
+            ]
+            with path.open("w") as f:
+                for r in records:
+                    f.write(json.dumps(r) + "\n")
+            loaded, source = cs_mod._load_completion_summary_files(Path(tmp), None)
+            self.assertEqual(source, "completion_summary")
+            self.assertEqual(len(loaded), 2)
+            self.assertEqual(loaded[0]["total_completions"], 8)
+
+    def test_load_with_pid_filter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for pid in (111, 222):
+                path = Path(tmp) / f"completion_summary.{pid}.jsonl"
+                with path.open("w") as f:
+                    f.write(json.dumps({"step": 0, "kind": "rollout", "pid": pid}) + "\n")
+            loaded, _ = cs_mod._load_completion_summary_files(Path(tmp), 111)
+            self.assertEqual(len(loaded), 1)
+            self.assertEqual(loaded[0]["pid"], 111)
+
+    def test_fallback_to_rollout_samples(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rollout_samples.99999.jsonl"
+            samples = [
+                {"kind": "rollout", "epoch": 0, "step": 0, "response_tokens": [1, 2, 3], "finish_reason": "stop"},
+                {"kind": "rollout", "epoch": 0, "step": 0, "response_tokens": [], "finish_reason": "length"},
+                {"kind": "rollout", "epoch": 0, "step": 1, "response_tokens": [1], "finish_reason": "stop"},
+            ]
+            with path.open("w") as f:
+                for s in samples:
+                    f.write(json.dumps(s) + "\n")
+            loaded, source = cs_mod._load_completion_summary_files(Path(tmp), None)
+            self.assertEqual(source, "rollout_samples")
+            self.assertEqual(len(loaded), 2)  # Two steps
+            self.assertEqual(loaded[0]["total_completions"], 2)
+            self.assertEqual(loaded[0]["empty_count"], 1)
+            self.assertEqual(loaded[0]["length_limit_count"], 1)
+
+    def test_no_files_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            loaded, source = cs_mod._load_completion_summary_files(Path(tmp), None)
+            self.assertEqual(loaded, [])
+            self.assertEqual(source, "none")
+
+    def test_missing_fields_filled_with_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "completion_summary.1.jsonl"
+            with path.open("w") as f:
+                # Minimal record—no stop_count, completion_lengths, etc.
+                f.write(json.dumps({"step": 0, "kind": "rollout", "total_completions": 4}) + "\n")
+            loaded, _ = cs_mod._load_completion_summary_files(Path(tmp), None)
+            self.assertEqual(loaded[0]["stop_count"], -1)  # default
+            self.assertEqual(loaded[0]["filtered_count"], 0)  # default
+            self.assertEqual(loaded[0]["completion_lengths"], [])  # default
+
+
+class AggregationTest(unittest.TestCase):
+
+    def test_aggregate_overall_merges_completion_lengths(self):
+        records = [
+            {"kind": "rollout", "completion_lengths": [10, 20], "total_generated_tokens": 30, "rollout_time_s": 1.0,
+             "total_completions": 2, "empty_count": 0, "length_limit_count": 0, "stop_count": 2,
+             "tool_calls_count": 0, "filtered_count": 0},
+            {"kind": "rollout", "completion_lengths": [30, 40], "total_generated_tokens": 70, "rollout_time_s": 2.0,
+             "total_completions": 2, "empty_count": 0, "length_limit_count": 1, "stop_count": 1,
+             "tool_calls_count": 0, "filtered_count": 0},
+        ]
+        overall = cs_mod._aggregate_overall(records)
+        rollout = overall["rollout"]
+        self.assertEqual(rollout["total_completions"], 4)
+        self.assertEqual(rollout["completion_length"]["min"], 10)
+        self.assertEqual(rollout["completion_length"]["max"], 40)
+
+    def test_aggregate_tokens_per_second_uses_total(self):
+        records = [
+            {"kind": "rollout", "total_generated_tokens": 100, "rollout_time_s": 10.0, "completion_lengths": [50, 50],
+             "total_completions": 2, "empty_count": 0, "length_limit_count": 0, "stop_count": 2,
+             "tool_calls_count": 0, "filtered_count": 0},
+            {"kind": "rollout", "total_generated_tokens": 200, "rollout_time_s": 10.0, "completion_lengths": [100, 100],
+             "total_completions": 2, "empty_count": 0, "length_limit_count": 0, "stop_count": 2,
+             "tool_calls_count": 0, "filtered_count": 0},
+        ]
+        overall = cs_mod._aggregate_overall(records)
+        # 300 total tokens / 20 total seconds = 15.0
+        self.assertAlmostEqual(overall["rollout"]["tokens_per_second"], 15.0, places=1)
+
+    def test_aggregate_empty_records_returns_none(self):
+        overall = cs_mod._aggregate_overall([])
+        self.assertIsNone(overall["rollout"])
+        self.assertIsNone(overall["agentic"])
+
+    def test_aggregate_mixed_kinds(self):
+        records = [
+            {"kind": "rollout", "total_generated_tokens": 10, "rollout_time_s": 1.0,
+             "completion_lengths": [10], "total_completions": 1, "empty_count": 0,
+             "length_limit_count": 0, "stop_count": 1, "tool_calls_count": 0, "filtered_count": 0},
+            {"kind": "agentic", "total_generated_tokens": 20, "rollout_time_s": 2.0,
+             "completion_lengths": [20], "total_completions": 1, "empty_count": 0,
+             "length_limit_count": 0, "stop_count": -1, "tool_calls_count": -1, "filtered_count": 1},
+        ]
+        overall = cs_mod._aggregate_overall(records)
+        self.assertIsNotNone(overall["rollout"])
+        self.assertIsNotNone(overall["agentic"])
+        self.assertEqual(overall["agentic"]["filtered_count"], 1)
+
+
+# ---------------------------------------------------------------------------
+# CLI command tests (via Click CliRunner)
+# ---------------------------------------------------------------------------
+
+class CompletionSummaryCliTest(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _write_summary_file(self, tmp: str, records: list[dict], pid: int = 12345):
+        path = Path(tmp) / f"completion_summary.{pid}.jsonl"
+        with path.open("w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+        return path
+
+    def test_json_output_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [
+                {"step": 0, "kind": "rollout", "total_completions": 8, "total_generated_tokens": 64,
+                 "empty_count": 0, "length_limit_count": 1, "stop_count": 7, "tool_calls_count": 0,
+                 "filtered_count": 0, "completion_lengths": [8] * 8, "rollout_time_s": 5.0,
+                 "tokens_per_second": 12.8, "completion_length_min": 8, "completion_length_max": 8,
+                 "completion_length_mean": 8.0, "completion_length_p50": 8, "completion_length_p90": 8},
+                {"step": 1, "kind": "rollout", "total_completions": 8, "total_generated_tokens": 80,
+                 "empty_count": 1, "length_limit_count": 0, "stop_count": 7, "tool_calls_count": 0,
+                 "filtered_count": 0, "completion_lengths": [0, 10, 10, 10, 10, 10, 10, 20],
+                 "rollout_time_s": 6.0, "tokens_per_second": 13.3, "completion_length_min": 0,
+                 "completion_length_max": 20, "completion_length_mean": 10.0,
+                 "completion_length_p50": 10, "completion_length_p90": 20},
+            ]
+            self._write_summary_file(tmp, records)
+            result = self.runner.invoke(completion_summary_command, ["--metrics-log-dir", tmp, "--json"])
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            data = json.loads(result.output)
+            self.assertEqual(data["source"], "completion_summary")
+            self.assertEqual(data["overall"]["rollout"]["num_steps"], 2)
+            self.assertEqual(data["overall"]["rollout"]["total_completions"], 16)
+            self.assertEqual(data["overall"]["rollout"]["empty_count"], 1)
+            self.assertEqual(len(data["per_step"]), 2)
+
+    def test_human_readable_output_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [
+                {"step": 0, "kind": "rollout", "total_completions": 4, "total_generated_tokens": 40,
+                 "empty_count": 0, "length_limit_count": 0, "stop_count": 4, "tool_calls_count": 0,
+                 "filtered_count": 0, "completion_lengths": [10] * 4, "rollout_time_s": 2.0,
+                 "tokens_per_second": 20.0, "completion_length_min": 10, "completion_length_max": 10,
+                 "completion_length_mean": 10.0, "completion_length_p50": 10, "completion_length_p90": 10},
+            ]
+            self._write_summary_file(tmp, records)
+            result = self.runner.invoke(completion_summary_command, ["--metrics-log-dir", tmp])
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn("Completion Quality Summary", result.output)
+            self.assertIn("rollout", result.output)
+            self.assertIn("Per-step detail", result.output)
+
+    def test_pid_filter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_summary_file(tmp, [{"step": 0, "kind": "rollout", "total_completions": 1,
+                "completion_lengths": [1]}], pid=111)
+            self._write_summary_file(tmp, [{"step": 0, "kind": "rollout", "total_completions": 1,
+                "completion_lengths": [1]}], pid=222)
+            result = self.runner.invoke(
+                completion_summary_command, ["--metrics-log-dir", tmp, "--json", "--pid", "222"]
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            data = json.loads(result.output)
+            self.assertEqual(len(data["per_step"]), 1)
+
+    def test_no_files_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.runner.invoke(completion_summary_command, ["--metrics-log-dir", tmp])
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("no completion_summary", result.output.lower())
+
+    def test_handles_missing_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "completion_summary.999.jsonl"
+            # Intentionally sparse record.
+            with path.open("w") as f:
+                f.write(json.dumps({"step": 0, "kind": "rollout", "total_completions": 2}) + "\n")
+            result = self.runner.invoke(
+                completion_summary_command, ["--metrics-log-dir", tmp, "--json"]
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            data = json.loads(result.output)
+            self.assertEqual(data["overall"]["rollout"]["total_completions"], 2)
+
+    def test_mixed_kinds_aggregation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            records = [
+                {"step": 0, "kind": "rollout", "total_completions": 4, "total_generated_tokens": 40,
+                 "empty_count": 0, "length_limit_count": 0, "stop_count": 4, "tool_calls_count": 0,
+                 "filtered_count": 0, "completion_lengths": [10] * 4, "rollout_time_s": 2.0,
+                 "tokens_per_second": 20.0, "completion_length_min": 10, "completion_length_max": 10,
+                 "completion_length_mean": 10.0, "completion_length_p50": 10, "completion_length_p90": 10},
+                {"step": 1, "kind": "agentic", "total_completions": 2, "total_generated_tokens": 60,
+                 "empty_count": 0, "length_limit_count": 0, "stop_count": -1, "tool_calls_count": -1,
+                 "filtered_count": 1, "completion_lengths": [30, 30], "rollout_time_s": 3.0,
+                 "tokens_per_second": 20.0, "completion_length_min": 30, "completion_length_max": 30,
+                 "completion_length_mean": 30.0, "completion_length_p50": 30, "completion_length_p90": 30},
+            ]
+            self._write_summary_file(tmp, records)
+            result = self.runner.invoke(
+                completion_summary_command, ["--metrics-log-dir", tmp, "--json"]
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            data = json.loads(result.output)
+            self.assertIsNotNone(data["overall"]["rollout"])
+            self.assertIsNotNone(data["overall"]["agentic"])
+            self.assertEqual(data["overall"]["agentic"]["filtered_count"], 1)
+
+    def test_command_registered_in_main(self):
+        result = self.runner.invoke(main, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("completion-summary", result.output)
+
+    def test_fallback_from_rollout_samples(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rollout_samples.555.jsonl"
+            with path.open("w") as f:
+                f.write(json.dumps({"kind": "rollout", "epoch": 0, "step": 0,
+                    "response_tokens": [1, 2, 3], "response_len": 3, "finish_reason": "stop"}) + "\n")
+                f.write(json.dumps({"kind": "rollout", "epoch": 0, "step": 0,
+                    "response_tokens": [], "response_len": 0, "finish_reason": "length"}) + "\n")
+            result = self.runner.invoke(
+                completion_summary_command, ["--metrics-log-dir", tmp, "--json"]
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            data = json.loads(result.output)
+            self.assertEqual(data["source"], "rollout_samples")
+            self.assertEqual(data["overall"]["rollout"]["total_completions"], 2)
+            self.assertEqual(data["overall"]["rollout"]["empty_count"], 1)
+
+
+# ---------------------------------------------------------------------------
+# MetricsRecorder.record_completion_summary I/O test
+# ---------------------------------------------------------------------------
+
+class RecordCompletionSummaryTest(unittest.TestCase):
+
+    def test_record_completion_summary_writes_jsonl(self):
+        class FakeWriter:
+            def close(self):
+                pass
+
+        old_factory = metrics_mod.create_tensorboard_writer
+        metrics_mod.create_tensorboard_writer = lambda _log_dir: FakeWriter()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                with MetricsRecorder(tmp) as recorder:
+                    recorder.record_completion_summary({"step": 0, "kind": "rollout", "total_completions": 4})
+                    recorder.record_completion_summary({"step": 1, "kind": "rollout", "total_completions": 4})
+                # Verify the file exists and contains 2 lines.
+                files = list(Path(tmp).glob("completion_summary.*.jsonl"))
+                self.assertEqual(len(files), 1)
+                lines = files[0].read_text().strip().split("\n")
+                self.assertEqual(len(lines), 2)
+                first = json.loads(lines[0])
+                self.assertEqual(first["step"], 0)
+                self.assertEqual(first["pid"], os.getpid())
+        finally:
+            metrics_mod.create_tensorboard_writer = old_factory
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #258 

## 摘要

本 PR 引入了一个新的独立 CLI 命令 `areno completion-summary`，旨在从训练产物中读取并汇总“完成质量”（Completion Quality）数据。该功能帮助开发者和研究人员快速评估模型生成的健康状况，包括响应长度分布、空响应率、截断率及生成速度等关键指标。

**主要特性：**
*   **多维度统计**：区分单轮对话（Single-turn/Rollout）和代理式生成（Agentic），报告完成长度分布、空响应计数、达到长度限制计数、被过滤计数以及每秒 Token 生成数。
*   **双模式输出**：支持终端人类可读表格输出和 `--json` 结构化输出，便于集成到其他监控工具。
*   **数据兼容性**：优先读取新生成的 `completion_summary.*.jsonl文件`；若不存在，则自动回退至解析 `rollout_samples.*.jsonl`（部分指标标记为 N/A）。
*   **向后兼容**：所有新增字段均设有默认值，不影响现有训练流程。

## 数据流架构

```mermaid
graph TD
    A[训练循环 Training Loop] -->|记录指标| B(MetricsRecorder.record_completion_summary)
    B -->|写入 JSONL| C["completion_summary.{pid}.jsonl<br/>(主数据源)"]
    B -->|增强字段| D["rollout_samples.{pid}.jsonl<br/>(新增 finish_reason/response_len, 回退数据源)"]
    C --> E[areno completion-summary CLI]
    D --> E
    E --> F[终端表格输出 / JSON 结构化输出]
```

## 实现细节

### 1. 数据通路改造

为了支持更精细的质量监控，对底层数据模型和记录器进行了以下扩展：

*   **`areno/api/models.py`**:
    *   在 `RolloutSequence`中新增 `finish_reason: str` 字段（默认 `""`）。
    *   取值包括：`"length"` (截断), `"stop"` (正常停止), `"tool_calls"`, `"unknown"`, `""` (未填充)。
*   **`areno/api/backend/areno/backend.py`**:
    *   在 `rollout_batch()` 和 `rollout_batch_async()` 中透传 backend 返回的 `finish_reason。
*   **`areno/api/agentic.py`**:
    *   在 `AgentTrainBatch` dataclass 中新增 `filtered_count: int` 字段，用于追踪被过滤的样本数。
*   **`areno/api/metrics.py`**:
    *   新增 `record_completion_summary()` 方法，将每步的统计摘要追加写入 `completion_summary.{pid}.jsonl`。
    *   新增辅助函数 `compute_percentile()` 供 CLI 复用。
*   **`areno/api/trainer.py` & `policy_only.py`**:
    *    Trainer 层新增委托方法 `record_completion_summary`。
    *   在 `_run_agentic_rollout` 和 `_record_sample_completions` 中注入统计逻辑：
        *   **单轮模式**：精确统计 `finish_reason` 分布、Token 长度百分位（p50/p90）、生成速度。
        *   **代理模式**：基于 `loss_masks` 估算长度，记录 `filtered_count`；暂不跟踪 per-turn 的 `finish_reason`（标记为 v2 增强项）。
    *   在训练循环中通过 `time.perf_counter()` 计算 rollout 耗时，进而计算 `tokens_per_second`。

### 2. CLI 命令实现 (`areno/cli/completion_summary.py`)

新建 CLI 命令 `completion-summary`，支持以下参数：
*   `--metrics-log-dir`: 指定指标日志目录。
*   `--json`: 输出 JSON 格式。
*   `--pid`: 可选，指定特定进程 ID的文件。

**处理逻辑：**
1.  **验证**：检查目录存在性及数据文件可用性。
2.  **加载**：优先加载 `completion_summary.*.jsonl`；若缺失，尝试解析 `rollout_samples.*.jsonl` 并进行字段映射（缺失字段填 null/N/A）。
3.  **聚合**按 `kind` ("rollout"/"agentic") 分组，合并所有步骤的数据，计算整体统计量（总和、平均值、百分位）。
4.  **格式化**：生成美观的终端表格或标准 JSON 对象。

### 3. 测试与文档

*   **测试 (`tests/test_completion_summary_cpu.py`)**:
    *   覆盖统计计算逻辑（边界条件如全空响应、除零保护）。
    *   覆盖 CLI 行为（JSON 输出结构、人类可读格式、错误处理、回退模式）。
    *   覆盖数据模型默认值及字段传递。
*   **文档 (`docs/cli/observability.rst`)**:
    *   新增 "Completion quality summary" 章节，包含命令用法、字段解释、单轮/代理模式差异说明及最小可运行示例。

## 输出示例

### 人类可读输出

```text
Completion Quality Summary
  Metrics directory: /tmp/areno/tfevent
  Source: completion_summary.12345.jsonl
  Steps: 10 (rollout: 10, agentic: 0)

Single-turn (rollout)
  Total completions      160
  Total generated tokens 15,360
  Empty count            0
  Length-limit count     12
  Stop count             148
  Filtered count         0
  Length (min/p50/p90/max)  32/96/124/128
  Mean length            96.0
  Tokens per second      307.2

Per-step detail
  Step  Kind     Comps  Empty  Len-Lim  Filtered  Mean   P50   P90   Tok/s
  0     rollout   16     0      1        0         92.3   93    121   301.5
  1     rollout   16     0      2        0         98.7   97    125   312.1
  ...
```

### JSON 结构化输出 (`--json`)

```json
{
  "overall": {
    "rollout": {
      "num_steps": 10,
      "total_completions": 160,
      "total_generated_tokens": 15360,
      "empty_count": 0,
      "length_limit_count": 12,
      "stop_count": 148,
      "filtered_count": 0,
      "completion_length_min": 32,
      "completion_length_max": 128,
      "completion_length_mean": 96.0,
      "completion_length_p50": 96,
      "completion_length_p90": 124,
      "tokens_per_second": 307.2
    },
    "agentic": null
  },
  "per_step": [...],
  "source": "completion_summary"
}
```

## 变更文件清单 

| 文件路径 | 操作 | 说明 |
| :--- | :--- | :--- |
| `areno/api/models.py` | Modify | `RolloutSequence` 增加 `finish_reason` |
| `areno/api/backend/areno/backend.py` | Modify | 透传 `finish_reason` |
| `areno/api/agentic.py` | Modify | `AgentTrainBatch` 增加 `filtered_count` |
| `areno/api/metrics.py` | Modify | 新增 `record_completion_summary` 及百分位计算 a> |
| `areno/api/trainer.py` | Modify | 新增委托方法 |
| `areno/api/trainers/policy_only.py` | Modify | 实现统计逻辑、训练循环集成及 JSONL 字段增强 |
| `areno/cli/main.py` | Modify | 注册新命令 |
| `areno/cli/completion_summary.py` | **New** | CLI 命令核心实现 |
| `tests/test_completion_summary_cpu.py` | **New** | 单元测试 |
| `docs/cli/observability.rst` | Modify | 添加相关文档 |

## 验收标准对照

- [x] **计数验证**：通过测试 fixture 验证各项计数（empty, length-limit, stop 等准确性。
- [x] **容错处理**：CLI 能优雅处理缺失字段，在回退模式下正确标注 N/A。
- [x] **隐私保护**：输出仅包含统计摘要，不包含任何原始 completion 文本。
- [x] **结构化暴露**：通过 JSONL文件和 `--json` 标志向外部消费者暴露结构化数据。
- [x] **契约遵循**：严格遵循现有的 Pydantic models、MetricsRecorder 和 Click CLI 规范。
- [x] **无外部依赖**：仅使用本地文件系统读写 JSONL，不引入数据库或沙箱。
- [x] **向后兼容**：新增字段均有默认值，未启用该命令时系统行为不变。
- [x] **测试覆盖**：涵盖成功路径、无效输入、边界条件及回退模式。
- [x] **文档完整**：包含最小可运行示例及字段说明。