### PR TITLE
feat(agentic): add partially observable maze agentic RL demo (#187)

### DIFF
--- a/examples/agentic/maze/README.md
+++ b/examples/agentic/maze/README.md
@@ -1,0 +1,102 @@
+# Maze Agentic Example
+
+A partially observable maze for agentic RLVR training. The agent sees only a
+local window around its position and must navigate to the goal, optionally
+picking up keys to open doors along the way.
+
+## Overview
+
+Unlike the tictactoe and duelgrid examples which are full-information, the
+maze demo is **partially observable**: the agent only sees a small window
+(e.g. 3x3 or 5x5) around its current position. This makes exploration and
+multi-step planning essential.
+
+Each episode is a multi-turn tool-call trajectory:
+
+1. The agent receives its local view as a text prompt.
+2. It calls the `act` tool with one action (`move`, `pickup`, or `use_key`).
+3. The action is executed and the new view is sent back as a tool result.
+4. Repeat until the goal is reached or `max_steps` is exhausted.
+
+### Tiles
+
+| Symbol | Meaning |
+|--------|---------|
+| `#` | Wall (impassable) |
+| `.` | Open floor |
+| `A` | Agent (you) |
+| `K` | Key (pick up) |
+| `D` | Locked door (needs a key to open) |
+| `G` | Goal (reach to win) |
+| `?` | Unknown (outside view range) |
+
+### Actions
+
+| Action | Parameters | Description |
+|--------|-----------|-------------|
+| `move` | `direction`: UP/DOWN/LEFT/RIGHT | Move one tile |
+| `pickup` | — | Pick up a key if standing on one |
+| `use_key` | `direction`: UP/DOWN/LEFT/RIGHT | Open an adjacent door if holding a key |
+
+### Rewards
+
+- Reach goal: **+1.0**
+- Pick up key: **+0.2**
+- Open door: **+0.1**
+- Move (step cost): **-0.01**
+- Invalid action (wall, no key, etc.): **-0.1**
+
+## Quick start
+
+Generate maze states:
+
+```bash
+python examples/agentic/maze/dataset_generator.py \
+  --count 256 \
+  --rows 4 --cols 4 \
+  --num-keys 1 \
+  --output /tmp/maze_states.jsonl
+```
+
+Train with GSPO:
+
+```bash
+areno train --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path /tmp/maze_states.jsonl \
+  --dataset-loader-fn examples/agentic/maze/dataset_loader.py \
+  --reward-fn-path examples/agentic/maze/reward.py \
+  --agent-fn examples/agentic/maze/run_agent.py \
+  --algo gspo --tp-size 1
+```
+
+## Dataset generator options
+
+```
+--count         Number of maze states to generate (default: 128)
+--seed          Master random seed (default: 2026)
+--rows          Maze cell rows before wall expansion (default: 4)
+--cols          Maze cell cols before wall expansion (default: 4)
+--num-keys      Maximum key-door pairs per maze (default: 1)
+--max-steps     Maximum steps per episode (default: 30)
+--view-radius   Local view radius (default: 1, i.e. 3x3 window)
+```
+
+## Testing
+
+CPU tests run without a GPU:
+
+```bash
+pytest tests/test_agentic_maze_example_cpu.py -v
+```
+
+## File structure
+
+```
+examples/agentic/maze/
+├── game.py              # Maze generation, state, local view, actions
+├── run_agent.py         # Multi-turn tool-call agent entrypoint
+├── reward.py            # reward_fn(record) — replay trajectory for reward
+├── dataset_loader.py    # Load JSONL into Areno prompt records
+├── dataset_generator.py # Seed-solvable maze JSONL generator
+└── README.md
+```

--- a/examples/agentic/maze/dataset_generator.py
+++ b/examples/agentic/maze/dataset_generator.py
@@ -1,0 +1,144 @@
+"""Generate seed-solvable maze states for the agentic maze example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = 2026
+DEFAULT_ROWS = 4
+DEFAULT_COLS = 4
+DEFAULT_MAX_STEPS = 30
+DEFAULT_VIEW_RADIUS = 1
+DEFAULT_NUM_KEYS = 1
+
+
+def generate_records(
+    count: int = DEFAULT_COUNT,
+    *,
+    seed: int = DEFAULT_SEED,
+    rows: int = DEFAULT_ROWS,
+    cols: int = DEFAULT_COLS,
+    num_keys: int = DEFAULT_NUM_KEYS,
+    max_steps: int = DEFAULT_MAX_STEPS,
+    view_radius: int = DEFAULT_VIEW_RADIUS,
+) -> list[dict]:
+    """Generate reproducible maze prompt states."""
+
+    rng = random.Random(seed)
+    records = []
+    seen: set[tuple[str, ...]] = set()
+    attempts = 0
+    while len(records) < count:
+        attempts += 1
+        if attempts > count * 20:
+            break
+        maze_seed = rng.randint(0, 2**31 - 1)
+        nk = rng.randint(0, num_keys)
+        grid, agent_pos, goal_pos, key_door_pairs = game.generate_maze(
+            rows, cols, seed=maze_seed, num_keys=nk
+        )
+        if grid in seen:
+            continue
+        seen.add(grid)
+        records.append(_state_to_record(
+            grid, agent_pos, goal_pos, key_door_pairs,
+            maze_seed, nk, max_steps, view_radius,
+            f"maze-{len(records):05d}",
+        ))
+    return records
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write generated records as JSONL."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def record_to_state(record: dict) -> game.State:
+    """Convert a JSONL record back to a :class:`game.State`."""
+
+    return game.make_state_from_record(record)
+
+
+def _state_to_record(
+    grid: tuple[str, ...],
+    agent_pos: tuple[int, int],
+    goal_pos: tuple[int, int],
+    key_door_pairs: list[dict],
+    maze_seed: int,
+    num_keys: int,
+    max_steps: int,
+    view_radius: int,
+    record_id: str,
+) -> dict:
+    return {
+        "id": record_id,
+        "grid": list(grid),
+        "agent_pos": list(agent_pos),
+        "goal_pos": list(goal_pos),
+        "key_door_pairs": [
+            {
+                "key_id": pair["key_id"],
+                "key_pos": list(pair["key_pos"]),
+                "door_pos": list(pair["door_pos"]),
+            }
+            for pair in key_door_pairs
+        ],
+        "maze_seed": maze_seed,
+        "num_keys": num_keys,
+        "max_steps": max_steps,
+        "view_radius": view_radius,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate JSONL maze states for the Areno agentic maze example."
+    )
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of states to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Master random seed.")
+    parser.add_argument("--rows", type=int, default=DEFAULT_ROWS, help="Maze cell rows (before wall expansion).")
+    parser.add_argument("--cols", type=int, default=DEFAULT_COLS, help="Maze cell cols (before wall expansion).")
+    parser.add_argument("--num-keys", type=int, default=DEFAULT_NUM_KEYS, help="Max key-door pairs per maze.")
+    parser.add_argument("--max-steps", type=int, default=DEFAULT_MAX_STEPS, help="Max steps per episode.")
+    parser.add_argument("--view-radius", type=int, default=DEFAULT_VIEW_RADIUS, help="Local view radius.")
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise ValueError("--count must be positive")
+    if args.rows <= 0 or args.cols <= 0:
+        raise ValueError("--rows and --cols must be positive")
+    if args.num_keys < 0:
+        raise ValueError("--num-keys must be non-negative")
+
+    records = generate_records(
+        args.count,
+        seed=args.seed,
+        rows=args.rows,
+        cols=args.cols,
+        num_keys=args.num_keys,
+        max_steps=args.max_steps,
+        view_radius=args.view_radius,
+    )
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/maze/dataset_loader.py
+++ b/examples/agentic/maze/dataset_loader.py
@@ -1,0 +1,48 @@
+"""Dataset loader for the maze agentic example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL maze states and convert them to Areno prompt records."""
+
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "maze_states.jsonl"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Maze dataset not found: {path}. Generate it with "
+            "`python examples/agentic/maze/dataset_generator.py --output <path>`."
+        )
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int) -> dict:
+    state = dataset_generator.record_to_state(raw)
+    radius = raw.get("view_radius", 1)
+    return {
+        "id": raw.get("id", f"maze-{index:05d}"),
+        "prompt": game.format_prompt(state, radius),
+        "state": raw,
+        "legal_actions": game.legal_actions(state),
+    }

--- a/examples/agentic/maze/game.py
+++ b/examples/agentic/maze/game.py
@@ -1,0 +1,579 @@
+"""Maze helpers for a partially-observable agentic RL example.
+
+The agent sees only a local window around its position and must navigate
+to the goal, optionally picking up keys to open doors along the way.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import deque
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tile symbols
+# ---------------------------------------------------------------------------
+
+EMPTY = "."
+WALL = "#"
+AGENT = "A"
+KEY = "K"
+DOOR = "D"
+GOAL = "G"
+UNKNOWN = "?"
+
+DIRECTIONS = {
+    "UP": (-1, 0),
+    "DOWN": (1, 0),
+    "LEFT": (0, -1),
+    "RIGHT": (0, 1),
+}
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class State:
+    """Immutable maze state.
+
+    ``grid`` uses the tile symbols above.  Doors that have been opened are
+    replaced with ``EMPTY`` on the grid so walkability checks are uniform.
+    ``keys`` is the set of key ids the agent currently holds.
+    """
+
+    grid: tuple[str, ...]
+    agent_row: int
+    agent_col: int
+    keys: frozenset[str] = frozenset()
+    steps: int = 0
+    max_steps: int = 30
+    done: bool = False
+    # bookkeeping for reward / metrics
+    invalid_moves: int = 0
+    picked_up_keys: int = 0
+    opened_doors: int = 0
+    reached_goal: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Maze generation
+# ---------------------------------------------------------------------------
+
+
+def generate_maze(
+    rows: int = 7,
+    cols: int = 7,
+    *,
+    seed: int = 0,
+    num_keys: int = 1,
+) -> tuple[tuple[str, ...], tuple[int, int], tuple[int, int], list[dict[str, Any]]]:
+    """Generate a solvable maze with keys and doors.
+
+    Returns ``(grid, agent_pos, goal_pos, key_door_pairs)`` where
+    ``key_door_pairs`` is a list of ``{"key_id": str, "key_pos": (r,c),
+    "door_pos": (r,c)}`` dicts.
+    """
+
+    rng = random.Random(seed)
+    grid, agent_pos, goal_pos = _carve_maze(rows, cols, rng)
+    key_door_pairs = _place_keys_and_doors(grid, agent_pos, goal_pos, num_keys, rng)
+    grid_tuple = tuple("".join(row) for row in grid)
+    return grid_tuple, agent_pos, goal_pos, key_door_pairs
+
+
+def _carve_maze(
+    rows: int, cols: int, rng: random.Random
+) -> tuple[list[list[str]], tuple[int, int], tuple[int, int]]:
+    """Carve a perfect maze using iterative DFS backtracking.
+
+    The grid is sized ``2*rows+1`` by ``2*cols+1`` so that walls separate
+    every pair of cells.  Returns ``(grid, agent_pos, goal_pos)``.
+    """
+
+    h = 2 * rows + 1
+    w = 2 * cols + 1
+    grid = [[WALL] * w for _ in range(h)]
+
+    # cell (cr, cc) maps to grid position (2*cr+1, 2*cc+1)
+    visited = [[False] * cols for _ in range(rows)]
+    stack: list[tuple[int, int]] = []
+    cr, cc = 0, 0
+    visited[cr][cc] = True
+    grid[2 * cr + 1][2 * cc + 1] = EMPTY
+    stack.append((cr, cc))
+
+    while stack:
+        cr, cc = stack[-1]
+        neighbours: list[tuple[int, int, int, int]] = []
+        for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+            nr, nc = cr + dr, cc + dc
+            if 0 <= nr < rows and 0 <= nc < cols and not visited[nr][nc]:
+                neighbours.append((nr, nc, 2 * cr + 1 + dr, 2 * cc + 1 + dc))
+        if not neighbours:
+            stack.pop()
+            continue
+        nr, nc, wr, wc = rng.choice(neighbours)
+        grid[wr][wc] = EMPTY
+        grid[2 * nr + 1][2 * nc + 1] = EMPTY
+        visited[nr][nc] = True
+        stack.append((nr, nc))
+
+    agent_pos = (1, 1)
+    goal_pos = (h - 2, w - 2)
+    grid[agent_pos[0]][agent_pos[1]] = AGENT
+    grid[goal_pos[0]][goal_pos[1]] = GOAL
+    return grid, agent_pos, goal_pos
+
+
+def _place_keys_and_doors(
+    grid: list[list[str]],
+    agent_pos: tuple[int, int],
+    goal_pos: tuple[int, int],
+    num_pairs: int,
+    rng: random.Random,
+) -> list[dict[str, Any]]:
+    """Place key-door pairs on wall positions that lie on the solution path.
+
+    Guarantees the key is reachable without passing through its paired door.
+    """
+
+    h = len(grid)
+    w = len(grid[0])
+    pairs: list[dict[str, Any]] = []
+    # Find wall positions that are on the path from agent to goal
+    path = _bfs_path(grid, agent_pos, goal_pos, set())
+    if not path or len(path) < 4:
+        return pairs
+
+    placed_doors: set[tuple[int, int]] = set()
+    for i in range(num_pairs):
+        # Pick a wall cell on the path to convert into a door
+        candidates = []
+        for idx in range(2, len(path) - 1):
+            r, c = path[idx]
+            if (r, c) in placed_doors:
+                continue
+            if grid[r][c] in (WALL, EMPTY):
+                candidates.append((r, c))
+        if not candidates:
+            break
+        door_pos = rng.choice(candidates)
+        placed_doors.add(door_pos)
+        grid[door_pos[0]][door_pos[1]] = DOOR
+
+        # Find a reachable key position that is before the door (on path)
+        key_pos = _find_key_position(grid, agent_pos, door_pos, path, rng)
+        if key_pos is None:
+            # Fallback: place key right before the door on the path
+            door_idx = path.index(door_pos)
+            key_pos = path[door_idx - 1]
+        grid[key_pos[0]][key_pos[1]] = KEY
+        pairs.append({
+            "key_id": f"k{i}",
+            "key_pos": key_pos,
+            "door_pos": door_pos,
+        })
+    return pairs
+
+
+def _find_key_position(
+    grid: list[list[str]],
+    agent_pos: tuple[int, int],
+    door_pos: tuple[int, int],
+    path: list[tuple[int, int]],
+    rng: random.Random,
+) -> tuple[int, int] | None:
+    """Find an empty cell reachable from agent without passing the door."""
+
+    door_idx = path.index(door_pos)
+    # Cells on path before the door are reachable without the key
+    before_door = set(path[:door_idx])
+    h = len(grid)
+    w = len(grid[0])
+    empty_cells = []
+    for r in range(h):
+        for c in range(w):
+            if grid[r][c] == EMPTY and (r, c) in before_door:
+                empty_cells.append((r, c))
+    if not empty_cells:
+        return None
+    return rng.choice(empty_cells)
+
+
+def _bfs_path(
+    grid: list[list[str]] | tuple[str, ...],
+    start: tuple[int, int],
+    goal: tuple[int, int],
+    blocked: set[tuple[int, int]],
+) -> list[tuple[int, int]]:
+    """BFS shortest path from *start* to *goal* avoiding *blocked* cells."""
+
+    h = len(grid)
+    w = len(grid[0])
+    if start == goal:
+        return [start]
+    visited = {start}
+    queue = deque([(start, [start])])
+    while queue:
+        (r, c), path = queue.popleft()
+        for dr, dc in DIRECTIONS.values():
+            nr, nc = r + dr, c + dc
+            if not (0 <= nr < h and 0 <= nc < w):
+                continue
+            if (nr, nc) in visited or (nr, nc) in blocked:
+                continue
+            tile = grid[nr][nc] if isinstance(grid, list) else grid[nr][nc]
+            if tile == WALL:
+                continue
+            visited.add((nr, nc))
+            new_path = path + [(nr, nc)]
+            if (nr, nc) == goal:
+                return new_path
+            queue.append(((nr, nc), new_path))
+    return []
+
+
+# ---------------------------------------------------------------------------
+# State construction
+# ---------------------------------------------------------------------------
+
+
+def make_state(
+    grid: tuple[str, ...] | list[str],
+    agent_row: int = 1,
+    agent_col: int = 1,
+    *,
+    keys: frozenset[str] | set[str] | None = None,
+    steps: int = 0,
+    max_steps: int = 30,
+) -> State:
+    """Parse and validate a maze grid into a :class:`State`."""
+
+    rows = tuple(str(row) for row in grid)
+    if not rows or len({len(row) for row in rows}) != 1:
+        raise ValueError("Maze grid must be a non-empty rectangle")
+    allowed = {EMPTY, WALL, AGENT, KEY, DOOR, GOAL}
+    for row in rows:
+        for cell in row:
+            if cell not in allowed:
+                raise ValueError(f"Invalid maze tile: {cell!r}")
+    return State(
+        grid=rows,
+        agent_row=agent_row,
+        agent_col=agent_col,
+        keys=frozenset(keys) if keys else frozenset(),
+        steps=steps,
+        max_steps=max_steps,
+    )
+
+
+def make_state_from_record(record: dict[str, Any]) -> State:
+    """Build a :class:`State` from a JSONL record dict."""
+
+    grid = tuple(record["grid"])
+    agent_pos = tuple(record["agent_pos"])
+    return make_state(
+        grid,
+        agent_row=agent_pos[0],
+        agent_col=agent_pos[1],
+        max_steps=record.get("max_steps", 30),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_full_map(state: State) -> str:
+    """Render the full maze grid with the agent overlaid."""
+
+    lines = []
+    for r in range(len(state.grid)):
+        chars = list(state.grid[r])
+        if r == state.agent_row and chars[state.agent_col] != WALL:
+            chars[state.agent_col] = AGENT
+        lines.append("".join(chars))
+    return "\n".join(lines)
+
+
+def render_local_view(state: State, radius: int = 1) -> str:
+    """Render a ``(2*radius+1)`` square window centred on the agent.
+
+    Cells outside the maze boundary are shown as ``UNKNOWN``.
+    """
+
+    size = 2 * radius + 1
+    h = len(state.grid)
+    w = len(state.grid[0])
+    lines = []
+    for dr in range(-radius, radius + 1):
+        r = state.agent_row + dr
+        chars = []
+        for dc in range(-radius, radius + 1):
+            c = state.agent_col + dc
+            if 0 <= r < h and 0 <= c < w:
+                if r == state.agent_row and c == state.agent_col:
+                    chars.append(AGENT)
+                else:
+                    chars.append(state.grid[r][c])
+            else:
+                chars.append(UNKNOWN)
+        lines.append("".join(chars))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+
+def format_prompt(state: State, radius: int = 1) -> str:
+    """Build the initial user prompt describing the visible maze."""
+
+    view = render_local_view(state, radius)
+    return (
+        "You are in a partially observable maze. You can only see the tiles "
+        f"around you ({radius*2+1}x{radius*2+1} window).\n\n"
+        "Tiles:\n"
+        f"  {WALL} = wall (blocked)   {EMPTY} = open floor   {AGENT} = you\n"
+        f"  {KEY} = key (pick up)   {DOOR} = locked door (needs key)   {GOAL} = goal\n"
+        f"  {UNKNOWN} = unknown (outside view)\n\n"
+        "Actions (one per turn):\n"
+        "  move  — step UP/DOWN/LEFT/RIGHT\n"
+        "  pickup — pick up a key if standing on one\n"
+        "  use_key — open an adjacent door if you hold a matching key\n\n"
+        f"Steps taken: {state.steps}/{state.max_steps}\n"
+        f"Keys held: {sorted(state.keys) if state.keys else 'none'}\n\n"
+        f"Your view:\n{view}\n\n"
+        "Call the act tool with one action to proceed."
+    )
+
+
+def format_step_prompt(state: State, radius: int = 1, feedback: str = "") -> str:
+    """Build a follow-up prompt after each action."""
+
+    view = render_local_view(state, radius)
+    parts = [f"Steps: {state.steps}/{state.max_steps}"]
+    if state.keys:
+        parts.append(f"Keys: {sorted(state.keys)}")
+    else:
+        parts.append("Keys: none")
+    if feedback:
+        parts.append(feedback)
+    parts.append(f"\nYour view:\n{view}")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+
+def legal_actions(state: State) -> list[dict[str, str]]:
+    """Return the list of currently legal actions."""
+
+    actions: list[dict[str, str]] = []
+    for direction, (dr, dc) in DIRECTIONS.items():
+        nr, nc = state.agent_row + dr, state.agent_col + dc
+        tile = _tile_at(state, nr, nc)
+        if tile is not None and tile != WALL and tile != DOOR:
+            actions.append({"action": "move", "direction": direction})
+        elif tile == DOOR:
+            # Door can be opened if agent holds any key
+            if state.keys:
+                actions.append({"action": "use_key", "direction": direction})
+    # Pickup if standing on a key
+    current_tile = _tile_at(state, state.agent_row, state.agent_col)
+    if current_tile == KEY:
+        actions.append({"action": "pickup"})
+    return actions
+
+
+def step(state: State, action: dict[str, str] | None) -> tuple[State, float, bool, dict[str, Any]]:
+    """Apply one action and return ``(next_state, reward, done, info)``."""
+
+    if state.done:
+        return state, 0.0, True, {"reason": "already_done"}
+
+    parsed = _parse_action(action)
+    if parsed is None:
+        new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+        return _check_terminal(new_state, -0.1, {"illegal": True, "reason": "invalid_action"})
+
+    act = parsed["action"]
+    if act == "move":
+        return _do_move(state, parsed)
+    if act == "pickup":
+        return _do_pickup(state, parsed)
+    if act == "use_key":
+        return _do_use_key(state, parsed)
+    # Unknown action
+    new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+    return _check_terminal(new_state, -0.1, {"illegal": True, "reason": f"unknown_action:{act}"})
+
+
+def _do_move(state: State, parsed: dict[str, str]) -> tuple[State, float, bool, dict[str, Any]]:
+    direction = parsed.get("direction", "")
+    delta = DIRECTIONS.get(direction)
+    if delta is None:
+        new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+        return _check_terminal(new_state, -0.1, {"illegal": True, "reason": "bad_direction"})
+
+    dr, dc = delta
+    nr, nc = state.agent_row + dr, state.agent_col + dc
+    tile = _tile_at(state, nr, nc)
+    if tile is None or tile == WALL or tile == DOOR:
+        new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+        return _check_terminal(new_state, -0.1, {"illegal": True, "reason": "blocked"})
+    new_state = replace(state, agent_row=nr, agent_col=nc, steps=state.steps + 1)
+    if tile == GOAL:
+        new_state = replace(new_state, done=True, reached_goal=True)
+        return new_state, 1.0, True, {"goal": True}
+    return _check_terminal(new_state, -0.01, {"moved": True, "direction": direction})
+
+
+def _do_pickup(state: State, parsed: dict[str, str]) -> tuple[State, float, bool, dict[str, Any]]:
+    tile = _tile_at(state, state.agent_row, state.agent_col)
+    if tile != KEY:
+        new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+        return _check_terminal(new_state, -0.1, {"illegal": True, "reason": "no_key_here"})
+    # Remove key from grid, add to inventory
+    new_grid = list(state.grid)
+    row_chars = list(new_grid[state.agent_row])
+    row_chars[state.agent_col] = EMPTY
+    new_grid[state.agent_row] = "".join(row_chars)
+    key_id = f"k{state.picked_up_keys}"
+    new_state = replace(
+        state,
+        grid=tuple(new_grid),
+        keys=state.keys | {key_id},
+        steps=state.steps + 1,
+        picked_up_keys=state.picked_up_keys + 1,
+    )
+    return _check_terminal(new_state, 0.2, {"picked_up": key_id})
+
+
+def _do_use_key(state: State, parsed: dict[str, str]) -> tuple[State, float, bool, dict[str, Any]]:
+    direction = parsed.get("direction", "")
+    delta = DIRECTIONS.get(direction)
+    if delta is None or not state.keys:
+        new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+        return _check_terminal(new_state, -0.1, {"illegal": True, "reason": "cannot_use_key"})
+    dr, dc = delta
+    nr, nc = state.agent_row + dr, state.agent_col + dc
+    tile = _tile_at(state, nr, nc)
+    if tile != DOOR:
+        new_state = replace(state, steps=state.steps + 1, invalid_moves=state.invalid_moves + 1)
+        return _check_terminal(new_state, -0.1, {"illegal": True, "reason": "no_door"})
+    # Open the door: replace with EMPTY
+    new_grid = list(state.grid)
+    row_chars = list(new_grid[nr])
+    row_chars[nc] = EMPTY
+    new_grid[nr] = "".join(row_chars)
+    new_state = replace(
+        state,
+        grid=tuple(new_grid),
+        steps=state.steps + 1,
+        opened_doors=state.opened_doors + 1,
+    )
+    return _check_terminal(new_state, 0.1, {"opened_door": True, "direction": direction})
+
+
+# ---------------------------------------------------------------------------
+# Reward helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_trajectory_reward(
+    state: State, actions: list[dict[str, str] | None]
+) -> tuple[float, dict[str, Any]]:
+    """Simulate a full action sequence and return ``(total_reward, metrics)``."""
+
+    current = state
+    total_reward = 0.0
+    invalid = 0
+    for action in actions:
+        current, reward, done, info = step(current, action)
+        total_reward += reward
+        if info.get("illegal"):
+            invalid += 1
+        if done:
+            break
+    metrics = {
+        "reached_goal": current.reached_goal,
+        "steps": current.steps,
+        "invalid_moves": invalid,
+        "total_invalid": current.invalid_moves,
+        "keys_picked": current.picked_up_keys,
+        "doors_opened": current.opened_doors,
+    }
+    return total_reward, metrics
+
+
+def shortest_path_length(state: State) -> int | None:
+    """Return the BFS shortest path length from agent to goal, or ``None``."""
+
+    h = len(state.grid)
+    w = len(state.grid[0])
+    start = (state.agent_row, state.agent_col)
+    goal = _find_tile(state, GOAL)
+    if goal is None:
+        return None
+    visited = {start}
+    queue = deque([(start, 0)])
+    while queue:
+        (r, c), dist = queue.popleft()
+        if (r, c) == goal:
+            return dist
+        for dr, dc in DIRECTIONS.values():
+            nr, nc = r + dr, c + dc
+            if not (0 <= nr < h and 0 <= nc < w):
+                continue
+            if (nr, nc) in visited:
+                continue
+            tile = state.grid[nr][nc]
+            if tile == WALL:
+                continue
+            # Doors are passable for shortest-path (assume key available)
+            visited.add((nr, nc))
+            queue.append(((nr, nc), dist + 1))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_action(action: dict[str, str] | None) -> dict[str, str] | None:
+    if action is None or not isinstance(action, dict):
+        return None
+    act = action.get("action")
+    if not act:
+        return None
+    return {"action": str(act), "direction": str(action.get("direction", ""))}
+
+
+def _tile_at(state: State, row: int, col: int) -> str | None:
+    if 0 <= row < len(state.grid) and 0 <= col < len(state.grid[0]):
+        return state.grid[row][col]
+    return None
+
+
+def _find_tile(state: State, tile: str) -> tuple[int, int] | None:
+    for r in range(len(state.grid)):
+        for c in range(len(state.grid[0])):
+            if state.grid[r][c] == tile:
+                return (r, c)
+    return None
+
+
+def _check_terminal(state: State, reward: float, info: dict[str, Any]) -> tuple[State, float, bool, dict[str, Any]]:
+    if state.steps >= state.max_steps and not state.done:
+        new_state = replace(state, done=True)
+        return new_state, reward, True, {**info, "timeout": True}
+    return state, reward, state.done, info

--- a/examples/agentic/maze/reward.py
+++ b/examples/agentic/maze/reward.py
@@ -1,0 +1,44 @@
+"""Reward function for the multi-turn maze tool-call example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def reward_fn(record: Any) -> float:
+    """Score one maze episode by replaying all act tool calls."""
+
+    state = dataset_generator.record_to_state(record.source_record)
+    actions = _extract_actions(record)
+    total, _metrics = game.compute_trajectory_reward(state, actions)
+    return total
+
+
+def _extract_actions(record: Any) -> list[dict[str, str] | None]:
+    """Pull the ordered list of act tool-call arguments from the record."""
+
+    actions: list[dict[str, str] | None] = []
+    for call in getattr(record, "tool_calls", []) or []:
+        if not isinstance(call, dict):
+            continue
+        if call.get("name") != "act":
+            continue
+        args = call.get("arguments")
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                actions.append(None)
+                continue
+        if isinstance(args, dict):
+            actions.append({"action": str(args.get("action", "")), "direction": str(args.get("direction", ""))})
+        else:
+            actions.append(None)
+    return actions

--- a/examples/agentic/maze/reward.py
+++ b/examples/agentic/maze/reward.py
@@ -1,4 +1,4 @@
-"""Reward function for the multi-turn maze tool-call example."""
+"""Reward function for the maze tool-call example."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ import game  # noqa: E402
 
 
 def reward_fn(record: Any) -> float:
-    """Score one maze episode by replaying all act tool calls."""
+    """Score one maze episode by replaying the act tool call actions."""
 
     source = record.source_record
     raw = source.get("state", source)
@@ -24,9 +24,8 @@ def reward_fn(record: Any) -> float:
 
 
 def _extract_actions(record: Any) -> list[dict[str, str] | None]:
-    """Pull the ordered list of act tool-call arguments from the record."""
+    """Pull the ordered action list from the act tool call."""
 
-    actions: list[dict[str, str] | None] = []
     for call in getattr(record, "tool_calls", []) or []:
         if not isinstance(call, dict):
             continue
@@ -37,10 +36,20 @@ def _extract_actions(record: Any) -> list[dict[str, str] | None]:
             try:
                 args = json.loads(args)
             except json.JSONDecodeError:
+                return []
+        if not isinstance(args, dict):
+            continue
+        raw_actions = args.get("actions", [])
+        if not isinstance(raw_actions, list):
+            continue
+        actions: list[dict[str, str] | None] = []
+        for item in raw_actions:
+            if isinstance(item, dict):
+                actions.append({
+                    "action": str(item.get("action", "")),
+                    "direction": str(item.get("direction", "")),
+                })
+            else:
                 actions.append(None)
-                continue
-        if isinstance(args, dict):
-            actions.append({"action": str(args.get("action", "")), "direction": str(args.get("direction", ""))})
-        else:
-            actions.append(None)
-    return actions
+        return actions
+    return []

--- a/examples/agentic/maze/reward.py
+++ b/examples/agentic/maze/reward.py
@@ -15,7 +15,9 @@ import game  # noqa: E402
 def reward_fn(record: Any) -> float:
     """Score one maze episode by replaying all act tool calls."""
 
-    state = dataset_generator.record_to_state(record.source_record)
+    source = record.source_record
+    raw = source.get("state", source)
+    state = dataset_generator.record_to_state(raw)
     actions = _extract_actions(record)
     total, _metrics = game.compute_trajectory_reward(state, actions)
     return total

--- a/examples/agentic/maze/run_agent.py
+++ b/examples/agentic/maze/run_agent.py
@@ -91,13 +91,17 @@ async def run_agent(ctx, batch):
             if state.done:
                 break
             tool_choice = {"type": "function", "function": {"name": "act"}}
-            response = await client.chat.completions.create(
-                model="policy",
-                messages=messages,
-                tools=[ACT_TOOL],
-                tool_choice=tool_choice,
-                stream=False,
-            )
+            try:
+                response = await client.chat.completions.create(
+                    model="policy",
+                    messages=messages,
+                    tools=[ACT_TOOL],
+                    tool_choice=tool_choice,
+                    stream=False,
+                )
+            except Exception as exc:
+                logger.warning("Maze agent rollout request failed, ending episode early: %s", exc)
+                break
             message = response.choices[0].message
             tool_calls = [call for call in (message.tool_calls or []) if call.function.name == "act"][:1]
             assistant_message = {

--- a/examples/agentic/maze/run_agent.py
+++ b/examples/agentic/maze/run_agent.py
@@ -1,0 +1,198 @@
+"""Agent entrypoint for multi-turn partially-observable maze rollouts.
+
+Each step the model sees only a local view of the maze and must call the
+``act`` tool with a single action (``move``, ``pickup``, or ``use_key``).
+The agent loops until the goal is reached or ``max_steps`` is exhausted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are navigating a partially observable maze. You can only see tiles "
+    "immediately around you. Reach the goal G by moving through open floor, "
+    "picking up keys K, and opening doors D with held keys. "
+    "Each turn call the act tool with exactly one action."
+)
+
+ACT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "act",
+        "description": "Perform one maze action: move, pickup, or use_key.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["move", "pickup", "use_key"],
+                    "description": "The action to perform.",
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["UP", "DOWN", "LEFT", "RIGHT"],
+                    "description": "Direction for move or use_key. Omit for pickup.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+DEFAULT_MAX_TURNS = 30
+
+
+async def run_agent(ctx, batch):
+    """Run multi-turn tool-call maze episodes for each item."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The maze agentic example requires `openai`. Install it with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info("Maze agent start tasks=%d max_running_prompts=%d", len(items), ctx.max_running_prompts)
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+
+    async def run_one(item):
+        state = game.make_state_from_record(item.record)
+        radius = item.record.get("view_radius", 1)
+        max_turns = min(item.record.get("max_steps", DEFAULT_MAX_TURNS), DEFAULT_MAX_TURNS)
+        turns: list[AgentTrajectoryTurn] = []
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": game.format_prompt(state, radius)},
+        ]
+
+        for _ in range(max_turns):
+            if state.done:
+                break
+            tool_choice = {"type": "function", "function": {"name": "act"}}
+            response = await client.chat.completions.create(
+                model="policy",
+                messages=messages,
+                tools=[ACT_TOOL],
+                tool_choice=tool_choice,
+                stream=False,
+            )
+            message = response.choices[0].message
+            tool_calls = [call for call in (message.tool_calls or []) if call.function.name == "act"][:1]
+            assistant_message = {
+                "role": "assistant",
+                "content": message.content,
+                "tool_calls": [
+                    {
+                        "id": call.id,
+                        "type": call.type,
+                        "function": {
+                            "name": call.function.name,
+                            "arguments": call.function.arguments,
+                        },
+                    }
+                    for call in tool_calls
+                ],
+            }
+            if not assistant_message["tool_calls"]:
+                assistant_message["tool_calls"] = [
+                    {
+                        "id": "missing_act",
+                        "type": "function",
+                        "function": {"name": "act", "arguments": "{}"},
+                    }
+                ]
+
+            turn = AgentTrajectoryTurn(
+                item=item,
+                messages=list(messages),
+                response=response,
+                tools=[ACT_TOOL],
+                tool_choice=tool_choice,
+            )
+            turns.append(turn)
+
+            # Execute the tool call locally
+            action = _parse_tool_action(tool_calls)
+            next_state, _reward, done, info = game.step(state, action)
+            feedback = _format_feedback(info)
+            tool_result = {"state": "ok", "feedback": feedback, "done": done}
+            if done:
+                tool_result["result"] = "reached_goal" if state.reached_goal or next_state.reached_goal else "timeout"
+
+            messages.append(assistant_message)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": assistant_message["tool_calls"][0]["id"],
+                "name": "act",
+                "content": json.dumps(tool_result, ensure_ascii=False),
+            })
+            if done:
+                break
+            # Add follow-up user message with new view
+            messages.append({
+                "role": "user",
+                "content": game.format_step_prompt(next_state, radius, feedback),
+            })
+            state = next_state
+
+        return turns
+
+    try:
+        grouped = await asyncio.gather(*(run_one(item) for item in items))
+        return AgentTrajectory(turns=[turn for turns in grouped for turn in turns])
+    finally:
+        await client.close()
+
+
+def _parse_tool_action(tool_calls: list) -> dict[str, str] | None:
+    """Extract an action dict from the first act tool call."""
+
+    if not tool_calls:
+        return None
+    call = tool_calls[0]
+    try:
+        args = json.loads(call.function.arguments or "{}")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+    if not isinstance(args, dict):
+        return None
+    return {"action": str(args.get("action", "")), "direction": str(args.get("direction", ""))}
+
+
+def _format_feedback(info: dict) -> str:
+    """Turn step info into a short feedback string for the model."""
+
+    if info.get("goal"):
+        return "You reached the goal!"
+    if info.get("timeout"):
+        return "Out of steps."
+    if info.get("illegal"):
+        return f"Invalid move: {info.get('reason', 'unknown')}"
+    if info.get("picked_up"):
+        return f"Picked up key {info['picked_up']}."
+    if info.get("opened_door"):
+        return f"Opened door ({info.get('direction', '')})."
+    if info.get("moved"):
+        return f"Moved {info.get('direction', '')}."
+    return ""

