### PR TITLE
Feat/qingpo/empty completion filter

### DIFF
--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -112,6 +112,9 @@ class RolloutTrainerConfig(TrainerConfig):
     top_k: int = -1
     top_p: float = 1.0
     max_running_prompts: int | None = None
+    # Empty / invalid completion handling.  "off" (default) preserves existing
+    # behavior; "filter" drops them before reward/training.
+    empty_completion_policy: str = "off"
 
     def resolved_max_running_prompts(self) -> int:
         """Return explicit or full-batch rollout concurrency."""

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -113,8 +113,10 @@ class RolloutTrainerConfig(TrainerConfig):
     top_p: float = 1.0
     max_running_prompts: int | None = None
     # Empty / invalid completion handling.  "off" (default) preserves existing
-    # behavior; "filter" drops them before reward/training.
+    # behavior; "filter" drops them before reward/training; "resample"
+    # re-generates invalid completions up to resample_budget times.
     empty_completion_policy: str = "off"
+    empty_completion_resample_budget: int = 3
 
     def resolved_max_running_prompts(self) -> int:
         """Return explicit or full-batch rollout concurrency."""

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -619,11 +619,15 @@ class PolicyOnlyTrainer:
                         vr.metrics,
                     )
                 if not result.sequences:
-                    raise RuntimeError(
+                    self.logger.warning(
                         "all completions for prompt were empty or invalid; "
-                        f"dropped={len(vr.dropped_indices)} policy=filter "
-                        f"prompt_preview={item.prompt[:200]!r}"
+                        "skipping this prompt (dropped=%d policy=filter "
+                        "prompt_preview=%r). Consider disabling "
+                        "--empty-completion-policy if this happens frequently.",
+                        len(vr.dropped_indices),
+                        item.prompt[:200],
                     )
+                    continue
 
             rewards = [
                 float(

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -242,6 +242,42 @@ class PolicyOnlyTrainer:
                     f"{self._format_agent_filter_diagnostics(filter_diagnostics)}"
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
+
+            # Validate completions before they reach reward_fn; drops empty,
+            # whitespace, special-token-only, and immediate-EOS responses when
+            # the policy is active.  When policy is "off" (default) this is a
+            # no-op that returns the inputs unchanged.
+            agent_policy = getattr(self.config, "empty_completion_policy", "off")
+            if agent_policy != "off":
+                from areno.engine.runtime.completion_validator import validate_completions
+
+                agent_eos_ids = self._completion_eos_ids(ctx._trainer.get_tokenizer())
+                agent_special_ids = self._completion_special_token_ids(ctx._trainer.get_tokenizer())
+                agent_completions = [record.completion for record in reward_records]
+                agent_resp_tokens = [record.tokens for record in reward_records]
+                agent_quarantine = None
+                if self.config.save_path:
+                    agent_quarantine = str(Path(self.config.save_path) / "empty_completions.jsonl")
+                kept_completions, _, agent_vr = validate_completions(
+                    agent_completions,
+                    agent_resp_tokens,
+                    policy=agent_policy,
+                    eos_token_ids=agent_eos_ids,
+                    special_token_ids=agent_special_ids,
+                    quarantine_path=agent_quarantine,
+                )
+                # Filter samples and reward_records to only kept rows.
+                kept_idx_set = set(agent_vr.kept_indices)
+                samples = [s for i, s in enumerate(samples) if i in kept_idx_set]
+                reward_records = [r for i, r in enumerate(reward_records) if i in kept_idx_set]
+                if not samples:
+                    raise RuntimeError(
+                        "all agent trajectories had empty or invalid completions; "
+                        f"dropped={len(agent_vr.dropped_indices)} policy={agent_policy}"
+                    )
+                if agent_vr.metrics:
+                    self.logger.info("agentic completion_validation metrics=%s", agent_vr.metrics)
+
             rewards = [float(self.reward_fn(record)) for record in reward_records]
             rows = ctx._train_rows_from_samples(samples)
             tool_call_count = sum(len(record.tool_calls) for record in reward_records)
@@ -506,6 +542,21 @@ class PolicyOnlyTrainer:
             if logged + 1 >= limit:
                 return
 
+    def _completion_eos_ids(self, tokenizer) -> tuple[int, ...]:
+        """Collect all EOS token ids from tokenizer and model config."""
+
+        from areno.api.tokenizer import eos_token_ids
+
+        model_path = self.areno._ctx.model_path if self.areno._ctx is not None else ""
+        return eos_token_ids(model_path, tokenizer)
+
+    def _completion_special_token_ids(self, tokenizer) -> tuple[int, ...]:
+        """Extract special token ids from tokenizer for completion validation."""
+
+        from areno.engine.runtime.completion_validator import get_special_token_ids
+
+        return get_special_token_ids(tokenizer)
+
     def _materialize_train_batch(self, tokenizer, prompt_batch, rollout_results):
         """Assemble TrainSequence rows for one rollout batch.
 
@@ -521,12 +572,53 @@ class PolicyOnlyTrainer:
         import areno.api
         from areno.api.rewards import compute_group_advantages, make_reward_record
 
+        # Lazily collect EOS and special-token ids once for completion validation.
+        policy = getattr(self.config, "empty_completion_policy", "off")
+        eos_ids: tuple[int, ...] = ()
+        special_ids: tuple[int, ...] = ()
+        if policy != "off":
+            eos_ids = self._completion_eos_ids(tokenizer)
+            special_ids = self._completion_special_token_ids(tokenizer)
+
         train_batch = []
         rewards_all = []
         rollout_logprobs = []
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
+
+            # Validate completions before they reach reward_fn; drops empty,
+            # whitespace, special-token-only, and immediate-EOS responses when
+            # the policy is active.  When policy is "off" (default) this is a
+            # no-op that returns the inputs unchanged.
+            if policy != "off":
+                from areno.engine.runtime.completion_validator import validate_completions
+
+                quarantine_path = None
+                if self.config.save_path:
+                    quarantine_path = str(Path(self.config.save_path) / "empty_completions.jsonl")
+                completions, kept_tokens, vr = validate_completions(
+                    completions,
+                    [seq.resp_tokens for seq in result.sequences],
+                    policy="filter",
+                    eos_token_ids=eos_ids,
+                    special_token_ids=special_ids,
+                    quarantine_path=quarantine_path,
+                    prompt=item.prompt,
+                )
+                # Rebuild sequences list to only kept rows so downstream
+                # reward, advantage, and train_batch construction stays aligned.
+                result = areno.api.RolloutResult(
+                    sequences=[
+                        result.sequences[idx] for idx in vr.kept_indices
+                    ]
+                )
+                if vr.metrics:
+                    self.logger.info(
+                        "epoch=? step=? completion_validation metrics=%s",
+                        vr.metrics,
+                    )
+
             rewards = [
                 float(
                     self.reward_fn(

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -644,7 +644,7 @@ class PolicyOnlyTrainer:
                 completions, kept_tokens, vr = validate_completions(
                     completions,
                     [seq.resp_tokens for seq in result.sequences],
-                    policy="filter",
+                    policy=policy,
                     eos_token_ids=eos_ids,
                     special_token_ids=special_ids,
                     quarantine_path=quarantine_path,

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -618,6 +618,12 @@ class PolicyOnlyTrainer:
                         "epoch=? step=? completion_validation metrics=%s",
                         vr.metrics,
                     )
+                if not result.sequences:
+                    raise RuntimeError(
+                        "all completions for prompt were empty or invalid; "
+                        f"dropped={len(vr.dropped_indices)} policy=filter "
+                        f"prompt_preview={item.prompt[:200]!r}"
+                    )
 
             rewards = [
                 float(

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -100,7 +100,7 @@ class PolicyOnlyTrainer:
                     # 2+3) Score rewards and broadcast group-normalised
                     #      advantages down to per-token tensors.
                     train_batch, rewards_all, rollout_logprobs = self._materialize_train_batch(
-                        tokenizer, prompt_batch, rollout_results
+                        tokenizer, prompt_batch, rollout_results, sampling_params=sampling_params
                     )
 
                 if rewards_all:
@@ -557,7 +557,17 @@ class PolicyOnlyTrainer:
 
         return get_special_token_ids(tokenizer)
 
-    def _materialize_train_batch(self, tokenizer, prompt_batch, rollout_results):
+    async def _run_prompt_rollout_for_tokens(self, sampling_params, prompt_tokens):
+        """Run rollout for a list of token lists, returning RolloutResult list."""
+
+        async with self.areno.rollout_session(
+            sampling_params=sampling_params,
+            max_running_prompts=self.config.resolved_max_running_prompts(),
+            proxy=False,
+        ):
+            return await self.areno.rollout_token_batch_async(prompt_tokens, self.config.n_samples, sampling_params)
+
+    def _materialize_train_batch(self, tokenizer, prompt_batch, rollout_results, *, sampling_params=None):
         """Assemble TrainSequence rows for one rollout batch.
 
         Steps:
@@ -593,6 +603,40 @@ class PolicyOnlyTrainer:
             # no-op that returns the inputs unchanged.
             if policy != "off":
                 from areno.engine.runtime.completion_validator import validate_completions
+
+                # resample: re-generate invalid completions up to budget times.
+                if policy == "resample" and sampling_params is not None:
+                    budget = getattr(self.config, "empty_completion_resample_budget", 3)
+                    for attempt in range(budget):
+                        _, _, check_vr = validate_completions(
+                            completions,
+                            [seq.resp_tokens for seq in result.sequences],
+                            policy="filter",
+                            eos_token_ids=eos_ids,
+                            special_token_ids=special_ids,
+                        )
+                        if not check_vr.dropped_indices:
+                            if attempt > 0:
+                                self.logger.info(
+                                    "resample succeeded after %d attempt(s)",
+                                    attempt,
+                                )
+                            break
+                        self.logger.info(
+                            "resample attempt %d/%d: re-generating prompt with %d invalid completions",
+                            attempt + 1, budget, len(check_vr.dropped_indices),
+                        )
+                        new_result = asyncio.run(
+                            self._run_prompt_rollout_for_tokens(sampling_params, [item.input_tokens])
+                        )
+                        result = new_result[0]
+                        completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
+                    else:
+                        self.logger.warning(
+                            "resample exhausted after %d attempt(s): %d completions still invalid, "
+                            "falling back to filter",
+                            budget, len(check_vr.dropped_indices),
+                        )
 
                 quarantine_path = None
                 if self.config.save_path:

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -91,7 +91,7 @@ class PPOTrainer(PolicyOnlyTrainer):
             role=role,
         )
 
-    def _materialize_train_batch(self, tokenizer, prompt_batch, rollout_results):
+    def _materialize_train_batch(self, tokenizer, prompt_batch, rollout_results, *, sampling_params=None):
         self._last_ppo_stats = {}
         train_batch = []
         rewards_all = []
@@ -108,6 +108,44 @@ class PPOTrainer(PolicyOnlyTrainer):
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
+
+            # resample: re-generate invalid completions up to budget times.
+            ppo_policy = getattr(self.config, "empty_completion_policy", "off")
+            if ppo_policy == "resample" and sampling_params is not None:
+                from areno.engine.runtime.completion_validator import validate_completions
+
+                budget = getattr(self.config, "empty_completion_resample_budget", 3)
+                for attempt in range(budget):
+                    _, _, check_vr = validate_completions(
+                        completions,
+                        [seq.resp_tokens for seq in result.sequences],
+                        policy="filter",
+                        eos_token_ids=self._completion_eos_ids(tokenizer),
+                        special_token_ids=self._completion_special_token_ids(tokenizer),
+                    )
+                    if not check_vr.dropped_indices:
+                        if attempt > 0:
+                            self.logger.info(
+                                "ppo resample succeeded after %d attempt(s)",
+                                attempt,
+                            )
+                        break
+                    self.logger.info(
+                        "ppo resample attempt %d/%d: re-generating prompt with %d invalid completions",
+                        attempt + 1, budget, len(check_vr.dropped_indices),
+                    )
+                    new_result = asyncio.run(
+                        self._run_prompt_rollout_for_tokens(sampling_params, [item.input_tokens])
+                    )
+                    result = new_result[0]
+                    completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
+                else:
+                    self.logger.warning(
+                        "ppo resample exhausted after %d attempt(s): %d completions still invalid, "
+                        "falling back to filter",
+                        budget, len(check_vr.dropped_indices),
+                    )
+
             for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True)):
                 tokens = item.input_tokens + seq.resp_tokens
                 token_rows.append(tokens)

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -127,6 +127,43 @@ class PPOTrainer(PolicyOnlyTrainer):
 
         # Reward scoring: either Python reward_fn or a backend-owned reward
         # role. Both produce one float per (prompt, sample) in row order.
