### PR TITLE
feat(skill): add agentic-project generator to build-agentic-workflow

### DIFF
--- a/.agents/skills/areno-build-agentic-workflow/SKILL.md
+++ b/.agents/skills/areno-build-agentic-workflow/SKILL.md
@@ -17,7 +17,11 @@ python .agents/skills/areno-run-training/scripts/inspect_dataset.py \
 ```
 
 ## Workflow
-
+0. **(Optional) Scaffold a project.** Start from a runnable, dependency-light
+   skeleton with `scripts/generate_agentic_project.py --name <name>`, then fill
+   in the domain. Generated output runs one fixed episode immediately and
+   reuses existing AReno contracts; see
+   [references/generator-output.md](references/generator-output.md).
 1. Define one deterministic environment/game domain and valid dataset records.
 2. Keep dataset loaders processor/tokenizer independent.
 3. Define strict JSON tool schemas and bounded execution. Read [references/message-contract.md](references/message-contract.md).

--- a/.agents/skills/areno-build-agentic-workflow/references/generator-output.md
+++ b/.agents/skills/areno-build-agentic-workflow/references/generator-output.md
@@ -1,0 +1,65 @@
+# Agentic Project Generator Output
+
+`scripts/generate_agentic_project.py` scaffolds a runnable, dependency-light
+AReno agentic project. It uses only AReno's existing public contracts and
+introduces no external database or mandatory sandbox.
+
+## Command
+
+```bash
+python .agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py \
+  --name my-gridworld \
+  --out examples/agentic/my-gridworld \
+  [--force] [--seed 2026]
+```
+
+## Input contract
+
+| Option   | Required | Default                       | Description                                            |
+| -------- | -------- | ----------------------------- | ------------------------------------------------------ |
+| `--name` | yes      | —                             | Project name, lowercase hyphen-case (`^[a-z0-9]+(-[a-z0-9]+)*$`). |
+| `--out`  | no       | `examples/agentic/<name>`     | Output directory.                                      |
+| `--force`| no       | off                           | Overwrite a non-empty output directory.                |
+| `--seed` | no       | `2026`                        | Deterministic seed for generated fixtures.             |
+
+## Defaults and safety
+
+- Default behavior is backward compatible: the generator only adds files; it
+  never deletes or modifies unrelated project state.
+- A non-empty `--out` is refused without `--force`, so existing user edits are
+  never silently overwritten.
+- Output is deterministic for a fixed `--name` and `--seed`.
+
+## Output fields (structured summary)
+
+The script prints human-readable progress lines followed by a single JSON line:
+
+```json
+{"ok": true, "name": "my-gridworld", "seed": 2026, "path": "...", "files": ["..."], "episode_cmd": "python .../run_episode.py"}
+```
+
+## Generated files
+
+| File                  | Contract                                                        |
+| --------------------- | --------------------------------------------------------------- |
+| `game.py`             | `Env` with `reset` / `step` / `legal_actions` / `render`; clear error and reward. |
+| `dataset_generator.py`| CLI `--output --count --seed`, reproducible JSONL.              |
+| `dataset_loader.py`   | `load_training_dataset(dataset_path, *, default_loader=None, **_) -> list[dict]`. |
+| `tool_defs.py`        | `tools() -> list[dict]`, `tool_choice() -> dict`.               |
+| `run_agent.py`        | `async def run_agent(ctx, batch) -> AgentTrajectory`.           |
+| `reward.py`           | `reward_fn(record) -> float`.                                   |
+| `run_episode.py`      | No-model smoke; runs one fixed episode, prints `episode_total_reward=`. |
+| `README.md`           | Minimal runnable example and observable output.                 |
+
+## Observable output
+
+`run_episode.py` prints reset/step/reward lines ending with
+`episode_total_reward=<float>`, so the scaffold can be verified on CPU without
+a model, network, or GPU.
+
+## Limitations
+
+- The generated environment is a placeholder gridwalk; replace `game.py` with
+  the real task domain.
+- `run_agent.py` requires `pip install openai` and a reachable
+  OpenAI-compatible endpoint; `run_episode.py` does not.

--- a/.agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py
+++ b/.agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Scaffold a runnable, dependency-light AReno agentic project.
+
+Generates a deterministic project under ``examples/agentic/<name>/`` containing
+an environment state machine, dataset generator/loader, JSON tool definitions,
+reward function, OpenAI-compatible agent entrypoint, and a no-model smoke
+episode runner. The output uses only AReno's existing public contracts and
+introduces no external database or mandatory sandbox.
+
+Usage:
+    python .agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py \
+        --name my-gridworld \
+        --out examples/agentic/my-gridworld \
+        [--force] [--seed 2026]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+DEFAULT_SEED = 2026
+
+
+def _module_name(name: str) -> str:
+    """Python module-safe name (hyphens -> underscores)."""
+    return name.replace("-", "_")
+
+
+def _header(name: str, seed: int, desc: str = "") -> str:
+    """Build a single module docstring (keeps `from __future__` legal)."""
+    body = f"Generated agentic project: {name} (seed={seed})."
+    if desc:
+        body += f"\n\n{desc}"
+    body += (
+        "\n\nDependency-light, self-contained, no external database or sandbox.\n"
+        "Re-run the generator with a different --seed to vary fixtures deterministically."
+    )
+    return f'"""\n{body}\n"""\n'
+
+
+# ---------------------------------------------------------------------------
+# Templates for the generated project files.
+# Each is a function of (name, seed) so output is fully deterministic.
+# ---------------------------------------------------------------------------
+
+
+def _game_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, "Deterministic environment state machine with clear reset/step/error/reward placeholders.")}
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+
+class Env:
+    """A tiny deterministic gridwalk used as a placeholder task.
+
+    The agent starts at position 0 on a line of {mod.upper()}_SIZE cells and
+    must reach the last cell. Each ``step`` moves left/right by one cell.
+    Rewards are +1 for reaching the goal, -0.1 otherwise, and a clear error
+    is raised on an illegal action.
+    """
+
+    SIZE = 5
+    GOAL_REWARD = 1.0
+    STEP_PENALTY = 0.1
+
+    def __init__(self, seed: int = {seed}) -> None:
+        self._rng = random.Random(seed)
+        self.position: int = 0
+        self._steps: int = 0
+        self._done: bool = False
+
+    # --- reset ---
+    def reset(self) -> dict[str, Any]:
+        """Reset the environment to its initial state and return an observation."""
+        self.position = 0
+        self._steps = 0
+        self._done = False
+        return self._observe()
+
+    # --- step ---
+    def step(self, action: int) -> tuple[dict[str, Any], float, bool, dict[str, Any]]:
+        """Apply one action and return (observation, reward, done, info).
+
+        action: -1 to move left, +1 to move right.
+        """
+        # --- error handling ---
+        if not isinstance(action, int) or action not in (-1, 1):
+            raise ValueError(f"illegal action {{action!r}}; expected -1 or +1")
+        if self._done:
+            raise RuntimeError("step() called on a finished episode; call reset() first")
+
+        self._steps += 1
+        self.position = max(0, min(self.SIZE - 1, self.position + action))
+        done = self.position == self.SIZE - 1
+        # --- reward ---
+        reward = self.GOAL_REWARD if done else -self.STEP_PENALTY
+        self._done = done
+        return self._observe(), reward, done, self._info()
+
+    def legal_actions(self) -> list[int]:
+        return [-1, 1]
+
+    def render(self) -> str:
+        cells = ["." for _ in range(self.SIZE)]
+        cells[self.position] = "A"
+        cells[-1] = "G"
+        return "[" + " ".join(cells) + "]"
+
+    def _observe(self) -> dict[str, Any]:
+        return {{"position": self.position, "size": self.SIZE}}
+
+    def _info(self) -> dict[str, Any]:
+        return {{"steps": self._steps, "position": self.position, "done": self._done}}
+
+
+def make_env(seed: int = {seed}) -> Env:
+    """Factory used by dataset_loader / run_agent."""
+    return Env(seed=seed)
+'''
+
+
+def _dataset_generator_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, "Generate reproducible JSONL task records.")}
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+
+def generate_records(count: int = 8, seed: int = {seed}) -> list[dict]:
+    """Produce ``count`` deterministic task records.
+
+    Each record is a starting position for the gridwalk placeholder.
+    """
+    rng = random.Random(seed)
+    size = 5
+    records = []
+    for i in range(count):
+        start = rng.randrange(0, size - 1)
+        records.append({{"id": f"{mod}-{{i:05d}}", "start": start, "size": size}})
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate JSONL task records.")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--count", type=int, default=8)
+    parser.add_argument("--seed", type=int, default={seed})
+    args = parser.parse_args()
+    records = generate_records(count=args.count, seed=args.seed)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\\n")
+    print(json.dumps({{"ok": True, "path": str(args.output), "count": len(records)}}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def _dataset_loader_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, f"Dataset loader for the {name} agentic example. Processor/tokenizer independent.")}
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: Any) -> list[dict]:
+    """Load JSONL records and convert them to Areno prompt records."""
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "tasks.jsonl"
+    if not path.exists():
+        import dataset_generator  # local fallback
+        return dataset_generator.generate_records()
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int) -> dict:
+    size = int(raw.get("size", game.Env.SIZE))
+    start = int(raw.get("start", 0))
+    return {{
+        "id": raw.get("id", f"{mod}-{{index:05d}}"),
+        "prompt": (
+            f"Reach the goal cell of a {{size}}-cell line. You start at cell {{start}}. "
+            f"Reply with a single action: -1 (left) or +1 (right)."
+        ),
+        "start": start,
+        "size": size,
+        "legal_actions": [-1, 1],
+    }}
+'''
+
+
+def _tool_defs_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, "Strict, bounded JSON tool schemas for the agent.")}
+
+from __future__ import annotations
+
+ACT_TOOL = {{
+    "type": "function",
+    "function": {{
+        "name": "act",
+        "description": "Move the agent one cell left (-1) or right (+1) on the line.",
+        "parameters": {{
+            "type": "object",
+            "properties": {{
+                "action": {{
+                    "type": "integer",
+                    "enum": [-1, 1],
+                    "description": "Direction to move: -1 = left, +1 = right.",
+                }}
+            }},
+            "required": ["action"],
+            "additionalProperties": False,
+        }},
+    }},
+}}
+
+
+def tools() -> list[dict]:
+    return [ACT_TOOL]
+
+
+def tool_choice() -> dict:
+    return {{"type": "function", "function": {{"name": "act"}}}}
+'''
+
+
+def _run_agent_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, f"Agent entrypoint for {name} tool-call rollouts.")}
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+import tool_defs  # local
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    f"You are an agent on a 1D line. Always call the `act` tool exactly once "
+    f"with action -1 (left) or +1 (right) to move toward the goal."
+)
+
+
+async def run_agent(ctx, batch):
+    """Run one tool-call model request for each task record."""
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            f"The {name} agentic example requires `openai` and `httpx`. "
+            f"Install with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    tools = tool_defs.tools()
+    choice = tool_defs.tool_choice()
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+
+    async def run_one(item):
+        messages = [
+            {{"role": "system", "content": SYSTEM_PROMPT}},
+            {{"role": "user", "content": item.prompt}},
+        ]
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=messages,
+            tools=tools,
+            tool_choice=choice,
+            stream=False,
+        )
+        return AgentTrajectoryTurn(item=item, messages=messages, response=response, tools=tools, tool_choice=choice)
+
+    try:
+        return AgentTrajectory(turns=list(await asyncio.gather(*(run_one(item) for item in items))))
+    finally:
+        await client.close()
+'''
+
+
+def _reward_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, f"Reward function for the {name} tool-call example.")}
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by replaying its `act` tool call against the env."""
+    source = record.source_record
+    env = game.Env()
+    env.position = int(source.get("start", 0))
+    action = _tool_action(record)
+    if action is None:
+        return -1.0  # malformed / missing tool call
+    try:
+        _, reward, done, _ = env.step(action)
+    except ValueError:
+        return -1.0  # illegal action
+    return reward
+
+
+def _tool_action(record: Any) -> int | None:
+    for call in record.tool_calls:
+        name = call.get("name") if isinstance(call, dict) else None
+        if name != "act":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return None
+        if isinstance(arguments, dict):
+            try:
+                return int(arguments.get("action"))
+            except (TypeError, ValueError):
+                return None
+    return None
+'''
+
+
+def _run_episode_py(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''{_header(name, seed, "Deterministic no-model smoke: run ONE fixed episode. No LLM, no network, no GPU.")}
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+# Fixed, deterministic action sequence: always reach the goal in {mod.upper()}_SIZE-1 steps.
+FIXED_ACTION_SEQ = [1] * (game.Env.SIZE - 1)
+
+
+def main() -> int:
+    env = game.Env()
+    obs = env.reset()  # --- reset ---
+    print(f"reset obs={{obs}} render={{env.render()}}")
+    total = 0.0
+    for i, action in enumerate(FIXED_ACTION_SEQ):
+        obs, reward, done, info = env.step(action)  # --- step ---
+        total += reward                              # --- reward ---
+        print(f"step i={{i}} action={{action}} reward={{reward}} done={{done}} info={{info}} render={{env.render()}}")
+        if done:
+            break
+    print(f"episode_total_reward={{total}}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def _readme_md(name: str, seed: int) -> str:
+    mod = _module_name(name)
+    return f'''# Agentic {name} Example (generated)
+
+A dependency-light, self-contained AReno agentic project scaffolded by
+`.agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py`.
+
+No external database, hosted service, or mandatory sandbox is required.
+
+## Files
+
+- `game.py` — environment state machine with clear `reset` / `step` / error / reward.
+- `dataset_generator.py` — reproducible JSONL task records (`--output --count --seed`).
+- `dataset_loader.py` — `load_training_dataset(...) -> list[dict]` (processor-independent).
+- `tool_defs.py` — strict, bounded JSON tool schema for the `act` tool.
+- `run_agent.py` — `async def run_agent(ctx, batch) -> AgentTrajectory` (OpenAI-compatible).
+- `reward.py` — `reward_fn(record) -> float`, replays the tool call against the env.
+- `run_episode.py` — no-model smoke that runs one fixed episode immediately.
+
+## Minimal runnable example
+
+```bash
+# 1. Run the no-model smoke (no LLM / no network / no GPU)
+python run_episode.py
+```
+
+Expected observable output:
+
+```
+reset obs={{'position': 0, 'size': 5}} render=[A . . . G]
+step i=0 action=1 reward=-0.1 done=False ...
+...
+episode_total_reward=0.6
+```
+
+## Train with AReno
+
+```bash
+python dataset_generator.py --output /tmp/{mod}.jsonl --count 16 --seed {seed}
+
+areno train \\
+  --ckpt Qwen/Qwen3-0.6B \\
+  --dataset-path /tmp/{mod}.jsonl \\
+  --dataset-loader-fn examples/agentic/{name}/dataset_loader.py \\
+  --reward-fn-path examples/agentic/{name}/reward.py \\
+  --agent-fn examples/agentic/{name}/run_agent.py \\
+  --algo gspo \\
+  --tp-size 1 --world-size 1
+```
+
+## Limitations
+
+- The environment is a placeholder gridwalk; replace `game.py` with your real task.
+- `run_agent.py` requires `pip install openai` and a reachable OpenAI-compatible endpoint.
+- `run_episode.py` needs no model and is the CI smoke entrypoint.
+'''
+
+
+# ---------------------------------------------------------------------------
+# Scaffold writer
+# ---------------------------------------------------------------------------
+
+_TEMPLATES = {
+    "game.py": _game_py,
+    "dataset_generator.py": _dataset_generator_py,
+    "dataset_loader.py": _dataset_loader_py,
+    "tool_defs.py": _tool_defs_py,
+    "run_agent.py": _run_agent_py,
+    "reward.py": _reward_py,
+    "run_episode.py": _run_episode_py,
+    "README.md": _readme_md,
+}
+
+
+def write_scaffold(out: Path, name: str, seed: int) -> list[Path]:
+    """Write all template files into ``out`` and return their paths."""
+    out.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for filename, fn in _TEMPLATES.items():
+        path = out / filename
+        path.write_text(fn(name, seed), encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scaffold a runnable, dependency-light AReno agentic project.",
+    )
+    parser.add_argument("--name", required=True, help="Project name (lowercase hyphen-case).")
+    parser.add_argument("--out", type=Path, default=None, help="Output directory (default: examples/agentic/<name>).")
+    parser.add_argument("--force", action="store_true", help="Overwrite a non-empty output directory.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Deterministic seed (default: %(default)s).")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if not NAME_RE.fullmatch(args.name):
+        print(f"error: --name must match {NAME_RE.pattern}", file=sys.stderr)
+        return 1
+
+    out = args.out or Path("examples/agentic") / args.name
+
+    if out.exists() and any(out.iterdir()) and not args.force:
+        print(
+            f"error: {out} is non-empty; pass --force to overwrite (existing edits will be lost)",
+            file=sys.stderr,
+        )
+        return 1
+
+    files = write_scaffold(out, args.name, args.seed)
+
+    # Human-readable progress.
+    for f in files:
+        print(f"created {f}")
+
+    # Structured summary (single JSON line on stdout for tooling).
+    summary = {
+        "ok": True,
+        "name": args.name,
+        "seed": args.seed,
+        "path": str(out),
+        "files": [str(f) for f in files],
+        "episode_cmd": f"python {out / 'run_episode.py'}",
+    }
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py
+++ b/.agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py
@@ -8,9 +8,9 @@ episode runner. The output uses only AReno's existing public contracts and
 introduces no external database or mandatory sandbox.
 
 Usage:
-    python .agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py \
-        --name my-gridworld \
-        --out examples/agentic/my-gridworld \
+    python .agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py \\
+        --name my-gridworld \\
+        --out examples/agentic/my-gridworld \\
         [--force] [--seed 2026]
 """
 
@@ -21,7 +21,6 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Iterable
 
 NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 DEFAULT_SEED = 2026
@@ -45,10 +44,33 @@ def _header(name: str, seed: int, desc: str = "") -> str:
 
 
 # ---------------------------------------------------------------------------
+# A small helper injected into every generated module that needs to import a
+# sibling file (game.py / dataset_generator.py). Loading via importlib with a
+# project-unique module name keeps the generated project off the global
+# ``sys.modules`` keys ("game", "dataset_generator", ...) so it never collides
+# with other AReno examples (e.g. tictactoe) that share those generic names.
+# ---------------------------------------------------------------------------
+
+_SIBLING_LOADER = '''import importlib.util as _ilu
+from pathlib import Path as _P
+
+_THIS_DIR = _P(__file__).resolve().parent
+
+
+def _load_sibling(filename: str, unique_name: str):
+    """Import a sibling module under a project-unique name (no global pollution)."""
+    spec = _ilu.spec_from_file_location(unique_name, _THIS_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+'''
+
+
+# ---------------------------------------------------------------------------
 # Templates for the generated project files.
 # Each is a function of (name, seed) so output is fully deterministic.
 # ---------------------------------------------------------------------------
-
 
 def _game_py(name: str, seed: int) -> str:
     mod = _module_name(name)
@@ -182,12 +204,12 @@ def _dataset_loader_py(name: str, seed: int) -> str:
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import game  # noqa: E402
+{_SIBLING_LOADER}
+
+game = _load_sibling("game.py", "{mod}_game")
 
 
 def load_training_dataset(dataset_path: str, *, default_loader=None, **_: Any) -> list[dict]:
@@ -202,7 +224,7 @@ def _load_records(dataset_path: str) -> list[dict]:
     if path.is_dir():
         path = path / "tasks.jsonl"
     if not path.exists():
-        import dataset_generator  # local fallback
+        dataset_generator = _load_sibling("dataset_generator.py", "{mod}_dataset_generator")
         return dataset_generator.generate_records()
     records = []
     with path.open("r", encoding="utf-8") as handle:
@@ -230,7 +252,6 @@ def _format_record(raw: dict, index: int) -> dict:
 
 
 def _tool_defs_py(name: str, seed: int) -> str:
-    mod = _module_name(name)
     return f'''{_header(name, seed, "Strict, bounded JSON tool schemas for the agent.")}
 
 from __future__ import annotations
@@ -266,7 +287,6 @@ def tool_choice() -> dict:
 
 
 def _run_agent_py(name: str, seed: int) -> str:
-    mod = _module_name(name)
     return f'''{_header(name, seed, f"Agent entrypoint for {name} tool-call rollouts.")}
 
 from __future__ import annotations
@@ -330,18 +350,16 @@ async def run_agent(ctx, batch):
 
 
 def _reward_py(name: str, seed: int) -> str:
-    mod = _module_name(name)
     return f'''{_header(name, seed, f"Reward function for the {name} tool-call example.")}
 
 from __future__ import annotations
 
 import json
-import sys
-from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import game  # noqa: E402
+{_SIBLING_LOADER}
+
+game = _load_sibling("game.py", "{_module_name(name)}_game")
 
 
 def reward_fn(record: Any) -> float:
@@ -385,11 +403,9 @@ def _run_episode_py(name: str, seed: int) -> str:
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+{_SIBLING_LOADER}
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import game  # noqa: E402
+game = _load_sibling("game.py", "{mod}_game")
 
 # Fixed, deterministic action sequence: always reach the goal in {mod.upper()}_SIZE-1 steps.
 FIXED_ACTION_SEQ = [1] * (game.Env.SIZE - 1)
@@ -447,7 +463,7 @@ Expected observable output:
 reset obs={{'position': 0, 'size': 5}} render=[A . . . G]
 step i=0 action=1 reward=-0.1 done=False ...
 ...
-episode_total_reward=0.6
+episode_total_reward=0.7
 ```
 
 ## Train with AReno