--- a/examples/agentic/maze/run_agent.py
+++ b/examples/agentic/maze/run_agent.py
@@ -1,8 +1,7 @@
-"""Agent entrypoint for multi-turn partially-observable maze rollouts.
+"""Agent entrypoint for single-turn maze tool-call rollouts.
 
-Each step the model sees only a local view of the maze and must call the
-``act`` tool with a single action (``move``, ``pickup``, or ``use_key``).
-The agent loops until the goal is reached or ``max_steps`` is exhausted.
+The model sees the full local view and returns a sequence of actions in one
+tool call. This avoids the multi-round latency of step-by-step interaction.
 """
 
 from __future__ import annotations
@@ -22,42 +21,53 @@ logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 SYSTEM_PROMPT = (
-    "You are navigating a partially observable maze. You can only see tiles "
-    "immediately around you. Reach the goal G by moving through open floor, "
+    "You are navigating a maze. You can see the full map. "
+    "Reach the goal G by moving through open floor, "
     "picking up keys K, and opening doors D with held keys. "
-    "Each turn call the act tool with exactly one action."
+    "Call the act tool with a sequence of actions. /no_think"
 )
 
 ACT_TOOL = {
     "type": "function",
     "function": {
         "name": "act",
-        "description": "Perform one maze action: move, pickup, or use_key.",
+        "description": "Submit a sequence of maze actions to execute in order.",
         "parameters": {
             "type": "object",
             "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["move", "pickup", "use_key"],
-                    "description": "The action to perform.",
-                },
-                "direction": {
-                    "type": "string",
-                    "enum": ["UP", "DOWN", "LEFT", "RIGHT"],
-                    "description": "Direction for move or use_key. Omit for pickup.",
-                },
+                "actions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 20,
+                    "description": "Ordered list of actions to execute.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "enum": ["move", "pickup", "use_key"],
+                                "description": "The action to perform.",
+                            },
+                            "direction": {
+                                "type": "string",
+                                "enum": ["UP", "DOWN", "LEFT", "RIGHT"],
+                                "description": "Direction for move or use_key. Omit for pickup.",
+                            },
+                        },
+                        "required": ["action"],
+                        "additionalProperties": False,
+                    },
+                }
             },
-            "required": ["action"],
+            "required": ["actions"],
             "additionalProperties": False,
         },
     },
 }
 
-DEFAULT_MAX_TURNS = 30
-
 
 async def run_agent(ctx, batch):
-    """Run multi-turn tool-call maze episodes for each item."""
+    """Run one tool-call model request for each maze."""
 
     try:
         import httpx
@@ -80,124 +90,32 @@ async def run_agent(ctx, batch):
         record = item.record.get("state", item.record)
         state = game.make_state_from_record(record)
         radius = record.get("view_radius", 1)
-        max_turns = min(record.get("max_steps", DEFAULT_MAX_TURNS), DEFAULT_MAX_TURNS)
-        turns: list[AgentTrajectoryTurn] = []
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": game.format_prompt(state, radius)},
         ]
-
-        for _ in range(max_turns):
-            if state.done:
-                break
-            tool_choice = {"type": "function", "function": {"name": "act"}}
-            try:
-                response = await client.chat.completions.create(
-                    model="policy",
-                    messages=messages,
-                    tools=[ACT_TOOL],
-                    tool_choice=tool_choice,
-                    stream=False,
-                )
-            except Exception as exc:
-                logger.warning("Maze agent rollout request failed, ending episode early: %s", exc)
-                break
-            message = response.choices[0].message
-            tool_calls = [call for call in (message.tool_calls or []) if call.function.name == "act"][:1]
-            assistant_message = {
-                "role": "assistant",
-                "content": message.content,
-                "tool_calls": [
-                    {
-                        "id": call.id,
-                        "type": call.type,
-                        "function": {
-                            "name": call.function.name,
-                            "arguments": call.function.arguments,
-                        },
-                    }
-                    for call in tool_calls
-                ],
-            }
-            if not assistant_message["tool_calls"]:
-                assistant_message["tool_calls"] = [
-                    {
-                        "id": "missing_act",
-                        "type": "function",
-                        "function": {"name": "act", "arguments": "{}"},
-                    }
-                ]
-
-            turn = AgentTrajectoryTurn(
-                item=item,
-                messages=list(messages),
-                response=response,
+        tool_choice = {"type": "function", "function": {"name": "act"}}
+        try:
+            response = await client.chat.completions.create(
+                model="policy",
+                messages=messages,
                 tools=[ACT_TOOL],
                 tool_choice=tool_choice,
+                stream=False,
             )
-            turns.append(turn)
-
-            # Execute the tool call locally
-            action = _parse_tool_action(tool_calls)
-            next_state, _reward, done, info = game.step(state, action)
-            feedback = _format_feedback(info)
-            tool_result = {"state": "ok", "feedback": feedback, "done": done}
-            if done:
-                tool_result["result"] = "reached_goal" if state.reached_goal or next_state.reached_goal else "timeout"
-
-            messages.append(assistant_message)
-            messages.append({
-                "role": "tool",
-                "tool_call_id": assistant_message["tool_calls"][0]["id"],
-                "name": "act",
-                "content": json.dumps(tool_result, ensure_ascii=False),
-            })
-            if done:
-                break
-            # Add follow-up user message with new view
-            messages.append({
-                "role": "user",
-                "content": game.format_step_prompt(next_state, radius, feedback),
-            })
-            state = next_state
-
-        return turns
+        except Exception as exc:
+            logger.warning("Maze agent rollout request failed: %s", exc)
+            response = None
+        return AgentTrajectoryTurn(
+            item=item,
+            messages=messages,
+            response=response,
+            tools=[ACT_TOOL],
+            tool_choice=tool_choice,
+        )
 
     try:
-        grouped = await asyncio.gather(*(run_one(item) for item in items))
-        return AgentTrajectory(turns=[turn for turns in grouped for turn in turns])
+        turns = list(await asyncio.gather(*(run_one(item) for item in items)))
+        return AgentTrajectory(turns=turns)
     finally:
         await client.close()
-
-
-def _parse_tool_action(tool_calls: list) -> dict[str, str] | None:
-    """Extract an action dict from the first act tool call."""
-
-    if not tool_calls:
-        return None
-    call = tool_calls[0]
-    try:
-        args = json.loads(call.function.arguments or "{}")
-    except (json.JSONDecodeError, AttributeError):
-        return None
-    if not isinstance(args, dict):
-        return None
-    return {"action": str(args.get("action", "")), "direction": str(args.get("direction", ""))}
-
-
-def _format_feedback(info: dict) -> str:
-    """Turn step info into a short feedback string for the model."""
-
-    if info.get("goal"):
-        return "You reached the goal!"
-    if info.get("timeout"):
-        return "Out of steps."
-    if info.get("illegal"):
-        return f"Invalid move: {info.get('reason', 'unknown')}"
-    if info.get("picked_up"):
-        return f"Picked up key {info['picked_up']}."
-    if info.get("opened_door"):
-        return f"Opened door ({info.get('direction', '')})."
-    if info.get("moved"):
-        return f"Moved {info.get('direction', '')}."
-    return ""

--- a/examples/agentic/maze/run_agent.py
+++ b/examples/agentic/maze/run_agent.py
@@ -77,9 +77,10 @@ async def run_agent(ctx, batch):
     client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
 
     async def run_one(item):
-        state = game.make_state_from_record(item.record)
-        radius = item.record.get("view_radius", 1)
-        max_turns = min(item.record.get("max_steps", DEFAULT_MAX_TURNS), DEFAULT_MAX_TURNS)
+        record = item.record.get("state", item.record)
+        state = game.make_state_from_record(record)
+        radius = record.get("view_radius", 1)
+        max_turns = min(record.get("max_steps", DEFAULT_MAX_TURNS), DEFAULT_MAX_TURNS)
         turns: list[AgentTrajectoryTurn] = []
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},

--- a/tests/test_agentic_maze_example_cpu.py
+++ b/tests/test_agentic_maze_example_cpu.py
@@ -1,0 +1,657 @@
+"""CPU tests for the maze agentic example — no GPU required."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_module(name: str):
+    path = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "maze" / f"{name}.py"
+    mod_name = f"agentic_maze_{name}_for_tests"
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Maze generation
+# ---------------------------------------------------------------------------
+
+
+def test_generate_maze_is_solvable():
+    game = _load_module("game")
+
+    grid, agent_pos, goal_pos, pairs = game.generate_maze(4, 4, seed=42, num_keys=1)
+
+    assert grid[agent_pos[0]][agent_pos[1]] == game.AGENT
+    assert grid[goal_pos[0]][goal_pos[1]] == game.GOAL
+    # BFS should find a path (doors treated as passable for solvability check)
+    state = game.make_state(grid, agent_pos[0], agent_pos[1])
+    path_len = game.shortest_path_length(state)
+    assert path_len is not None and path_len > 0
+
+
+def test_generate_maze_deterministic_with_same_seed():
+    game = _load_module("game")
+
+    g1, a1, g1p, p1 = game.generate_maze(4, 4, seed=123, num_keys=1)
+    g2, a2, g2p, p2 = game.generate_maze(4, 4, seed=123, num_keys=1)
+
+    assert g1 == g2
+    assert a1 == a2
+    assert g1p == g2p
+    assert p1 == p2
+
+
+def test_generate_maze_different_seeds_produce_different_mazes():
+    game = _load_module("game")
+
+    g1, _, _, _ = game.generate_maze(5, 5, seed=1, num_keys=0)
+    g2, _, _, _ = game.generate_maze(5, 5, seed=2, num_keys=0)
+
+    assert g1 != g2
+
+
+def test_generate_maze_key_reachable_before_door():
+    game = _load_module("game")
+
+    for seed in range(20):
+        grid, agent_pos, goal_pos, pairs = game.generate_maze(4, 4, seed=seed, num_keys=1)
+        for pair in pairs:
+            key_pos = tuple(pair["key_pos"])
+            door_pos = tuple(pair["door_pos"])
+            # Key must be reachable from agent without passing through the door
+            state = game.make_state(grid, agent_pos[0], agent_pos[1])
+            path = game._bfs_path(grid, agent_pos, key_pos, {door_pos})
+            assert path, f"seed={seed}: key at {key_pos} unreachable without passing door at {door_pos}"
+
+
+def test_generate_maze_no_keys_when_num_keys_zero():
+    game = _load_module("game")
+
+    grid, agent_pos, goal_pos, pairs = game.generate_maze(4, 4, seed=0, num_keys=0)
+
+    assert pairs == []
+    # No K or D tiles in the grid
+    for row in grid:
+        assert game.KEY not in row
+        assert game.DOOR not in row
+
+
+# ---------------------------------------------------------------------------
+# Local view rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_local_view_radius_one():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#.#.#",
+        "#..G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    view = game.render_local_view(state, radius=1)
+
+    lines = view.split("\n")
+    assert len(lines) == 3
+    assert all(len(line) == 3 for line in lines)
+    # Centre is the agent
+    assert lines[1][1] == game.AGENT
+    # Top-left is wall, top is wall
+    assert lines[0][0] == game.WALL
+    assert lines[0][1] == game.WALL
+
+
+def test_render_local_view_corner_agent():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#.#.#",
+        "#..G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    view = game.render_local_view(state, radius=2)
+
+    lines = view.split("\n")
+    assert len(lines) == 5
+    assert all(len(line) == 5 for line in lines)
+    # Top-left corner is unknown (outside maze)
+    assert lines[0][0] == game.UNKNOWN
+
+
+def test_render_local_view_shows_goal_when_in_range():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A.G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    view = game.render_local_view(state, radius=2)
+
+    lines = view.split("\n")
+    # Goal is at (1,3), agent at (1,1), radius=2 covers it
+    # lines[2] is the agent row (dr=0), index 4 is dc=2 -> col 3 -> G
+    assert lines[2][4] == game.GOAL
+
+
+# ---------------------------------------------------------------------------
+# Actions and step
+# ---------------------------------------------------------------------------
+
+
+def test_move_into_wall_is_invalid():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "move", "direction": "UP"})
+
+    assert info["illegal"] is True
+    assert reward < 0
+    assert next_state.invalid_moves == 1
+
+
+def test_move_into_open_floor():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "move", "direction": "RIGHT"})
+
+    assert info.get("moved") is True
+    assert next_state.agent_row == 1
+    assert next_state.agent_col == 2
+    assert not done
+
+
+def test_move_to_goal_gives_positive_reward():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#AG.#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "move", "direction": "RIGHT"})
+
+    assert done is True
+    assert reward == 1.0
+    assert next_state.reached_goal is True
+
+
+def test_move_into_door_blocked_without_key():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#ADG#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "move", "direction": "RIGHT"})
+
+    assert info["illegal"] is True
+    assert next_state.agent_col == 1  # did not move
+
+
+def test_pickup_key_when_standing_on_key():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#K.G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "pickup"})
+
+    assert info.get("picked_up") is not None
+    assert len(next_state.keys) == 1
+    assert reward > 0
+
+
+def test_pickup_without_key_is_invalid():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A.G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "pickup"})
+
+    assert info["illegal"] is True
+    assert reward < 0
+
+
+def test_use_key_opens_door():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#KDG#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    # Pickup key first
+    state, _, _, _ = game.step(state, {"action": "pickup"})
+    # Use key on door to the right
+    next_state, reward, done, info = game.step(state, {"action": "use_key", "direction": "RIGHT"})
+
+    assert info.get("opened_door") is True
+    assert reward > 0
+    # Door tile is now empty
+    assert next_state.grid[1][2] == game.EMPTY
+
+
+def test_use_key_without_key_is_invalid():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#ADG#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, {"action": "use_key", "direction": "RIGHT"})
+
+    assert info["illegal"] is True
+
+
+def test_use_key_on_non_door_is_invalid():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A.G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1, keys=frozenset({"k0"}))
+    next_state, reward, done, info = game.step(state, {"action": "use_key", "direction": "RIGHT"})
+
+    assert info["illegal"] is True
+
+
+def test_invalid_action_returns_penalty():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    next_state, reward, done, info = game.step(state, None)
+
+    assert info["illegal"] is True
+    assert reward < 0
+
+
+def test_step_after_done_returns_zero_reward():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#AG.#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    state, _, done, _ = game.step(state, {"action": "move", "direction": "RIGHT"})
+    assert done
+    next_state, reward, done2, _ = game.step(state, {"action": "move", "direction": "RIGHT"})
+
+    assert done2 is True
+    assert reward == 0.0
+
+
+def test_max_steps_triggers_terminal():
+    game = _load_module("game")
+
+    grid = (
+        "#######",
+        "#A....#",
+        "#######",
+    )
+    state = game.make_state(grid, 1, 1, max_steps=2)
+    state, _, done, _ = game.step(state, {"action": "move", "direction": "RIGHT"})
+    assert not done
+    state, _, done, info = game.step(state, {"action": "move", "direction": "RIGHT"})
+    assert done
+    assert info.get("timeout") is True
+
+
+# ---------------------------------------------------------------------------
+# Legal actions
+# ---------------------------------------------------------------------------
+
+
+def test_legal_actions_includes_move_options():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    actions = game.legal_actions(state)
+
+    move_dirs = {a["direction"] for a in actions if a["action"] == "move"}
+    assert "RIGHT" in move_dirs
+    assert "UP" not in move_dirs  # wall
+
+
+def test_legal_actions_includes_pickup_on_key():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#K.G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    actions = game.legal_actions(state)
+
+    assert any(a["action"] == "pickup" for a in actions)
+
+
+def test_legal_actions_includes_use_key_adjacent_to_door():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#ADG#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1, keys=frozenset({"k0"}))
+    actions = game.legal_actions(state)
+
+    use_dirs = {a["direction"] for a in actions if a["action"] == "use_key"}
+    assert "RIGHT" in use_dirs
+
+
+# ---------------------------------------------------------------------------
+# Trajectory reward
+# ---------------------------------------------------------------------------
+
+
+def test_compute_trajectory_reward_reaching_goal():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#AG.#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    actions = [{"action": "move", "direction": "RIGHT"}]
+    reward, metrics = game.compute_trajectory_reward(state, actions)
+
+    assert reward == 1.0
+    assert metrics["reached_goal"] is True
+
+
+def test_compute_trajectory_reward_invalid_moves():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1, max_steps=5)
+    actions = [
+        {"action": "move", "direction": "UP"},  # wall
+        {"action": "move", "direction": "LEFT"},  # wall
+    ]
+    reward, metrics = game.compute_trajectory_reward(state, actions)
+
+    assert reward < 0
+    assert metrics["invalid_moves"] >= 2
+
+
+def test_compute_trajectory_reward_key_door_goal():
+    game = _load_module("game")
+
+    # A at (1,1), K at (1,2), D at (1,3), G at (1,4)
+    grid = (
+        "#######",
+        "#AKDG.#",
+        "#######",
+    )
+    state = game.make_state(grid, 1, 1)
+    actions = [
+        {"action": "move", "direction": "RIGHT"},  # step onto key
+        {"action": "pickup"},                       # pick up key
+        {"action": "use_key", "direction": "RIGHT"},  # open door
+        {"action": "move", "direction": "RIGHT"},  # through opened door
+        {"action": "move", "direction": "RIGHT"},  # to goal
+    ]
+    reward, metrics = game.compute_trajectory_reward(state, actions)
+
+    assert metrics["reached_goal"] is True
+    assert metrics["keys_picked"] == 1
+    assert metrics["doors_opened"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Dataset generator
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_generator_produces_valid_records():
+    generator = _load_module("dataset_generator")
+    game = _load_module("game")
+
+    records = generator.generate_records(16, seed=7, rows=3, cols=3, num_keys=1)
+
+    assert len(records) == 16
+    for record in records:
+        state = generator.record_to_state(record)
+        # Every generated maze should be solvable
+        path_len = game.shortest_path_length(state)
+        assert path_len is not None and path_len > 0
+
+
+def test_dataset_generator_deterministic():
+    generator = _load_module("dataset_generator")
+
+    r1 = generator.generate_records(8, seed=99, rows=3, cols=3, num_keys=0)
+    r2 = generator.generate_records(8, seed=99, rows=3, cols=3, num_keys=0)
+
+    assert r1 == r2
+
+
+def test_dataset_generator_write_jsonl(tmp_path):
+    generator = _load_module("dataset_generator")
+
+    records = generator.generate_records(4, seed=1, rows=3, cols=3)
+    out = tmp_path / "maze.jsonl"
+    with out.open("w") as f:
+        generator.write_jsonl(records, f)
+
+    lines = out.read_text().strip().split("\n")
+    assert len(lines) == 4
+    for line in lines:
+        record = json.loads(line)
+        assert "grid" in record
+        assert "agent_pos" in record
+        assert "goal_pos" in record
+
+
+# ---------------------------------------------------------------------------
+# Dataset loader
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_loader_loads_and_formats(tmp_path):
+    generator = _load_module("dataset_generator")
+    loader = _load_module("dataset_loader")
+    game = _load_module("game")
+
+    records = generator.generate_records(4, seed=1, rows=3, cols=3)
+    out = tmp_path / "maze.jsonl"
+    with out.open("w") as f:
+        generator.write_jsonl(records, f)
+
+    loaded = loader.load_training_dataset(str(out))
+
+    assert len(loaded) == 4
+    for item in loaded:
+        assert "prompt" in item
+        assert "state" in item
+        assert "legal_actions" in item
+        assert game.AGENT in item["prompt"]
+
+
+def test_dataset_loader_missing_file_raises(tmp_path):
+    loader = _load_module("dataset_loader")
+
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        loader.load_training_dataset(str(tmp_path / "nonexistent.jsonl"))
+
+
+# ---------------------------------------------------------------------------
+# Reward function
+# ---------------------------------------------------------------------------
+
+
+def test_reward_fn_reaching_goal():
+    reward = _load_module("reward")
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+
+    grid = (
+        "#####",
+        "#AG.#",
+        "#####",
+    )
+    record = {
+        "grid": list(grid),
+        "agent_pos": [1, 1],
+        "max_steps": 5,
+    }
+    state = generator.record_to_state(record)
+    # Simulate tool calls
+    record_obj = SimpleNamespace(
+        source_record=record,
+        tool_calls=[{"name": "act", "arguments": {"action": "move", "direction": "RIGHT"}}],
+    )
+
+    result = reward.reward_fn(record_obj)
+    assert result == 1.0
+
+
+def test_reward_fn_invalid_moves():
+    reward = _load_module("reward")
+    generator = _load_module("dataset_generator")
+
+    grid = (
+        "#####",
+        "#A..#",
+        "#####",
+    )
+    record = {
+        "grid": list(grid),
+        "agent_pos": [1, 1],
+        "max_steps": 10,
+    }
+    record_obj = SimpleNamespace(
+        source_record=record,
+        tool_calls=[
+            {"name": "act", "arguments": {"action": "move", "direction": "UP"}},
+            {"name": "act", "arguments": {"action": "move", "direction": "LEFT"}},
+        ],
+    )
+
+    result = reward.reward_fn(record_obj)
+    assert result < 0
+
+
+def test_reward_fn_ignores_non_act_tool_calls():
+    reward = _load_module("reward")
+    generator = _load_module("dataset_generator")
+
+    grid = (
+        "#####",
+        "#AG.#",
+        "#####",
+    )
+    record = {
+        "grid": list(grid),
+        "agent_pos": [1, 1],
+        "max_steps": 5,
+    }
+    record_obj = SimpleNamespace(
+        source_record=record,
+        tool_calls=[
+            {"name": "look", "arguments": {}},
+            {"name": "act", "arguments": {"action": "move", "direction": "RIGHT"}},
+        ],
+    )
+
+    result = reward.reward_fn(record_obj)
+    assert result == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Shortest path
+# ---------------------------------------------------------------------------
+
+
+def test_shortest_path_length_simple():
+    game = _load_module("game")
+
+    grid = (
+        "#####",
+        "#A.G#",
+        "#####",
+    )
+    state = game.make_state(grid, 1, 1)
+    length = game.shortest_path_length(state)
+
+    assert length == 2
+
+
+def test_shortest_path_length_none_if_unreachable():
+    game = _load_module("game")
+
+    grid = (
+        "#######",
+        "#A....#",
+        "#######",
+        "#G....#",
+        "#######",
+    )
+    state = game.make_state(grid, 1, 1)
+    length = game.shortest_path_length(state)
+
+    assert length is None

--- a/tests/test_agentic_maze_example_cpu.py
+++ b/tests/test_agentic_maze_example_cpu.py
@@ -559,11 +559,9 @@ def test_reward_fn_reaching_goal():
         "agent_pos": [1, 1],
         "max_steps": 5,
     }