+        #
+        # Validate completions before they reach reward_fn; drops empty,
+        # whitespace, special-token-only, and immediate-EOS responses when
+        # the policy is active.  When policy is "off" (default) this is a
+        # no-op that returns the inputs unchanged.
+        ppo_policy = getattr(self.config, "empty_completion_policy", "off")
+        if ppo_policy != "off":
+            from areno.engine.runtime.completion_validator import validate_completions
+
+            ppo_eos_ids = self._completion_eos_ids(tokenizer)
+            ppo_special_ids = self._completion_special_token_ids(tokenizer)
+            ppo_completions = [record.completion for record in reward_records]
+            ppo_resp_tokens = [record.tokens for record in reward_records]
+            ppo_quarantine = None
+            if self.config.save_path:
+                ppo_quarantine = str(Path(self.config.save_path) / "empty_completions.jsonl")
+            _, _, ppo_vr = validate_completions(
+                ppo_completions,
+                ppo_resp_tokens,
+                policy=ppo_policy,
+                eos_token_ids=ppo_eos_ids,
+                special_token_ids=ppo_special_ids,
+                quarantine_path=ppo_quarantine,
+            )
+            # Filter token_rows, row_meta, and reward_records to only kept rows.
+            kept_idx_set = set(ppo_vr.kept_indices)
+            token_rows = [r for i, r in enumerate(token_rows) if i in kept_idx_set]
+            row_meta = [r for i, r in enumerate(row_meta) if i in kept_idx_set]
+            reward_records = [r for i, r in enumerate(reward_records) if i in kept_idx_set]
+            if not token_rows:
+                raise RuntimeError(
+                    "all completions were empty or invalid; "
+                    f"dropped={len(ppo_vr.dropped_indices)} policy={ppo_policy}"
+                )
+            if ppo_vr.metrics:
+                self.logger.info("ppo completion_validation metrics=%s", ppo_vr.metrics)
+
         if self.reward_fn is not None:
             self._record_ppo_state(stage="score_start", role="reward")
             reward_start = time.perf_counter()

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -1305,10 +1305,10 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 @click.option("--train-tool-results", is_flag=True, help="Include tool-result spans in agentic policy loss.")
 @click.option(
     "--empty-completion-policy",
-    type=click.Choice(["off", "filter"], case_sensitive=False),
+    type=click.Choice(["off", "filter", "resample"], case_sensitive=False),
     default="off",
     show_default=True,
-    help="How to handle empty or invalid model completions: 'off' (preserve current behavior) or 'filter' (drop them before reward/training).",
+    help="How to handle empty or invalid model completions: 'off' (preserve current behavior), 'filter' (drop them), or 'resample' (re-generate up to budget times).",
 )
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -727,6 +727,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            empty_completion_policy=args.empty_completion_policy,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -788,6 +789,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
+        empty_completion_policy=args.empty_completion_policy,
     )
 
 
@@ -904,6 +906,7 @@ def _training_config_settings(config: TrainerConfig) -> dict:
                 "train_tool_results",
                 "reward_fn_path",
                 "reward_ckpt",
+                "empty_completion_policy",
             ],
         ),
         section(
@@ -1300,6 +1303,13 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--agent-timeout-s", type=float, default=300.0, show_default=True, help="Agentic rollout proxy request timeout."
 )
 @click.option("--train-tool-results", is_flag=True, help="Include tool-result spans in agentic policy loss.")
+@click.option(
+    "--empty-completion-policy",
+    type=click.Choice(["off", "filter"], case_sensitive=False),
+    default="off",
+    show_default=True,
+    help="How to handle empty or invalid model completions: 'off' (preserve current behavior) or 'filter' (drop them before reward/training).",
+)
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."
 )

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -243,6 +243,10 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--max-running-prompts must be positive")
     if args.agent_timeout_s <= 0:
         raise click.UsageError("--agent-timeout-s must be positive")
+    if args.empty_completion_policy not in ("off", "filter", "resample"):
+        raise click.UsageError("--empty-completion-policy must be one of: off, filter, resample")
+    if args.empty_completion_policy == "resample" and args.empty_completion_resample_budget <= 0:
+        raise click.UsageError("--empty-completion-resample-budget must be positive when using resample")
     _require_positive_float(args.lr, "--lr")
     if args.min_lr < 0:
         raise click.UsageError("--min-lr must be non-negative")
@@ -728,6 +732,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
             empty_completion_policy=args.empty_completion_policy,
+            empty_completion_resample_budget=args.empty_completion_resample_budget,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -790,6 +795,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
         empty_completion_policy=args.empty_completion_policy,
+        empty_completion_resample_budget=args.empty_completion_resample_budget,
     )
 
 
@@ -1309,6 +1315,13 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     default="off",
     show_default=True,
     help="How to handle empty or invalid model completions: 'off' (preserve current behavior), 'filter' (drop them), or 'resample' (re-generate up to budget times).",
+)
+@click.option(
+    "--empty-completion-resample-budget",
+    type=int,
+    default=3,
+    show_default=True,
+    help="Maximum re-generation attempts when --empty-completion-policy is resample.",
 )
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."

--- a/areno/engine/runtime/completion_validator.py
+++ b/areno/engine/runtime/completion_validator.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 InvalidType = Literal["empty", "whitespace", "special_token", "immediate_eos"]
-Policy = Literal["off", "filter"]
+Policy = Literal["off", "filter", "resample"]
 
 
 @dataclass(slots=True)
