### PR TITLE
feat(cli): preview launcher validation results and the final command before training

### DIFF
--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -482,3 +482,446 @@ def _print_env_report(report: dict[str, Any]) -> None:
     click.echo("  Environment variables:")
     for name, value in report["env"].items():
         click.echo(f"    {name}={value if value is not None else '<unset>'}")
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks for ``areno train``
+#
+# These checks run before training starts so that environment problems (missing
+# GPU, insufficient disk, broken paths) are caught *before* a potentially long
+# model download.  The three-level severity model lets users override
+# non-fatal issues with ``--skip-check`` while hard failures always block:
+#
+#   CRITICAL — training is impossible (no GPU, no PyTorch).  Cannot be skipped.
+#   ERROR    — training will almost certainly fail (wrong PyTorch version,
+#              missing areno_accel, path not found).  Skippable with --skip-check.
+#   WARNING  — training works but may be slower or limited (no flash_attn,
+#              non-Linux platform).  Never blocks.
+# ---------------------------------------------------------------------------
+
+# Kept for backward compatibility with any external callers that inspect labels.
+_CHECK_LABEL = "PASS", "WARN", "ERROR", "CRITICAL"
+
+
+@dataclass(frozen=True)
+class PreflightCheck:
+    """A single pre-flight check result with severity level."""
+
+    level: str  # "PASS", "WARN", "ERROR", "CRITICAL"
+    name: str
+    detail: str = ""
+    next_step: str = ""
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Aggregated pre-flight check results.
+
+    ``critical_failures`` block training unconditionally (even with
+    ``--skip-check``).  ``errors`` block training unless the user passes
+    ``--skip-check``.  ``warnings`` never block.
+    """
+
+    checks: list[PreflightCheck]
+    kaggle_detected: bool = False
+
+    @property
+    def passed(self) -> list[PreflightCheck]:
+        return [c for c in self.checks if c.level == "PASS"]
+
+    @property
+    def warnings(self) -> list[PreflightCheck]:
+        return [c for c in self.checks if c.level == "WARN"]
+
+    @property
+    def errors(self) -> list[PreflightCheck]:
+        return [c for c in self.checks if c.level == "ERROR"]
+
+    @property
+    def critical_failures(self) -> list[PreflightCheck]:
+        return [c for c in self.checks if c.level == "CRITICAL"]
+
+
+def _is_kaggle() -> bool:
+    """Detect whether we are running inside a Kaggle Notebook.
+
+    Kaggle sets ``KAGGLE_KERNEL_RUN_TYPE`` and always mounts ``/kaggle/working``.
+    We check both so the detection works even if one indicator is missing.
+    """
+
+    if os.environ.get("KAGGLE_KERNEL_RUN_TYPE"):
+        return True
+    return Path("/kaggle/working").is_dir()
+
+
+def _disk_free_gb(path: str) -> float | None:
+    """Return available disk space in GB for the partition holding *path*."""
+
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return None
+    return usage.free / (1024**3)
+
+
+_MIN_DISK_GB = 5.0
+
+
+def run_preflight_checks(
+    config,
+    *,
+    reward_ckpt: str | None = None,
+) -> PreflightResult:
+    """Run pre-flight environment and config checks before training.
+
+    *config* is a ``TrainerConfig`` (or subclass).  The function reuses
+    :func:`collect_env` for system-level inspection, then adds training-specific
+    checks such as GPU/world_size matching and path reachability.
+    """
+
+    report = collect_env()
+    checks: list[PreflightCheck] = []
+
+    # --- CRITICAL: cannot train without these ---------------------------
+    py_version = sys.version_info
+    checks.append(
+        PreflightCheck(
+            "PASS" if py_version >= (3, 10) else "CRITICAL",
+            "Python >= 3.10",
+            f"found {platform.python_version()}",
+            "Use Python 3.10 or newer.",
+        )
+    )
+
+    torch_info = report["torch"]
+    torch_imported = bool(torch_info["imported"])
+    checks.append(
+        PreflightCheck(
+            "PASS" if torch_imported else "CRITICAL",
+            "PyTorch import",
+            torch_info.get("version") or torch_info.get("error", ""),
+            "Install CUDA-enabled PyTorch matching your CUDA version.",
+        )
+    )
+
+    cuda_available = bool(torch_info.get("cuda_available"))
+    checks.append(
+        PreflightCheck(
+            "PASS" if cuda_available else "CRITICAL",
+            "torch.cuda.is_available()",
+            f"visible_gpus={torch_info.get('device_count')}",
+            "Check NVIDIA driver installation and CUDA_VISIBLE_DEVICES.",
+        )
+    )
+
+    gpu_count = len(report.get("gpus", []))
+    checks.append(
+        PreflightCheck(
+            "PASS" if gpu_count >= 1 else "CRITICAL",
+            "NVIDIA GPU visibility",
+            ", ".join(g["name"] for g in report["gpus"]) if report["gpus"] else "no GPUs reported",
+            "Make at least one NVIDIA GPU visible to the process.",
+        )
+    )
+
+    # --- ERROR: training will almost certainly fail ----------------------
+    checks.append(
+        PreflightCheck(
+            "PASS" if (torch_imported and _version_at_least(torch_info.get("version"), (2, 6))) else "ERROR",
+            "PyTorch >= 2.6",
+            torch_info.get("version") or "not importable",
+            "Install PyTorch 2.6 or newer with CUDA support.",
+        )
+    )
+
+    cuda_build = torch_info.get("cuda_build")
+    checks.append(
+        PreflightCheck(
+            "PASS" if cuda_build else "ERROR",
+            "PyTorch CUDA build",
+            f"torch.version.cuda={cuda_build}" if cuda_build else "CPU-only build",
+            "Install a CUDA-enabled PyTorch build; CPU-only torch cannot run AReno.",
+        )
+    )
+
+    checks.append(
+        PreflightCheck(
+            "PASS" if gpu_count >= config.world_size else "ERROR",
+            "GPU count >= world_size",
+            f"gpus={gpu_count}, world_size={config.world_size}",
+            f"Reduce --world-size to <= {gpu_count} or make more GPUs visible.",
+        )
+    )
+
+    accel = report["dependencies"]["areno_accel"]
+    checks.append(
+        PreflightCheck(
+            "PASS" if accel["imported"] else "ERROR",
+            "areno_accel import",
+            accel.get("error", "imported") if not accel["imported"] else "imported",
+            "Reinstall AReno from source: pip install -e . --no-build-isolation",
+        )
+    )
+
+    # --- ERROR: path reachability ----------------------------------------
+    # Distinguish local paths from remote model repo IDs.  The order matters:
+    # we check existence first, then use the leading character to decide
+    # whether a non-existent path is a local file (absolute/home-relative) or
+    # a remote repo ID (e.g. "Qwen/Qwen3-0.6B" contains "/" but is not a
+    # filesystem path).  We cannot rely on Path.suffix alone because names
+    # like "Qwen3.5-0.8B" have a suffix-like trailing segment.
+    ckpt_path = Path(config.ckpt)
+    if ckpt_path.exists() or ckpt_path.is_dir():
+        # Path exists locally — no further checks needed.
+        checks.append(
+            PreflightCheck(
+                "PASS",
+                "Checkpoint path",
+                f"{config.ckpt} (found)",
+            )
+        )
+    elif config.ckpt.startswith(("/", "~")):
+        # Absolute or home-relative path that doesn't exist — this is a user
+        # error, not a remote download target.
+        checks.append(
+            PreflightCheck(
+                "ERROR",
+                "Checkpoint path",
+                f"{config.ckpt} (not found)",
+                f"Verify --ckpt path: {config.ckpt}",
+            )
+        )
+    elif "/" in config.ckpt or "\\" in config.ckpt:
+        # Relative path with a separator but no leading slash — convention for
+        # HuggingFace/ModelScope repo IDs like "Qwen/Qwen3-0.6B".  These will
+        # be fetched from the model hub at training time.
+        checks.append(
+            PreflightCheck(
+                "PASS",
+                "Checkpoint path",
+                f"{config.ckpt} (remote, will download from {config.model_hub})",
+            )
+        )
+    else:
+        # Bare name without a path separator — could be a local file in the
+        # current directory or a hub shorthand.  Check existence to decide.
+        checks.append(
+            PreflightCheck(
+                "PASS" if ckpt_path.exists() else "ERROR",
+                "Checkpoint path",
+                f"{config.ckpt} ({'found' if ckpt_path.exists() else 'not found'})",
+                f"Verify --ckpt path: {config.ckpt}",
+            )
+        )
+
+    # Dataset paths come in three forms: local files/directories (check existence),
+    # remote dataset refs like "AI-MO/NuminaMath-CoT" (will be fetched by the
+    # datasets library), or local files with known suffixes that should exist.
+    dataset_path = Path(config.dataset_path)
+    dataset_supported = dataset_path.suffix.lower() in _SUPPORTED_DATASET_SUFFIXES
+    if dataset_path.exists() or dataset_path.is_dir():
+        checks.append(
+            PreflightCheck(
+                "PASS",
+                "Dataset path",
+                f"{config.dataset_path} (found)",
+            )
+        )
+    elif dataset_supported and not dataset_path.exists():
+        checks.append(
+            PreflightCheck(
+                "ERROR",
+                "Dataset path",
+                f"{config.dataset_path} (not found)",
+                f"Verify --dataset-path: {config.dataset_path}",
+            )
+        )
+    else:
+        checks.append(
+            PreflightCheck(
+                "PASS",
+                "Dataset path",
+                f"{config.dataset_path} (remote, will download)",
+            )
+        )
+
+    # --- ERROR: disk space -----------------------------------------------
+    cwd_free = _disk_free_gb(os.getcwd())
+    if cwd_free is not None:
+        checks.append(
+            PreflightCheck(
+                "PASS" if cwd_free >= _MIN_DISK_GB else "ERROR",
+                "Disk space (workdir)",
+                f"{cwd_free:.1f} GB available in {os.getcwd()}",
+                f"Free at least {_MIN_DISK_GB:.0f} GB in the working directory.",
+            )
+        )
+
+    save_path = getattr(config, "save_path", None)
+    if save_path:
+        save_dir = Path(save_path)
+        target_dir = save_dir if save_dir.is_dir() else save_dir.parent
+        if not target_dir.exists():
+            target_dir = _nearest_existing_parent(save_dir)
+        save_free = _disk_free_gb(str(target_dir))
+        if save_free is not None:
+            checks.append(
+                PreflightCheck(
+                    "PASS" if save_free >= _MIN_DISK_GB else "ERROR",
+                    "Disk space (save-path)",
+                    f"{save_free:.1f} GB available for {save_path}",
+                    f"Free at least {_MIN_DISK_GB:.0f} GB for --save-path.",
+                )
+            )
+
+    # --- ERROR: metrics log dir writable ---------------------------------
+    metrics_dir = getattr(config, "metrics_log_dir", None)
+    if metrics_dir:
+        checks.append(_writable_preflight_check("metrics_log_dir", metrics_dir))
+
+    # --- WARNING: optional dependencies ----------------------------------
+    # These never block training. flash_attn falls back to native attention;
+    # CUDA_HOME/nvcc are only needed for source compilation, not runtime;
+    # non-Linux platforms may work via WSL2.
+    for label in ("flash_attn", "flash_linear_attention"):
+        dep = report["dependencies"][label]
+        checks.append(
+            PreflightCheck(
+                "PASS" if dep["imported"] else "WARN",
+                f"{label} import",
+                dep.get("version") or dep.get("error", "not installed"),
+                f"Install {dep['distribution']} for better performance (optional).",
+            )
+        )
+
+    cuda_home = report["cuda"]["cuda_home"]
+    checks.append(
+        PreflightCheck(
+            "PASS" if cuda_home else "WARN",
+            "CUDA_HOME",
+            cuda_home or "not set",
+            "export CUDA_HOME=/usr/local/cuda (optional; not required if areno_accel imports).",
+        )
+    )
+
+    nvcc = report["cuda"]["nvcc"]
+    checks.append(
+        PreflightCheck(
+            "PASS" if nvcc["path"] else "WARN",
+            "nvcc",
+            nvcc["version"] or nvcc["path"] or "not found",
+            "Add CUDA's bin directory to PATH (optional; not required if areno_accel imports).",
+        )
+    )
+
+    system = report["platform"]["system"]
+    checks.append(
+        PreflightCheck(
+            "PASS" if system == "Linux" else "WARN",
+            "Supported platform",
+            f"{system} {report['platform']['machine']}",
+            "Run AReno on Linux with an NVIDIA CUDA GPU. On Windows, use WSL2.",
+        )
+    )
+
+    return PreflightResult(checks=checks, kaggle_detected=_is_kaggle())
+
+
+def _writable_preflight_check(label: str, path_text: str) -> PreflightCheck:
+    """Return a preflight check for path writability."""
+
+    path = Path(path_text).expanduser()
+    if path.exists() and not path.is_dir():
+        return PreflightCheck(
+            "ERROR",
+            f"{label} writable",
+            f"{path} (exists but is a file, not a directory)",
+            "Remove the file or choose a different directory path.",
+        )
+    parent = path if path.is_dir() else _nearest_existing_parent(path)
+    ok = os.access(parent, os.W_OK)
+    return PreflightCheck(
+        "PASS" if ok else "ERROR",
+        f"{label} writable",
+        str(path),
+        f"Create the directory: mkdir -p {path}",
+    )
+
+
+_SUPPORTED_DATASET_SUFFIXES = {".json", ".jsonl", ".parquet", ".csv", ".tsv", ".arrow"}
+
+
+def _style(text: str, *, color: bool, fg: str | None = None, bold: bool = False) -> str:
+    return click.style(text, fg=fg, bold=bold) if color else text
+
+
+def _preflight_level_str(level: str, *, color: bool) -> str:
+    """Return a padded, optionally colored level label."""
+
+    colors = {
+        "PASS": "bright_green",
+        "WARN": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "red",
+    }
+    text = level.ljust(8)
+    if color:
+        return click.style(text, fg=colors.get(level, "white"), bold=level in {"ERROR", "CRITICAL"})
+    return text
+
+
+def print_preflight_result(result: PreflightResult, *, color: bool = True) -> None:
+    """Print pre-flight check results in a readable format.
+
+    The output is designed to be readable in both interactive terminals and
+    non-interactive environments (Kaggle ``!`` cells, CI logs, piped output).
+    We deliberately do *not* use ``click.confirm`` to prompt the user because
+    stdin may not be a TTY; instead, train.py decides whether to proceed or
+    exit based on the structured ``PreflightResult``.
+    """
+
+    bar = "=" * 80
+    click.echo(_style(bar, color=color, fg="bright_black"))
+    click.echo(_style("Pre-flight environment check", color=color, fg="bright_white", bold=True))
+    click.echo(_style(bar, color=color, fg="bright_black"))
+
+    for check in result.checks:
+        level_str = _preflight_level_str(check.level, color=color)
+        line = f"  {level_str}  {check.name}"
+        if check.detail:
+            line += f": {check.detail}"
+        click.echo(line)
+
+    # Summary line
+    n_pass = len(result.passed)
+    n_warn = len(result.warnings)
+    n_err = len(result.errors)
+    n_crit = len(result.critical_failures)
+
+    click.echo()
+    if n_crit:
+        summary = _style("FAILED", color=color, fg="red", bold=True)
+        summary += f" — {n_crit} critical, {n_err} errors, {n_warn} warnings, {n_pass} passed."
+    elif n_err:
+        summary = _style("FAILED", color=color, fg="red", bold=True)
+        summary += f" — {n_err} errors, {n_warn} warnings, {n_pass} passed."
+    else:
+        summary = _style("OK", color=color, fg="bright_green", bold=True)
+        summary += f" — {n_pass} passed, {n_warn} warning(s)."
+
+    click.echo(f"  Result: {summary}")
+
+    if result.kaggle_detected:
+        click.echo()
+        click.echo(f"  {_style('INFO', color=color, fg='bright_cyan')}  Kaggle environment detected.")
+        click.echo(f"  {_style('INFO', color=color, fg='bright_cyan')}  If training is slow, try reducing --batch-size and --max-new-tokens.")
+
+    # Next steps for failures
+    next_steps = [c.next_step for c in result.checks if c.level in {"CRITICAL", "ERROR"} and c.next_step]
+    if next_steps:
+        click.echo()
+        click.echo("  Next steps:")
+        for step in next_steps:
+            click.echo(f"    - {step}")
+
+    click.echo(_style(bar, color=color, fg="bright_black"))

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -15,6 +15,7 @@ import ast
 import importlib.util
 import json
 import logging
+import os
 import shutil
 import textwrap
 from dataclasses import fields
@@ -68,6 +69,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "max_steps",
             "world_size",
             "tp_size",
+            "skip_check",
         ),
     ),
     (
@@ -379,6 +381,199 @@ def _print_training_config_summary(
         _format_training_config_summary(config, reward_ckpt=reward_ckpt, model_config=model_config, color=True),
         color=True,
     )
+
+
+# Params that only make sense for specific algorithm families.  The resolved
+# command omits them when they are irrelevant to the chosen --algo so the
+# reproduced command stays clean and correct — a student copying an SFT
+# command should not see --reward-fn-path or --critic-lr in the output.
+#
+# The grouping mirrors the TrainerConfig inheritance hierarchy:
+#   - _ROLLOUT_ONLY_PARAMS: only on RolloutTrainerConfig and its subclasses
+#     (GSPO, GRPO, PPO).  SFT and DPO don't have rollout/reward fields.
+#   - _PPO_ONLY_PARAMS: only on PPOTrainerConfig (critic, KL, value loss, GAE).
+#   - _DPO_ONLY_PARAMS: only on DPOTrainerConfig (ref_ckpt, dpo_beta).
+_ROLLOUT_ONLY_PARAMS = {
+    "reward_fn_path",
+    "agent_fn",
+    "agent_timeout_s",
+    "train_tool_results",
+    "n_samples",
+    "max_running_prompts",
+    "greedy",
+    "temperature",
+    "top_k",
+    "top_p",
+    "eager_decode",
+    "drop_rollout_state",
+    "reward_ckpt",
+    "gspo_clip_eps",
+    "grpo_clip_eps",
+}
+
+_PPO_ONLY_PARAMS = {
+    "ref_ckpt",
+    "critic_ckpt",
+    "critic_lr",
+    "critic_warmup_steps",
+    "use_kl_loss",
+    "kl_loss_coef",
+    "kl_loss_type",
+    "clip_eps",
+    "clip_ratio_c",
+    "value_clip_eps",
+    "value_loss_coef",
+    "gamma",
+    "lam",
+}
+
+_DPO_ONLY_PARAMS = {
+    "ref_ckpt",
+    "dpo_beta",
+}
+
+
+def _params_hidden_for_algo(algo: str) -> set[str]:
+    """Return the set of CLI param names to omit from the resolved command."""
+
+    hidden: set[str] = set()
+    if algo == "sft":
+        hidden |= _ROLLOUT_ONLY_PARAMS | _PPO_ONLY_PARAMS | _DPO_ONLY_PARAMS
+    elif algo == "dpo":
+        hidden |= _ROLLOUT_ONLY_PARAMS | _PPO_ONLY_PARAMS
+    elif algo in {"gspo", "grpo"}:
+        hidden |= _PPO_ONLY_PARAMS | _DPO_ONLY_PARAMS
+    return hidden
+
+
+def _format_resolved_command(config: TrainerConfig, *, reward_ckpt: str | None = None) -> str:
+    """Build a copy-pasteable ``areno train`` command from a resolved config.
+
+    The command includes *all* resolved parameter values (defaults + user-specified)
+    so that a student can copy it into an experiment report and reproduce the
+    run exactly.  Algorithm-irrelevant parameters are filtered out via
+    :func:`_params_hidden_for_algo` to keep the command clean.
+
+    Some CLI flag names differ from the config dataclass field names (e.g.
+    ``--lr`` maps to ``config.optimizer_lr``).  The ``flag_overrides`` dict
+    bridges this gap so we read the right attribute from the config.
+    """
+
+    # Map config dataclass field names to CLI flag names by introspecting
+    # the Click command's declared parameters.  This avoids hardcoding flag
+    # strings and stays in sync if options are renamed.
+    field_to_flag: dict[str, str] = {}
+    ctx = click.Context(train_command)
+    for param in train_command.get_params(ctx):
+        flag = param.opts[0] if param.opts else f"--{param.name.replace('_', '-')}"
+        field_to_flag[param.name] = flag
+
+    hidden = _params_hidden_for_algo(config.algo)
+
+    # Build ordered list of (flag, value) pairs for all config fields.
+    lines: list[str] = ["areno train \\"]
+
+    # Manually ordered for readability, matching the TRAIN_OPTION_GROUPS order.
+    ordered_fields = [
+        "algo", "ckpt", "dataset_path", "model_hub", "dataset_loader_fn",
+        "reward_fn_path", "ref_ckpt", "reward_ckpt", "critic_ckpt",
+        "save_path", "save_interval", "metrics_log_dir",
+        "epochs", "max_steps",
+        "tp_size", "world_size",
+        "batch_size", "n_samples", "mini_bs", "score_micro_bs",
+        "gradient_accumulation_steps",
+        "max_prompt_tokens", "max_new_tokens", "max_context_len",
+        "max_running_prompts",
+        "temperature", "top_k", "top_p", "greedy",
+        "lr", "min_lr", "lr_decay_steps", "lr_decay_style",
+        "adam_beta1", "adam_beta2", "adam_8bit", "weight_decay", "grad_clip_norm",
+        "activation_checkpointing",
+        "drop_rollout_state", "eager_decode", "attn_backend",
+        "disable_thinking",
+        "agent_fn", "agent_timeout_s", "train_tool_results",
+        "gspo_clip_eps", "grpo_clip_eps", "dpo_beta",
+        "critic_lr", "critic_warmup_steps",
+        "use_kl_loss", "kl_loss_coef", "kl_loss_type",
+        "clip_eps", "clip_ratio_c", "value_clip_eps", "value_loss_coef",
+        "gamma", "lam",
+    ]
+
+    # Several CLI flags map to differently-named config fields because the config
+    # dataclass uses more descriptive names (e.g. --lr → optimizer_lr).  We also
+    # handle boolean flags that are inverted on the config (e.g. --drop-rollout-state
+    # stores keep_rollout_state=False) and flags that are only shown when set
+    # (e.g. --disable-thinking only appears when chat_template_enable_thinking is False).
+    flag_overrides: dict[str, str] = {
+        "lr": "optimizer_lr",
+        "min_lr": "optimizer_min_lr",
+        "adam_beta1": "optimizer_beta1",
+        "adam_beta2": "optimizer_beta2",
+        "drop_rollout_state": "keep_rollout_state",
+        "disable_thinking": "chat_template_enable_thinking",
+    }
+
+    parts: list[tuple[str, str]] = []
+    for field_name in ordered_fields:
+        if field_name in hidden:
+            continue
+        flag = field_to_flag.get(field_name, f"--{field_name.replace('_', '-')}")
+
+        # Special handling for transformed fields
+        if field_name == "drop_rollout_state":
+            value = not getattr(config, "keep_rollout_state", True)
+            if not value:
+                continue  # Don't show --no-drop-rollout-state; only show when True
+            parts.append((flag, ""))
+            continue
+        if field_name == "disable_thinking":
+            thinking = getattr(config, "chat_template_enable_thinking", None)
+            if thinking is False:
+                parts.append((flag, ""))
+            continue
+        if field_name == "activation_checkpointing":
+            value = getattr(config, "activation_checkpointing", True)
+            if not value:
+                flag = "--no-activation-checkpointing"
+                parts.append((flag, ""))
+            continue
+
+        config_field = flag_overrides.get(field_name, field_name)
+        if not hasattr(config, config_field):
+            continue
+        value = getattr(config, config_field)
+
+        # Skip None values (optional params not set)
+        if value is None:
+            continue
+        # Skip False boolean flags (only show when True)
+        if isinstance(value, bool):
+            if value:
+                parts.append((flag, ""))
+            continue
+
+        parts.append((flag, str(value)))
+
+    # Build command string
+    for i, (flag, val) in enumerate(parts):
+        is_last = i == len(parts) - 1
+        suffix = "" if is_last else " \\"
+        if val:
+            lines.append(f"  {flag} {val}{suffix}")
+        else:
+            lines.append(f"  {flag}{suffix}")
+
+    return "\n".join(lines)
+
+
+def _print_resolved_command(config: TrainerConfig, *, reward_ckpt: str | None = None) -> None:
+    """Print the resolved command in a highlighted block."""
+
+    bar = "=" * 80
+    click.echo(_style(bar, color=True, fg="bright_black"))
+    click.echo(_style("Resolved command (copy to reproduce):", color=True, fg="bright_white", bold=True))
+    click.echo(_style(bar, color=True, fg="bright_black"))
+    click.echo(_format_resolved_command(config, reward_ckpt=reward_ckpt))
+    click.echo(_style(bar, color=True, fg="bright_black"))
 
 
 def _print_auto_tune_summary(result) -> None:
@@ -1222,6 +1417,11 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     help="Dummy-load the model and run one minimal synthetic train step, then exit.",
 )
 @click.option("--tp-size", type=int, default=4, show_default=True, help="Tensor parallel size for the backend.")
+@click.option(
+    "--skip-check",
+    is_flag=True,
+    help="Skip pre-flight environment checks (CRITICAL failures still block training).",
+)
 @click.option("--world-size", type=int, default=8, show_default=True, help="Total device count for the backend.")
 @click.option("--batch-size", type=int, default=32, show_default=True, help="Prompt/pair batch size.")
 @click.option(
@@ -1350,11 +1550,53 @@ def train_command(**options) -> None:
         )
         trainer_config = result.config
         _print_auto_tune_summary(result)
+
+    # Pre-flight environment checks before starting training.
+    #
+    # Why this runs *after* smoke/tune but *before* config summary: smoke and
+    # tune branches have their own model-loading probes and return early, so
+    # they don't need preflight.  For normal training, we want checks to run
+    # before the config summary is printed so users see "PASS/GPU OK" first,
+    # then the config, then the resolved command — a natural reading order for
+    # "is my environment ready → what am I training → how to reproduce".
+    #
+    # CRITICAL failures always block (even with --skip-check) because training
+    # is physically impossible without a GPU or PyTorch.  ERROR failures block
+    # by default but can be bypassed with --skip-check for experienced users
+    # who know what they're doing.
+    skip_check = bool(options.get("skip_check"))
+    if not skip_check:
+        from areno.cli.diagnostics import print_preflight_result, run_preflight_checks
+
+        preflight = run_preflight_checks(
+            trainer_config,
+            reward_ckpt=options.get("reward_ckpt"),
+        )
+        print_preflight_result(preflight)
+        if preflight.critical_failures:
+            names = ", ".join(c.name for c in preflight.critical_failures)
+            raise click.ClickException(
+                f"Pre-flight check failed (CRITICAL): {names}.\n"
+                "These failures cannot be skipped; fix the environment before training."
+            )
+        if preflight.errors:
+            names = ", ".join(c.name for c in preflight.errors)
+            raise click.ClickException(
+                f"Pre-flight check failed (ERROR): {names}.\n"
+                "Fix the environment or use --skip-check to bypass (not recommended)."
+            )
+    else:
+        # Even with --skip-check, show a brief notice.
+        click.echo(
+            _style("Pre-flight checks skipped (--skip-check).", color=True, fg="yellow")
+        )
+
     _print_training_config_summary(
         trainer_config,
         reward_ckpt=options.get("reward_ckpt"),
         model_config=_model_config_for_summary(trainer_config),
     )
+    _print_resolved_command(trainer_config, reward_ckpt=options.get("reward_ckpt"))
     from areno.cli.dashboard_registry import register_dashboard_job
 
     register_dashboard_job(

--- a/tests/test_preflight_cpu.py
+++ b/tests/test_preflight_cpu.py
@@ -1,0 +1,519 @@
+"""CPU tests for pre-flight environment checks and resolved command output.
+
+These tests mock ``collect_env()`` so they run on any machine without requiring
+a GPU or CUDA.  The ``_ready_report`` helper builds a fully-passing environment
+report; individual tests mutate specific fields to simulate failures.
+
+Test coverage:
+- PreflightCheck / PreflightResult dataclass behavior
+- CRITICAL failures (no GPU, no PyTorch) block unconditionally
+- ERROR failures (wrong version, missing accel, bad paths) block by default
+- WARNING (missing flash_attn) never blocks
+- Resolved command filtering per algorithm (SFT vs GSPO vs DPO)
+- train_command integration: preflight + resolved command output, --skip-check
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from areno.api.trainer_config import PolicyTrainerConfig, TrainerConfig
+from areno.cli import diagnostics
+from areno.cli import train as train_cli
+from areno.cli.diagnostics import (
+    PreflightCheck,
+    PreflightResult,
+    run_preflight_checks,
+)
+from click.testing import CliRunner
+from click import unstyle
+
+
+def _ready_report(tmp_path: str) -> dict:
+    """A fully-passing environment report, mirroring test_cli_diagnostics_cpu."""
+
+    return {
+        "areno": {"version": "0.1.0"},
+        "python": {"version": "3.11.0", "executable": "/python"},
+        "platform": {"system": "Linux", "release": "6.0", "machine": "x86_64", "platform": "Linux"},
+        "torch": {
+            "imported": True,
+            "error": None,
+            "version": "2.6.0",
+            "cuda_build": "12.4",
+            "cuda_runtime": "12.4.0",
+            "cuda_runtime_error": None,
+            "cuda_available": True,
+            "device_count": 2,
+            "gpus": [
+                {"index": 0, "name": "NVIDIA T4", "capability": "7.5"},
+                {"index": 1, "name": "NVIDIA T4", "capability": "7.5"},
+            ],
+        },
+        "cuda": {
+            "cuda_home": "/usr/local/cuda",
+            "inferred_cuda_home": "/usr/local/cuda",
+            "nvcc": {"path": "/usr/local/cuda/bin/nvcc", "version": "release 12.4"},
+            "driver": {"path": "/usr/bin/nvidia-smi", "driver_version": "550.0", "cuda_version": "12.4", "error": None},
+        },
+        "gpus": [
+            {"index": 0, "name": "NVIDIA T4", "capability": "7.5"},
+            {"index": 1, "name": "NVIDIA T4", "capability": "7.5"},
+        ],
+        "dependencies": {
+            "flash_attn": {
+                "distribution": "flash-attn",
+                "module": "flash_attn",
+                "version": "2.7.0",
+                "imported": True,
+                "error": None,
+            },
+            "flash_linear_attention": {
+                "distribution": "flash-linear-attention",
+                "module": "fla",
+                "version": "0.2.0",
+                "imported": True,
+                "error": None,
+            },
+            "areno_accel": {
+                "distribution": None,
+                "module": "areno.accel._areno_accel",
+                "version": None,
+                "imported": True,
+                "error": None,
+            },
+        },
+        "install": {"build_ext_disabled": False},
+        "env": {"CUDA_HOME": "/usr/local/cuda", "MAX_JOBS": "8"},
+        "paths": {"metrics_log_dir": tmp_path, "hf_cache": tmp_path},
+    }
+
+
+def _ready_config(world_size: int = 2, algo: str = "gspo", **kwargs) -> TrainerConfig:
+    """Build a minimal passing config for preflight tests."""
+
+    defaults = dict(
+        algo=algo,
+        ckpt="Qwen/Qwen3-0.6B",
+        dataset_path="gsm8k:main",
+        model_hub="hf",
+        tp_size=1,
+        world_size=world_size,
+        batch_size=2,
+        mini_bs=1,
+        save_path=None,
+        save_interval=100,
+        epochs=1,
+        metrics_log_dir=None,
+    )
+    defaults.update(kwargs)
+    if algo in {"gspo", "grpo"}:
+        defaults.setdefault("reward_fn_path", "examples/math/math_verify_reward.py")
+        defaults.setdefault("n_samples", 2)
+        return PolicyTrainerConfig(**defaults)
+    return TrainerConfig(**defaults)
+
+
+class PreflightCheckTest(unittest.TestCase):
+    """Test run_preflight_checks with various environment conditions."""
+
+    def test_all_pass_returns_no_failures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            config = _ready_config()
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        self.assertEqual(result.critical_failures, [])
+        self.assertEqual(result.errors, [])
+        self.assertGreater(len(result.passed), 0)
+
+    def test_critical_failure_when_pytorch_not_importable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["torch"]["imported"] = False
+            report["torch"]["version"] = None
+            report["torch"]["error"] = "ModuleNotFoundError: No module named 'torch'"
+            report["torch"]["cuda_available"] = False
+            report["torch"]["device_count"] = 0
+            report["gpus"] = []
+            config = _ready_config()
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        crit_names = [c.name for c in result.critical_failures]
+        self.assertIn("PyTorch import", crit_names)
+        self.assertIn("torch.cuda.is_available()", crit_names)
+
+    def test_critical_failure_when_no_gpu(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["torch"]["cuda_available"] = False
+            report["torch"]["device_count"] = 0
+            report["torch"]["gpus"] = []
+            report["gpus"] = []
+            config = _ready_config()
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        crit_names = [c.name for c in result.critical_failures]
+        self.assertIn("torch.cuda.is_available()", crit_names)
+        self.assertIn("NVIDIA GPU visibility", crit_names)
+
+    def test_error_when_gpu_count_less_than_world_size(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["torch"]["device_count"] = 2
+            report["gpus"] = [
+                {"index": 0, "name": "NVIDIA T4", "capability": "7.5"},
+                {"index": 1, "name": "NVIDIA T4", "capability": "7.5"},
+            ]
+            config = _ready_config(world_size=8)
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        err_names = [c.name for c in result.errors]
+        self.assertIn("GPU count >= world_size", err_names)
+        self.assertEqual(result.critical_failures, [])
+
+    def test_error_when_areno_accel_not_imported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["dependencies"]["areno_accel"]["imported"] = False
+            report["dependencies"]["areno_accel"]["error"] = "ModuleNotFoundError"
+            config = _ready_config()
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        err_names = [c.name for c in result.errors]
+        self.assertIn("areno_accel import", err_names)
+
+    def test_warning_for_missing_flash_attn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["dependencies"]["flash_attn"]["imported"] = False
+            report["dependencies"]["flash_attn"]["error"] = "ModuleNotFoundError"
+            config = _ready_config()
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        warn_names = [c.name for c in result.warnings]
+        self.assertIn("flash_attn import", warn_names)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.critical_failures, [])
+
+    def test_error_for_missing_local_dataset_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            config = _ready_config(dataset_path="/nonexistent/file.json")
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        err_names = [c.name for c in result.errors]
+        self.assertIn("Dataset path", err_names)
+
+    def test_pass_for_remote_dataset_ref(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            config = _ready_config(dataset_path="AI-MO/NuminaMath-CoT")
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        dataset_check = next(c for c in result.checks if c.name == "Dataset path")
+        self.assertEqual(dataset_check.level, "PASS")
+        self.assertIn("remote", dataset_check.detail)
+
+    def test_error_for_missing_local_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            config = _ready_config(ckpt="/nonexistent/model.ckpt")
+            with patch.object(diagnostics, "collect_env", return_value=report):
+                result = run_preflight_checks(config)
+
+        err_names = [c.name for c in result.errors]
+        self.assertIn("Checkpoint path", err_names)
+
+    def test_kaggle_detection_via_env_var(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            config = _ready_config()
+            with (
+                patch.object(diagnostics, "collect_env", return_value=report),
+                patch.dict("os.environ", {"KAGGLE_KERNEL_RUN_TYPE": "interactive"}),
+            ):
+                result = run_preflight_checks(config)
+
+        self.assertTrue(result.kaggle_detected)
+
+
+class PreflightResultDataclassTest(unittest.TestCase):
+    """Test the PreflightResult dataclass properties."""
+
+    def test_result_properties_partition_checks_correctly(self):
+        checks = [
+            PreflightCheck("PASS", "ok1"),
+            PreflightCheck("WARN", "warn1"),
+            PreflightCheck("ERROR", "err1"),
+            PreflightCheck("CRITICAL", "crit1"),
+            PreflightCheck("PASS", "ok2"),
+        ]
+        result = PreflightResult(checks=checks)
+
+        self.assertEqual(len(result.passed), 2)
+        self.assertEqual(len(result.warnings), 1)
+        self.assertEqual(len(result.errors), 1)
+        self.assertEqual(len(result.critical_failures), 1)
+
+
+class ResolvedCommandTest(unittest.TestCase):
+    """Test _format_resolved_command output."""
+
+    def test_sft_command_omits_rollout_params(self):
+        config = _ready_config(algo="sft", dataset_loader_fn="examples/sft/alpaca/dataset_loader.py")
+        cmd = train_cli._format_resolved_command(config)
+
+        self.assertIn("--algo sft", cmd)
+        self.assertIn("--ckpt", cmd)
+        self.assertIn("--dataset-loader-fn", cmd)
+        # Rollout-only params should not appear
+        self.assertNotIn("--reward-fn-path", cmd)
+        self.assertNotIn("--agent-fn", cmd)
+        self.assertNotIn("--n-samples", cmd)
+        self.assertNotIn("--max-running-prompts", cmd)
+        self.assertNotIn("--gspo-clip-eps", cmd)
+
+    def test_gspo_command_includes_rollout_params(self):
+        config = _ready_config(algo="gspo")
+        cmd = train_cli._format_resolved_command(config)
+
+        self.assertIn("--algo gspo", cmd)
+        self.assertIn("--reward-fn-path", cmd)
+        self.assertIn("--n-samples", cmd)
+
+    def test_command_includes_model_hub(self):
+        config = _ready_config(algo="sft", model_hub="hf", dataset_loader_fn="loader.py")
+        cmd = train_cli._format_resolved_command(config)
+
+        self.assertIn("--model-hub hf", cmd)
+
+    def test_command_is_copy_pastable(self):
+        config = _ready_config(algo="sft", dataset_loader_fn="loader.py")
+        cmd = train_cli._format_resolved_command(config)
+
+        # Should start with "areno train"
+        self.assertTrue(cmd.startswith("areno train"))
+        # Lines should use backslash continuation except the last
+        lines = cmd.split("\n")
+        for line in lines[:-1]:
+            self.assertTrue(line.rstrip().endswith("\\") or line.startswith("areno train"),
+                          f"Line missing backslash: {line}")
+
+    def test_dpo_command_omits_rollout_and_ppo_params(self):
+        from areno.api.trainer_config import DPOTrainerConfig
+
+        config = DPOTrainerConfig(
+            algo="dpo",
+            ckpt="actor",
+            dataset_path="dataset",
+            model_hub="hf",
+            dataset_loader_fn="loader.py",
+            tp_size=1,
+            world_size=2,
+            batch_size=2,
+            mini_bs=1,
+            save_path=None,
+            save_interval=100,
+            epochs=1,
+            ref_ckpt="ref",
+            dpo_beta=0.1,
+            metrics_log_dir=None,
+        )
+        cmd = train_cli._format_resolved_command(config)
+
+        self.assertIn("--algo dpo", cmd)
+        self.assertIn("--dpo-beta", cmd)
+        # Should not include rollout or PPO params
+        self.assertNotIn("--reward-fn-path", cmd)
+        self.assertNotIn("--n-samples", cmd)
+        self.assertNotIn("--critic-lr", cmd)
+        self.assertNotIn("--clip-eps", cmd)
+
+
+class TrainCommandPreflightIntegrationTest(unittest.TestCase):
+    """Test that train_command runs preflight and resolved command output.
+
+    These tests mock ``run_preflight_checks`` directly (instead of mocking
+    ``collect_env``) because the integration test's purpose is to verify that
+    train_command *calls* preflight and *prints* the result — not to test
+    the check logic itself (that's covered by PreflightCheckTest above).
+    Mocking at the run_preflight_checks level also avoids environment-dependent
+    failures: a test using --ckpt actor would fail on a real preflight check
+    because "actor" doesn't exist as a local file.
+    """
+
+    def test_train_command_shows_preflight_and_resolved_command(self):
+        events = []
+
+        def fake_run(config):
+            events.append(("run", config.algo))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            with (
+                patch.object(train_cli, "run", fake_run),
+                patch.object(diagnostics, "collect_env", return_value=report),
+                patch.object(diagnostics, "run_preflight_checks",
+                             lambda config, **kw: PreflightResult(checks=[], kaggle_detected=False)),
+                patch.object(
+                    train_cli, "resolve_model_refs_for_config", lambda config: config
+                ),
+                patch.object(
+                    train_cli, "_model_config_for_summary", lambda config: None
+                ),
+                patch("areno.cli.dashboard_registry.register_dashboard_job"),
+            ):
+                result = CliRunner().invoke(
+                    train_cli.train_command,
+                    [
+                        "--algo", "sft",
+                        "--ckpt", "actor",
+                        "--dataset-path", "dataset",
+                        "--dataset-loader-fn", "examples/sft/alpaca/dataset_loader.py",
+                        "--world-size", "2",
+                        "--tp-size", "1",
+                        "--save-path", "out",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        output = unstyle(result.output)
+        self.assertIn("Pre-flight environment check", output)
+        self.assertIn("Resolved command", output)
+        self.assertIn("areno train", output)
+        self.assertEqual(events, [("run", "sft")])
+
+    def test_train_command_blocks_on_critical_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["torch"]["imported"] = False
+            report["torch"]["version"] = None
+            report["torch"]["error"] = "ModuleNotFoundError"
+            report["torch"]["cuda_available"] = False
+            report["torch"]["device_count"] = 0
+            report["gpus"] = []
+            with (
+                patch.object(diagnostics, "collect_env", return_value=report),
+            ):
+                result = CliRunner().invoke(
+                    train_cli.train_command,
+                    [
+                        "--algo", "sft",
+                        "--ckpt", "actor",
+                        "--dataset-path", "dataset",
+                        "--dataset-loader-fn", "examples/sft/alpaca/dataset_loader.py",
+                        "--world-size", "2",
+                        "--tp-size", "1",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        output = unstyle(result.output)
+        self.assertIn("CRITICAL", output)
+        self.assertIn("Pre-flight check failed", output)
+
+    def test_train_command_blocks_on_error_without_skip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["dependencies"]["areno_accel"]["imported"] = False
+            report["dependencies"]["areno_accel"]["error"] = "ModuleNotFoundError"
+            with (
+                patch.object(diagnostics, "collect_env", return_value=report),
+            ):
+                result = CliRunner().invoke(
+                    train_cli.train_command,
+                    [
+                        "--algo", "sft",
+                        "--ckpt", "actor",
+                        "--dataset-path", "dataset",
+                        "--dataset-loader-fn", "examples/sft/alpaca/dataset_loader.py",
+                        "--world-size", "2",
+                        "--tp-size", "1",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+        output = unstyle(result.output)
+        self.assertIn("Pre-flight check failed", output)
+        self.assertIn("areno_accel", output)
+
+    def test_skip_check_bypasses_errors_but_not_critical(self):
+        events = []
+
+        def fake_run(config):
+            events.append(("run", config.algo))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["dependencies"]["areno_accel"]["imported"] = False
+            report["dependencies"]["areno_accel"]["error"] = "ModuleNotFoundError"
+            with (
+                patch.object(train_cli, "run", fake_run),
+                patch.object(diagnostics, "collect_env", return_value=report),
+                patch.object(
+                    train_cli, "resolve_model_refs_for_config", lambda config: config
+                ),
+                patch.object(
+                    train_cli, "_model_config_for_summary", lambda config: None
+                ),
+                patch("areno.cli.dashboard_registry.register_dashboard_job"),
+            ):
+                result = CliRunner().invoke(
+                    train_cli.train_command,
+                    [
+                        "--algo", "sft",
+                        "--ckpt", "actor",
+                        "--dataset-path", "dataset",
+                        "--dataset-loader-fn", "examples/sft/alpaca/dataset_loader.py",
+                        "--world-size", "2",
+                        "--tp-size", "1",
+                        "--skip-check",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        output = unstyle(result.output)
+        self.assertIn("Pre-flight checks skipped", output)
+        self.assertEqual(events, [("run", "sft")])
+
+    def test_skip_check_does_not_bypass_critical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = _ready_report(tmp)
+            report["torch"]["imported"] = False
+            report["torch"]["version"] = None
+            report["torch"]["error"] = "ModuleNotFoundError"
+            report["torch"]["cuda_available"] = False
+            report["torch"]["device_count"] = 0
+            report["gpus"] = []
+            with (
+                patch.object(diagnostics, "collect_env", return_value=report),
+            ):
+                result = CliRunner().invoke(
+                    train_cli.train_command,
+                    [
+                        "--algo", "sft",
+                        "--ckpt", "actor",
+                        "--dataset-path", "dataset",
+                        "--dataset-loader-fn", "examples/sft/alpaca/dataset_loader.py",
+                        "--world-size", "2",
+                        "--tp-size", "1",
+                        "--skip-check",
+                    ],
+                )
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -417,6 +417,15 @@ def test_train_command_prints_summary_before_run(monkeypatch):
         events.append(("run", config.algo))
 
     monkeypatch.setattr(train_cli, "run", fake_run)
+    # Mock preflight to avoid environment-dependent failures in CI.
+    # Without this mock, the test would fail on machines without a GPU or
+    # where --ckpt "actor" doesn't exist locally.  The preflight feature
+    # itself is tested in test_preflight_cpu.py.
+    from areno.cli.diagnostics import PreflightResult
+    monkeypatch.setattr(
+        "areno.cli.diagnostics.run_preflight_checks",
+        lambda config, **kw: PreflightResult(checks=[], kaggle_detected=False),
+    )
 
     result = CliRunner().invoke(
         train_cli.train_command,
@@ -440,7 +449,9 @@ def test_train_command_prints_summary_before_run(monkeypatch):
 
     assert result.exit_code == 0, result.output
     output = unstyle(result.output)
-    assert output.startswith("AReno training config\n")
+    # Uses "in" (not startswith) because preflight output now precedes the
+    # config summary in the train_command output stream.
+    assert "AReno training config" in output
     assert "dp_size       2" in output
     assert "save_path        out" in output
     assert "WARNING: no checkpoint output path configured" not in output
@@ -490,6 +501,12 @@ def test_train_command_tunes_params_before_summary_and_run(monkeypatch):
     monkeypatch.setattr("areno.cli.auto_tune.auto_tune_config", fake_auto_tune)
     monkeypatch.setattr(train_cli, "resolve_model_refs_for_config", lambda config: config)
     monkeypatch.setattr(train_cli, "run", fake_run)
+    # Mock preflight (same reason as test_train_command_prints_summary_before_run).
+    from areno.cli.diagnostics import PreflightResult
+    monkeypatch.setattr(
+        "areno.cli.diagnostics.run_preflight_checks",
+        lambda config, **kw: PreflightResult(checks=[], kaggle_detected=False),
+    )
 
     result = CliRunner().invoke(
         train_cli.train_command,


### PR DESCRIPTION
## What

Run pre-flight environment checks and print the resolved command before `areno train` starts training.

## Why

- Environment issues (no GPU, wrong PyTorch version, insufficient disk) are only discovered after model download completes — wastes several minutes on Kaggle T4
- `areno check` is a separate command that users forget to run
- No copy-pasteable command line in the output — hard to reproduce runs in experiment reports

## Changes

**1. Pre-flight checks (`diagnostics.py`)**
- Reuses existing `collect_env()`, adds `run_preflight_checks()` with three severity levels
- CRITICAL (no GPU / no PyTorch): blocks unconditionally, cannot skip
- ERROR (wrong version / missing accel / bad path / low disk): blocks by default, `--skip-check` bypasses
- WARNING (no flash_attn / non-Linux): shows warning, never blocks
- Detects Kaggle environment, shows helpful tips

**2. Resolved command (`train.py`)**
- Prints a full `areno train` command with all resolved params (defaults + user-specified)
- Filters irrelevant params by `--algo`: SFT hides rollout/PPO params, GSPO hides PPO params
- `--model-hub` always shown

**3. CLI (`train.py`)**
- New `--skip-check` flag
- Flow: preflight → config summary → resolved command → training
- Non-interactive: no `click.confirm()`, works in Kaggle / CI / pipes

## Example output

```
================================================================================
Pre-flight environment check
================================================================================
  PASS      Python >= 3.10: found 3.12.13
  PASS      PyTorch import: 2.10.0+cu128
  PASS      torch.cuda.is_available(): visible_gpus=2
  PASS      GPU count >= world_size: gpus=2, world_size=2
  PASS      areno_accel import: imported
  WARN      flash_attn import: not installed (native attention will be used)

  Result: OK — 16 passed, 1 warning(s).

  INFO  Kaggle environment detected.
  INFO  If training is slow, try reducing --batch-size and --max-new-tokens.
================================================================================

AReno training config
  ...

================================================================================
Resolved command (copy to reproduce):
================================================================================
areno train \
  --algo gspo \
  --ckpt Qwen/Qwen3.5-0.8B \
  --dataset-path tictactoe.json \
  --model-hub modelscope \
  ...
================================================================================
```

## Files

| File | Change |
|------|--------|
| `areno/cli/diagnostics.py` | +PreflightCheck, PreflightResult, run_preflight_checks(), print_preflight_result() |
| `areno/cli/train.py` | +--skip-check, _format_resolved_command(), preflight integration |
| `tests/test_preflight_cpu.py` | New, 21 CPU tests |
| `tests/test_train_cli_config_cpu.py` | Mock preflight in existing tests |

## Testing

- 21/21 new tests pass
- No regressions (2 pre-existing Kaggle T4 env failures, unrelated)
- Manually verified on Kaggle T4 x2: SFT, GSPO, --skip-check