-    state = generator.record_to_state(record)
-    # Simulate tool calls
     record_obj = SimpleNamespace(
         source_record=record,
-        tool_calls=[{"name": "act", "arguments": {"action": "move", "direction": "RIGHT"}}],
+        tool_calls=[{"name": "act", "arguments": {"actions": [{"action": "move", "direction": "RIGHT"}]}}],
     )
 
     result = reward.reward_fn(record_obj)
@@ -586,10 +584,10 @@ def test_reward_fn_invalid_moves():
     }
     record_obj = SimpleNamespace(
         source_record=record,
-        tool_calls=[
-            {"name": "act", "arguments": {"action": "move", "direction": "UP"}},
-            {"name": "act", "arguments": {"action": "move", "direction": "LEFT"}},
-        ],
+        tool_calls=[{"name": "act", "arguments": {"actions": [
+            {"action": "move", "direction": "UP"},
+            {"action": "move", "direction": "LEFT"},
+        ]}}],
     )
 
     result = reward.reward_fn(record_obj)
@@ -614,7 +612,7 @@ def test_reward_fn_ignores_non_act_tool_calls():
         source_record=record,
         tool_calls=[
             {"name": "look", "arguments": {}},
-            {"name": "act", "arguments": {"action": "move", "direction": "RIGHT"}},
+            {"name": "act", "arguments": {"actions": [{"action": "move", "direction": "RIGHT"}]}},
         ],
     )
 