@@ -118,6 +118,7 @@ def validate_completions(
     policy: Policy = "off",
     eos_token_ids: tuple[int, ...] = (),
     special_token_ids: tuple[int, ...] = (),
+    resample_budget: int = 3,
     quarantine_path: str | Path | None = None,
     prompt: str | None = None,
 ) -> tuple[list[str], list[list[int]], ValidationResult]:
@@ -195,6 +196,9 @@ def validate_completions(
 
     if policy == "filter":
         metrics["completion_filtered"] = float(len(result.dropped_indices))
+    elif policy == "resample":
+        metrics["completion_resample_candidates"] = float(len(result.dropped_indices))
+        metrics["completion_resample_budget"] = float(resample_budget)
 
     result.metrics = metrics
 

--- a/areno/engine/runtime/completion_validator.py
+++ b/areno/engine/runtime/completion_validator.py
@@ -1,0 +1,243 @@
+"""Classify and handle empty or invalid model completions.
+
+During RL rollout the model may produce completions that carry no real
+content: empty strings, whitespace-only text, special-token-only output, or
+immediate-EOS generations.  These degenerate completions should not silently
+reach ``reward_fn`` or training code because they pollute rewards and gradients.
+
+This module provides a single entry point -- :func:`validate_completions` --
+that inspects a batch of completions, classifies invalid ones, and applies a
+configured policy (``filter`` / ``resample``).  The feature is
+**off** by default; callers must pass ``policy != "off"`` to activate it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public data structures
+# ---------------------------------------------------------------------------
+
+InvalidType = Literal["empty", "whitespace", "special_token", "immediate_eos"]
+Policy = Literal["off", "filter"]
+
+
+@dataclass(slots=True)
+class CompletionCheck:
+    """Result of checking a single completion."""
+
+    is_valid: bool
+    invalid_type: InvalidType | None = None
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    """Outcome of :func:`validate_completions` for one batch.
+
+    ``kept_indices`` / ``dropped_indices`` are positions into the original
+    completions list.  ``metrics`` holds counters that callers should merge
+    into step-level metrics.  ``quarantine_records`` holds structured records
+    of every dropped completion for offline inspection.
+    """
+
+    kept_indices: list[int] = field(default_factory=list)
+    dropped_indices: list[int] = field(default_factory=list)
+    metrics: dict[str, float] = field(default_factory=dict)
+    quarantine_records: list[dict[str, Any]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+def classify_completion(
+    completion: str,
+    resp_tokens: list[int],
+    eos_token_ids: tuple[int, ...] = (),
+    special_token_ids: tuple[int, ...] = (),
+) -> CompletionCheck:
+    """Classify a single completion as valid or invalid.
+
+    Parameters
+    ----------
+    completion
+        Decoded text of the model's response.
+    resp_tokens
+        Raw token ids of the response (before decoding).
+    eos_token_ids
+        Token ids that count as EOS for this tokenizer.
+    special_token_ids
+        Token ids that count as special (non-content) tokens.
+
+    Notes
+    -----
+    All four invalid types are detectable from ``completion`` and
+    ``resp_tokens`` alone; ``finish_reason`` from the engine is **not**
+    required because ``RolloutSequence`` does not carry it.
+    """
+
+    # 1. No response tokens at all (some tokenizers decode this to "").
+    if not resp_tokens:
+        return CompletionCheck(is_valid=False, invalid_type="empty")
+
+    # 2. Empty string.
+    if completion == "":
+        return CompletionCheck(is_valid=False, invalid_type="empty")
+
+    # 3. Whitespace-only.
+    if completion.strip() == "":
+        return CompletionCheck(is_valid=False, invalid_type="whitespace")
+
+    # 4. Immediate EOS: the response is a single token and it is an EOS token.
+    if len(resp_tokens) == 1 and resp_tokens[0] in eos_token_ids:
+        return CompletionCheck(is_valid=False, invalid_type="immediate_eos")
+
+    # 5. Special-token-only: every token in the response is a special token.
+    if resp_tokens and special_token_ids:
+        if all(tid in special_token_ids for tid in resp_tokens):
+            return CompletionCheck(is_valid=False, invalid_type="special_token")
+
+    return CompletionCheck(is_valid=True)
+
+
+# ---------------------------------------------------------------------------
+# Batch validation + policy application
+# ---------------------------------------------------------------------------
+
+def validate_completions(
+    completions: list[str],
+    resp_tokens_list: list[list[int]],
+    *,
+    policy: Policy = "off",
+    eos_token_ids: tuple[int, ...] = (),
+    special_token_ids: tuple[int, ...] = (),
+    quarantine_path: str | Path | None = None,
+    prompt: str | None = None,
+) -> tuple[list[str], list[list[int]], ValidationResult]:
+    """Validate a batch of completions and apply the configured policy.
+
+    Returns a 3-tuple ``(filtered_completions, filtered_tokens, result)``
+    containing only the completions that survived validation, plus the
+    :class:`ValidationResult` with metrics and quarantine records.
+
+    When ``policy == "off"`` (the default) the inputs are returned unchanged
+    and ``result`` contains no dropped indices.
+    """
+
+    result = ValidationResult()
+
+    if policy == "off":
+        result.kept_indices = list(range(len(completions)))
+        return completions, resp_tokens_list, result
+
+    # Classify every completion.
+    checks = [
+        classify_completion(
+            completion=completion,
+            resp_tokens=tokens,
+            eos_token_ids=eos_token_ids,
+            special_token_ids=special_token_ids,
+        )
+        for completion, tokens in zip(completions, resp_tokens_list, strict=True)
+    ]
+
+    # Tally counters by invalid type.
+    type_counts: dict[str, int] = {}
+    for check in checks:
+        if not check.is_valid and check.invalid_type is not None:
+            type_counts[check.invalid_type] = type_counts.get(check.invalid_type, 0) + 1
+
+    total_invalid = sum(type_counts.values())
+    total_valid = len(completions) - total_invalid
+
+    # Apply policy: filter and resample both drop invalid rows so they never
+    # reach reward_fn or training code.  For resample, the caller is expected
+    # to re-generate dropped rows up to ``resample_budget`` times; this
+    # function only reports which rows need resampling.
+    kept_completions: list[str] = []
+    kept_tokens: list[list[int]] = []
+
+    for idx, (completion, tokens, check) in enumerate(
+        zip(completions, resp_tokens_list, checks, strict=True)
+    ):
+        if check.is_valid:
+            result.kept_indices.append(idx)
+            kept_completions.append(completion)
+            kept_tokens.append(tokens)
+        else:
+            result.dropped_indices.append(idx)
+            result.quarantine_records.append(
+                {
+                    "index": idx,
+                    "invalid_type": check.invalid_type,
+                    "completion": completion[:500],  # truncate to avoid huge records
+                    "resp_token_count": len(tokens),
+                    "prompt": prompt[:500] if prompt else None,
+                    "policy": policy,
+                }
+            )
+
+    # Build metrics.
+    metrics: dict[str, float] = {
+        "completion_total": float(len(completions)),
+        "completion_valid": float(total_valid),
+        "completion_invalid": float(total_invalid),
+    }
+    for invalid_type, count in type_counts.items():
+        metrics[f"completion_invalid_{invalid_type}"] = float(count)
+
+    if policy == "filter":
+        metrics["completion_filtered"] = float(len(result.dropped_indices))
+
+    result.metrics = metrics
+
+    # Write quarantine file if requested.
+    if quarantine_path and result.quarantine_records:
+        _write_quarantine(quarantine_path, result.quarantine_records)
+
+    if result.dropped_indices:
+        logger.warning(
+            "completion_validator: dropped %d/%d completions (policy=%s, types=%s)",
+            len(result.dropped_indices),
+            len(completions),
+            policy,
+            type_counts,
+        )
+
+    return kept_completions, kept_tokens, result
+
+
+def get_special_token_ids(tokenizer: Any) -> tuple[int, ...]:
+    """Extract special token ids from a HuggingFace tokenizer.
+
+    Covers ``all_special_ids`` and the EOS tokens that some tokenizers list
+    separately.
+    """
+
+    ids: set[int] = set()
+    all_special = getattr(tokenizer, "all_special_ids", [])
+    ids.update(all_special)
+
+    # Some tokenizers expose additional special tokens via added_tokens.
+    added = getattr(tokenizer, "added_tokens_encoder", {})
+    for token_id in added.values():
+        ids.add(int(token_id))
+
+    return tuple(sorted(ids))
+
+
+def _write_quarantine(path: str | Path, records: list[dict[str, Any]]) -> None:
+    """Append invalid completion records to a JSONL quarantine file."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/docs/troubleshooting/empty-completion.rst
+++ b/docs/troubleshooting/empty-completion.rst
@@ -79,6 +79,12 @@ validated before ``reward_fn``:
 
 The resample budget is configured via:
 
+.. code-block:: bash
+
+   areno train ... --empty-completion-policy resample --empty-completion-resample-budget 5
+
+Or via the SDK:
+
 .. code-block:: python
 
    from areno.api.trainer_config import PolicyTrainerConfig
@@ -90,6 +96,12 @@ The resample budget is configured via:
        empty_completion_policy="resample",
        empty_completion_resample_budget=5,  # default 3
    )
