### PR TITLE
feat(cli): add 'areno run' CLI to show run details in terminal

### DIFF
--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -19,6 +19,7 @@ class ArenoCli(click.Group):
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
+        "run": ("areno.cli.run", "run_command", "List and inspect AReno training and serving runs."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
     }

--- a/areno/cli/run.py
+++ b/areno/cli/run.py
@@ -1,0 +1,415 @@
+"""List and inspect AReno training and serving runs from the terminal."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import click
+
+from areno.dashboard.server import (
+    TIME_SEGMENT_ORDER,
+    dashboard_state_source,
+    pid_is_running,
+    registered_job_items,
+    rollout_sample_sources,
+    run_config_sources,
+    tensorboard_event_sources,
+    tensorboard_time_segment_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunSummary:
+    """Aggregated information for a single AReno run."""
+
+    run_id: str = ""
+    kind: str = ""
+    name: str = ""
+    pid: int | None = None
+    status: str = "unknown"
+    stage: str = ""
+    step: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    metrics_dir: str | None = None
+    config: dict[str, Any] = field(default_factory=dict)
+    config_text: str = ""
+    metrics: list[dict[str, Any]] = field(default_factory=list)
+    timeperf: list[dict[str, Any]] = field(default_factory=list)
+    samples: list[dict[str, Any]] = field(default_factory=list)
+    returncode: int | None = None
+    command: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_status(entry: dict[str, Any]) -> str:
+    """Determine the effective status of a registered job."""
+    pid = entry.get("pid")
+    if pid is not None and pid_is_running(pid):
+        return "running"
+    rc = entry.get("returncode")
+    if rc is not None:
+        return "succeeded" if rc == 0 else "failed"
+    return "exited"
+
+
+def _format_timestamp(value: Any) -> str:
+    """Convert a float epoch or ISO string to a readable timestamp."""
+    if value is None or value == "":
+        return ""
+    try:
+        return dt.datetime.fromtimestamp(float(value), tz=dt.timezone.utc).replace(microsecond=0).isoformat()
+    except (TypeError, ValueError):
+        return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Data collection
+# ---------------------------------------------------------------------------
+
+
+def _summary_from_item(item: dict[str, Any]) -> RunSummary:
+    """Build a RunSummary from a registry entry."""
+    return RunSummary(
+        run_id=item.get("id", ""),
+        kind=item.get("kind", ""),
+        name=item.get("name", ""),
+        pid=item.get("pid"),
+        status=_resolve_status(item),
+        returncode=item.get("returncode"),
+        created_at=_format_timestamp(item.get("created_at")),
+        updated_at=_format_timestamp(item.get("updated_at")),
+        metrics_dir=item.get("metrics_dir"),
+        config=dict(item.get("config") or {}),
+        command=list(item.get("command") or []),
+    )
+
+
+def list_runs() -> list[RunSummary]:
+    """List all registered runs from the dashboard registry."""
+    return [_summary_from_item(item) for item in registered_job_items()]
+
+
+def get_run(run_id: str) -> RunSummary | None:
+    """Get detailed information for a specific run."""
+    for item in registered_job_items():
+        if item.get("id") == run_id:
+            summary = _summary_from_item(item)
+            _load_run_metrics(summary)
+            return summary
+    return None
+
+
+def _load_run_metrics(summary: RunSummary) -> None:
+    """Load metrics, samples, state, and config from the metrics directory."""
+    if not summary.metrics_dir:
+        return
+    path = Path(summary.metrics_dir)
+    if not path.exists() or not path.is_dir():
+        return
+    pid = summary.pid
+    _load_dashboard_state(summary, path, pid)
+    _load_tensorboard_scalars(summary, path, pid)
+    _load_rollout_samples(summary, path, pid)
+    _load_run_config(summary, path, pid)
+
+
+def _load_dashboard_state(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load live stage/step/status from dashboard_state.{pid}.json."""
+    state_file = dashboard_state_source(path, pid)
+    if state_file is None:
+        return
+    try:
+        payload = json.loads(state_file.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if not isinstance(payload, dict):
+        return
+    stage = payload.get("stage")
+    if isinstance(stage, str) and stage:
+        summary.stage = stage
+    try:
+        summary.step = max(summary.step, int(payload.get("step", summary.step)))
+    except (TypeError, ValueError):
+        pass
+    status = payload.get("status")
+    if isinstance(status, str) and summary.status not in {"stopped", "failed", "succeeded", "exited"}:
+        summary.status = status
+    summary.updated_at = _format_timestamp(payload.get("updated_at")) or summary.updated_at
+
+
+def _load_tensorboard_scalars(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load scalar metrics and time performance from TensorBoard event files."""
+    try:
+        from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+    except Exception:
+        return
+    by_step: dict[int, dict[str, float]] = {}
+    for event_path in tensorboard_event_sources(path, pid):
+        try:
+            accumulator = EventAccumulator(str(event_path), size_guidance={"scalars": 10000})
+            accumulator.Reload()
+            tags = accumulator.Tags().get("scalars", [])
+        except Exception:
+            continue
+        for tag in tags:
+            try:
+                events = accumulator.Scalars(tag)[-500:]
+            except Exception:
+                continue
+            for event in events:
+                step = int(event.step)
+                value = float(event.value)
+                if math.isnan(value):
+                    continue
+                summary.metrics.append({"name": tag, "value": value, "step": step})
+                summary.step = max(summary.step, step)
+                time_name = tensorboard_time_segment_name(tag)
+                if time_name:
+                    by_step.setdefault(step, {})[time_name] = value
+                if tag in {"train/step_e2e_time_s", "time/total", "time/e2e"}:
+                    by_step.setdefault(step, {})["total"] = value
+                elif tag == "train/step_rollout_time_s":
+                    by_step.setdefault(step, {})["rollout"] = value
+                elif tag in {"train/step_train_time_s", "train/policy_train_wall_time_s"}:
+                    by_step.setdefault(step, {})["train"] = value
+    for step, values in sorted(by_step.items()):
+        total = values.pop("total", None)
+        if total is None:
+            total = sum(v for v in values.values() if v > 0)
+        if total <= 0:
+            continue
+        ordered = sorted(
+            [{"name": name, "seconds": max(v, 0.0)} for name, v in values.items() if v > 0],
+            key=lambda item: (
+                TIME_SEGMENT_ORDER.index(item["name"])
+                if item["name"] in TIME_SEGMENT_ORDER
+                else len(TIME_SEGMENT_ORDER)
+            ),
+        )
+        accounted = sum(item["seconds"] for item in ordered)
+        if total > accounted:
+            ordered.append({"name": "other", "seconds": total - accounted})
+        summary.timeperf.append({"step": step, "segments": ordered, "total_s": total})
+
+
+def _load_rollout_samples(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load rollout samples from JSONL files."""
+    for sample_file in rollout_sample_sources(path, pid):
+        try:
+            lines = sample_file.read_text(encoding="utf-8").splitlines()[-100:]
+        except Exception:
+            continue
+        for line in lines:
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            summary.samples.append(item)
+
+
+def _load_run_config(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load run configuration from areno_run_config.{pid}.txt/.json."""
+    text_file, json_file = run_config_sources(path, pid)
+    if text_file.exists():
+        try:
+            summary.config_text = text_file.read_text(encoding="utf-8")
+        except Exception:
+            pass
+    if not json_file.exists():
+        return
+    try:
+        payload = json.loads(json_file.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if isinstance(payload, dict):
+        settings = payload.get("settings")
+        if isinstance(settings, dict):
+            summary.config = settings
+        if not summary.config_text and isinstance(payload.get("summary_text"), str):
+            summary.config_text = payload["summary_text"]
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def collect_metric_summaries(metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group metrics by name, return count/latest_step/latest_value per group."""
+    grouped: dict[str, dict[str, Any]] = {}
+    for point in metrics:
+        name = str(point.get("name") or "")
+        if not name:
+            continue
+        step = int(point.get("step") or 0)
+        value = point.get("value")
+        current = grouped.get(name)
+        if current is None:
+            grouped[name] = {"name": name, "count": 1, "latest_step": step, "latest_value": value}
+            continue
+        current["count"] += 1
+        if step >= int(current.get("latest_step") or 0):
+            current["latest_step"] = step
+            current["latest_value"] = value
+    return sorted(grouped.values(), key=lambda item: item["name"])
+
+
+def collect_timeperf_summary(timeperf: list[dict[str, Any]]) -> list[tuple[str, float]]:
+    """Aggregate average time spent in each RL phase across all steps."""
+    if not timeperf:
+        return []
+    totals: dict[str, list[float]] = {}
+    for row in timeperf:
+        segments = row.get("segments")
+        if not isinstance(segments, list):
+            continue
+        for seg in segments:
+            if not isinstance(seg, dict):
+                continue
+            name = str(seg.get("name", ""))
+            if not name:
+                continue
+            try:
+                totals.setdefault(name, []).append(float(seg.get("seconds", 0)))
+            except (TypeError, ValueError):
+                continue
+    result = [(name, sum(values) / len(values)) for name, values in totals.items() if values]
+    order = {name: i for i, name in enumerate(TIME_SEGMENT_ORDER)}
+    result.sort(key=lambda item: order.get(item[0], len(order)))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_run_info(run: RunSummary) -> str:
+    """Format a RunSummary into a structured terminal-friendly string."""
+    lines: list[str] = []
+
+    # Section 1: Basic Info
+    lines.append(f"Run: {run.run_id}")
+    lines.append(f"  Kind:        {run.kind}")
+    lines.append(f"  Name:        {run.name}")
+    status_line = f"  Status:      {run.status}"
+    if run.returncode is not None:
+        status_line += f" (returncode={run.returncode})"
+    lines.append(status_line)
+    lines.append(f"  Stage:       {run.stage or '-'}")
+    lines.append(f"  Step:        {run.step}")
+    lines.append(f"  PID:         {run.pid or '-'}")
+    lines.append(f"  Created:     {run.created_at or '-'}")
+    lines.append(f"  Updated:     {run.updated_at or '-'}")
+    lines.append(f"  Metrics Dir: {run.metrics_dir or '-'}")
+
+    # Section 2: Configuration
+    if run.config_text:
+        lines.append("")
+        lines.append("Configuration:")
+        lines.append(textwrap.indent(run.config_text, "  "))
+    elif run.config:
+        lines.append("")
+        lines.append("Configuration:")
+        for key, val in sorted(run.config.items()):
+            lines.append(f"  {key}: {val}")
+
+    # Section 3: Metric Summaries
+    summaries = collect_metric_summaries(run.metrics)
+    if summaries:
+        lines.append("")
+        lines.append("Metrics Summary:")
+        lines.append(f"  {'Name':<40} {'Latest':>12} {'Step':>8} {'Count':>6}")
+        lines.append(f"  {'-' * 40} {'-' * 12} {'-' * 8} {'-' * 6}")
+        for m in summaries:
+            latest = m.get("latest_value")
+            latest_str = f"{latest:>12.6f}" if isinstance(latest, (int, float)) else f"{str(latest):>12}"
+            lines.append(
+                f"  {m['name']:<40} {latest_str} "
+                f"{int(m.get('latest_step') or 0):>8} {int(m.get('count') or 0):>6}"
+            )
+
+    # Section 4: Time Performance
+    time_summary = collect_timeperf_summary(run.timeperf)
+    if time_summary:
+        lines.append("")
+        lines.append("Time Breakdown (avg per step):")
+        for name, seconds in time_summary:
+            lines.append(f"  {name:<25} {seconds:>8.2f}s")
+
+    # Section 5: Recent Rollout Samples
+    if run.samples:
+        lines.append("")
+        lines.append(f"Recent Rollout Samples (last {min(len(run.samples), 5)}):")
+        for s in run.samples[-5:]:
+            reward = s.get("reward", "?")
+            resp_len = s.get("response_len", "?")
+            lines.append(f"  step={s.get('step', '?')} reward={reward} resp_len={resp_len}")
+
+    return "\n".join(lines)
+
+
+def format_run_list(runs: list[RunSummary]) -> str:
+    """Format a compact table of all runs."""
+    if not runs:
+        return "No runs found."
+    lines: list[str] = []
+    header = f"  {'ID':<12} {'Kind':<6} {'Status':<12} {'Step':>6} {'Name':<40} {'Created'}"
+    lines.append(header)
+    lines.append(f"  {'-' * 12} {'-' * 6} {'-' * 12} {'-' * 6} {'-' * 40} {'-' * 20}")
+    for r in runs:
+        lines.append(
+            f"  {r.run_id:<12} {r.kind:<6} {r.status:<12} {r.step:>6} "
+            f"{r.name[:40]:<40} {r.created_at[:19]}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
+@click.group(
+    name="run",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def run_command() -> None:
+    """List and inspect AReno training and serving runs."""
+
+
+@run_command.command("list")
+def list_command() -> None:
+    """List active and recent AReno runs."""
+    runs = list_runs()
+    if not runs:
+        click.echo("No runs found.")
+        return
+    click.echo(format_run_list(runs))
+
+
+@run_command.command("info")
+@click.argument("run_id")
+def info_command(run_id: str) -> None:
+    """Show detailed information for one run."""
+    run = get_run(run_id)
+    if run is None:
+        click.echo(f"Run not found: {run_id}", err=True)
+        raise click.Abort()
+    click.echo(format_run_info(run))

--- a/tests/test_cli_run_cpu.py
+++ b/tests/test_cli_run_cpu.py
@@ -1,0 +1,226 @@
+"""CPU-safe tests for the 'areno run' CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.cli.main import main
+from areno.cli.run import (
+    RunSummary,
+    _format_timestamp,
+    _resolve_status,
+    collect_metric_summaries,
+    format_run_info,
+    format_run_list,
+)
+
+
+class RunCliTest(unittest.TestCase):
+    def test_top_level_cli_lists_run_command(self):
+        result = CliRunner().invoke(main, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("run", result.output)
+
+    def test_run_help_shows_list_and_info(self):
+        result = CliRunner().invoke(main, ["run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("list", result.output)
+        self.assertIn("info", result.output)
+
+    def test_run_list_empty_registry(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No runs found.", result.output)
+
+    def test_run_list_with_entries(self):
+        entries = [
+            {
+                "id": "abc123",
+                "kind": "train",
+                "name": "train gspo Qwen",
+                "pid": None,
+                "created_at": 1700000000.0,
+                "updated_at": 1700000000.0,
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("abc123", result.output)
+        self.assertIn("train gspo Qwen", result.output)
+
+    def test_run_info_not_found(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "info", "nonexistent"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Run not found", result.output)
+
+    def test_run_info_with_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pid = os.getpid()
+            metrics_dir = tmp
+            # Create dashboard_state file
+            state_file = os.path.join(tmp, f"dashboard_state.{pid}.json")
+            with open(state_file, "w") as f:
+                json.dump({"pid": pid, "stage": "train_end", "status": "running", "step": 10}, f)
+            # Create run config files
+            config_txt = os.path.join(tmp, f"areno_run_config.{pid}.txt")
+            with open(config_txt, "w") as f:
+                f.write("algo: gspo\nckpt: Qwen/Qwen3-0.6B")
+            config_json = os.path.join(tmp, f"areno_run_config.{pid}.json")
+            with open(config_json, "w") as f:
+                json.dump({"settings": {"algo": "gspo", "ckpt": "Qwen/Qwen3-0.6B"}}, f)
+
+            entries = [
+                {
+                    "id": "test123",
+                    "kind": "train",
+                    "name": "test run",
+                    "pid": pid,
+                    "created_at": 1700000000.0,
+                    "updated_at": 1700000000.0,
+                    "metrics_dir": metrics_dir,
+                    "config": {},
+                    "command": [],
+                }
+            ]
+            with patch("areno.cli.run.registered_job_items", return_value=entries):
+                result = CliRunner().invoke(main, ["run", "info", "test123"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Run: test123", result.output)
+        self.assertIn("Configuration:", result.output)
+        self.assertIn("gspo", result.output)
+        self.assertIn("train_end", result.output)
+
+    def test_format_run_info_contains_all_sections(self):
+        run = RunSummary(
+            run_id="test",
+            kind="train",
+            name="test run",
+            status="succeeded",
+            step=10,
+            config={"algo": "gspo"},
+            config_text="algo: gspo\nckpt: Qwen/Qwen3-0.6B",
+            metrics=[
+                {"name": "loss", "value": 0.5, "step": 1},
+                {"name": "loss", "value": 0.3, "step": 2},
+            ],
+            timeperf=[
+                {"segments": [{"name": "rollout", "seconds": 1.0}, {"name": "train", "seconds": 2.0}]},
+                {"segments": [{"name": "rollout", "seconds": 1.5}, {"name": "train", "seconds": 2.5}]},
+            ],
+            samples=[{"step": 1, "reward": 0.8, "response_len": 100}],
+        )
+        output = format_run_info(run)
+        self.assertIn("Run: test", output)
+        self.assertIn("Configuration:", output)
+        self.assertIn("Metrics Summary:", output)
+        self.assertIn("Time Breakdown", output)
+        self.assertIn("Recent Rollout Samples", output)
+
+    def test_format_run_list_empty(self):
+        self.assertEqual(format_run_list([]), "No runs found.")
+
+    def test_format_run_list_with_entries(self):
+        runs = [RunSummary(run_id="abc", kind="train", name="test", status="running", step=5)]
+        output = format_run_list(runs)
+        self.assertIn("abc", output)
+        self.assertIn("train", output)
+
+    def test_collect_metric_summaries_groups_by_name(self):
+        metrics = [
+            {"name": "loss", "value": 0.5, "step": 1},
+            {"name": "loss", "value": 0.3, "step": 2},
+            {"name": "reward", "value": 1.0, "step": 2},
+        ]
+        result = collect_metric_summaries(metrics)
+        self.assertEqual(len(result), 2)
+        loss = next(m for m in result if m["name"] == "loss")
+        self.assertEqual(loss["count"], 2)
+        self.assertEqual(loss["latest_step"], 2)
+        self.assertEqual(loss["latest_value"], 0.3)
+
+    def test_resolve_status_running(self):
+        with patch("areno.cli.run.pid_is_running", return_value=True):
+            self.assertEqual(_resolve_status({"pid": 123}), "running")
+
+    def test_resolve_status_exited(self):
+        self.assertEqual(_resolve_status({"pid": None}), "exited")
+
+    def test_resolve_status_succeeded(self):
+        self.assertEqual(_resolve_status({"pid": None, "returncode": 0}), "succeeded")
+
+    def test_resolve_status_failed(self):
+        self.assertEqual(_resolve_status({"pid": None, "returncode": 1}), "failed")
+
+    def test_format_timestamp_converts_epoch(self):
+        result = _format_timestamp(0)
+        self.assertTrue(result.startswith("1970"))
+
+    def test_format_timestamp_empty(self):
+        self.assertEqual(_format_timestamp(None), "")
+        self.assertEqual(_format_timestamp(""), "")
+
+    def test_returncode_populated_from_registry(self):
+        """returncode is read from the registry entry and displayed."""
+        entries = [
+            {
+                "id": "rc1",
+                "kind": "train",
+                "name": "failed run",
+                "pid": None,
+                "returncode": 1,
+                "created_at": 1700000000.0,
+                "updated_at": 1700000000.0,
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "info", "rc1"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("returncode=1", result.output)
+
+    def test_returncode_none_not_displayed(self):
+        """returncode is None when not in registry, and not shown in output."""
+        run = RunSummary(run_id="x", status="exited")
+        output = format_run_info(run)
+        self.assertNotIn("returncode", output)
+
+    def test_summary_from_item_dedup(self):
+        """list_runs and get_run produce the same base summary for the same entry."""
+        from areno.cli.run import _summary_from_item
+
+        item = {
+            "id": "dup1",
+            "kind": "train",
+            "name": "test",
+            "pid": None,
+            "returncode": 0,
+            "created_at": 1700000000.0,
+            "updated_at": 1700000000.0,
+            "metrics_dir": None,
+            "config": {"algo": "gspo"},
+            "command": ["areno", "train"],
+        }
+        s1 = _summary_from_item(item)
+        s2 = _summary_from_item(item)
+        self.assertEqual(s1, s2)
+        self.assertEqual(s1.returncode, 0)
+        self.assertEqual(s1.config, {"algo": "gspo"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Add `areno run list` and `areno run info <run_id>` CLI subcommands that display training/serving run information in structured terminal output, without requiring the dashboard web server.

- `areno/cli/run.py`: data collection (reuses dashboard server helpers like `registered_job_items`, `tensorboard_event_sources`, `dashboard_state_source`, `pid_is_running`), terminal formatting (5 sections: basic info, configuration, metrics summary, time breakdown, recent rollout samples), and Click command group
- `areno/cli/main.py`: register `run` in `_COMMANDS` (1 line added)
- `tests/test_cli_run_cpu.py`: 19 CPU-safe tests

## Related issue

Fixes #251

## Type of change

- [x] ✨ New feature

## How was it tested?

CPU tests: `pytest tests/ -k cpu` — 373 passed (19 new + 354 existing), 0 failures.

GPU verification: Verified on Kaggle Tesla T4 with real SFT training (Qwen3.5-0.8B, 125 steps). `areno run info` correctly displays all sections:
- Basic info (status, stage, step, metrics dir)
- Configuration (algorithm, model, runtime, training params)
- Metrics Summary (27 metrics including loss, lr, grad_norm, etc.)
- Time Breakdown (train avg per step)
- Rollout Samples (only for rollout-based algorithms)

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).