--- a/xingfa/issue-187-maze-agentic-demo.md
+++ b/xingfa/issue-187-maze-agentic-demo.md
@@ -1,0 +1,217 @@
+# Issue #187: Build a partially observable maze agentic RL demo
+
+> 原始 issue: https://github.com/inclusionAI/AReno/issues/187
+> 创建者: xsuler (Collaborator) | 标签: `kind/feature` `area/agentic` `priority/backlog`
+
+---
+
+## 一、Issue 要做什么
+
+### 1.1 核心目标
+
+在 `examples/agentic/` 下新增一个 **部分可观测迷宫（partially observable maze）** 的 agentic RL demo，让用户能快速体验和测试 AReno 在多步决策、探索性场景下的 RL 训练能力。
+
+### 1.2 迷宫功能规格
+
+迷宫包含以下元素：
+
+| 元素 | 符号 | 说明 |
+|------|------|------|
+| 墙壁 | `#` | 不可通行 |
+| 空地 | `.` | 可通行 |
+| Agent | `A` | 玩家起始位置 |
+| 钥匙 | `K` | 可拾取，用于打开对应门 |
+| 门 | `D` | 需要持有对应钥匙才能通过 |
+| 目标 | `G` | 到达即成功 |
+
+关键约束：
+
+- **部分可观测**：agent 只能看到周围局部视野（如 3×3 或 5×5 窗口），不能看到完整地图
+- **单步移动**：每次只能向上下左右移动一格
+- **种子化生成**：迷宫通过 seed 确定性生成，保证可复现
+- **保证可解**：生成的迷宫必须存在从起点到目标的合法路径
+
+### 1.3 需要创建的文件
+
+按照 AReno 现有 agentic 示例的**统一文件结构契约**（参考 `examples/agentic/tictactoe/` 和 `examples/agentic/duelgrid/`）：
+
+```
+examples/agentic/maze/
+├── game.py              # 迷宫生成、状态管理、局部视野渲染、移动/拾取/开门逻辑
+├── run_agent.py         # async run_agent(ctx, batch) — 调用模型选择动作
+├── reward.py            # reward_fn(record) — 奖励函数
+├── dataset_loader.py    # 加载预生成的迷宫 JSONL
+├── dataset_generator.py # 种子化生成可解迷宫（含钥匙-门配对）
+└── README.md            # 使用说明
+```
+
+### 1.4 各文件职责详解
+
+#### `game.py` — 迷宫核心逻辑
+
+- **迷宫生成**：使用种子化算法（如 Prim、DFS backtracking）生成保证可解的迷宫
+- **钥匙-门配对**：在迷宫中放置钥匙和对应颜色的门，确保钥匙在门之前可达
+- **局部视野渲染**：`render_local_view(state, radius=N)` 只返回 agent 周围 N 格范围内的地图
+- **动作系统**：`move(direction)` 移动、`pickup()` 拾取钥匙、`use_key()` 开门
+- **状态管理**：`State` dataclass 包含 grid、agent 位置、持有钥匙、步数等
+- **合法性校验**：撞墙检测、无钥匙开门检测、动作耗尽检测
+
+#### `run_agent.py` — Agent 入口
+
+- 定义 `async run_agent(ctx, batch)` 函数（AReno agentic 的标准入口签名）
+- 通过 `ctx.get_base_url()` 获取本地 OpenAI-compatible 端点
+- 定义 tool schema（如 `move`、`pickup`、`use_key`、`look` 等工具）
+- 每轮将局部视野作为 prompt 发给模型，模型通过 tool call 返回动作
+- 返回 `AgentTrajectory`（包含多轮 `AgentTrajectoryTurn`）
+
+#### `reward.py` — 奖励函数
+
+- `reward_fn(record)` 根据轨迹计算奖励
+- 稀疏奖励为主：到达目标 +1.0，撞墙/无效动作 -0.1
+- 可选步数惩罚：鼓励最短路径
+
+#### `dataset_generator.py` — 数据生成
+
+- 种子化生成迷宫 JSONL 文件
+- 每条记录包含：迷宫 grid、agent 起始位置、目标位置、钥匙-门配对信息
+- 参考 `examples/agentic/duelgrid/dataset_generator.py` 的模式
+
+#### `dataset_loader.py` — 数据加载
+
+- `load_training_dataset(dataset_path, ...)` 加载 JSONL 并转为 AReno prompt 格式
+- 直接复用 duelgrid 的加载模式
+
+### 1.5 与现有代码的复用关系
+
+迷宫示例**不需要修改任何 AReno 核心代码**，只需使用 `areno/api/__init__.py` 已导出的公共类型：
+
+```python
+from areno.api.agentic import (
+    AgentBatch, AgentItem, AgentTrainBatch,
+    AgentTrajectory, AgentTrajectoryTurn,
+    LossMaskPolicy, RolloutSession,
+)
+```
+
+CLI 入口 `areno/cli/train.py` 已支持 `--agent-fn` 参数（`areno/cli/train.py:1298`），用户只需：
+
+```bash
+areno train --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path examples/agentic/maze/maze_states.jsonl \
+  --dataset-loader-fn examples/agentic/maze/dataset_loader.py \
+  --reward-fn-path examples/agentic/maze/reward.py \
+  --agent-fn examples/agentic/maze/run_agent.py \
+  --algo gspo --tp-size 1
+```
+
+### 1.6 验收标准（来自 issue）
+
+- [ ] 覆盖多种迷宫尺寸和布局、不可行走路径、需要钥匙的门、动作耗尽、确定性重放
+- [ ] 指标覆盖：成功率、路径长度、无效移动次数、超出最短路径的步数
+- [ ] 使用现有 AReno 契约，不引入外部数据库或强制沙箱
+- [ ] 默认行为向后兼容（不影响现有功能）
+- [ ] 聚焦的自动化 CPU 测试覆盖成功路径、无效输入、边界/失败路径
+- [ ] 用户文档包含最小可运行示例
+
+---
+
+## 二、实现难度评估
+
+### 2.1 总体评估
+
+| 维度 | 评估 |
+|------|------|
+| 整体难度 | **中等** |
+| 预估代码量 | ~800-1200 行（不含测试） |
+| 核心挑战 | 迷宫生成算法、局部视野渲染、钥匙-门可达性保证 |
+| 风险点 | 迷宫生成算法的可解性验证、多轮 tool-call 轨迹的正确 tokenization |
+
+### 2.2 各模块难度分解
+
+| 模块 | 难度 | 预估行数 | 说明 |
+|------|------|----------|------|
+| `game.py` | **中高** | 300-400 行 | 核心难点：迷宫生成算法需保证可解性；钥匙-门配对需保证钥匙在门之前可达；局部视野渲染需正确处理边界 |
+| `run_agent.py` | **低** | 80-120 行 | 直接复用 tictactoe/duelgrid 的模式，只需定义不同的 tool schema 和 system prompt |
+| `reward.py` | **低** | 40-60 行 | 稀疏奖励为主，逻辑简单 |
+| `dataset_generator.py` | **中** | 150-200 行 | 种子化迷宫生成，参考 duelgrid 的 `dataset_generator.py` 模式 |
+| `dataset_loader.py` | **低** | 30-50 行 | 直接复用 duelgrid 的加载模式 |
+| `README.md` | **低** | 50-80 行 | 使用说明和可运行示例 |
+| CPU 测试 | **中** | 200-300 行 | 需覆盖迷宫逻辑的各种边界情况 |
+
+### 2.3 各模块技术要点
+
+#### `game.py` — 难度中高
+
+**迷宫生成算法**（核心挑战）：
+
+- 推荐使用 **Prim 算法** 或 **递归回溯（DFS backtracking）** 生成保证连通的迷宫
+- 需要保证从起点到目标存在路径
+- 钥匙-门配对需要额外验证：钥匙必须在门之前可达（即不经过门就能到达钥匙）
+
+**局部视野渲染**：
+
+- `render_local_view(state, radius=2)` 返回 agent 周围 (2*radius+1)×(2*radius+1) 的地图
+- 边界外的格子标记为未知（如 `?`）
+- 已探索但当前不可见的区域可以保留记忆（可选，增加复杂度）
+
+**动作合法性校验**：
+
+- 移动：目标格不能是墙壁 `#` 或未打开的门 `D`
+- 拾取：当前格必须是钥匙 `K`
+- 开门：必须持有对应钥匙，且目标格是门 `D`
+
+#### `run_agent.py` — 难度低
+
+- 与 tictactoe/duelgrid 的 `run_agent.py` 结构几乎一致
+- 差异仅在 tool schema 定义和 system prompt
+- 多轮交互：agent 需要多轮 tool-call 才能完成迷宫（移动→拾取钥匙→开门→到达目标）
+
+#### `dataset_generator.py` — 难度中
+
+- 参考 `examples/agentic/duelgrid/dataset_generator.py` 的模式
+- 迷宫生成需要保证多样性（不同尺寸、不同钥匙-门数量）
+- 输出 JSONL 格式，每条记录包含完整的迷宫状态
+
+#### CPU 测试 — 难度中
+
+- 参考 `tests/test_agentic_cpu.py` 的测试模式
+- 需要覆盖：
+  - 迷宫生成的可解性验证
+  - 局部视野渲染的正确性（边界处理、未知区域）
+  - 移动/拾取/开门的合法性校验
+  - 钥匙-门配对逻辑
+  - 确定性重放（相同 seed → 相同迷宫）
+  - 无效输入处理（撞墙、无钥匙开门、动作耗尽）
+  - 指标计算（成功/路径长度/无效移动次数）
+
+### 2.4 与现有示例的对比
+
+| 特性 | tictactoe | duelgrid | maze（新增） |
+|------|-----------|----------|-------------|
+| 可观测性 | 完全信息 | 完全信息 | **部分可观测** |
+| 交互轮次 | 单轮 | 多轮 | 多轮 |
+| 工具数量 | 1 个 | 1 个 | 3-4 个 |
+| 状态空间 | 小（3×3） | 中（11×11） | 可配置 |
+| 核心挑战 | 对抗推理 | 战术决策 | **探索+规划** |
+| 实现复杂度 | 低 | 中 | 中 |
+
+### 2.5 实现顺序建议
+
+1. **`game.py`** — 先实现迷宫核心逻辑，这是所有其他模块的基础
+2. **`dataset_generator.py`** — 能生成数据后才能验证 game.py 的正确性
+3. **CPU 测试（game 部分）** — 在写 agent 之前确保迷宫逻辑正确
+4. **`run_agent.py`** — agent 入口，依赖 game.py 的局部视野渲染
+5. **`reward.py`** — 奖励函数，依赖 game.py 的状态判定
+6. **`dataset_loader.py`** — 数据加载，最简单
+7. **CPU 测试（集成部分）** — 端到端验证
+8. **`README.md`** — 最后写文档
+
+---
+
+## 三、非目标（明确排除）
+
+- 不替换 AReno 的 trainer、rollout engine、dashboard 存储或公共 SDK 架构
+- 不引入外部数据库、托管控制面板或重量级依赖
+- 不自动修改用户配置、删除产物或终止无关进程
+- 不解决可以拆分为独立 issue 的相邻功能
+- 不需要实现图形化界面（可选的 web_ui 是后续工作）