+
+Parameter validation runs before model initialization:
+
+* ``--empty-completion-policy`` must be one of ``off``, ``filter``, ``resample``.
+* ``--empty-completion-resample-budget`` must be positive when policy is
+  ``resample``.
 
 Log output reference
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/troubleshooting/empty-completion.rst
+++ b/docs/troubleshooting/empty-completion.rst
@@ -1,0 +1,123 @@
+:orphan:
+
+Empty completion handling
+=========================
+
+During RL rollout the model may produce completions that carry no real
+content: empty strings, whitespace-only text, special-token-only output, or
+immediate-EOS generations.  These degenerate completions pollute rewards and
+gradients if they silently reach ``reward_fn`` or training code.
+
+AReno provides a configurable completion validation step that classifies and
+filters such completions **before** they enter reward computation.
+
+Quick start
+~~~~~~~~~~~
+
+Add ``--empty-completion-policy filter`` to your training command:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --empty-completion-policy filter
+
+The feature is **off** by default.  Existing runs are unaffected unless you
+explicitly enable it.
+
+Classification
+~~~~~~~~~~~~~~
+
+The validator classifies a completion as invalid when it matches any of the
+following:
+
+============================  ==================================================
+Type                          Detection rule
+============================  ==================================================
+``empty``                     No response tokens, or decoded text is ``""``
+``whitespace``                Decoded text contains only whitespace
+``immediate_eos``             Response is a single token and it is an EOS token
+``special_token``             Every response token is a special token
+============================  ==================================================
+
+Policies
+~~~~~~~~
+
+``--empty-completion-policy off``
+   Default.  No validation; all completions reach ``reward_fn`` unchanged.
+
+``--empty-completion-policy filter``
+   Invalid completions are dropped before ``reward_fn``.  Valid completions
+   in the same prompt group are preserved and used for reward and advantage
+   computation.
+
+Observable output
+~~~~~~~~~~~~~~~~~
+
+When filtering is active, each training step emits log lines like:
+
+.. code-block:: text
+
+   completion_validation metrics={'completion_total': 8.0, 'completion_valid': 5.0, 'completion_invalid': 3.0, 'completion_invalid_empty': 2.0, 'completion_invalid_whitespace': 1.0, 'completion_filtered': 3.0}
+
+When ``--save-path`` is set, dropped completions are also written to:
+
+.. code-block:: text
+
+   {save_path}/empty_completions.jsonl
+
+Each line is a JSON record with the following fields:
+
+==================  =========================================
+Field               Description
+==================  =========================================
+``index``           Position in the original batch
+``invalid_type``    One of the four classification types
+``completion``      Decoded text (truncated to 500 chars)
+``resp_token_count`` Number of response tokens
+``prompt``          Original prompt text (truncated to 500 chars)
+``policy``          The active policy (``filter``)
+==================  =========================================
+
+Covered algorithms
+~~~~~~~~~~~~~~~~~~
+
+The feature applies to all algorithms that perform rollout and reward
+scoring:
+
+* **GSPO** / **GRPO** (standard and agentic modes)
+* **PPO**
+
+SFT and DPO do not use rollout and are unaffected.
+
+Configuration
+~~~~~~~~~~~~~
+
+The policy is stored in ``RolloutTrainerConfig`` and inherited by
+``PolicyTrainerConfig`` (GSPO/GRPO) and ``PPOTrainerConfig`` (PPO):
+
+.. code-block:: python
+
+   from areno.api.trainer_config import PolicyTrainerConfig
+
+   config = PolicyTrainerConfig(
+       algo="gspo",
+       ckpt="Qwen/Qwen3-0.6B",
+       dataset_path="gsm8k:main",
+       empty_completion_policy="filter",  # "off" (default) or "filter"
+   )
+
+Testing
+~~~~~~~
+
+CPU-only tests live in ``tests/test_completion_validator_cpu.py``:
+
+.. code-block:: bash
+
+   pytest tests/test_completion_validator_cpu.py -v

--- a/docs/troubleshooting/empty-completion.rst
+++ b/docs/troubleshooting/empty-completion.rst
@@ -55,52 +55,29 @@ Policies
 ``--empty-completion-policy filter``
    Invalid completions are dropped before ``reward_fn``.  Valid completions
    in the same prompt group are preserved and used for reward and advantage
-   computation.
+   computation.  If all completions for a prompt are invalid, the prompt is
+   skipped with a warning.
 
-Observable output
+``--empty-completion-policy resample``
+   Invalid completions trigger re-generation of the entire prompt group
+   (all ``n_samples`` completions) up to ``--empty-completion-resample-budget``
+   times (default 3).  After the budget is exhausted, any remaining invalid
+   completions are filtered.  Only supported for standard GSPO/GRPO and PPO
+   training; agentic mode uses ``filter`` semantics.
+
+Resample behavior
 ~~~~~~~~~~~~~~~~~
 
-When filtering is active, each training step emits log lines like:
+When ``--empty-completion-policy resample`` is active, each prompt group is
+validated before ``reward_fn``:
 
-.. code-block:: text
+1. Check all completions in the group.
+2. If any are invalid, re-run rollout for that prompt (replacing all
+   ``n_samples`` completions).
+3. Repeat up to ``--empty-completion-resample-budget`` times.
+4. After the budget is exhausted, apply ``filter`` as a fallback.
 
-   completion_validation metrics={'completion_total': 8.0, 'completion_valid': 5.0, 'completion_invalid': 3.0, 'completion_invalid_empty': 2.0, 'completion_invalid_whitespace': 1.0, 'completion_filtered': 3.0}
-
-When ``--save-path`` is set, dropped completions are also written to:
-
-.. code-block:: text
-
-   {save_path}/empty_completions.jsonl
-
-Each line is a JSON record with the following fields:
-
-==================  =========================================
-Field               Description
-==================  =========================================
-``index``           Position in the original batch
-``invalid_type``    One of the four classification types
-``completion``      Decoded text (truncated to 500 chars)
-``resp_token_count`` Number of response tokens
-``prompt``          Original prompt text (truncated to 500 chars)
-``policy``          The active policy (``filter``)
-==================  =========================================
-
-Covered algorithms
-~~~~~~~~~~~~~~~~~~
-
-The feature applies to all algorithms that perform rollout and reward
-scoring:
-
-* **GSPO** / **GRPO** (standard and agentic modes)
-* **PPO**
-
-SFT and DPO do not use rollout and are unaffected.
-
-Configuration
-~~~~~~~~~~~~~
-
-The policy is stored in ``RolloutTrainerConfig`` and inherited by
-``PolicyTrainerConfig`` (GSPO/GRPO) and ``PPOTrainerConfig`` (PPO):
+The resample budget is configured via:
 
 .. code-block:: python
 
@@ -110,7 +87,103 @@ The policy is stored in ``RolloutTrainerConfig`` and inherited by
        algo="gspo",
        ckpt="Qwen/Qwen3-0.6B",
        dataset_path="gsm8k:main",
-       empty_completion_policy="filter",  # "off" (default) or "filter"
+       empty_completion_policy="resample",
+       empty_completion_resample_budget=5,  # default 3
+   )
+
+Log output reference
+~~~~~~~~~~~~~~~~~~~~
+
+The following log messages may appear depending on the active policy and
+outcome.  All messages are emitted at INFO or WARNING level.
+
+**Normal operation (filter)**
+
+.. code-block:: text
+
+   completion_validation metrics={'completion_total': 8.0, 'completion_valid': 5.0,
+     'completion_invalid': 3.0, 'completion_invalid_empty': 2.0,
+     'completion_invalid_whitespace': 1.0, 'completion_filtered': 3.0}
+
+**All completions invalid (filter)**
+
+.. code-block:: text
+
+   WARNING  all completions for prompt were empty or invalid; skipping this prompt
+            (dropped=4 policy=filter prompt_preview='What is 1+1?').
+            Consider disabling --empty-completion-policy if this happens frequently.
+
+**Resample attempt in progress**
+
+.. code-block:: text
+
+   resample attempt 1/3: re-generating prompt with 2 invalid completions
+
+**Resample succeeded**
+
+.. code-block:: text
+
+   resample succeeded after 2 attempt(s)
+
+**Resample exhausted (falling back to filter)**
+
+.. code-block:: text
+
+   WARNING  resample exhausted after 3 attempt(s): 2 completions still invalid,
+            falling back to filter
+
+**PPO-specific variants** use the prefix ``ppo resample`` instead of
+``resample``.
+
+**Agentic path** uses ``agentic completion_validation metrics=...``.
+
+Quarantine file
+~~~~~~~~~~~~~~~
+
+When ``--save-path`` is set, dropped completions are written to:
+
+.. code-block:: text
+
+   {save_path}/empty_completions.jsonl
+
+Each line is a JSON record:
+
+==================  =========================================
+Field               Description
+==================  =========================================
+``index``           Position in the original batch
+``invalid_type``    One of ``empty`` / ``whitespace`` / ``immediate_eos`` / ``special_token``
+``completion``      Decoded text (truncated to 500 chars)
+``resp_token_count`` Number of response tokens
+``prompt``          Original prompt text (truncated to 500 chars)
+``policy``          The active policy
+==================  =========================================
+
+Covered algorithms
+~~~~~~~~~~~~~~~~~~
+
+The feature applies to all algorithms that perform rollout and reward
+scoring:
+
+* **GSPO** / **GRPO** — ``filter`` and ``resample``
+* **PPO** — ``filter`` and ``resample``
+* **Agentic** (GSPO/GRPO + ``--agent-fn``) — ``filter`` only
+
+SFT and DPO do not use rollout and are unaffected.
+
+Configuration
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from areno.api.trainer_config import PolicyTrainerConfig
+
+   config = PolicyTrainerConfig(
+       algo="gspo",
+       ckpt="Qwen/Qwen3-0.6B",
+       dataset_path="gsm8k:main",
+       empty_completion_policy="filter",            # "off" (default), "filter", "resample"
+       empty_completion_resample_budget=3,          # max re-generation attempts
    )
 
 Limitations