--- a/tests/test_agentic_generator_cpu.py
+++ b/tests/test_agentic_generator_cpu.py
@@ -1,0 +1,148 @@
+"""CPU tests for the local agentic-project generator skill (#279).
+
+Covers success, invalid input, and one boundary/failure path, plus a
+deterministic smoke run of the generated fixed episode. No GPU, no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GEN = ROOT / ".agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py"
+
+EXPECTED_FILES = [
+    "game.py",
+    "dataset_generator.py",
+    "dataset_loader.py",
+    "tool_defs.py",
+    "run_agent.py",
+    "reward.py",
+    "run_episode.py",
+    "README.md",
+]
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GEN), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_generator_creates_valid_scaffold(tmp_path: Path) -> None:
+    """Success path: all expected files exist, compile, and structured output is emitted."""
+    out = tmp_path / "proj"
+    result = _run(["--name", "my-grid", "--out", str(out)], tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    for name in EXPECTED_FILES:
+        assert (out / name).is_file(), f"missing generated file: {name}"
+
+    # Every generated Python file must compile.
+    for name in EXPECTED_FILES:
+        if name.endswith(".py"):
+            compile((out / name).read_text(encoding="utf-8"), str(out / name), "exec")
+
+    # Structured JSON summary on the last stdout line.
+    summary = json.loads(result.stdout.strip().splitlines()[-1])
+    assert summary["ok"] is True
+    assert summary["name"] == "my-grid"
+    assert summary["episode_cmd"].endswith("run_episode.py")
+
+
+def test_generator_rejects_invalid_name(tmp_path: Path) -> None:
+    """Invalid input: a name that violates the lowercase-hyphen contract fails fast."""
+    result = _run(["--name", "Bad_Name", "--out", str(tmp_path / "p")], tmp_path)
+    assert result.returncode == 1
+    assert "name" in result.stderr.lower()
+
+
+def test_generator_refuses_nonempty_without_force(tmp_path: Path) -> None:
+    """Boundary/failure path: refuse to overwrite existing user edits without --force."""
+    out = tmp_path / "existing"
+    out.mkdir()
+    (out / "user_edit.py").write_text("x = 1\n", encoding="utf-8")
+
+    result = _run(["--name", "my-grid", "--out", str(out)], tmp_path)
+    assert result.returncode == 1
+    assert "force" in result.stderr.lower()
+    # Existing user edit must be preserved.
+    assert (out / "user_edit.py").read_text(encoding="utf-8") == "x = 1\n"
+    # No scaffold file should have been written.
+    assert not (out / "game.py").exists()
+
+
+def test_generator_force_overwrites(tmp_path: Path) -> None:
+    """--force overwrites a non-empty directory and regenerates the scaffold."""
+    out = tmp_path / "existing"
+    out.mkdir()
+    (out / "stale.txt").write_text("old", encoding="utf-8")
+
+    result = _run(["--name", "my-grid", "--out", str(out), "--force"], tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert (out / "game.py").is_file()
+
+
+def test_generated_episode_runs(tmp_path: Path) -> None:
+    """Smoke: the generated no-model episode runs and prints observable reward output."""
+    out = tmp_path / "proj"
+    _run(["--name", "my-grid", "--out", str(out)], tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(out / "run_episode.py")],
+        cwd=out,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "reset obs=" in result.stdout
+    assert "episode_total_reward=" in result.stdout
+
+
+def test_generated_reward_fn_scores(tmp_path: Path) -> None:
+    """Integration: the generated reward_fn scores legal, illegal, and missing tool calls."""
+    out = tmp_path / "proj"
+    _run(["--name", "my-grid", "--out", str(out)], tmp_path)
+
+    spec = importlib.util.spec_from_file_location("generated_reward", out / "reward.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    class _Record:
+        def __init__(self, tool_calls, source_record):
+            self.tool_calls = tool_calls
+            self.source_record = source_record
+
+    legal = _Record([{"name": "act", "arguments": {"action": 1}}], {"start": 0})
+    illegal = _Record([{"name": "act", "arguments": {"action": 9}}], {"start": 0})
+    missing = _Record([{"name": "nope", "arguments": {}}], {"start": 0})
+
+    assert isinstance(mod.reward_fn(legal), float)
+    assert mod.reward_fn(illegal) == -1.0
+    assert mod.reward_fn(missing) == -1.0
+
+
+def test_generator_is_deterministic(tmp_path: Path) -> None:
+    """Snapshot: regenerating with the same seed reproduces identical output."""
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+    _run(["--name", "my-grid", "--out", str(out_a)], tmp_path)
+    _run(["--name", "my-grid", "--out", str(out_b)], tmp_path)
+
+    for name in EXPECTED_FILES:
+        if name.endswith(".py") or name.endswith(".md"):
+            assert (out_a / name).read_text(encoding="utf-8") == (out_b / name).read_text(
+                encoding="utf-8"
+            ), f"non-deterministic output for {name}"

--- a/tests/test_agentic_generator_cpu.py
+++ b/tests/test_agentic_generator_cpu.py
@@ -115,23 +115,37 @@ def test_generated_reward_fn_scores(tmp_path: Path) -> None:
     out = tmp_path / "proj"
     _run(["--name", "my-grid", "--out", str(out)], tmp_path)
 
-    spec = importlib.util.spec_from_file_location("generated_reward", out / "reward.py")
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    # --- Isolation: the generated reward.py imports a sibling game.py via
+    # importlib under a project-unique name, but we still snapshot sys.modules
+    # and sys.path so this test cannot leak state into sibling test modules
+    # (e.g. tests/test_agentic_tictactoe_example_cpu.py). ---
+    saved_modules = set(sys.modules.keys())
+    saved_path = list(sys.path)
+    try:
+        spec = importlib.util.spec_from_file_location("generated_reward", out / "reward.py")
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
 
-    class _Record:
-        def __init__(self, tool_calls, source_record):
-            self.tool_calls = tool_calls
-            self.source_record = source_record
+        class _Record:
+            def __init__(self, tool_calls, source_record):
+                self.tool_calls = tool_calls
+                self.source_record = source_record
 
-    legal = _Record([{"name": "act", "arguments": {"action": 1}}], {"start": 0})
-    illegal = _Record([{"name": "act", "arguments": {"action": 9}}], {"start": 0})
-    missing = _Record([{"name": "nope", "arguments": {}}], {"start": 0})
+        legal = _Record([{"name": "act", "arguments": {"action": 1}}], {"start": 0})
+        illegal = _Record([{"name": "act", "arguments": {"action": 9}}], {"start": 0})
+        missing = _Record([{"name": "nope", "arguments": {}}], {"start": 0})
 
-    assert isinstance(mod.reward_fn(legal), float)
-    assert mod.reward_fn(illegal) == -1.0
-    assert mod.reward_fn(missing) == -1.0
+        assert isinstance(mod.reward_fn(legal), float)
+        assert mod.reward_fn(illegal) == -1.0
+        assert mod.reward_fn(missing) == -1.0
+    finally:
+        # Restore sys.modules: drop any modules added during this test.
+        for key in list(sys.modules.keys()):
+            if key not in saved_modules:
+                del sys.modules[key]
+        # Restore sys.path.
+        sys.path[:] = saved_path
 
 
 def test_generator_is_deterministic(tmp_path: Path) -> None:
@@ -142,7 +156,7 @@ def test_generator_is_deterministic(tmp_path: Path) -> None:
     _run(["--name", "my-grid", "--out", str(out_b)], tmp_path)
 
     for name in EXPECTED_FILES:
-        if name.endswith(".py") or name.endswith(".md"):
+        if name.endswith((".py", ".md")):
             assert (out_a / name).read_text(encoding="utf-8") == (out_b / name).read_text(
                 encoding="utf-8"
             ), f"non-deterministic output for {name}"


### PR DESCRIPTION
## What does this PR do?

Adds a local agentic-project generator to the `areno-build-agentic-workflow` skill.

- Add `generate_agentic_project.py` to `.agents/skills/areno-build-agentic-workflow/scripts/`, which scaffolds a runnable, dependency-light agentic project (env / dataset / tools / reward / agent / smoke episode) under `examples/agentic/<name>/`.
- The generated project reuses existing `areno.api.agentic` contracts and introduces no external database or mandatory sandbox.
- Generated modules are loaded via `importlib` under project-unique names (e.g. `<name>_game`) instead of bare `import game`, so they never pollute the global `sys.modules` and cannot collide with sibling examples (e.g. `tictactoe`).
- Add `tests/test_agentic_generator_cpu.py` covering success, invalid input, and one boundary/failure path, plus a no-model smoke run.

## Related issue

Fixes #279

## Type of change

- [x] ✨ New feature

## How was it tested?

All commands run on CPU (no GPU / no network), Python 3.10.

```bash
# 1. Skill validation
python3 .agents/scripts/validate_skills.py
# -> ok=true, skill_count=10, script_count=25

# 2. Generate a project and run the no-model smoke episode
python3 .agents/skills/areno-build-agentic-workflow/scripts/generate_agentic_project.py \
    --name my-gridworld --out examples/agentic/my-gridworld --seed 2026
python3 examples/agentic/my-gridworld/run_episode.py
# -> 8 files created; prints episode_total_reward=0.7

# 3. Generator unit tests (success / invalid / boundary)
pytest tests/test_agentic_generator_cpu.py -v
# -> 7 passed

# 4. No regression, including the previously colliding tictactoe example
pytest tests/test_agentic_tictactoe_example_cpu.py -v
# -> 3 passed
```

The generated `run_episode.py` observable output:

```
reset obs={'position': 0, 'size': 5} render=[A . . . G]
step i=0 action=1 reward=-0.1 done=False ...
step i=1 action=1 reward=-0.1 done=False ...
step i=2 action=1 reward=-0.1 done=False ...
step i=3 action=1 reward=1.0 done=True  ...
episode_total_reward=0.7
```

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).