--- a/xingfa/issue-187-original.md
+++ b/xingfa/issue-187-original.md
@@ -1,0 +1,71 @@
+# Issue #187 原文: Build a partially observable maze agentic RL demo
+
+> 原始链接: https://github.com/inclusionAI/AReno/issues/187
+> 创建者: [xsuler](https://github.com/xsuler) (Collaborator)
+> 创建时间: 2026-07-27
+> 状态: Open
+> 标签: `kind/feature` `area/agentic` `priority/backlog`
+
+---
+
+## Motivation
+
+AReno users need **build a partially observable maze agentic RL demo** as a focused, independently reviewable capability. The current workflow either lacks this behavior or requires one-off user code, which makes post-training runs harder to operate, compare, and reproduce.
+
+## Proposed feature
+
+Generate seeded solvable mazes containing walls, keys, doors, and a goal. Reveal only a bounded local view and expose one-step movement actions; never expose the hidden map through tool output.
+
+The implementation should use AReno's existing public contracts and local artifact formats. Any new public option must have a safe default that preserves current behavior, a clear validation error, and both human-readable and structured output when the feature is exposed through the CLI.
+
+### Expected user flow
+
+1. The user enables or invokes the feature with explicit inputs.
+2. AReno validates those inputs before expensive model or worker initialization.
+3. The feature produces an observable result through existing logs, metrics, artifacts, CLI output, or the dashboard.
+4. Failure identifies the affected stage and input without exposing full training samples or hiding the original error.
+
+### Likely implementation areas
+
+Start with `examples/agentic/`, `areno/api/agentic.py`, and focused CPU tests. Keep the change narrow; reuse existing data, metric, lifecycle, and registry contracts rather than introducing a parallel subsystem.
+
+### Minimal example
+
+Provide one tiny deterministic example or fixture that can run without external databases. Agentic examples must also avoid network services and sandbox requirements. The example must demonstrate the successful path and at least one invalid or boundary input.
+
+## Non-goals
+
+- Replacing AReno's trainer, rollout engine, local dashboard storage, or public SDK architecture.
+- Adding an external database, hosted control plane, or mandatory heavyweight dependency.
+- Automatically changing user configuration, deleting artifacts, or terminating unrelated processes.
+- Solving adjacent features that can be reviewed as separate issues.
+
+## Reference
+
+Use only existing AReno dependencies unless a small new dependency is separately justified. The repository's current implementation and contracts are the primary reference; no research-paper implementation is required for this issue.
+
+## Alternatives considered
+
+- Keep the behavior in project-specific loaders, reward hooks, or shell scripts. This does not provide one consistent contract, diagnostics, or reusable tests.
+- Build a separate service for the feature. That would add deployment and storage complexity to a capability that can operate on AReno's existing local artifacts.
+- Fold the work into a broad runtime or dashboard rewrite. A focused addition is easier to review, test, and adopt without changing unrelated behavior.
+
+## Testing requirements
+
+- Add focused CPU tests for the core logic, malformed input, boundary values, disabled/default behavior, and deterministic output.
+- Add an integration-style test using tiny local fixtures where the feature crosses modules.
+- For distributed or GPU-only behavior, isolate orchestration logic behind fakes and document the minimal GPU validation that remains.
+- Assert emitted metric/artifact fields and error messages, not only exit status.
+- Verify existing behavior is unchanged when the feature is not enabled.
+
+## Documentation requirements
+
+Document the user-facing option or command, input contract, defaults, output fields, limitations, and one copyable example. Update the relevant skill or troubleshooting page if this changes an operator workflow.
+
+## Acceptance criteria
+
+- [ ] Cover multiple sizes and layouts, impossible moves, required-key doors, action exhaustion, deterministic replay, and metrics for success, path length, invalid moves, and excess steps over a shortest-path oracle.
+- [ ] The implementation uses existing AReno contracts and introduces no external database or mandatory sandbox.
+- [ ] Default behavior remains backward compatible.
+- [ ] Focused automated tests cover success, invalid input, and one boundary/failure path.
+- [ ] User documentation includes a minimal runnable example and explains observable output.


### PR DESCRIPTION
## What does this PR do?
Add a partially observable maze agentic RL demo, including seeded maze generation (walls, keys, doors, goal), bounded local view, one-step movement actions, reward function, dataset generator/loader, and a run agent script. Also includes a CPU test.

## Related issue
Closes #187

## Type of change
- [x] New feature

## How was it tested?
pytest tests/test_agentic_maze_example_cpu.py -k cpu

## Checklist
- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