@@ -137,9 +210,14 @@ Limitations
   numerically safe but eliminates the group-normalization benefit for that
   prompt.
 
-* **No resample.** The current implementation only supports ``filter``.
-  Bounded regeneration (``resample``) is not yet available and may be added in
-  a future release.
+* **Resample replaces the entire group.** When resample re-generates, all
+  ``n_samples`` completions for the prompt are replaced, not just the invalid
+  ones.  Previously valid completions are discarded.
+
+* **Agentic mode does not support resample.** Agentic trajectories involve
+  multi-turn tool interactions; re-running the entire agent loop is not
+  supported.  Agentic mode uses ``filter`` semantics even when
+  ``--empty-completion-policy resample`` is set.
 
 Testing
 ~~~~~~~

--- a/docs/troubleshooting/empty-completion.rst
+++ b/docs/troubleshooting/empty-completion.rst
@@ -113,6 +113,34 @@ The policy is stored in ``RolloutTrainerConfig`` and inherited by
        empty_completion_policy="filter",  # "off" (default) or "filter"
    )
 
+Limitations
+~~~~~~~~~~~
+
+* **Rollout only.** The validator inspects completions produced by the model
+  during RL rollout.  It does **not** filter empty or invalid records in
+  supervised datasets (SFT/DPO).  Pre-filter your training data for those
+  algorithms.
+
+* **Quarantine file growth.** The ``empty_completions.jsonl`` file is appended
+  to on every step.  It is not rotated or truncated automatically.  Monitor
+  disk usage for long-running jobs.
+
+* **Special-token classification depends on the tokenizer.** The
+  ``special_token`` check uses ``tokenizer.all_special_ids`` and
+  ``tokenizer.added_tokens_encoder``.  Different tokenizer versions or
+  configurations may expose different special token sets, which can affect
+  whether a completion is classified as ``special_token``.
+
+* **GRPO/GSPO group size.** Filtering reduces the number of completions per
+  prompt group.  If a group shrinks to a single completion,
+  ``compute_group_advantages`` returns zero advantage (std=0), which is
+  numerically safe but eliminates the group-normalization benefit for that
+  prompt.
+
+* **No resample.** The current implementation only supports ``filter``.
+  Bounded regeneration (``resample``) is not yet available and may be added in
+  a future release.
+
 Testing
 ~~~~~~~
 

--- a/examples/empty_completion_demo.py
+++ b/examples/empty_completion_demo.py
@@ -1,0 +1,103 @@
+"""Minimal runnable demo for completion validation (Issue #240).
+
+Run without GPU or model loading:
+
+    python examples/empty_completion_demo.py
+
+The demo constructs fake completions (including all four invalid types),
+runs them through ``validate_completions``, and prints the classification,
+filtering result, metrics, and quarantine records.
+"""
+
+from __future__ import annotations
+
+from areno.engine.runtime.completion_validator import (
+    classify_completion,
+    validate_completions,
+)
+
+
+def main() -> None:
+    # Simulate a batch of 8 completions from one prompt (n_samples=8).
+    # The EOS token id is 2; special token ids are {2, 100, 101}.
+    eos_token_ids = (2,)
+    special_token_ids = (2, 100, 101)
+
+    completions = [
+        "The answer is 42.",        # 0: valid
+        "",                          # 1: empty string
+        "   \n  ",                   # 2: whitespace-only
+        "<|endoftext|>",             # 3: immediate EOS (single token id=2)
+        "<|im_start|><|im_end|>",    # 4: special-token-only (ids=100,101)
+        "The answer is 17.",        # 5: valid
+        "",                          # 6: empty (no response tokens)
+        "The answer is 9.",         # 7: valid
+    ]
+    resp_tokens = [
+        [10, 20, 30],          # valid
+        [],                     # empty
+        [40, 41],              # whitespace
+        [2],                   # immediate EOS
+        [100, 101],            # special tokens
+        [11, 21, 31],          # valid
+        [],                     # empty
+        [12, 22, 32],          # valid
+    ]
+
+    print("=== Step 1: Classify each completion ===")
+    for i, (text, tokens) in enumerate(zip(completions, resp_tokens, strict=True)):
+        check = classify_completion(
+            completion=text,
+            resp_tokens=tokens,
+            eos_token_ids=eos_token_ids,
+            special_token_ids=special_token_ids,
+        )
+        status = "VALID" if check.is_valid else f"INVALID ({check.invalid_type})"
+        preview = text[:40] if text else "(empty)"
+        print(f"  [{i}] {status:25s} completion={preview!r}")
+
+    print("\n=== Step 2: Filter with policy='off' (default, no-op) ===")
+    kept, _, vr = validate_completions(
+        completions, resp_tokens,
+        policy="off",
+        eos_token_ids=eos_token_ids,
+        special_token_ids=special_token_ids,
+    )
+    print(f"  kept: {len(kept)} / {len(completions)}")
+    print(f"  dropped: {vr.dropped_indices}")
+    print(f"  metrics: {vr.metrics}")
+
+    print("\n=== Step 3: Filter with policy='filter' ===")
+    kept, _, vr = validate_completions(
+        completions, resp_tokens,
+        policy="filter",
+        eos_token_ids=eos_token_ids,
+        special_token_ids=special_token_ids,
+        prompt="What is the meaning of life?",
+    )
+    print(f"  kept: {len(kept)} / {len(completions)}")
+    print(f"  kept_indices: {vr.kept_indices}")
+    print(f"  dropped_indices: {vr.dropped_indices}")
+    print(f"  metrics: {vr.metrics}")
+
+    print("\n=== Step 4: Quarantine records ===")
+    for record in vr.quarantine_records:
+        print(f"  index={record['index']} type={record['invalid_type']} "
+              f"tokens={record['resp_token_count']} policy={record['policy']}")
+
+    print("\n=== Step 5: All-invalid boundary case ===")
+    kept, _, vr = validate_completions(
+        ["", "  "], [[], [40]],
+        policy="filter",
+        eos_token_ids=eos_token_ids,
+        special_token_ids=special_token_ids,
+    )
+    print(f"  kept: {len(kept)}")
+    print(f"  dropped: {vr.dropped_indices}")
+    print(f"  metrics: {vr.metrics}")
+
+    print("\nDone. Invalid completions never reach reward_fn or training code.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_completion_validator_cpu.py
+++ b/tests/test_completion_validator_cpu.py
@@ -527,8 +527,8 @@ class MaterializeTrainBatchIntegrationTest(unittest.TestCase):
         for c in seen_completions:
             self.assertTrue(len(c) > 0)
 
-    def test_filter_all_invalid_raises_runtime_error(self):
-        """When all samples are invalid, should raise RuntimeError with stage and input info."""
+    def test_filter_all_invalid_skips_prompt(self):
+        """When all samples are invalid, should skip the prompt with a warning, not crash."""
         trainer, tokenizer = self._make_trainer(policy="filter")
         prompt_batch = self._make_prompt_batch(n_prompts=1)
         rollout_results = self._make_rollout_results(
@@ -540,13 +540,12 @@ class MaterializeTrainBatchIntegrationTest(unittest.TestCase):
             self.fail("reward_fn should not be called when all completions are invalid")
 
         trainer.reward_fn = reward_fn
-        with self.assertRaises(RuntimeError) as ctx:
-            trainer._materialize_train_batch(tokenizer, prompt_batch, rollout_results)
-        # Error message should identify the affected stage and input without
-        # exposing full training samples.
-        self.assertIn("all completions for prompt were empty or invalid", str(ctx.exception))
-        self.assertIn("dropped=4", str(ctx.exception))
-        self.assertIn("prompt_preview=", str(ctx.exception))
+        train_batch, rewards_all, _ = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+        # Should skip the prompt entirely, producing empty train_batch.
+        self.assertEqual(len(train_batch), 0)
+        self.assertEqual(len(rewards_all), 0)
 
     def test_filter_mixed_valid_invalid_advantages_correct(self):
         """After filtering, advantages should be computed only over valid samples."""

--- a/tests/test_completion_validator_cpu.py
+++ b/tests/test_completion_validator_cpu.py
@@ -599,6 +599,44 @@ class MaterializeTrainBatchIntegrationTest(unittest.TestCase):
         self.assertEqual(len(train_batch), 2)
         self.assertEqual(len(rewards_all), 2)
 
+    def test_resample_policy_all_valid_no_retry(self):
+        """With resample policy and all valid completions, no retry should occur."""
+        trainer, tokenizer = self._make_trainer(policy="resample")
+        trainer.config = SimpleNamespace(
+            empty_completion_policy="resample",
+            empty_completion_resample_budget=3,
+            save_path=None,
+        )
+        prompt_batch = self._make_prompt_batch(n_prompts=1)
+        rollout_results = self._make_rollout_results(
+            n_prompts=1, n_samples=4,
+            invalid_indices={},  # all valid
+        )
+
+        def reward_fn(record):
+            return 1.0
+
+        trainer.reward_fn = reward_fn
+        train_batch, rewards_all, _ = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+
+        self.assertEqual(len(train_batch), 4)
+        self.assertEqual(len(rewards_all), 4)
+
+    def test_resample_metrics(self):
+        """Resample policy should produce resample-specific metrics."""
+        completions = ["ok", ""]
+        resp_tokens = [[1], []]
+        _, _, vr = validate_completions(
+            completions, resp_tokens, policy="resample",
+            eos_token_ids=(0,), special_token_ids=(0,),
+            resample_budget=5,
+        )
+        self.assertIn("completion_resample_candidates", vr.metrics)
+        self.assertEqual(vr.metrics["completion_resample_candidates"], 1.0)
+        self.assertEqual(vr.metrics["completion_resample_budget"], 5.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_completion_validator_cpu.py
+++ b/tests/test_completion_validator_cpu.py
@@ -527,8 +527,8 @@ class MaterializeTrainBatchIntegrationTest(unittest.TestCase):
         for c in seen_completions:
             self.assertTrue(len(c) > 0)
 
-    def test_filter_all_invalid_produces_empty_batch(self):
-        """When all samples are invalid, train_batch should be empty but not crash."""
+    def test_filter_all_invalid_raises_runtime_error(self):
+        """When all samples are invalid, should raise RuntimeError with stage and input info."""
         trainer, tokenizer = self._make_trainer(policy="filter")
         prompt_batch = self._make_prompt_batch(n_prompts=1)
         rollout_results = self._make_rollout_results(
@@ -540,12 +540,13 @@ class MaterializeTrainBatchIntegrationTest(unittest.TestCase):
             self.fail("reward_fn should not be called when all completions are invalid")
 
         trainer.reward_fn = reward_fn
-        train_batch, rewards_all, rollout_logprobs = trainer._materialize_train_batch(
-            tokenizer, prompt_batch, rollout_results
-        )
-
-        self.assertEqual(len(train_batch), 0)
-        self.assertEqual(len(rewards_all), 0)
+        with self.assertRaises(RuntimeError) as ctx:
+            trainer._materialize_train_batch(tokenizer, prompt_batch, rollout_results)
+        # Error message should identify the affected stage and input without
+        # exposing full training samples.
+        self.assertIn("all completions for prompt were empty or invalid", str(ctx.exception))
+        self.assertIn("dropped=4", str(ctx.exception))
+        self.assertIn("prompt_preview=", str(ctx.exception))
 
     def test_filter_mixed_valid_invalid_advantages_correct(self):
         """After filtering, advantages should be computed only over valid samples."""

--- a/tests/test_completion_validator_cpu.py
+++ b/tests/test_completion_validator_cpu.py
@@ -1,0 +1,604 @@
+"""CPU-only tests for the completion validation module.
+
+These tests cover classification of all four invalid types, the ``off``
+(default) no-op path, ``filter`` policy behaviour, metrics output,
+quarantine file writing, and boundary cases (all-invalid batch, empty
+input).  No GPU or model loading is required.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from areno.engine.runtime.completion_validator import (
+    CompletionCheck,
+    ValidationResult,
+    classify_completion,
+    get_special_token_ids,
+    validate_completions,
+)
+
+
+class ClassifyCompletionTest(unittest.TestCase):
+    """Unit tests for the single-completion classifier."""
+
+    def test_valid_completion(self):
+        """A normal completion with content should be valid."""
+        check = classify_completion("answer is 42", [1, 2, 3])
+        self.assertTrue(check.is_valid)
+        self.assertIsNone(check.invalid_type)
+
+    def test_empty_string(self):
+        """An empty decoded string should be classified as empty."""
+        check = classify_completion("", [0], eos_token_ids=(0,))
+        self.assertFalse(check.is_valid)
+        self.assertEqual(check.invalid_type, "empty")
+
+    def test_no_response_tokens(self):
+        """Zero response tokens should be classified as empty."""
+        check = classify_completion("", [])
+        self.assertFalse(check.is_valid)
+        self.assertEqual(check.invalid_type, "empty")
+
+    def test_whitespace_only(self):
+        """Whitespace-only text should be classified as whitespace."""
+        check = classify_completion("   \n  ", [10, 11])
+        self.assertFalse(check.is_valid)
+        self.assertEqual(check.invalid_type, "whitespace")
+
+    def test_immediate_eos(self):
+        """A single EOS token should be classified as immediate_eos."""
+        check = classify_completion("<|endoftext|>", [2], eos_token_ids=(2,))
+        self.assertFalse(check.is_valid)
+        self.assertEqual(check.invalid_type, "immediate_eos")
+
+    def test_special_token_only(self):
+        """All-special-token responses should be classified as special_token."""
+        check = classify_completion(
+            "<|im_start|><|im_end|>",
+            [100, 101],
+            eos_token_ids=(2,),
+            special_token_ids=(100, 101),
+        )
+        self.assertFalse(check.is_valid)
+        self.assertEqual(check.invalid_type, "special_token")
+
+    def test_eos_not_in_special_ids_still_immediate_eos(self):
+        """Immediate EOS should take priority over special_token when len==1."""
+        check = classify_completion(
+            "<|endoftext|>",
+            [2],
+            eos_token_ids=(2,),
+            special_token_ids=(2,),
+        )
+        self.assertFalse(check.is_valid)
+        self.assertEqual(check.invalid_type, "immediate_eos")
+
+    def test_valid_completion_with_eos_at_end(self):
+        """A completion that has content followed by EOS should be valid."""
+        check = classify_completion(
+            "answer is 42",
+            [1, 2, 3, 2],
+            eos_token_ids=(2,),
+            special_token_ids=(2,),
+        )
+        self.assertTrue(check.is_valid)
+
+
+class ValidateCompletionsTest(unittest.TestCase):
+    """Tests for the batch-level validate_completions function."""
+
+    def test_policy_off_returns_inputs_unchanged(self):
+        """When policy is 'off', all completions should be kept with no metrics."""
+        completions = ["ok", "", "  ", "ok2"]
+        resp_tokens = [[1, 2], [], [10], [3, 4]]
+        kept_c, kept_t, vr = validate_completions(
+            completions, resp_tokens, policy="off",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+        self.assertEqual(len(kept_c), 4)
+        self.assertEqual(vr.kept_indices, [0, 1, 2, 3])
+        self.assertEqual(vr.dropped_indices, [])
+        self.assertEqual(vr.metrics, {})
+
+    def test_filter_drops_invalid(self):
+        """Filter policy should drop empty and whitespace completions."""
+        completions = ["ok", "", "  ", "ok2"]
+        resp_tokens = [[1, 2], [], [10], [3, 4]]
+        kept_c, kept_t, vr = validate_completions(
+            completions, resp_tokens, policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+        self.assertEqual(len(kept_c), 2)
+        self.assertEqual(vr.kept_indices, [0, 3])
+        self.assertEqual(vr.dropped_indices, [1, 2])
+        self.assertEqual(vr.quarantine_records[0]["invalid_type"], "empty")
+        self.assertEqual(vr.quarantine_records[1]["invalid_type"], "whitespace")
+
+    def test_filter_metrics(self):
+        """Metrics should include per-type counts and filtered total."""
+        completions = ["ok", "", "", "ok2"]
+        resp_tokens = [[1], [], [], [2]]
+        _, _, vr = validate_completions(
+            completions, resp_tokens, policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+        self.assertEqual(vr.metrics["completion_total"], 4.0)
+        self.assertEqual(vr.metrics["completion_valid"], 2.0)
+        self.assertEqual(vr.metrics["completion_invalid"], 2.0)
+        self.assertEqual(vr.metrics["completion_invalid_empty"], 2.0)
+        self.assertEqual(vr.metrics["completion_filtered"], 2.0)
+
+    def test_all_invalid_batch(self):
+        """A batch where every completion is invalid should drop all rows."""
+        completions = ["", "  "]
+        resp_tokens = [[], [10]]
+        kept_c, kept_t, vr = validate_completions(
+            completions, resp_tokens, policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+        self.assertEqual(len(kept_c), 0)
+        self.assertEqual(vr.kept_indices, [])
+        self.assertEqual(vr.dropped_indices, [0, 1])
+
+    def test_all_valid_batch(self):
+        """A batch with no invalid completions should keep everything."""
+        completions = ["answer1", "answer2"]
+        resp_tokens = [[1, 2], [3, 4]]
+        kept_c, kept_t, vr = validate_completions(
+            completions, resp_tokens, policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+        self.assertEqual(len(kept_c), 2)
+        self.assertEqual(vr.dropped_indices, [])
+
+    def test_empty_input_batch(self):
+        """An empty completions list should produce empty results."""
+        kept_c, kept_t, vr = validate_completions(
+            [], [], policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+        self.assertEqual(len(kept_c), 0)
+        self.assertEqual(vr.metrics["completion_total"], 0.0)
+        self.assertEqual(vr.metrics["completion_valid"], 0.0)
+
+    def test_quarantine_file_written(self):
+        """Quarantine records should be written as JSONL to the specified path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quarantine_path = Path(tmpdir) / "empty_completions.jsonl"
+            validate_completions(
+                ["ok", ""],
+                [[1], []],
+                policy="filter",
+                eos_token_ids=(0,),
+                special_token_ids=(0,),
+                quarantine_path=str(quarantine_path),
+                prompt="What is 1+1?",
+            )
+            self.assertTrue(quarantine_path.exists())
+            lines = quarantine_path.read_text(encoding="utf-8").strip().split("\n")
+            self.assertEqual(len(lines), 1)
+            record = json.loads(lines[0])
+            self.assertEqual(record["invalid_type"], "empty")
+            self.assertEqual(record["prompt"], "What is 1+1?")
+            self.assertEqual(record["policy"], "filter")
+
+    def test_quarantine_not_written_when_all_valid(self):
+        """No quarantine file should be created when there are no invalid completions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quarantine_path = Path(tmpdir) / "empty_completions.jsonl"
+            validate_completions(
+                ["ok"],
+                [[1]],
+                policy="filter",
+                eos_token_ids=(0,),
+                special_token_ids=(0,),
+                quarantine_path=str(quarantine_path),
+            )
+            self.assertFalse(quarantine_path.exists())
+
+    def test_completion_truncated_in_quarantine(self):
+        """Long completions should be truncated to 500 chars in quarantine records."""
+        long_completion = "x" * 1000
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quarantine_path = Path(tmpdir) / "q.jsonl"
+            validate_completions(
+                [long_completion, ""],
+                [[1] * 1000, []],
+                policy="filter",
+                eos_token_ids=(0,),
+                special_token_ids=(0,),
+                quarantine_path=str(quarantine_path),
+            )
+            lines = quarantine_path.read_text(encoding="utf-8").strip().split("\n")
+            # Only the empty completion should be in quarantine (the long one is valid).
+            self.assertEqual(len(lines), 1)
+            record = json.loads(lines[0])
+            self.assertEqual(record["invalid_type"], "empty")
+
+    def test_prompt_truncated_in_quarantine(self):
+        """Long prompts should be truncated to 500 chars in quarantine records."""
+        long_prompt = "p" * 1000
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quarantine_path = Path(tmpdir) / "q.jsonl"
+            validate_completions(
+                ["", "ok"],
+                [[], [1]],
+                policy="filter",
+                eos_token_ids=(0,),
+                special_token_ids=(0,),
+                quarantine_path=str(quarantine_path),
+                prompt=long_prompt,
+            )
+            lines = quarantine_path.read_text(encoding="utf-8").strip().split("\n")
+            record = json.loads(lines[0])
+            self.assertEqual(len(record["prompt"]), 500)
+
+
+class GetSpecialTokenIdsTest(unittest.TestCase):
+    """Tests for the tokenizer special-token-id extraction helper."""
+
+    def test_extracts_all_special_ids(self):
+        """all_special_ids from a tokenizer should be returned as a sorted tuple."""
+
+        class FakeTokenizer:
+            all_special_ids = [3, 1, 2]
+            added_tokens_encoder = {"<extra>": 5}
+
+        result = get_special_token_ids(FakeTokenizer())
+        self.assertEqual(result, (1, 2, 3, 5))
+
+    def test_handles_missing_attributes(self):
+        """A tokenizer without all_special_ids should not raise."""
+
+        class MinimalTokenizer:
+            pass
+
+        result = get_special_token_ids(MinimalTokenizer())
+        self.assertEqual(result, ())
+
+
+class ConfigFieldTest(unittest.TestCase):
+    """Tests that the config dataclass carries the new field with correct default."""
+
+    def test_default_policy_is_off(self):
+        """RolloutTrainerConfig should default empty_completion_policy to 'off'."""
+        from areno.api.trainer_config import PolicyTrainerConfig
+
+        config = PolicyTrainerConfig(algo="gspo", ckpt="unused", dataset_path="unused")
+        self.assertEqual(config.empty_completion_policy, "off")
+
+    def test_policy_inherited_by_ppo(self):
+        """PPOTrainerConfig should inherit the field from RolloutTrainerConfig."""
+        from areno.api.trainer_config import PPOTrainerConfig
+
+        config = PPOTrainerConfig(algo="ppo", ckpt="unused", dataset_path="unused")
+        self.assertEqual(config.empty_completion_policy, "off")
+
+    def test_sft_config_has_no_field(self):
+        """SFT uses TrainerConfig which should not have the field."""
+        from areno.api.trainer_config import TrainerConfig
+
+        config = TrainerConfig(algo="sft", ckpt="unused", dataset_path="unused")
+        self.assertFalse(hasattr(config, "empty_completion_policy"))
+
+
+class QuarantineRecordFieldsTest(unittest.TestCase):
+    """Tests that quarantine records contain all required fields with correct values."""
+
+    def test_record_contains_all_fields(self):
+        """Each quarantine record should have index, invalid_type, completion, resp_token_count, prompt, policy."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quarantine_path = Path(tmpdir) / "q.jsonl"
+            validate_completions(
+                ["ok", ""],
+                [[1, 2], []],
+                policy="filter",
+                eos_token_ids=(0,),
+                special_token_ids=(0,),
+                quarantine_path=str(quarantine_path),
+                prompt="test prompt",
+            )
+            lines = quarantine_path.read_text(encoding="utf-8").strip().split("\n")
+            record = json.loads(lines[0])
+            self.assertEqual(record["index"], 1)
+            self.assertEqual(record["invalid_type"], "empty")
+            self.assertEqual(record["completion"], "")
+            self.assertEqual(record["resp_token_count"], 0)
+            self.assertEqual(record["prompt"], "test prompt")
+            self.assertEqual(record["policy"], "filter")
+
+    def test_multiple_records_preserve_order(self):
+        """Multiple invalid completions should produce records in original index order."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            quarantine_path = Path(tmpdir) / "q.jsonl"
+            validate_completions(
+                ["", "ok", "  ", "ok2"],
+                [[], [1], [2], [3]],
+                policy="filter",
+                eos_token_ids=(0,),
+                special_token_ids=(0,),
+                quarantine_path=str(quarantine_path),
+                prompt="p",
+            )
+            lines = quarantine_path.read_text(encoding="utf-8").strip().split("\n")
+            self.assertEqual(len(lines), 2)
+            r0 = json.loads(lines[0])
+            r1 = json.loads(lines[1])
+            self.assertEqual(r0["index"], 0)
+            self.assertEqual(r0["invalid_type"], "empty")
+            self.assertEqual(r1["index"], 2)
+            self.assertEqual(r1["invalid_type"], "whitespace")
+
+
+class RewardFnIsolationTest(unittest.TestCase):
+    """Integration-style tests verifying invalid completions never reach reward_fn.
+
+    These tests simulate the filtering step that runs before reward_fn in the
+    trainer and assert that only valid completions survive to be scored.
+    """
+
+    def test_filter_then_reward_only_receives_valid(self):
+        """After filtering, reward_fn should only be called with valid completions."""
+        completions = ["answer is 42", "", "  ", "answer is 9"]
+        resp_tokens = [[1, 2, 3], [], [10, 11], [4, 5, 6]]
+
+        kept_completions, kept_tokens, vr = validate_completions(
+            completions, resp_tokens, policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+
+        # Simulate reward_fn: it should only see kept completions.
+        seen_by_reward = list(kept_completions)
+        self.assertEqual(seen_by_reward, ["answer is 42", "answer is 9"])
+        self.assertNotIn("", seen_by_reward)
+        self.assertNotIn("  ", seen_by_reward)
+
+    def test_off_policy_passes_everything_to_reward(self):
+        """When policy is 'off', reward_fn should receive all completions including invalid."""
+        completions = ["ok", ""]
+        resp_tokens = [[1], []]
+
+        kept_completions, _, vr = validate_completions(
+            completions, resp_tokens, policy="off",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+
+        seen_by_reward = list(kept_completions)
+        self.assertEqual(seen_by_reward, ["ok", ""])
+        self.assertIn("", seen_by_reward)
+
+    def test_all_invalid_yields_empty_for_reward(self):
+        """When all completions are invalid, reward_fn should receive nothing."""
+        completions = ["", "  "]
+        resp_tokens = [[], [10]]
+
+        kept_completions, _, vr = validate_completions(
+            completions, resp_tokens, policy="filter",
+            eos_token_ids=(0,), special_token_ids=(0,),
+        )
+
+        self.assertEqual(len(kept_completions), 0)
+
+
+class MaterializeTrainBatchIntegrationTest(unittest.TestCase):
+    """Integration tests that mock rollout results and exercise the full
+    _materialize_train_batch pipeline including validation, reward, and
+    TrainSequence assembly.
+    """
+
+    def _make_trainer(self, policy="off"):
+        """Build a minimal PolicyOnlyTrainer with mocked dependencies."""
+
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        class FakeTokenizer:
+            eos_token_id = 2
+            chat_template = None
+
+            def decode(self, token_ids):
+                if not token_ids:
+                    return ""
+                if token_ids == [2]:
+                    return "<|endoftext|>"
+                if all(t in (2,) for t in token_ids):
+                    return "<|endoftext|>" * len(token_ids)
+                return "answer_" + "".join(chr(t + 60) for t in token_ids)
+
+        class FakeContext:
+            model_path = ""
+
+        config = SimpleNamespace(
+            empty_completion_policy=policy,
+            save_path=None,
+        )
+
+        trainer = PolicyOnlyTrainer.__new__(PolicyOnlyTrainer)
+        trainer.config = config
+        trainer.areno = SimpleNamespace(_ctx=FakeContext())
+        trainer.reward_fn = None  # set per-test
+        trainer.loss_fn = None
+        trainer.logger = __import__("logging").getLogger("test")
+        trainer._agent_run_fn = None
+
+        return trainer, FakeTokenizer()
+
+    def _make_prompt_batch(self, n_prompts=1):
+        """Create a PromptBatch with simple tokenized prompts."""
+        from areno.api.data import PromptBatch, PromptItem
+
+        items = [
+            PromptItem(
+                prompt=f"question {i}",
+                solutions=[str(i)],
+                input_tokens=[100 + i],
+                record={"answer": str(i)},
+            )
+            for i in range(n_prompts)
+        ]
+        return PromptBatch(items=items, scanned=n_prompts, skipped_long=0, total_skipped_long=0)
+
+    def _make_rollout_results(self, n_prompts=1, n_samples=4, invalid_indices=None):
+        """Create mock RolloutResult list with specified invalid completions.
+
+        invalid_indices is a dict mapping prompt_idx -> set of sample indices
+        that should be invalid.  Invalid samples get empty resp_tokens.
+        """
+        from areno.api.models import RolloutResult, RolloutSequence
+
+        if invalid_indices is None:
+            invalid_indices = {}
+
+        results = []
+        for p in range(n_prompts):
+            invalid_for_prompt = invalid_indices.get(p, set())
+            sequences = []
+            for s in range(n_samples):
+                if s in invalid_for_prompt:
+                    sequences.append(RolloutSequence(resp_tokens=[], resp_logprobs=[]))
+                else:
+                    sequences.append(
+                        RolloutSequence(
+                            resp_tokens=[10 + s, 20 + s],
+                            resp_logprobs=[-0.5, -0.3],
+                        )
+                    )
+            results.append(RolloutResult(sequences=sequences))
+        return results
+
+    def test_off_policy_preserves_all_samples(self):
+        """With policy='off', all samples should reach reward_fn and TrainSequence."""
+        from areno.api.rewards import RewardRecord
+
+        trainer, tokenizer = self._make_trainer(policy="off")
+        prompt_batch = self._make_prompt_batch(n_prompts=1)
+        rollout_results = self._make_rollout_results(
+            n_prompts=1, n_samples=4,
+            invalid_indices={0: {1, 2}},  # samples 1 and 2 are empty
+        )
+
+        seen_completions = []
+
+        def reward_fn(record):
+            seen_completions.append(record.completion)
+            return 1.0
+
+        trainer.reward_fn = reward_fn
+        train_batch, rewards_all, rollout_logprobs = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+
+        # All 4 samples should be present (including empty ones).
+        self.assertEqual(len(train_batch), 4)
+        self.assertEqual(len(rewards_all), 4)
+        self.assertIn("", seen_completions)
+
+    def test_filter_removes_invalid_before_reward(self):
+        """With policy='filter', invalid completions should not reach reward_fn."""
+        from areno.api.rewards import RewardRecord
+
+        trainer, tokenizer = self._make_trainer(policy="filter")
+        prompt_batch = self._make_prompt_batch(n_prompts=1)
+        rollout_results = self._make_rollout_results(
+            n_prompts=1, n_samples=4,
+            invalid_indices={0: {1, 2}},  # samples 1 and 2 are empty
+        )
+
+        seen_completions = []
+
+        def reward_fn(record):
+            seen_completions.append(record.completion)
+            return 1.0
+
+        trainer.reward_fn = reward_fn
+        train_batch, rewards_all, rollout_logprobs = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+
+        # Only 2 valid samples should reach reward_fn and TrainSequence.
+        self.assertEqual(len(train_batch), 2)
+        self.assertEqual(len(rewards_all), 2)
+        self.assertNotIn("", seen_completions)
+        # All seen completions should be non-empty.
+        for c in seen_completions:
+            self.assertTrue(len(c) > 0)
+
+    def test_filter_all_invalid_produces_empty_batch(self):
+        """When all samples are invalid, train_batch should be empty but not crash."""
+        trainer, tokenizer = self._make_trainer(policy="filter")
+        prompt_batch = self._make_prompt_batch(n_prompts=1)
+        rollout_results = self._make_rollout_results(
+            n_prompts=1, n_samples=4,
+            invalid_indices={0: {0, 1, 2, 3}},  # all empty
+        )
+
+        def reward_fn(record):
+            self.fail("reward_fn should not be called when all completions are invalid")
+
+        trainer.reward_fn = reward_fn
+        train_batch, rewards_all, rollout_logprobs = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+
+        self.assertEqual(len(train_batch), 0)
+        self.assertEqual(len(rewards_all), 0)
+
+    def test_filter_mixed_valid_invalid_advantages_correct(self):
+        """After filtering, advantages should be computed only over valid samples."""
+        trainer, tokenizer = self._make_trainer(policy="filter")
+        prompt_batch = self._make_prompt_batch(n_prompts=1)
+        rollout_results = self._make_rollout_results(
+            n_prompts=1, n_samples=4,
+            invalid_indices={0: {0, 3}},  # samples 0 and 3 are empty
+        )
+
+        def reward_fn(record):
+            # Give different rewards to the two valid samples.
+            # sample 1 has resp_tokens=[11,21], sample 2 has [12,22].
+            if len(record.tokens) > 1 and record.tokens[1] == 11:  # sample 1
+                return 2.0
+            return 0.0  # sample 2
+
+        trainer.reward_fn = reward_fn
+        train_batch, rewards_all, _ = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+
+        # 2 valid samples, 2 rewards.
+        self.assertEqual(len(rewards_all), 2)
+        self.assertEqual(len(train_batch), 2)
+        # Rewards should be [2.0, 0.0] for samples 1 and 2.
+        self.assertIn(2.0, rewards_all)
+        self.assertIn(0.0, rewards_all)
+        # Each TrainSequence should have matching reward.
+        for seq in train_batch:
+            self.assertIn(seq.reward, [2.0, 0.0])
+
+    def test_filter_multiple_prompts(self):
+        """Filtering should work correctly across multiple prompts in one batch."""
+        trainer, tokenizer = self._make_trainer(policy="filter")
+        prompt_batch = self._make_prompt_batch(n_prompts=2)
+        rollout_results = self._make_rollout_results(
+            n_prompts=2, n_samples=2,
+            invalid_indices={0: {0}, 1: {1}},  # prompt0 sample0 empty, prompt1 sample1 empty
+        )
+
+        def reward_fn(record):
+            return 1.0
+
+        trainer.reward_fn = reward_fn
+        train_batch, rewards_all, _ = trainer._materialize_train_batch(
+            tokenizer, prompt_batch, rollout_results
+        )
+
+        # 2 prompts × 1 valid sample each = 2 TrainSequences.
+        self.assertEqual(len(train_batch), 2)
+        self.assertEqual(len(rewards_all), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #240 — classify and filter empty/invalid model completions before they reach `reward_fn` or training code.

## Files changed

| File | Change |
|---|---|
| `areno/engine/runtime/completion_validator.py` | New — core validation module |
| `areno/api/trainer_config.py` | Add `empty_completion_policy` and `empty_completion_resample_budget` |
| `areno/api/trainers/policy_only.py` | Validation in GSPO/GRPO + Agentic paths |
| `areno/api/trainers/ppo.py` | Validation in PPO path |
| `areno/cli/train.py` | Add `--empty-completion-policy` and `--empty-completion-resample-budget` |
| `tests/test_completion_validator_cpu.py` | New — 35 CPU tests |
| `docs/troubleshooting/empty-completion.rst` | New — user documentation |
| `examples/empty_completion_demo.py` | New — standalone runnable demo |

## Policies

| Policy | Behavior |
|---|---|
| `off` (default) | No validation, backward compatible |
| `filter` | Drop invalid completions before `reward_fn` |
| `resample` | Re-generate invalid completions up to budget times, then filter |

## Classification

Detects four types: `empty`, `whitespace`, `immediate_eos`, `special_token`.

## Covered algorithms

| Algorithm | filter | resample |
|---|---|---|
| GSPO / GRPO | ✅ | ✅ |
| PPO | ✅ | ✅ |
| Agentic | ✅ | ❌ |

## Test

```bash
pytest tests/test_completion_validator_cpu.py -v
# 35 passed
<img width="2880" height="4170" alt="merged_output" src="https://github.com/user-attachments/assets/0c2f58bb-6809-4225-a1df-ef5a554a4df5" />
