### PR TITLE
feat(agentic): build a calendar-scheduling agentic RL demo (#192)

### DIFF
--- a/examples/agentic/calendar/README.md
+++ b/examples/agentic/calendar/README.md
@@ -31,7 +31,13 @@ This also creates `/tmp/calendar.held_out.jsonl` for held-out evaluation.
 
 ### 2. Train with AReno
 
+The multi-turn agent flow produces longer trajectories than single-turn agents.
+On GPUs with limited VRAM (e.g. Tesla T4 16 GB), use `--disable-thinking` to
+suppress Qwen3 reasoning tokens, keep `--n-samples` small, and set
+`--max-context-len` conservatively. See [Known Issues](#known-issues) below.
+
 ```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
 areno train \
   --ckpt Qwen/Qwen3-0.6B \
   --dataset-path /tmp/calendar.jsonl \
@@ -42,10 +48,14 @@ areno train \
   --tp-size 1 \
   --world-size 1 \
   --batch-size 1 \
-  --n-samples 8 \
-  --max-new-tokens 512 \
-  --max-context-len 2048 \
-  --mini-bs 1
+  --n-samples 2 \
+  --max-running-prompts 2 \
+  --max-new-tokens 256 \
+  --max-context-len 4096 \
+  --mini-bs 1 \
+  --max-steps 20 \
+  --disable-thinking \
+  --drop-rollout-state
 ```
 
 ## Scenario Structure
@@ -91,3 +101,51 @@ python3 -m pytest tests/test_calendar_agent_cpu.py -v
 - Hour-level granularity.
 - No recurring meetings.
 - No optional participants.
+
+## Known Issues
+
+### CUDA OOM on limited-VRAM GPUs (e.g. Tesla T4)
+
+**Symptom:** Training crashes with `torch.OutOfMemoryError` during the logprobs
+computation (`exp_logits = torch.exp(...)`) in the train step, even though
+rollout succeeds.
+
+**Root cause:** The multi-turn agent flow (query_availability per participant →
+propose_slot → confirm_slot) produces trajectories with 3–5 model calls per
+scenario. Each assistant response is appended to the conversation, so total
+token counts per trajectory reach 3 000–7 000 tokens. Qwen3-0.6B has a ~152k
+vocabulary; the logprobs layer allocates
+`total_tokens × vocab_size × 4 bytes × 2` (logits + exp_logits), which for
+8 000 tokens is already ~9.7 GB. Combined with model weights, gradients, and
+Adam optimizer state (~9.6 GB), this exceeds T4's 15 GB VRAM.
+
+Qwen3's **thinking mode** (enabled by default) exacerbates the problem: the
+model generates 200–500 tokens of chain-of-thought reasoning before each tool
+call, inflating trajectory length by 3–5×.
+
+**Mitigations (in order of impact):**
+
+1. **`--disable-thinking`** — suppresses Qwen3 thinking tokens, reducing each
+   assistant response from ~500 to ~50 tokens. This is the single most
+   effective flag for VRAM-constrained GPUs.
+2. **Reduce `--n-samples`** — fewer samples per prompt means fewer trajectories
+   in each train batch. `--n-samples 2` is the minimum for GSPO (group-relative
+   advantage requires at least 2 samples to produce non-zero gradients).
+3. **Lower `--max-context-len`** — filters out trajectories whose total token
+   count exceeds the limit before they enter the train batch. Values of 3072–4096
+   are practical on T4.
+4. **Reduce `--max-new-tokens`** — caps the length of each model response during
+   rollout, indirectly limiting trajectory length.
+5. **`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** — reduces VRAM
+   fragmentation.
+
+**Trade-off:** With `--disable-thinking`, the model loses chain-of-thought
+reasoning ability and may produce lower-quality tool calls, leading to all
+trajectories receiving the same reward (e.g. -1.0). When all samples in a group
+share the same reward, GSPO computes zero advantage and zero gradient, so no
+learning occurs. If this persists across many steps, consider:
+
+- Increasing `--n-samples` (more diversity → higher chance of reward variance).
+- Increasing `--lr` (e.g. `1e-5` instead of `1e-6`).
+- Increasing `--max-steps` (more opportunities for reward variance to emerge).
+- Using a larger GPU (A100 40 GB+ allows `--n-samples 4+` with thinking enabled).

--- a/examples/agentic/calendar/README.md
+++ b/examples/agentic/calendar/README.md
@@ -31,13 +31,7 @@ This also creates `/tmp/calendar.held_out.jsonl` for held-out evaluation.
 
 ### 2. Train with AReno
 
-The multi-turn agent flow produces longer trajectories than single-turn agents.
-On GPUs with limited VRAM (e.g. Tesla T4 16 GB), use `--disable-thinking` to
-suppress Qwen3 reasoning tokens, keep `--n-samples` small, and set
-`--max-context-len` conservatively. See [Known Issues](#known-issues) below.
-
 ```bash
-PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
 areno train \
   --ckpt Qwen/Qwen3-0.6B \
   --dataset-path /tmp/calendar.jsonl \
@@ -48,14 +42,10 @@ areno train \
   --tp-size 1 \
   --world-size 1 \
   --batch-size 1 \
-  --n-samples 2 \
-  --max-running-prompts 2 \
-  --max-new-tokens 256 \
-  --max-context-len 4096 \
-  --mini-bs 1 \
-  --max-steps 20 \
-  --disable-thinking \
-  --drop-rollout-state
+  --n-samples 8 \
+  --max-new-tokens 512 \
+  --max-context-len 2048 \
+  --mini-bs 1
 ```
 
 ## Scenario Structure
@@ -101,51 +91,3 @@ python3 -m pytest tests/test_calendar_agent_cpu.py -v
 - Hour-level granularity.
 - No recurring meetings.
 - No optional participants.
-
-## Known Issues
-
-### CUDA OOM on limited-VRAM GPUs (e.g. Tesla T4)
-
-**Symptom:** Training crashes with `torch.OutOfMemoryError` during the logprobs
-computation (`exp_logits = torch.exp(...)`) in the train step, even though
-rollout succeeds.
-
-**Root cause:** The multi-turn agent flow (query_availability per participant →
-propose_slot → confirm_slot) produces trajectories with 3–5 model calls per
-scenario. Each assistant response is appended to the conversation, so total
-token counts per trajectory reach 3 000–7 000 tokens. Qwen3-0.6B has a ~152k
-vocabulary; the logprobs layer allocates
-`total_tokens × vocab_size × 4 bytes × 2` (logits + exp_logits), which for
-8 000 tokens is already ~9.7 GB. Combined with model weights, gradients, and
-Adam optimizer state (~9.6 GB), this exceeds T4's 15 GB VRAM.
-
-Qwen3's **thinking mode** (enabled by default) exacerbates the problem: the
-model generates 200–500 tokens of chain-of-thought reasoning before each tool
-call, inflating trajectory length by 3–5×.
-
-**Mitigations (in order of impact):**
-
-1. **`--disable-thinking`** — suppresses Qwen3 thinking tokens, reducing each
-   assistant response from ~500 to ~50 tokens. This is the single most
-   effective flag for VRAM-constrained GPUs.
-2. **Reduce `--n-samples`** — fewer samples per prompt means fewer trajectories
-   in each train batch. `--n-samples 2` is the minimum for GSPO (group-relative
-   advantage requires at least 2 samples to produce non-zero gradients).
-3. **Lower `--max-context-len`** — filters out trajectories whose total token
-   count exceeds the limit before they enter the train batch. Values of 3072–4096
-   are practical on T4.
-4. **Reduce `--max-new-tokens`** — caps the length of each model response during
-   rollout, indirectly limiting trajectory length.
-5. **`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** — reduces VRAM
-   fragmentation.
-
-**Trade-off:** With `--disable-thinking`, the model loses chain-of-thought
-reasoning ability and may produce lower-quality tool calls, leading to all
-trajectories receiving the same reward (e.g. -1.0). When all samples in a group
-share the same reward, GSPO computes zero advantage and zero gradient, so no
-learning occurs. If this persists across many steps, consider:
-
-- Increasing `--n-samples` (more diversity → higher chance of reward variance).
-- Increasing `--lr` (e.g. `1e-5` instead of `1e-6`).
-- Increasing `--max-steps` (more opportunities for reward variance to emerge).
-- Using a larger GPU (A100 40 GB+ allows `--n-samples 4+` with thinking enabled).

--- a/examples/agentic/calendar/README.md
+++ b/examples/agentic/calendar/README.md
@@ -1,0 +1,93 @@
+# Calendar Scheduling Agentic RL Demo
+
+A self-contained calendar scheduling agent for AReno. The agent must schedule
+meetings across participants in different time zones by calling three tools:
+**query_availability**, **propose_slot**, and **confirm_slot**.
+
+No external calendars, databases, or network services are used. All
+availability, time zone conversion, and conflict detection are computed
+locally in `game.py`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `game.py` | Calendar scheduling engine: time zones, availability intersection, conflict detection, scoring |
+| `dataset_generator.py` | Generate reproducible calendar scenarios as JSONL |
+| `dataset_loader.py` | Load JSONL and convert to AReno prompt records |
+| `reward.py` | Reward function: constraint satisfaction (0.7) + tool-call efficiency (0.3) |
+| `run_agent.py` | Agent entrypoint with three tool definitions |
+
+## Quick Start
+
+### 1. Generate the dataset
+
+```bash
+python3 examples/agentic/calendar/dataset_generator.py \
+  --output /tmp/calendar.jsonl --count 128 --seed 2026
+```
+
+This also creates `/tmp/calendar.held_out.jsonl` for held-out evaluation.
+
+### 2. Train with AReno
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path /tmp/calendar.jsonl \
+  --dataset-loader-fn examples/agentic/calendar/dataset_loader.py \
+  --reward-fn-path examples/agentic/calendar/reward.py \
+  --agent-fn examples/agentic/calendar/run_agent.py \
+  --algo gspo \
+  --tp-size 1 \
+  --world-size 1 \
+  --batch-size 1 \
+  --n-samples 8 \
+  --max-new-tokens 512 \
+  --max-context-len 2048 \
+  --mini-bs 1
+```
+
+## Scenario Structure
+
+Each JSONL record contains:
+
+```json
+{
+  "id": "meeting-0000",
+  "participants": {
+    "Alice": {"name": "Alice", "timezone": "UTC+8", "available_slots": [{"start_hour": 9, "end_hour": 17}]},
+    "Bob": {"name": "Bob", "timezone": "UTC-5", "available_slots": [{"start_hour": 8, "end_hour": 14}]}
+  },
+  "meetings": [
+    {"id": "meeting-0000", "duration_hours": 1, "required_participants": ["Alice", "Bob"]}
+  ],
+  "confirmed": {},
+  "target_meeting_id": "meeting-0000"
+}
+```
+
+## Reward Function
+
+The reward combines two dimensions:
+
+- **Constraint satisfaction (0.7 weight):** correct time zone conversion, all
+  required participants available, no conflicts with confirmed meetings,
+  correct meeting duration.
+- **Tool-call efficiency (0.3 weight):** minimal redundant queries, single
+  propose, single confirm.
+
+Score range: -1.0 (invalid proposal) to 1.0 (perfect scheduling).
+
+## Testing
+
+```bash
+python3 -m pytest tests/test_calendar_agent_cpu.py -v
+```
+
+## Limitations
+
+- Fixed-offset time zones only (no DST).
+- Hour-level granularity.
+- No recurring meetings.
+- No optional participants.

--- a/examples/agentic/calendar/dataset_generator.py
+++ b/examples/agentic/calendar/dataset_generator.py
@@ -19,7 +19,7 @@ HELD_OUT_FRACTION = 0.2
 # A small set of time zones with fixed offsets (no DST).
 TIMEZONES = ["UTC", "UTC+1", "UTC+2", "UTC+3", "UTC+8", "UTC-5", "UTC-8", "UTC+5:30"]
 
-PARTicipant_NAMES = ["Alice", "Bob", "Carol", "David", "Eve", "Frank"]
+PARTICIPANT_NAMES = ["Alice", "Bob", "Carol", "David", "Eve", "Frank"]
 
 
 def generate_records(count: int = DEFAULT_COUNT, *, seed: int = DEFAULT_SEED) -> list[dict]:
@@ -30,7 +30,7 @@ def generate_records(count: int = DEFAULT_COUNT, *, seed: int = DEFAULT_SEED) ->
 
     while len(records) < count:
         num_participants = rng.randint(2, 3)
-        chosen_names = rng.sample(PARTicipant_NAMES, num_participants)
+        chosen_names = rng.sample(PARTICIPANT_NAMES, num_participants)
 
         participants = {}
         for name in chosen_names:

--- a/examples/agentic/calendar/dataset_generator.py
+++ b/examples/agentic/calendar/dataset_generator.py
@@ -1,0 +1,135 @@
+"""Generate calendar scheduling scenarios for the agentic RL example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = 2026
+HELD_OUT_FRACTION = 0.2
+
+# A small set of time zones with fixed offsets (no DST).
+TIMEZONES = ["UTC", "UTC+1", "UTC+2", "UTC+3", "UTC+8", "UTC-5", "UTC-8", "UTC+5:30"]
+
+PARTicipant_NAMES = ["Alice", "Bob", "Carol", "David", "Eve", "Frank"]
+
+
+def generate_records(count: int = DEFAULT_COUNT, *, seed: int = DEFAULT_SEED) -> list[dict]:
+    """Generate reproducible calendar scheduling scenarios."""
+    rng = random.Random(seed)
+    records: list[dict] = []
+    seen: set[str] = set()
+
+    while len(records) < count:
+        num_participants = rng.randint(2, 3)
+        chosen_names = rng.sample(PARTicipant_NAMES, num_participants)
+
+        participants = {}
+        for name in chosen_names:
+            tz = rng.choice(TIMEZONES)
+            num_slots = rng.randint(1, 2)
+            slots = []
+            cursor = rng.randint(0, 8)
+            for _ in range(num_slots):
+                start = cursor
+                duration = rng.randint(2, 6)
+                end = min(start + duration, 24)
+                if start < end:
+                    slots.append({"start_hour": start, "end_hour": end})
+                cursor = end + rng.randint(1, 3)
+            if not slots:
+                slots.append({"start_hour": 9, "end_hour": 17})
+            participants[name] = {
+                "name": name,
+                "timezone": tz,
+                "available_slots": slots,
+            }
+
+        meeting_id = f"meeting-{len(records):04d}"
+        duration_hours = rng.randint(1, 2)
+        required = chosen_names
+
+        # Sometimes add an already-confirmed meeting to create conflicts.
+        confirmed = {}
+        if rng.random() < 0.3:
+            other_id = f"meeting-{len(records):04d}-prior"
+            other_start = rng.randint(0, 20)
+            other_end = min(other_start + rng.randint(1, 3), 24)
+            confirmed[other_id] = [other_start, other_end]
+
+        record = {
+            "id": meeting_id,
+            "participants": participants,
+            "meetings": [
+                {
+                    "id": meeting_id,
+                    "duration_hours": duration_hours,
+                    "required_participants": required,
+                }
+            ],
+            "confirmed": confirmed,
+            "target_meeting_id": meeting_id,
+        }
+
+        # Deterministic uniqueness check.
+        key = json.dumps(record, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append(record)
+
+    return records
+
+
+def split_held_out(records: list[dict], *, fraction: float = HELD_OUT_FRACTION) -> tuple[list[dict], list[dict]]:
+    """Split records into train and held-out test sets."""
+    n_test = max(1, int(len(records) * fraction))
+    return records[n_test:], records[:n_test]
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate JSONL calendar scenarios for the AReno calendar agentic example."
+    )
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of scenarios to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    parser.add_argument("--held-out", type=float, default=HELD_OUT_FRACTION, help="Fraction held out for testing.")
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise ValueError("--count must be positive")
+
+    records = generate_records(args.count, seed=args.seed)
+    train, test = split_held_out(records, fraction=args.held_out)
+
+    if args.output == "-":
+        write_jsonl(train, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(train, handle)
+        # Also write held-out set.
+        test_path = output_path.with_suffix(".held_out.jsonl")
+        with test_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(test, handle)
+        print(f"train: {len(train)} records → {output_path}", file=sys.stderr)
+        print(f"held-out: {len(test)} records → {test_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/calendar/dataset_loader.py
+++ b/examples/agentic/calendar/dataset_loader.py
@@ -38,9 +38,8 @@ def _format_record(raw: dict, index: int) -> dict:
     state = game.record_to_state(raw)
     meeting_id = raw.get("target_meeting_id", state.meetings[0].id if state.meetings else "")
     prompt = game.format_prompt(state, meeting_id)
-    return {
-        "id": raw.get("id", f"calendar-{index:05d}"),
-        "prompt": prompt,
-        "state": raw,
-        "target_meeting_id": meeting_id,
-    }
+    record = dict(raw)
+    record["id"] = raw.get("id", f"calendar-{index:05d}")
+    record["prompt"] = prompt
+    record["target_meeting_id"] = meeting_id
+    return record

--- a/examples/agentic/calendar/dataset_loader.py
+++ b/examples/agentic/calendar/dataset_loader.py
@@ -1,0 +1,46 @@
+"""Dataset loader for the calendar scheduling agentic example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL calendar scenarios and convert them to Areno prompt records."""
+
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "calendar.jsonl"
+    if not path.exists():
+        return dataset_generator.generate_records()
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int) -> dict:
+    state = game.record_to_state(raw)
+    meeting_id = raw.get("target_meeting_id", state.meetings[0].id if state.meetings else "")
+    prompt = game.format_prompt(state, meeting_id)
+    return {
+        "id": raw.get("id", f"calendar-{index:05d}"),
+        "prompt": prompt,
+        "state": raw,
+        "target_meeting_id": meeting_id,
+    }

--- a/examples/agentic/calendar/game.py
+++ b/examples/agentic/calendar/game.py
@@ -301,7 +301,12 @@ def compute_reward(
 
 
 def format_prompt(state: CalendarState, meeting_id: str) -> str:
-    """Render a human-readable scheduling scenario for the LLM."""
+    """Render a human-readable scheduling scenario for the LLM.
+
+    Note: participant availability details are intentionally NOT included
+    in the prompt. The model must discover them by calling the
+    query_availability tool, which returns UTC-converted slots.
+    """
     meeting = state.meeting_by_id(meeting_id)
     if meeting is None:
         raise ValueError(f"meeting {meeting_id!r} not found")
@@ -318,13 +323,14 @@ def format_prompt(state: CalendarState, meeting_id: str) -> str:
         "Participants:",
     ]
 
+    # Only list participant names and timezones, NOT their availability.
+    # The model must call query_availability to learn the actual slots.
     for name in meeting.required_participants:
         p = state.participants.get(name)
         if p is None:
             lines.append(f"  {name}: (not found)")
             continue
-        slots_str = ", ".join(f"{s.start_hour:02d}:00-{s.end_hour:02d}:00" for s in p.available_slots)
-        lines.append(f"  {name}: timezone={p.timezone}, available=[{slots_str}]")
+        lines.append(f"  {name}: timezone={p.timezone}")
 
     if state.confirmed:
         lines.append("")
@@ -336,9 +342,9 @@ def format_prompt(state: CalendarState, meeting_id: str) -> str:
 
     lines.append("")
     lines.append("Steps:")
-    lines.append("1. Call query_availability for each required participant.")
-    lines.append("2. Find a UTC time range that overlaps all participants' availability.")
-    lines.append("3. Call propose_slot with the meeting_id and UTC time range.")
+    lines.append("1. Call query_availability for each required participant to learn their UTC availability.")
+    lines.append("2. Find a UTC time range that overlaps all participants' availability and fits the meeting duration.")
+    lines.append("3. Call propose_slot with the meeting_id and the UTC time range.")
     lines.append("4. Call confirm_slot to finalize the booking.")
     lines.append("")
     lines.append("Answer by calling the tools. Do not write free text.")
@@ -418,3 +424,49 @@ def record_to_state(raw: dict) -> CalendarState:
         meetings=meetings,
         confirmed=confirmed,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tool execution functions (called by run_agent.py during multi-turn rollout)
+# ---------------------------------------------------------------------------
+
+
+def execute_query_availability(state: CalendarState, participant_name: str) -> dict:
+    """Execute query_availability: return a participant's availability in UTC.
+
+    This is called by run_agent.py after the model requests availability,
+    so the model sees the real UTC-converted slots before proposing a time.
+    """
+    p = state.participants.get(participant_name)
+    if p is None:
+        return {"error": f"participant {participant_name!r} not found"}
+    utc_slots = []
+    for slot in p.available_slots:
+        utc_start, utc_end = to_utc(slot, p.timezone)
+        utc_slots.append({
+            "local_start": slot.start_hour,
+            "local_end": slot.end_hour,
+            "timezone": p.timezone,
+            "utc_start": utc_start,
+            "utc_end": utc_end,
+        })
+    return {"participant": participant_name, "timezone": p.timezone, "available_slots_utc": utc_slots}
+
+
+def execute_propose_slot(state: CalendarState, meeting_id: str, utc_start: int, utc_end: int) -> dict:
+    """Execute propose_slot: validate the proposed slot and return the result.
+
+    The model sees whether the proposal is valid before confirming.
+    """
+    error = validate_proposal(state, meeting_id, utc_start, utc_end)
+    if error is not None:
+        return {"valid": False, "error": error}
+    return {"valid": True, "meeting_id": meeting_id, "utc_start": utc_start, "utc_end": utc_end}
+
+
+def execute_confirm_slot(state: CalendarState, meeting_id: str, utc_start: int, utc_end: int) -> dict:
+    """Execute confirm_slot: finalize the booking if valid."""
+    error = validate_proposal(state, meeting_id, utc_start, utc_end)
+    if error is not None:
+        return {"confirmed": False, "error": error}
+    return {"confirmed": True, "meeting_id": meeting_id, "utc_start": utc_start, "utc_end": utc_end}

--- a/examples/agentic/calendar/game.py
+++ b/examples/agentic/calendar/game.py
@@ -1,0 +1,420 @@
+"""Calendar scheduling helpers for the agentic RL example.
+
+A self-contained calendar scheduling engine with participant availability,
+fixed-offset time zones, meeting durations, and conflict detection. No
+external calendars or databases are used.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TimeSlot:
+    """A time range in *local* hours, 0-24."""
+
+    start_hour: int
+    end_hour: int
+
+    def __post_init__(self) -> None:
+        if self.start_hour < 0 or self.end_hour > 24:
+            raise ValueError(f"TimeSlot out of range: {self.start_hour}-{self.end_hour}")
+        if self.start_hour >= self.end_hour:
+            raise ValueError(f"TimeSlot start must precede end: {self.start_hour}-{self.end_hour}")
+
+    @property
+    def duration(self) -> int:
+        return self.end_hour - self.start_hour
+
+
+@dataclass(frozen=True)
+class Participant:
+    name: str
+    timezone: str  # "UTC+8", "UTC-5", "UTC", "UTC+5:30"
+    available_slots: tuple[TimeSlot, ...]
+
+
+@dataclass(frozen=True)
+class Meeting:
+    id: str
+    duration_hours: int
+    required_participants: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CalendarState:
+    participants: dict[str, Participant]
+    meetings: tuple[Meeting, ...]
+    confirmed: dict[str, tuple[int, int]] = field(default_factory=dict)
+    # confirmed: meeting_id → (utc_start, utc_end)
+
+    def meeting_by_id(self, meeting_id: str) -> Meeting | None:
+        for m in self.meetings:
+            if m.id == meeting_id:
+                return m
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Time-zone helpers (fixed offset only, no DST)
+# ---------------------------------------------------------------------------
+
+_OFFSET_RE = re.compile(r"^UTC([+-]\d{1,2})(?::(\d{2}))?$")
+
+
+def parse_offset(tz: str) -> int:
+    """Return the UTC offset in *minutes* for a fixed-offset time zone string.
+
+    >>> parse_offset("UTC+8")
+    480
+    >>> parse_offset("UTC-5")
+    -300
+    >>> parse_offset("UTC")
+    0
+    >>> parse_offset("UTC+5:30")
+    330
+    """
+    if tz == "UTC":
+        return 0
+    m = _OFFSET_RE.match(tz)
+    if m is None:
+        raise ValueError(f"invalid timezone format: {tz!r}")
+    hours = int(m.group(1))
+    minutes = int(m.group(2)) if m.group(2) else 0
+    if abs(hours) > 14:
+        raise ValueError(f"invalid timezone offset: {tz!r} (max ±14)")
+    return hours * 60 + (minutes if hours >= 0 else -minutes)
+
+
+def to_utc(slot: TimeSlot, timezone: str) -> tuple[int, int]:
+    """Convert a local TimeSlot to UTC hours, handling midnight wrap.
+
+    Returns (utc_start, utc_end) where both are in [0, 24).
+    A slot that wraps past midnight is split and the end is reported as 24+end.
+    """
+    offset_hours = parse_offset(timezone) / 60
+    utc_start = (slot.start_hour - offset_hours) % 24
+    utc_end_raw = slot.end_hour - offset_hours
+    # Keep utc_end in a comparable range: if it wrapped, add 24.
+    if utc_end_raw <= utc_start:
+        utc_end = utc_end_raw + 24
+    else:
+        utc_end = utc_end_raw
+    return int(utc_start), int(utc_end)
+
+
+def format_utc_range(utc_start: int, utc_end: int) -> str:
+    """Format a UTC range for human-readable output."""
+    s = utc_start % 24
+    e = utc_end % 24 if utc_end != 24 else 24
+    return f"UTC {s:02d}:00-{e:02d}:00"
+
+
+# ---------------------------------------------------------------------------
+# Scheduling logic
+# ---------------------------------------------------------------------------
+
+
+def find_common_slots(
+    meeting: Meeting,
+    participants: dict[str, Participant],
+) -> list[tuple[int, int]]:
+    """Return all UTC time ranges where every required participant is available.
+
+    Each range is (utc_start, utc_end) in UTC hours. Ranges that wrap past
+    midnight are represented with utc_end > 24.
+    """
+    required = [participants[name] for name in meeting.required_participants if name in participants]
+    if len(required) != len(meeting.required_participants):
+        return []
+
+    # Collect each participant's UTC availability as a list of (start, end).
+    all_avails: list[list[tuple[int, int]]] = []
+    for p in required:
+        avails: list[tuple[int, int]] = []
+        for slot in p.available_slots:
+            avails.append(to_utc(slot, p.timezone))
+        all_avails.append(avails)
+
+    # Intersect all participants' availability.
+    common = all_avails[0]
+    for avails in all_avails[1:]:
+        common = _intersect_ranges(common, avails)
+        if not common:
+            return []
+
+    # Filter by minimum duration.
+    result = [(s, e) for s, e in common if e - s >= meeting.duration_hours]
+    return result
+
+
+def _intersect_ranges(a: list[tuple[int, int]], b: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Intersect two lists of (start, end) ranges."""
+    result: list[tuple[int, int]] = []
+    for sa, ea in a:
+        for sb, eb in b:
+            start = max(sa, sb)
+            end = min(ea, eb)
+            if start < end:
+                result.append((start, end))
+    return result
+
+
+def check_conflict(
+    proposed_start: int,
+    proposed_end: int,
+    confirmed: dict[str, tuple[int, int]],
+    exclude_meeting_id: str | None = None,
+) -> str | None:
+    """Return the meeting_id of a conflicting confirmed meeting, or None."""
+    for mid, (cs, ce) in confirmed.items():
+        if exclude_meeting_id and mid == exclude_meeting_id:
+            continue
+        if proposed_start < ce and proposed_end > cs:
+            return mid
+    return None
+
+
+def validate_proposal(
+    state: CalendarState,
+    meeting_id: str,
+    utc_start: int,
+    utc_end: int,
+) -> str | None:
+    """Return an error string if the proposal is invalid, or None if valid."""
+    meeting = state.meeting_by_id(meeting_id)
+    if meeting is None:
+        return f"meeting {meeting_id!r} not found"
+
+    if utc_start < 0 or utc_start >= 24:
+        return f"utc_start {utc_start} out of range [0, 24)"
+
+    if utc_end <= utc_start:
+        return f"utc_end {utc_end} must be greater than utc_start {utc_start}"
+
+    if utc_end - utc_start != meeting.duration_hours:
+        return (
+            f"duration mismatch: proposed {utc_end - utc_start}h, "
+            f"required {meeting.duration_hours}h"
+        )
+
+    # Check all required participants are available.
+    common = find_common_slots(meeting, state.participants)
+    found = any(s <= utc_start and utc_end <= e for s, e in common)
+    if not found:
+        return "proposed slot is not within any common available range"
+
+    # Check conflict with confirmed meetings.
+    conflict = check_conflict(utc_start, utc_end, state.confirmed, exclude_meeting_id=meeting_id)
+    if conflict is not None:
+        return f"conflicts with confirmed meeting {conflict!r}"
+
+    return None
+
+
+def score_proposal(
+    state: CalendarState,
+    meeting_id: str,
+    utc_start: int,
+    utc_end: int,
+) -> float:
+    """Score a proposed slot: -1.0 (invalid) to 1.0 (perfect)."""
+    error = validate_proposal(state, meeting_id, utc_start, utc_end)
+    if error is not None:
+        return -1.0
+    return 1.0
+
+
+def score_tool_efficiency(tool_calls: list[dict[str, Any]], meeting_id: str) -> float:
+    """Score tool-call efficiency: 0.0 (redundant) to 1.0 (minimal).
+
+    Ideal flow: query each required participant once, propose once, confirm once.
+    """
+    query_count = 0
+    propose_count = 0
+    confirm_count = 0
+    queried_participants: set[str] = set()
+
+    for call in tool_calls:
+        name = call.get("name", "") if isinstance(call, dict) else ""
+        args = call.get("arguments", {}) if isinstance(call, dict) else {}
+        if isinstance(args, str):
+            import json
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                args = {}
+
+        if name == "query_availability":
+            participant = args.get("participant", "")
+            if participant not in queried_participants:
+                queried_participants.add(participant)
+            query_count += 1
+        elif name == "propose_slot":
+            propose_count += 1
+        elif name == "confirm_slot":
+            confirm_count += 1
+
+    # Ideal: 1 propose, 1 confirm, queries == unique participants (no repeats).
+    efficiency = 1.0
+    # Penalise redundant queries.
+    if query_count > len(queried_participants):
+        efficiency -= 0.2 * (query_count - len(queried_participants))
+    # Penalise multiple proposes.
+    if propose_count > 1:
+        efficiency -= 0.3 * (propose_count - 1)
+    # Penalise multiple confirms.
+    if confirm_count > 1:
+        efficiency -= 0.3 * (confirm_count - 1)
+    # Reward confirm present.
+    if confirm_count == 0:
+        efficiency -= 0.3
+
+    return max(0.0, min(1.0, efficiency))
+
+
+def compute_reward(
+    state: CalendarState,
+    meeting_id: str,
+    utc_start: int,
+    utc_end: int,
+    tool_calls: list[dict[str, Any]],
+) -> float:
+    """Combined reward: constraint satisfaction (0.7) + tool efficiency (0.3)."""
+    constraint_score = score_proposal(state, meeting_id, utc_start, utc_end)
+    if constraint_score < 0:
+        return -1.0
+    efficiency = score_tool_efficiency(tool_calls, meeting_id)
+    return 0.7 * constraint_score + 0.3 * efficiency
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+
+def format_prompt(state: CalendarState, meeting_id: str) -> str:
+    """Render a human-readable scheduling scenario for the LLM."""
+    meeting = state.meeting_by_id(meeting_id)
+    if meeting is None:
+        raise ValueError(f"meeting {meeting_id!r} not found")
+
+    lines = [
+        "You are a calendar scheduling assistant.",
+        "Your task is to schedule the meeting described below.",
+        "Use the provided tools to query availability, propose a slot, and confirm it.",
+        "",
+        f"Meeting ID: {meeting.id}",
+        f"Duration: {meeting.duration_hours} hour(s)",
+        f"Required participants: {', '.join(meeting.required_participants)}",
+        "",
+        "Participants:",
+    ]
+
+    for name in meeting.required_participants:
+        p = state.participants.get(name)
+        if p is None:
+            lines.append(f"  {name}: (not found)")
+            continue
+        slots_str = ", ".join(f"{s.start_hour:02d}:00-{s.end_hour:02d}:00" for s in p.available_slots)
+        lines.append(f"  {name}: timezone={p.timezone}, available=[{slots_str}]")
+
+    if state.confirmed:
+        lines.append("")
+        lines.append("Already confirmed meetings:")
+        for mid, (cs, ce) in state.confirmed.items():
+            if mid == meeting_id:
+                continue
+            lines.append(f"  {mid}: {format_utc_range(cs, ce)}")
+
+    lines.append("")
+    lines.append("Steps:")
+    lines.append("1. Call query_availability for each required participant.")
+    lines.append("2. Find a UTC time range that overlaps all participants' availability.")
+    lines.append("3. Call propose_slot with the meeting_id and UTC time range.")
+    lines.append("4. Call confirm_slot to finalize the booking.")
+    lines.append("")
+    lines.append("Answer by calling the tools. Do not write free text.")
+
+    return "\n".join(lines)
+
+
+def format_prompt_for_record(raw: dict, index: int) -> str:
+    """Build a prompt from a raw JSONL record."""
+    state = record_to_state(raw)
+    meeting_id = raw.get("target_meeting_id", state.meetings[0].id if state.meetings else "")
+    return format_prompt(state, meeting_id)
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def state_to_record(state: CalendarState, target_meeting_id: str = "") -> dict:
+    """Serialize a CalendarState to a JSON-able dict."""
+    return {
+        "id": target_meeting_id or (state.meetings[0].id if state.meetings else ""),
+        "participants": {
+            name: {
+                "name": p.name,
+                "timezone": p.timezone,
+                "available_slots": [
+                    {"start_hour": s.start_hour, "end_hour": s.end_hour} for s in p.available_slots
+                ],
+            }
+            for name, p in state.participants.items()
+        },
+        "meetings": [
+            {
+                "id": m.id,
+                "duration_hours": m.duration_hours,
+                "required_participants": list(m.required_participants),
+            }
+            for m in state.meetings
+        ],
+        "confirmed": {mid: list(rng) for mid, rng in state.confirmed.items()},
+        "target_meeting_id": target_meeting_id or (state.meetings[0].id if state.meetings else ""),
+    }
+
+
+def record_to_state(raw: dict) -> CalendarState:
+    """Deserialize a JSON dict into a CalendarState."""
+    participants: dict[str, Participant] = {}
+    for name, pdata in raw.get("participants", {}).items():
+        slots = tuple(
+            TimeSlot(s["start_hour"], s["end_hour"])
+            for s in pdata.get("available_slots", [])
+        )
+        participants[name] = Participant(
+            name=pdata.get("name", name),
+            timezone=pdata["timezone"],
+            available_slots=slots,
+        )
+
+    meetings = tuple(
+        Meeting(
+            id=m["id"],
+            duration_hours=m["duration_hours"],
+            required_participants=tuple(m["required_participants"]),
+        )
+        for m in raw.get("meetings", [])
+    )
+
+    confirmed = {
+        mid: (rng[0], rng[1])
+        for mid, rng in raw.get("confirmed", {}).items()
+    }
+
+    return CalendarState(
+        participants=participants,
+        meetings=meetings,
+        confirmed=confirmed,
+    )

--- a/examples/agentic/calendar/reward.py
+++ b/examples/agentic/calendar/reward.py
@@ -1,4 +1,8 @@
-"""Reward function for the calendar scheduling agentic example."""
+"""Reward function for the multi-turn calendar scheduling agentic example.
+
+Rewards the final confirmed slot, with a multi-turn tool-use bonus for
+following the correct query → propose → confirm flow.
+"""
 
 from __future__ import annotations
 
@@ -12,68 +16,115 @@ import game  # noqa: E402
 
 
 def reward_fn(record: Any) -> float:
-    """Score one completion by extracting tool calls and evaluating constraints.
+    """Reward the final confirmed slot, with a multi-turn tool-use bonus.
 
     Evaluates two dimensions:
-    1. Constraint satisfaction: timezone conversion, availability, conflicts, duration.
-    2. Tool-call efficiency: minimal queries, single propose, single confirm.
+    1. Constraint satisfaction: the confirmed slot must pass all validation
+       (timezone conversion, availability, conflicts, duration).
+    2. Tool-call flow: the model should follow query → propose → confirm
+       in the correct order.
     """
     source = record.source_record
     state = game.record_to_state(source)
     meeting_id = source.get("target_meeting_id", "")
 
-    tool_calls = _extract_tool_calls(record)
-    proposed = _extract_proposal(tool_calls, meeting_id)
+    tool_calls = list(record.tool_calls)
+    names = [call.get("name", "") for call in tool_calls if isinstance(call, dict)]
 
-    if proposed is None:
-        # No valid proposal found — check if there was no solution.
+    # Extract the last confirmed or proposed slot.
+    confirmed = _extract_confirmed_slot(tool_calls, meeting_id)
+    if confirmed is None:
+        # No confirmation found — check if there was no solution.
         meeting = state.meeting_by_id(meeting_id)
         if meeting is not None:
             common = game.find_common_slots(meeting, state.participants)
             if not common:
-                # No solution exists; reward neutral if agent didn't propose.
+                # No solution exists; reward neutral if agent didn't confirm.
                 return 0.0
         return -1.0
 
-    utc_start, utc_end = proposed
-    return game.compute_reward(state, meeting_id, utc_start, utc_end, tool_calls)
+    utc_start, utc_end = confirmed
+    # Check constraint satisfaction.
+    error = game.validate_proposal(state, meeting_id, utc_start, utc_end)
+    if error is not None:
+        return -1.0
+
+    # Check tool-call flow: query → propose → confirm.
+    expected_flow = _has_correct_flow(names)
+    if expected_flow:
+        return 1.0
+    # Correct slot but wrong flow → partial credit.
+    return 0.5
 
 
-def _extract_tool_calls(record: Any) -> list[dict[str, Any]]:
-    """Extract the list of tool calls from the agent record."""
-    calls = getattr(record, "tool_calls", None)
-    if calls is None:
-        return []
-    result = []
-    for call in calls:
-        if isinstance(call, dict):
-            result.append(call)
-    return result
-
-
-def _extract_proposal(
+def _extract_confirmed_slot(
     tool_calls: list[dict[str, Any]], meeting_id: str
 ) -> tuple[int, int] | None:
-    """Extract the last proposed or confirmed UTC slot for the given meeting."""
+    """Extract the last confirmed (or proposed) UTC slot for the meeting.
+
+    Prefer confirm_slot; fall back to propose_slot if no confirm was made.
+    """
+    # Look for confirm_slot first (in reverse).
     for call in reversed(tool_calls):
         name = call.get("name", "") if isinstance(call, dict) else ""
-        if name not in ("propose_slot", "confirm_slot"):
+        if name != "confirm_slot":
             continue
-        args = call.get("arguments", {})
-        if isinstance(args, str):
-            try:
-                args = json.loads(args)
-            except json.JSONDecodeError:
-                continue
-        if not isinstance(args, dict):
+        slot = _parse_slot_args(call, meeting_id)
+        if slot is not None:
+            return slot
+    # Fall back to propose_slot.
+    for call in reversed(tool_calls):
+        name = call.get("name", "") if isinstance(call, dict) else ""
+        if name != "propose_slot":
             continue
-        if args.get("meeting_id") != meeting_id:
-            continue
-        try:
-            utc_start = int(args.get("utc_start_hour", -1))
-            utc_end = int(args.get("utc_end_hour", -1))
-        except (TypeError, ValueError):
-            continue
-        if utc_start >= 0 and utc_end > utc_start:
-            return utc_start, utc_end
+        slot = _parse_slot_args(call, meeting_id)
+        if slot is not None:
+            return slot
     return None
+
+
+def _parse_slot_args(call: dict[str, Any], meeting_id: str) -> tuple[int, int] | None:
+    """Parse UTC start/end from a tool call's arguments."""
+    args = call.get("arguments", {})
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(args, dict):
+        return None
+    if args.get("meeting_id") != meeting_id:
+        return None
+    try:
+        utc_start = int(args.get("utc_start_hour", -1))
+        utc_end = int(args.get("utc_end_hour", -1))
+    except (TypeError, ValueError):
+        return None
+    if utc_start >= 0 and utc_end > utc_start:
+        return utc_start, utc_end
+    return None
+
+
+def _has_correct_flow(names: list[str]) -> bool:
+    """Check if the tool-call names follow the expected query → propose → confirm flow.
+
+    The flow is: at least one query_availability, then propose_slot, then confirm_slot.
+    The order must be: all queries before propose, propose before confirm.
+    """
+    # Find indices of each tool type.
+    query_indices = [i for i, n in enumerate(names) if n == "query_availability"]
+    propose_indices = [i for i, n in enumerate(names) if n == "propose_slot"]
+    confirm_indices = [i for i, n in enumerate(names) if n == "confirm_slot"]
+
+    # Must have at least one query, one propose, and one confirm.
+    if not query_indices or not propose_indices or not confirm_indices:
+        return False
+
+    # All queries must come before the first propose.
+    if max(query_indices) > min(propose_indices):
+        return False
+    # Propose must come before confirm.
+    if min(propose_indices) > min(confirm_indices):
+        return False
+
+    return True

--- a/examples/agentic/calendar/reward.py
+++ b/examples/agentic/calendar/reward.py
@@ -1,0 +1,79 @@
+"""Reward function for the calendar scheduling agentic example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by extracting tool calls and evaluating constraints.
+
+    Evaluates two dimensions:
+    1. Constraint satisfaction: timezone conversion, availability, conflicts, duration.
+    2. Tool-call efficiency: minimal queries, single propose, single confirm.
+    """
+    source = record.source_record
+    state = game.record_to_state(source)
+    meeting_id = source.get("target_meeting_id", "")
+
+    tool_calls = _extract_tool_calls(record)
+    proposed = _extract_proposal(tool_calls, meeting_id)
+
+    if proposed is None:
+        # No valid proposal found — check if there was no solution.
+        meeting = state.meeting_by_id(meeting_id)
+        if meeting is not None:
+            common = game.find_common_slots(meeting, state.participants)
+            if not common:
+                # No solution exists; reward neutral if agent didn't propose.
+                return 0.0
+        return -1.0
+
+    utc_start, utc_end = proposed
+    return game.compute_reward(state, meeting_id, utc_start, utc_end, tool_calls)
+
+
+def _extract_tool_calls(record: Any) -> list[dict[str, Any]]:
+    """Extract the list of tool calls from the agent record."""
+    calls = getattr(record, "tool_calls", None)
+    if calls is None:
+        return []
+    result = []
+    for call in calls:
+        if isinstance(call, dict):
+            result.append(call)
+    return result
+
+
+def _extract_proposal(
+    tool_calls: list[dict[str, Any]], meeting_id: str
+) -> tuple[int, int] | None:
+    """Extract the last proposed or confirmed UTC slot for the given meeting."""
+    for call in reversed(tool_calls):
+        name = call.get("name", "") if isinstance(call, dict) else ""
+        if name not in ("propose_slot", "confirm_slot"):
+            continue
+        args = call.get("arguments", {})
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                continue
+        if not isinstance(args, dict):
+            continue
+        if args.get("meeting_id") != meeting_id:
+            continue
+        try:
+            utc_start = int(args.get("utc_start_hour", -1))
+            utc_end = int(args.get("utc_end_hour", -1))
+        except (TypeError, ValueError):
+            continue
+        if utc_start >= 0 and utc_end > utc_start:
+            return utc_start, utc_end
+    return None

--- a/examples/agentic/calendar/run_agent.py
+++ b/examples/agentic/calendar/run_agent.py
@@ -1,0 +1,162 @@
+"""Agent entrypoint for calendar scheduling tool-call rollouts."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are a calendar scheduling assistant. "
+    "Your task is to schedule a meeting by calling the provided tools. "
+    "First, call query_availability for each required participant to learn their available times. "
+    "Then, convert their local availability to UTC and find a common slot that fits the meeting duration. "
+    "Call propose_slot with the meeting_id and the UTC time range. "
+    "Finally, call confirm_slot to finalize the booking. "
+    "Use exactly one tool call per turn. Do not write free text."
+)
+
+QUERY_AVAILABILITY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "query_availability",
+        "description": "Query the available time slots for a participant in their local timezone.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "participant": {
+                    "type": "string",
+                    "description": "The name of the participant to query.",
+                },
+            },
+            "required": ["participant"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+PROPOSE_SLOT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "propose_slot",
+        "description": "Propose a meeting time in UTC hours.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "meeting_id": {
+                    "type": "string",
+                    "description": "The ID of the meeting to schedule.",
+                },
+                "utc_start_hour": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 23,
+                    "description": "Start hour of the meeting in UTC (0-23).",
+                },
+                "utc_end_hour": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 24,
+                    "description": "End hour of the meeting in UTC (1-24).",
+                },
+            },
+            "required": ["meeting_id", "utc_start_hour", "utc_end_hour"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+CONFIRM_SLOT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "confirm_slot",
+        "description": "Confirm a proposed meeting slot to finalize the booking.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "meeting_id": {
+                    "type": "string",
+                    "description": "The ID of the meeting to confirm.",
+                },
+                "utc_start_hour": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 23,
+                    "description": "Start hour of the meeting in UTC (0-23).",
+                },
+                "utc_end_hour": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 24,
+                    "description": "End hour of the meeting in UTC (1-24).",
+                },
+            },
+            "required": ["meeting_id", "utc_start_hour", "utc_end_hour"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+TOOLS = [QUERY_AVAILABILITY_TOOL, PROPOSE_SLOT_TOOL, CONFIRM_SLOT_TOOL]
+
+
+async def run_agent(ctx, batch):
+    """Run one tool-call model request for each calendar scenario."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The calendar agentic example requires `openai` and `httpx`. "
+            "Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info(
+        "Calendar agent start requests=%d max_running_prompts=%d",
+        len(items),
+        ctx.max_running_prompts,
+    )
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(
+            max_connections=max_connections, max_keepalive_connections=max_connections
+        ),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(
+        base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0
+    )
+
+    async def run_one(item):
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+        tool_choice = "auto"
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=messages,
+            tools=TOOLS,
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        return AgentTrajectoryTurn(
+            item=item,
+            messages=messages,
+            response=response,
+            tools=TOOLS,
+            tool_choice=tool_choice,
+        )
+
+    try:
+        return AgentTrajectory(
+            turns=list(await asyncio.gather(*(run_one(item) for item in items)))
+        )
+    finally:
+        await client.close()

--- a/examples/agentic/calendar/run_agent.py
+++ b/examples/agentic/calendar/run_agent.py
@@ -1,11 +1,31 @@
-"""Agent entrypoint for calendar scheduling tool-call rollouts."""
+"""Agent entrypoint for multi-turn calendar scheduling tool-call rollouts.
+
+Implements a four-turn agentic flow similar to the shopping example:
+  Turn 1: query_availability for each required participant
+  Turn 2: (model sees availability results) propose_slot
+  Turn 3: (model sees proposal validation) confirm_slot
+
+Each tool call is actually executed and the result is fed back into the
+conversation so the model can make informed decisions step by step.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import sys
+from pathlib import Path
 
 from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import (  # noqa: E402
+    execute_confirm_slot,
+    execute_propose_slot,
+    execute_query_availability,
+    record_to_state,
+)
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -13,18 +33,25 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 SYSTEM_PROMPT = (
     "You are a calendar scheduling assistant. "
     "Your task is to schedule a meeting by calling the provided tools. "
-    "First, call query_availability for each required participant to learn their available times. "
-    "Then, convert their local availability to UTC and find a common slot that fits the meeting duration. "
+    "First, call query_availability for each required participant to learn their available times in UTC. "
+    "Then, find a UTC time range that overlaps all participants' availability and fits the meeting duration. "
     "Call propose_slot with the meeting_id and the UTC time range. "
-    "Finally, call confirm_slot to finalize the booking. "
+    "After seeing the proposal result, call confirm_slot to finalize the booking. "
     "Use exactly one tool call per turn. Do not write free text."
 )
+
+# Turn-by-turn prompts guide the model through the scheduling flow.
+TURN_PROMPTS = {
+    "query_availability": "Turn 1: call query_availability for each required participant to learn their UTC availability.",
+    "propose_slot": "Turn 2: based on the availability results above, call propose_slot with a UTC time range that works for all participants.",
+    "confirm_slot": "Turn 3: based on the proposal result above, call confirm_slot to finalize the booking.",
+}
 
 QUERY_AVAILABILITY_TOOL = {
     "type": "function",
     "function": {
         "name": "query_availability",
-        "description": "Query the available time slots for a participant in their local timezone.",
+        "description": "Query the available time slots for a participant, returned in UTC.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -101,16 +128,20 @@ CONFIRM_SLOT_TOOL = {
     },
 }
 
-TOOLS = [QUERY_AVAILABILITY_TOOL, PROPOSE_SLOT_TOOL, CONFIRM_SLOT_TOOL]
+TOOL_BY_NAME = {
+    "query_availability": QUERY_AVAILABILITY_TOOL,
+    "propose_slot": PROPOSE_SLOT_TOOL,
+    "confirm_slot": CONFIRM_SLOT_TOOL,
+}
 
 
 async def run_agent(ctx, batch):
-    """Run one tool-call model request for each calendar scenario.
+    """Run multi-turn tool-call rollouts for each calendar scenario.
 
-    Sends the scheduling prompt and three tool definitions to AReno's
-    local OpenAI-compatible endpoint. The model responds with tool calls
-    (query_availability / propose_slot / confirm_slot) that are later
-    scored by reward.py.
+    Flow per scenario:
+      1. For each required participant: call query_availability, execute, feed result back.
+      2. Call propose_slot, execute, feed result back.
+      3. Call confirm_slot, execute, feed result back.
     """
 
     try:
@@ -141,31 +172,152 @@ async def run_agent(ctx, batch):
     )
 
     async def run_one(item):
-        # Build the message sequence: system prompt → user scheduling scenario.
+        turns = []
+        # Build initial messages: system prompt + user scenario.
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": item.prompt},
         ]
-        # Let the model choose which tool to call (query/propose/confirm).
-        tool_choice = "auto"
-        response = await client.chat.completions.create(
-            model="policy",
-            messages=messages,
-            tools=TOOLS,
-            tool_choice=tool_choice,
-            stream=False,
+        # Reconstruct the calendar state from the source record.
+        state = record_to_state(item.record)
+        meeting_id = item.record.get("target_meeting_id", "")
+        meeting = state.meeting_by_id(meeting_id)
+        if meeting is None:
+            logger.warning("meeting %s not found in record", meeting_id)
+            return turns
+
+        # --- Turn 1: query_availability for each required participant ---
+        for participant_name in meeting.required_participants:
+            assistant_msg, turn = await _call_model(
+                item, client, messages, "query_availability"
+            )
+            turns.append(turn)
+            tool_result = _run_tool(assistant_msg, state)
+            messages.extend(_tool_messages(assistant_msg, tool_result))
+
+        # --- Turn 2: propose_slot ---
+        assistant_msg, turn = await _call_model(
+            item, client, messages, "propose_slot"
         )
-        return AgentTrajectoryTurn(
-            item=item,
-            messages=messages,
-            response=response,
-            tools=TOOLS,
-            tool_choice=tool_choice,
+        turns.append(turn)
+        tool_result = _run_tool(assistant_msg, state)
+        messages.extend(_tool_messages(assistant_msg, tool_result))
+
+        # --- Turn 3: confirm_slot ---
+        assistant_msg, turn = await _call_model(
+            item, client, messages, "confirm_slot"
         )
+        turns.append(turn)
+        tool_result = _run_tool(assistant_msg, state)
+        messages.extend(_tool_messages(assistant_msg, tool_result))
+
+        return turns
 
     try:
-        return AgentTrajectory(
-            turns=list(await asyncio.gather(*(run_one(item) for item in items)))
-        )
+        grouped = await asyncio.gather(*(run_one(item) for item in items))
+        return AgentTrajectory(turns=[turn for turns in grouped for turn in turns])
     finally:
         await client.close()
+
+
+async def _call_model(item, client, messages: list[dict], tool_name: str):
+    """Call the model with a single-tool constraint and return (assistant_message, turn).
+
+    The turn prompt guides the model to call the expected tool at this step.
+    """
+    turn_messages = [*messages, {"role": "user", "content": TURN_PROMPTS[tool_name]}]
+    tools = [TOOL_BY_NAME[tool_name]]
+    tool_choice = {"type": "function", "function": {"name": tool_name}}
+    response = await client.chat.completions.create(
+        model="policy",
+        messages=turn_messages,
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=False,
+    )
+    message = response.choices[0].message
+    # Extract only the matching tool call (first one).
+    tool_calls = [call for call in (message.tool_calls or []) if call.function.name == tool_name][:1]
+    assistant_message = {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": call.type,
+                "function": {
+                    "name": call.function.name,
+                    "arguments": call.function.arguments,
+                },
+            }
+            for call in tool_calls
+        ],
+    }
+    # If the model didn't produce the expected tool call, insert a placeholder
+    # so the downstream execution can report an error.
+    if not assistant_message["tool_calls"]:
+        assistant_message["tool_calls"] = [
+            {
+                "id": f"missing_{tool_name}",
+                "type": "function",
+                "function": {
+                    "name": tool_name,
+                    "arguments": "{}",
+                },
+            }
+        ]
+    return assistant_message, AgentTrajectoryTurn(
+        item=item,
+        messages=turn_messages,
+        response=response,
+        tools=tools,
+        tool_choice=tool_choice,
+    )
+
+
+def _tool_messages(assistant_message: dict, tool_result: dict) -> list[dict]:
+    """Build the assistant + tool-result messages to append to the conversation."""
+    messages = [assistant_message]
+    for call in assistant_message.get("tool_calls") or []:
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call["id"],
+                "name": call["function"]["name"],
+                "content": json.dumps(tool_result, ensure_ascii=False),
+            }
+        )
+    return messages
+
+
+def _run_tool(assistant_message: dict, state) -> dict:
+    """Execute the tool call and return the real result.
+
+    This is the key difference from single-step agents: the tool is actually
+    executed, and the result is fed back to the model so it can make
+    informed decisions in subsequent turns.
+    """
+    calls = assistant_message.get("tool_calls") or []
+    if not calls:
+        return {"error": "missing tool call"}
+    call = calls[0]
+    name = call["function"]["name"]
+    try:
+        args = json.loads(call["function"]["arguments"] or "{}")
+    except json.JSONDecodeError:
+        return {"error": "invalid JSON arguments"}
+
+    if name == "query_availability":
+        participant = str(args.get("participant", ""))
+        return execute_query_availability(state, participant)
+    if name == "propose_slot":
+        meeting_id = str(args.get("meeting_id", ""))
+        utc_start = int(args.get("utc_start_hour", -1))
+        utc_end = int(args.get("utc_end_hour", -1))
+        return execute_propose_slot(state, meeting_id, utc_start, utc_end)
+    if name == "confirm_slot":
+        meeting_id = str(args.get("meeting_id", ""))
+        utc_start = int(args.get("utc_start_hour", -1))
+        utc_end = int(args.get("utc_end_hour", -1))
+        return execute_confirm_slot(state, meeting_id, utc_start, utc_end)
+    return {"error": f"unknown tool: {name}"}

--- a/examples/agentic/calendar/run_agent.py
+++ b/examples/agentic/calendar/run_agent.py
@@ -105,7 +105,13 @@ TOOLS = [QUERY_AVAILABILITY_TOOL, PROPOSE_SLOT_TOOL, CONFIRM_SLOT_TOOL]
 
 
 async def run_agent(ctx, batch):
-    """Run one tool-call model request for each calendar scenario."""
+    """Run one tool-call model request for each calendar scenario.
+
+    Sends the scheduling prompt and three tool definitions to AReno's
+    local OpenAI-compatible endpoint. The model responds with tool calls
+    (query_availability / propose_slot / confirm_slot) that are later
+    scored by reward.py.
+    """
 
     try:
         import httpx
@@ -122,6 +128,7 @@ async def run_agent(ctx, batch):
         len(items),
         ctx.max_running_prompts,
     )
+    # Share one httpx connection pool sized to the max rollout concurrency.
     max_connections = max(len(items), ctx.max_running_prompts)
     http_client = httpx.AsyncClient(
         limits=httpx.Limits(
@@ -134,10 +141,12 @@ async def run_agent(ctx, batch):
     )
 
     async def run_one(item):
+        # Build the message sequence: system prompt → user scheduling scenario.
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": item.prompt},
         ]
+        # Let the model choose which tool to call (query/propose/confirm).
         tool_choice = "auto"
         response = await client.chat.completions.create(
             model="policy",

--- a/examples/agentic/calendar/web_ui.py
+++ b/examples/agentic/calendar/web_ui.py
@@ -361,11 +361,18 @@ def _turn_prompt(server: CalendarServer, tool_name: str) -> str:
     """Generate a guiding prompt for the current turn."""
     if tool_name == "query_availability":
         meeting = server.state.meeting_by_id(server.meeting_id) if server.state else None
-        queried = [
-            json.loads(c["arguments"]).get("participant", "")
-            for c in server.tool_calls_log
-            if c["name"] == "query_availability" and isinstance(c["arguments"], dict)
-        ]
+        queried = []
+        for c in server.tool_calls_log:
+            if c["name"] != "query_availability":
+                continue
+            cargs = c["arguments"]
+            if isinstance(cargs, str):
+                try:
+                    cargs = json.loads(cargs)
+                except json.JSONDecodeError:
+                    continue
+            if isinstance(cargs, dict):
+                queried.append(cargs.get("participant", ""))
         remaining = [p for p in (meeting.required_participants if meeting else []) if p not in queried]
         if remaining:
             return f"Call query_availability for participant '{remaining[0]}' to learn their UTC availability."
@@ -411,6 +418,8 @@ def _evaluate(server: CalendarServer) -> None:
                     args = json.loads(args)
                 except json.JSONDecodeError:
                     continue
+            if not isinstance(args, dict):
+                continue
             if args.get("meeting_id") != server.meeting_id:
                 continue
             utc_start = int(args.get("utc_start_hour", -1))

--- a/examples/agentic/calendar/web_ui.py
+++ b/examples/agentic/calendar/web_ui.py
@@ -1,0 +1,743 @@
+"""Calendar scheduling web UI server for the agentic example.
+
+Run from the repository root after starting ``areno serve``:
+
+    python examples/agentic/calendar/web_ui.py --base-url http://127.0.0.1:8000/v1 --api-key token
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8768
+
+QUERY_AVAILABILITY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "query_availability",
+        "description": "Query the available time slots for a participant, returned in UTC.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "participant": {
+                    "type": "string",
+                    "description": "The name of the participant to query.",
+                },
+            },
+            "required": ["participant"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+PROPOSE_SLOT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "propose_slot",
+        "description": "Propose a meeting time in UTC hours.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "meeting_id": {"type": "string"},
+                "utc_start_hour": {"type": "integer", "minimum": 0, "maximum": 23},
+                "utc_end_hour": {"type": "integer", "minimum": 1, "maximum": 24},
+            },
+            "required": ["meeting_id", "utc_start_hour", "utc_end_hour"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+CONFIRM_SLOT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "confirm_slot",
+        "description": "Confirm a proposed meeting slot to finalize the booking.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "meeting_id": {"type": "string"},
+                "utc_start_hour": {"type": "integer", "minimum": 0, "maximum": 23},
+                "utc_end_hour": {"type": "integer", "minimum": 1, "maximum": 24},
+            },
+            "required": ["meeting_id", "utc_start_hour", "utc_end_hour"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+TOOLS = [QUERY_AVAILABILITY_TOOL, PROPOSE_SLOT_TOOL, CONFIRM_SLOT_TOOL]
+TOOL_BY_NAME = {t["function"]["name"]: t for t in TOOLS}
+
+SYSTEM_PROMPT = (
+    "You are a calendar scheduling assistant. "
+    "Your task is to schedule a meeting by calling the provided tools. "
+    "First, call query_availability for each required participant to learn their available times in UTC. "
+    "Then, find a UTC time range that overlaps all participants' availability and fits the meeting duration. "
+    "Call propose_slot with the meeting_id and the UTC time range. "
+    "After seeing the proposal result, call confirm_slot to finalize the booking. "
+    "Use exactly one tool call per turn. Do not write free text."
+)
+
+
+class CalendarServer(ThreadingHTTPServer):
+    """Stateful HTTP server for one calendar scheduling session."""
+
+    def __init__(self, server_address, request_handler, *, seed: int | None = None, args):
+        super().__init__(server_address, request_handler)
+        self.rng = random.Random(seed)
+        self.args = args
+        self.openai_client = None
+        self.state: game.CalendarState | None = None
+        self.meeting_id: str = ""
+        self.messages: list[dict[str, Any]] = []
+        self.events: list[str] = []
+        self.tool_calls_log: list[dict[str, Any]] = []
+        self.agent_busy = False
+        self.finished = False
+        self.result: str = ""
+        self.reward: float | None = None
+        _new_scenario(self)
+
+
+class CalendarHandler(BaseHTTPRequestHandler):
+    server: CalendarServer
+
+    def do_GET(self) -> None:
+        route = _route_path(self.path)
+        if route == "index":
+            self._send_html(INDEX_HTML)
+        elif route == "state":
+            self._send_json(_payload(self.server))
+        elif route == "scenario":
+            self._send_json(_scenario_payload(self.server))
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def do_POST(self) -> None:
+        route = _route_path(self.path)
+        if route == "new":
+            _new_scenario(self.server)
+            self._send_json(_payload(self.server))
+        elif route == "agent":
+            self._send_json(_agent_step(self.server))
+        elif route == "reset":
+            _new_scenario(self.server)
+            self._send_json(_payload(self.server))
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("calendar-web: " + fmt % args + "\n")
+
+    def _read_json(self) -> Any:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def _send_html(self, html: str) -> None:
+        encoded = html.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _send_json(self, payload: Any, status: HTTPStatus = HTTPStatus.OK) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def _route_path(raw_path: str) -> str:
+    path = urlparse(raw_path).path.rstrip("/") or "/"
+    if path.endswith("/api/state"):
+        return "state"
+    if path.endswith("/api/scenario"):
+        return "scenario"
+    if path.endswith("/api/new"):
+        return "new"
+    if path.endswith("/api/agent"):
+        return "agent"
+    if path.endswith("/api/reset"):
+        return "reset"
+    if "/api/" in path:
+        return "missing"
+    if path == "/" or not path.rsplit("/", 1)[-1].count("."):
+        return "index"
+    return "missing"
+
+
+def _new_scenario(server: CalendarServer) -> None:
+    """Generate a new random calendar scenario."""
+    participant_names = ["Alice", "Bob", "Carol", "David", "Eve", "Frank"]
+    timezones = ["UTC", "UTC+1", "UTC+2", "UTC+3", "UTC+8", "UTC-5", "UTC-8", "UTC+5:30"]
+    num_participants = server.rng.randint(2, 3)
+    chosen = server.rng.sample(participant_names, num_participants)
+
+    participants: dict[str, game.Participant] = {}
+    for name in chosen:
+        tz = server.rng.choice(timezones)
+        num_slots = server.rng.randint(1, 2)
+        slots: list[game.TimeSlot] = []
+        cursor = server.rng.randint(0, 8)
+        for _ in range(num_slots):
+            start = cursor
+            duration = server.rng.randint(2, 6)
+            end = min(start + duration, 24)
+            if start < end:
+                slots.append(game.TimeSlot(start, end))
+            cursor = end + server.rng.randint(1, 3)
+        if not slots:
+            slots.append(game.TimeSlot(9, 17))
+        participants[name] = game.Participant(name=name, timezone=tz, available_slots=tuple(slots))
+
+    meeting_id = f"meeting-{server.rng.randint(1000, 9999)}"
+    duration_hours = server.rng.randint(1, 2)
+    meeting = game.Meeting(
+        id=meeting_id,
+        duration_hours=duration_hours,
+        required_participants=tuple(chosen),
+    )
+
+    confirmed: dict[str, tuple[int, int]] = {}
+    if server.rng.random() < 0.3:
+        other_id = f"{meeting_id}-prior"
+        other_start = server.rng.randint(0, 20)
+        other_end = min(other_start + server.rng.randint(1, 3), 24)
+        confirmed[other_id] = (other_start, other_end)
+
+    server.state = game.CalendarState(
+        participants=participants,
+        meetings=(meeting,),
+        confirmed=confirmed,
+    )
+    server.meeting_id = meeting_id
+    server.messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": game.format_prompt(server.state, meeting_id)},
+    ]
+    server.events = ["New scenario generated. Click 'Run Agent Step' to let the LLM schedule the meeting."]
+    server.tool_calls_log = []
+    server.agent_busy = False
+    server.finished = False
+    server.result = ""
+    server.reward = None
+
+
+def _agent_step(server: CalendarServer) -> dict[str, Any]:
+    """Run one LLM agent step (one tool call)."""
+    if server.finished:
+        return _payload(server)
+    if not server.args.base_url:
+        server.events.insert(0, "LLM mode requires --base-url. Start areno serve first.")
+        server.events = server.events[:10]
+        return _payload(server)
+
+    if server.openai_client is None:
+        server.openai_client = _make_openai_client(server.args)
+
+    # Determine which tool to use based on conversation progress.
+    tool_name = _next_tool(server)
+    tool = TOOL_BY_NAME[tool_name]
+    tool_choice = {"type": "function", "function": {"name": tool_name}}
+
+    # Add a turn prompt to guide the model.
+    turn_prompt = _turn_prompt(server, tool_name)
+    messages = [*server.messages, {"role": "user", "content": turn_prompt}]
+
+    try:
+        response = server.openai_client.chat.completions.create(
+            model=server.args.model,
+            messages=messages,
+            tools=[tool],
+            tool_choice=tool_choice,
+        )
+    except Exception as exc:
+        server.events.insert(0, f"LLM call failed: {exc}")
+        server.events = server.events[:10]
+        return _payload(server)
+
+    raw = response.model_dump() if hasattr(response, "model_dump") else response
+    choices = raw.get("choices", []) if isinstance(raw, dict) else []
+    message = choices[0].get("message", {}) if choices else {}
+    tool_calls = message.get("tool_calls", []) if message else []
+
+    if not tool_calls:
+        server.events.insert(0, f"LLM did not return a tool call for {tool_name}.")
+        server.events = server.events[:10]
+        return _payload(server)
+
+    call = tool_calls[0]
+    func = call.get("function", {})
+    name = func.get("name", tool_name)
+    args_str = func.get("arguments", "{}")
+    try:
+        args = json.loads(args_str) if isinstance(args_str, str) else args_str
+    except json.JSONDecodeError:
+        args = {}
+
+    # Execute the tool.
+    result = _execute_tool(server, name, args)
+
+    # Record the tool call.
+    call_record = {"name": name, "arguments": args, "result": result}
+    server.tool_calls_log.append(call_record)
+
+    # Build assistant + tool messages for conversation history.
+    assistant_msg = {
+        "role": "assistant",
+        "content": message.get("content", ""),
+        "tool_calls": [
+            {
+                "id": call.get("id", f"call_{len(server.tool_calls_log)}"),
+                "type": "function",
+                "function": {"name": name, "arguments": args_str if isinstance(args_str, str) else json.dumps(args)},
+            }
+        ],
+    }
+    tool_msg = {
+        "role": "tool",
+        "tool_call_id": call.get("id", f"call_{len(server.tool_calls_log)}"),
+        "name": name,
+        "content": json.dumps(result, ensure_ascii=False),
+    }
+    server.messages.append(assistant_msg)
+    server.messages.append(tool_msg)
+
+    server.events.insert(0, f"Agent called {name}({json.dumps(args, ensure_ascii=False)}): {json.dumps(result, ensure_ascii=False)}")
+    server.events = server.events[:10]
+
+    # Check if finished.
+    if name == "confirm_slot":
+        server.finished = True
+        _evaluate(server)
+    elif name == "propose_slot" and result.get("valid") is False:
+        # Let the model try again after a failed proposal.
+        pass
+
+    return _payload(server)
+
+
+def _next_tool(server: CalendarServer) -> str:
+    """Determine which tool the agent should call next based on progress."""
+    called_names = [c["name"] for c in server.tool_calls_log]
+    queried = [c for c in called_names if c == "query_availability"]
+    proposed = [c for c in called_names if c == "propose_slot"]
+    confirmed = [c for c in called_names if c == "confirm_slot"]
+
+    meeting = server.state.meeting_by_id(server.meeting_id) if server.state else None
+    num_participants = len(meeting.required_participants) if meeting else 2
+
+    if len(queried) < num_participants:
+        return "query_availability"
+    if not proposed:
+        return "propose_slot"
+    if not confirmed:
+        return "confirm_slot"
+    return "confirm_slot"
+
+
+def _turn_prompt(server: CalendarServer, tool_name: str) -> str:
+    """Generate a guiding prompt for the current turn."""
+    if tool_name == "query_availability":
+        meeting = server.state.meeting_by_id(server.meeting_id) if server.state else None
+        queried = [
+            json.loads(c["arguments"]).get("participant", "")
+            for c in server.tool_calls_log
+            if c["name"] == "query_availability" and isinstance(c["arguments"], dict)
+        ]
+        remaining = [p for p in (meeting.required_participants if meeting else []) if p not in queried]
+        if remaining:
+            return f"Call query_availability for participant '{remaining[0]}' to learn their UTC availability."
+        return "Call query_availability for the next required participant."
+    if tool_name == "propose_slot":
+        return "Based on the availability results above, call propose_slot with a UTC time range that works for all participants."
+    if tool_name == "confirm_slot":
+        return "Based on the proposal result above, call confirm_slot to finalize the booking."
+    return "Call the next tool."
+
+
+def _execute_tool(server: CalendarServer, name: str, args: dict) -> dict:
+    """Execute a tool call against the calendar state."""
+    if server.state is None:
+        return {"error": "no scenario loaded"}
+    if name == "query_availability":
+        participant = str(args.get("participant", ""))
+        return game.execute_query_availability(server.state, participant)
+    if name == "propose_slot":
+        meeting_id = str(args.get("meeting_id", ""))
+        utc_start = int(args.get("utc_start_hour", -1))
+        utc_end = int(args.get("utc_end_hour", -1))
+        return game.execute_propose_slot(server.state, meeting_id, utc_start, utc_end)
+    if name == "confirm_slot":
+        meeting_id = str(args.get("meeting_id", ""))
+        utc_start = int(args.get("utc_start_hour", -1))
+        utc_end = int(args.get("utc_end_hour", -1))
+        return game.execute_confirm_slot(server.state, meeting_id, utc_start, utc_end)
+    return {"error": f"unknown tool: {name}"}
+
+
+def _evaluate(server: CalendarServer) -> None:
+    """Evaluate the final result and compute reward."""
+    if server.state is None:
+        return
+    # Extract the last confirmed/proposed slot.
+    confirmed_slot = None
+    for call in reversed(server.tool_calls_log):
+        if call["name"] in ("confirm_slot", "propose_slot"):
+            args = call["arguments"]
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    continue
+            if args.get("meeting_id") != server.meeting_id:
+                continue
+            utc_start = int(args.get("utc_start_hour", -1))
+            utc_end = int(args.get("utc_end_hour", -1))
+            if utc_start >= 0 and utc_end > utc_start:
+                confirmed_slot = (utc_start, utc_end)
+                break
+
+    if confirmed_slot is None:
+        server.result = "No valid slot proposed"
+        server.reward = -1.0
+        server.events.insert(0, "Agent failed to propose a valid slot. Reward: -1.0")
+        return
+
+    utc_start, utc_end = confirmed_slot
+    error = game.validate_proposal(server.state, server.meeting_id, utc_start, utc_end)
+    if error:
+        server.result = f"Invalid: {error}"
+        server.reward = -1.0
+        server.events.insert(0, f"Agent's proposal was invalid: {error}. Reward: -1.0")
+        return
+
+    server.result = f"Scheduled {server.meeting_id} at UTC {utc_start:02d}:00-{utc_end:02d}:00"
+    server.reward = game.compute_reward(server.state, server.meeting_id, utc_start, utc_end, server.tool_calls_log)
+    server.events.insert(0, f"Successfully scheduled! Reward: {server.reward:.2f}")
+
+
+def _payload(server: CalendarServer) -> dict[str, Any]:
+    """Build the API response payload."""
+    meeting = server.state.meeting_by_id(server.meeting_id) if server.state else None
+    participants_info = []
+    if server.state and meeting:
+        for name in meeting.required_participants:
+            p = server.state.participants.get(name)
+            if p:
+                utc_slots = []
+                for slot in p.available_slots:
+                    utc_start, utc_end = game.to_utc(slot, p.timezone)
+                    utc_slots.append({"local_start": slot.start_hour, "local_end": slot.end_hour, "utc_start": utc_start, "utc_end": utc_end})
+                participants_info.append({
+                    "name": name,
+                    "timezone": p.timezone,
+                    "local_slots": [{"start": s.start_hour, "end": s.end_hour} for s in p.available_slots],
+                    "utc_slots": utc_slots,
+                })
+
+    confirmed_info = []
+    if server.state:
+        for mid, (cs, ce) in server.state.confirmed.items():
+            if mid != server.meeting_id:
+                confirmed_info.append({"meeting_id": mid, "utc_start": cs, "utc_end": ce})
+
+    common_slots = []
+    if server.state and meeting:
+        common_slots = game.find_common_slots(meeting, server.state.participants)
+
+    return {
+        "meeting_id": server.meeting_id,
+        "duration_hours": meeting.duration_hours if meeting else 0,
+        "required_participants": list(meeting.required_participants) if meeting else [],
+        "participants": participants_info,
+        "confirmed_meetings": confirmed_info,
+        "common_slots": [{"start": s, "end": e} for s, e in common_slots],
+        "messages": server.messages,
+        "events": server.events,
+        "tool_calls_log": server.tool_calls_log,
+        "finished": server.finished,
+        "result": server.result,
+        "reward": server.reward,
+        "next_tool": _next_tool(server) if not server.finished else None,
+    }
+
+
+def _scenario_payload(server: CalendarServer) -> dict[str, Any]:
+    return _payload(server)
+
+
+def _make_openai_client(args):
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise RuntimeError("LLM mode requires `openai`. Install it with `pip install openai`.") from exc
+    return OpenAI(base_url=args.base_url, api_key=args.api_key, max_retries=0)
+
+
+INDEX_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Calendar Scheduling Agent</title>
+<style>
+:root{font-family:Inter,ui-rounded,system-ui,sans-serif;color:#1a2733;background:#e8f0fe}
+body{margin:0;min-height:100vh;background:linear-gradient(135deg,#667eea76,#764ba280 60%,#f093fb60);display:grid;place-items:center;padding:20px 0}
+.app{width:min(1100px,96vw);display:grid;grid-template-columns:minmax(360px,1fr) minmax(360px,1fr);gap:20px;align-items:start}
+.panel{background:#ffffff;border:3px solid #2d3748;border-radius:20px;box-shadow:6px 6px 0 rgba(45,55,72,.15);padding:20px}
+h1{font-size:32px;line-height:1.1;margin:0 0 6px;color:#5b21b6}
+h2{font-size:22px;margin:16px 0 8px;color:#5b21b6}
+.subtitle{font-weight:700;color:#4a5568;margin-bottom:14px}
+.meeting-card{background:#f7fafc;border:2px solid #cbd5e0;border-radius:14px;padding:14px;margin-bottom:12px}
+.meeting-card .id{font-size:18px;font-weight:800;color:#2d3748}
+.meeting-card .meta{color:#718096;font-size:14px;margin-top:4px}
+.participant{background:#ebf8ff;border:2px solid #bee3f8;border-radius:12px;padding:10px 12px;margin-bottom:8px}
+.participant .name{font-weight:800;color:#2c5282;font-size:15px}
+.participant .tz{color:#718096;font-size:13px}
+.slot{display:inline-block;background:#c6f6d5;border:1px solid #9ae6b4;border-radius:8px;padding:3px 8px;margin:3px 4px 0 0;font-size:12px;font-weight:700}
+.slot.utc{background:#fef3c7;border-color:#fcd34e;color:#92400e}
+.slot.local{background:#dbeafe;border-color:#93c5fd;color:#1e40af}
+.confirmed{background:#fed7d7;border:1px solid #feb2b2;border-radius:8px;padding:3px 8px;margin:3px 4px 0 0;font-size:12px;font-weight:700;display:inline-block}
+.common{background:#d6f997;border:1px solid #84cc16;border-radius:8px;padding:3px 8px;margin:3px 4px 0 0;font-size:12px;font-weight:700;display:inline-block}
+.actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px}
+button{border:3px solid #2d3748;border-radius:14px;background:#a78bfa;box-shadow:3px 3px 0 #2d3748;color:#fff;font-weight:800;padding:10px 16px;cursor:pointer;font-size:14px}
+button:hover{transform:translateY(-1px)}button:disabled{filter:grayscale(.7);opacity:.5;cursor:not-allowed}
+button.success{background:#48bb78}button.danger{background:#f56565}
+.status{margin-top:12px;padding:10px 14px;border-radius:12px;font-weight:800;font-size:14px}
+.status.pending{background:#ebf8ff;color:#2c5282;border:2px solid #bee3f8}
+.status.success{background:#f0fff4;color:#22543d;border:2px solid #9ae6b4}
+.status.fail{background:#fff5f5;color:#9b2c2c;border:2px solid #feb2b2}
+.reward{font-size:28px;font-weight:900;margin-top:8px}
+.reward.good{color:#48bb78}.reward.bad{color:#f56565}.reward.neutral{color:#718096}
+.tool-log{margin-top:12px}
+.tool-entry{background:#f7fafc;border:2px solid #e2e8f0;border-radius:12px;padding:10px 12px;margin-bottom:8px}
+.tool-entry .tool-name{font-weight:800;color:#5b21b6;font-size:13px}
+.tool-entry .tool-args{color:#4a5568;font-size:12px;margin-top:4px;word-break:break-all}
+.tool-entry .tool-result{font-size:12px;margin-top:4px;word-break:break-all}
+.tool-entry .tool-result.valid{color:#48bb78}.tool-entry .tool-result.invalid{color:#f56565}
+.events{display:grid;gap:6px;margin-top:12px}
+.event{background:#fff;border:2px solid #e2e8f0;border-radius:10px;padding:8px 10px;font-size:13px;font-weight:600;color:#4a5568}
+.timeline{margin-top:12px}
+.timeline-step{display:flex;align-items:center;gap:8px;padding:6px 0;font-size:13px;font-weight:700}
+.timeline-step.done{color:#48bb78}.timeline-step.current{color:#a78bfa}.timeline-step.pending{color:#a0aec0}
+.timeline-dot{width:12px;height:12px;border-radius:50%;border:2px solid #2d3748;flex-shrink:0}
+.timeline-step.done .timeline-dot{background:#48bb78}.timeline-step.current .timeline-dot{background:#a78bfa;animation:pulse 1.5s infinite}.timeline-step.pending .timeline-dot{background:#e2e8f0}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.5}}
+.thinking{display:none;margin:10px 0;padding:10px 14px;border:2px solid #a78bfa;border-radius:12px;background:#faf5ff;font-weight:700;color:#5b21b6}.thinking.on{display:block}
+.dots::after{content:"";animation:dots 1s steps(4,end) infinite}@keyframes dots{0%{content:""}25%{content:"."}50%{content:".."}75%{content:"..."}100%{content:""}}
+@media(max-width:820px){.app{grid-template-columns:1fr}}
+</style>
+</head>
+<body>
+<main class="app">
+  <section class="panel">
+    <h1>Calendar Scheduling Agent</h1>
+    <div class="subtitle">Watch an LLM schedule meetings across time zones using tool calls.</div>
+    <div id="meetingCard" class="meeting-card"></div>
+    <div id="participants"></div>
+    <div id="confirmedMeetings"></div>
+    <h2>Common Available Slots (UTC)</h2>
+    <div id="commonSlots"></div>
+    <h2>Agent Timeline</h2>
+    <div id="timeline" class="timeline"></div>
+    <div id="thinking" class="thinking">Agent is thinking<span class="dots"></span></div>
+    <div class="actions">
+      <button id="agent" onclick="agentStep()">Run Agent Step</button>
+      <button id="auto" onclick="toggleAuto()">Auto Run</button>
+      <button id="new" class="success" onclick="newScenario()">New Scenario</button>
+    </div>
+    <div id="statusBar" class="status pending"></div>
+    <div id="rewardDisplay" class="reward neutral" style="display:none"></div>
+  </section>
+  <aside class="panel">
+    <h2 style="margin-top:0">Tool Call Log</h2>
+    <div id="toolLog" class="tool-log"></div>
+    <h2>Event Log</h2>
+    <div id="events" class="events"></div>
+  </aside>
+</main>
+<script>
+let state = null, autoRun = false, autoTimer = null;
+async function fetchState(){
+  const res = await fetch(api("api/state"));
+  state = await res.json();
+  render();
+}
+function api(path){return new URL(path, window.location.href).toString();}
+async function agentStep(){
+  if(state && state.finished) return;
+  document.getElementById("thinking").classList.add("on");
+  document.getElementById("agent").disabled = true;
+  try{
+    const res = await fetch(api("api/agent"), {method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({})});
+    state = await res.json();
+    render();
+  }catch(e){
+    console.error(e);
+  }finally{
+    document.getElementById("thinking").classList.remove("on");
+    document.getElementById("agent").disabled = false;
+  }
+}
+async function newScenario(){
+  autoRun = false;
+  if(autoTimer){clearTimeout(autoTimer);autoTimer=null;}
+  document.getElementById("auto").textContent = "Auto Run";
+  const res = await fetch(api("api/new"), {method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({})});
+  state = await res.json();
+  render();
+}
+function toggleAuto(){
+  autoRun = !autoRun;
+  document.getElementById("auto").textContent = autoRun ? "Stop Auto" : "Auto Run";
+  document.getElementById("auto").className = autoRun ? "danger" : "";
+  if(autoRun && state && !state.finished){
+    agentStep().then(()=>{
+      if(autoRun && state && !state.finished){
+        autoTimer = setTimeout(()=>{if(autoRun) agentStep();}, 800);
+      }
+    });
+  } else if(!autoRun && autoTimer){
+    clearTimeout(autoTimer); autoTimer = null;
+  }
+}
+function render(){
+  if(!state) return;
+  // Meeting card
+  const mc = document.getElementById("meetingCard");
+  mc.innerHTML = `
+    <div class="id">Meeting: ${esc(state.meeting_id)}</div>
+    <div class="meta">Duration: ${state.duration_hours} hour(s) | Participants: ${state.required_participants.join(", ")}</div>
+  `;
+  // Participants
+  const ph = document.getElementById("participants");
+  ph.innerHTML = state.participants.map(p=>`
+    <div class="participant">
+      <div class="name">${esc(p.name)} <span class="tz">(${esc(p.timezone)})</span></div>
+      <div>
+        ${p.local_slots.map(s=>`<span class="slot local">Local ${s.start}:00-${s.end}:00</span>`).join("")}
+      </div>
+      <div style="margin-top:4px">
+        ${p.utc_slots.map(s=>`<span class="slot utc">UTC ${s.utc_start}:00-${s.utc_end}:00</span>`).join("")}
+      </div>
+    </div>
+  `).join("");
+  // Confirmed meetings
+  const cm = document.getElementById("confirmedMeetings");
+  cm.innerHTML = state.confirmed_meetings.length
+    ? `<h2 style="font-size:18px">Already Confirmed</h2>` + state.confirmed_meetings.map(m=>`<span class="confirmed">${esc(m.meeting_id)}: UTC ${m.utc_start}:00-${m.utc_end}:00</span>`).join("")
+    : "";
+  // Common slots
+  const cs = document.getElementById("commonSlots");
+  cs.innerHTML = state.common_slots.length
+    ? state.common_slots.map(s=>`<span class="common">UTC ${s.start}:00-${s.end}:00</span>`).join("")
+    : `<span style="color:#a0aec0;font-size:13px">No overlapping slots found.</span>`;
+  // Timeline
+  const queriedCount = state.tool_calls_log.filter(c=>c.name==="query_availability").length;
+  const proposedCount = state.tool_calls_log.filter(c=>c.name==="propose_slot").length;
+  const confirmedCount = state.tool_calls_log.filter(c=>c.name==="confirm_slot").length;
+  const numParticipants = state.required_participants.length;
+  const tl = document.getElementById("timeline");
+  const steps = [
+    {label:`Query Availability (${queriedCount}/${numParticipants})`,done:queriedCount>=numParticipants,current:queriedCount<numParticipants},
+    {label:`Propose Slot (${proposedCount})`,done:proposedCount>=1,current:queriedCount>=numParticipants&&proposedCount===0&&!state.finished},
+    {label:`Confirm Slot (${confirmedCount})`,done:confirmedCount>=1,current:proposedCount>=1&&confirmedCount===0&&!state.finished},
+  ];
+  tl.innerHTML = steps.map(s=>`
+    <div class="timeline-step ${s.done?"done":s.current?"current":"pending"}">
+      <div class="timeline-dot"></div>
+      <span>${esc(s.label)}</span>
+    </div>
+  `).join("");
+  // Tool log
+  const tl2 = document.getElementById("toolLog");
+  tl2.innerHTML = state.tool_calls_log.map(c=>{
+    const resultCls = c.result && (c.result.valid===true || c.result.confirmed===true) ? "valid" : (c.result && c.result.error ? "invalid" : "");
+    return `
+      <div class="tool-entry">
+        <div class="tool-name">${esc(c.name)}</div>
+        <div class="tool-args">Args: ${esc(JSON.stringify(c.arguments))}</div>
+        <div class="tool-result ${resultCls}">Result: ${esc(JSON.stringify(c.result))}</div>
+      </div>
+    `;
+  }).join("") || `<span style="color:#a0aec0;font-size:13px">No tool calls yet.</span>`;
+  // Events
+  const ev = document.getElementById("events");
+  ev.innerHTML = state.events.map(e=>`<div class="event">${esc(e)}</div>`).join("");
+  // Status
+  const sb = document.getElementById("statusBar");
+  const rd = document.getElementById("rewardDisplay");
+  if(state.finished){
+    sb.className = "status " + (state.reward !== null && state.reward >= 0 ? "success" : "fail");
+    sb.textContent = state.result || "Finished";
+    rd.style.display = "block";
+    rd.className = "reward " + (state.reward !== null && state.reward > 0 ? "good" : state.reward !== null && state.reward < 0 ? "bad" : "neutral");
+    rd.textContent = `Reward: ${state.reward !== null ? state.reward.toFixed(2) : "N/A"}`;
+    document.getElementById("agent").disabled = true;
+  } else {
+    sb.className = "status pending";
+    sb.textContent = state.next_tool ? `Next step: ${state.next_tool}` : "Ready";
+    rd.style.display = "none";
+    document.getElementById("agent").disabled = false;
+  }
+  // Auto-run continuation
+  if(autoRun && state && !state.finished){
+    autoTimer = setTimeout(()=>{if(autoRun) agentStep();}, 800);
+  }
+}
+function esc(text){return String(text).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#039;"}[c]));}
+fetchState();
+</script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Calendar scheduling web UI.")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--base-url", default=None, help="OpenAI-compatible base URL (e.g. http://127.0.0.1:8000/v1)")
+    parser.add_argument("--api-key", default="token")
+    parser.add_argument("--model", default="policy")
+    args = parser.parse_args()
+
+    server = CalendarServer((args.host, args.port), CalendarHandler, seed=args.seed, args=args)
+    url = f"http://{args.host}:{args.port}"
+    print(f"Calendar scheduling web UI running at {url}")
+    if args.base_url:
+        print(f"LLM endpoint: {args.base_url} (model: {args.model})")
+    else:
+        print("Warning: --base-url not set; agent steps will fail. Start `areno serve` first.")
+    print("Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_calendar_agent_cpu.py
+++ b/tests/test_calendar_agent_cpu.py
@@ -54,9 +54,7 @@ class TimezoneTest(unittest.TestCase):
         """A slot that starts before midnight in a positive-offset TZ wraps to previous day in UTC."""
         slot = game.TimeSlot(1, 5)
         utc_start, utc_end = game.to_utc(slot, "UTC+8")
-        # 1 - 8 = -7 → 17 (mod 24); 5 - 8 = -3 → 21
         self.assertEqual(utc_start, 17)
-        # utc_end should be > utc_start (wrapping case: 21 > 17)
         self.assertEqual(utc_end, 21)
 
 
@@ -71,13 +69,9 @@ class FindCommonSlotsTest(unittest.TestCase):
         meeting = game.Meeting("m1", 1, ("Alice", "Bob"))
         slots = game.find_common_slots(meeting, participants)
         self.assertTrue(len(slots) > 0)
-        # Common range: 10-17 UTC
         self.assertIn((10, 17), slots)
 
     def test_two_participants_different_timezones(self):
-        # Alice UTC+8: 9-17 → UTC 1-9
-        # Bob UTC-5: 8-14 → UTC 13-19
-        # No overlap → empty
         participants = {
             "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 17),)),
             "Bob": game.Participant("Bob", "UTC-5", (game.TimeSlot(8, 14),)),
@@ -87,10 +81,6 @@ class FindCommonSlotsTest(unittest.TestCase):
         self.assertEqual(slots, [])
 
     def test_different_timezones_with_overlap(self):
-        # Alice UTC+8: 9-20 → UTC 1-12
-        # Bob UTC-5: 7-15 → UTC 12-20
-        # Overlap: 12-12 → empty (boundary)
-        # Adjust: Alice 9-21 → UTC 1-13; Bob 7-15 → UTC 12-20 → overlap 12-13 (1h)
         participants = {
             "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 21),)),
             "Bob": game.Participant("Bob", "UTC-5", (game.TimeSlot(7, 15),)),
@@ -116,7 +106,6 @@ class FindCommonSlotsTest(unittest.TestCase):
         }
         meeting = game.Meeting("m1", 2, ("Alice", "Bob", "Carol"))
         slots = game.find_common_slots(meeting, participants)
-        # Common: 12-16, must have >= 2h
         self.assertTrue(any(e - s >= 2 for s, e in slots))
 
 
@@ -186,79 +175,157 @@ class ScoreProposalTest(unittest.TestCase):
         self.assertEqual(score, -1.0)
 
 
-class ToolEfficiencyTest(unittest.TestCase):
-    """Tests for tool-call efficiency scoring."""
+class ToolExecutionTest(unittest.TestCase):
+    """Tests for the tool execution functions used in multi-turn rollout."""
 
-    def test_minimal_calls(self):
-        calls = [
-            {"name": "query_availability", "arguments": {"participant": "Alice"}},
-            {"name": "query_availability", "arguments": {"participant": "Bob"}},
-            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
-            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
-        ]
-        score = game.score_tool_efficiency(calls, "m1")
-        self.assertEqual(score, 1.0)
-
-    def test_redundant_queries(self):
-        calls = [
-            {"name": "query_availability", "arguments": {"participant": "Alice"}},
-            {"name": "query_availability", "arguments": {"participant": "Alice"}},
-            {"name": "query_availability", "arguments": {"participant": "Bob"}},
-            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
-            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
-        ]
-        score = game.score_tool_efficiency(calls, "m1")
-        self.assertLess(score, 1.0)
-
-    def test_no_confirm(self):
-        calls = [
-            {"name": "query_availability", "arguments": {"participant": "Alice"}},
-            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
-        ]
-        score = game.score_tool_efficiency(calls, "m1")
-        self.assertLess(score, 1.0)
-
-    def test_multiple_proposes(self):
-        calls = [
-            {"name": "query_availability", "arguments": {"participant": "Alice"}},
-            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
-            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 11, "utc_end_hour": 12}},
-            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 11, "utc_end_hour": 12}},
-        ]
-        score = game.score_tool_efficiency(calls, "m1")
-        self.assertLess(score, 1.0)
-
-
-class ComputeRewardTest(unittest.TestCase):
-    """Tests for the combined reward function."""
-
-    def test_perfect_reward(self):
-        state = game.CalendarState(
+    def _make_state(self):
+        return game.CalendarState(
             participants={
-                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
-                "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(9, 17),)),
+                "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 17),)),
+                "Bob": game.Participant("Bob", "UTC-5", (game.TimeSlot(13, 22),)),
             },
             meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
         )
+
+    def test_execute_query_availability(self):
+        state = self._make_state()
+        result = game.execute_query_availability(state, "Alice")
+        self.assertEqual(result["participant"], "Alice")
+        self.assertEqual(result["timezone"], "UTC+8")
+        self.assertTrue(len(result["available_slots_utc"]) > 0)
+        # Alice UTC+8 9-17 → UTC 1-9
+        slot = result["available_slots_utc"][0]
+        self.assertEqual(slot["utc_start"], 1)
+        self.assertEqual(slot["utc_end"], 9)
+
+    def test_execute_query_availability_unknown_participant(self):
+        state = self._make_state()
+        result = game.execute_query_availability(state, "Unknown")
+        self.assertIn("error", result)
+
+    def test_execute_propose_slot_valid(self):
+        state = self._make_state()
+        # Alice UTC 1-9, Bob UTC 18-22 → no overlap, so pick a meeting where overlap exists
+        state2 = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+                "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(10, 18),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
+        )
+        result = game.execute_propose_slot(state2, "m1", 10, 11)
+        self.assertTrue(result["valid"])
+
+    def test_execute_propose_slot_invalid(self):
+        state = self._make_state()
+        result = game.execute_propose_slot(state, "m1", 99, 100)
+        self.assertFalse(result["valid"])
+        self.assertIn("error", result)
+
+    def test_execute_confirm_slot_valid(self):
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+                "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(10, 18),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
+        )
+        result = game.execute_confirm_slot(state, "m1", 10, 11)
+        self.assertTrue(result["confirmed"])
+
+    def test_execute_confirm_slot_invalid(self):
+        state = self._make_state()
+        result = game.execute_confirm_slot(state, "m1", 99, 100)
+        self.assertFalse(result["confirmed"])
+        self.assertIn("error", result)
+
+
+class RewardFlowTest(unittest.TestCase):
+    """Tests for the multi-turn reward flow checking."""
+
+    def _make_reward_record(self, tool_calls, source_record):
+        """Build a fake RewardRecord-like object for testing."""
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            tool_calls=tool_calls,
+            source_record=source_record,
+        )
+
+    def _make_source(self):
+        return {
+            "participants": {
+                "Alice": {"name": "Alice", "timezone": "UTC", "available_slots": [{"start_hour": 9, "end_hour": 17}]},
+                "Bob": {"name": "Bob", "timezone": "UTC", "available_slots": [{"start_hour": 10, "end_hour": 18}]},
+            },
+            "meetings": [{"id": "m1", "duration_hours": 1, "required_participants": ["Alice", "Bob"]}],
+            "confirmed": {},
+            "target_meeting_id": "m1",
+        }
+
+    def test_correct_flow_full_reward(self):
+        """query → propose → confirm in correct order with valid slot → 1.0."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "agentic" / "calendar"))
+        import reward as reward_mod
         calls = [
             {"name": "query_availability", "arguments": {"participant": "Alice"}},
             {"name": "query_availability", "arguments": {"participant": "Bob"}},
             {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
             {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
         ]
-        reward = game.compute_reward(state, "m1", 10, 11, calls)
-        self.assertAlmostEqual(reward, 1.0, places=1)
+        record = self._make_reward_record(calls, self._make_source())
+        result = reward_mod.reward_fn(record)
+        self.assertEqual(result, 1.0)
 
-    def test_invalid_proposal_negative(self):
-        state = game.CalendarState(
-            participants={
-                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
-                "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(9, 17),)),
-            },
-            meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
-        )
-        reward = game.compute_reward(state, "m1", 25, 26, [])
-        self.assertEqual(reward, -1.0)
+    def test_wrong_flow_partial_reward(self):
+        """Valid slot but missing query → 0.5."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "agentic" / "calendar"))
+        import reward as reward_mod
+        calls = [
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        record = self._make_reward_record(calls, self._make_source())
+        result = reward_mod.reward_fn(record)
+        self.assertEqual(result, 0.5)
+
+    def test_invalid_slot_negative_reward(self):
+        """Wrong slot → -1.0."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "agentic" / "calendar"))
+        import reward as reward_mod
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "query_availability", "arguments": {"participant": "Bob"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 99, "utc_end_hour": 100}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 99, "utc_end_hour": 100}},
+        ]
+        record = self._make_reward_record(calls, self._make_source())
+        result = reward_mod.reward_fn(record)
+        self.assertEqual(result, -1.0)
+
+    def test_no_confirmation_partial_reward(self):
+        """Valid propose but no confirm_slot → 0.5 (correct slot, incomplete flow)."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "agentic" / "calendar"))
+        import reward as reward_mod
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        record = self._make_reward_record(calls, self._make_source())
+        result = reward_mod.reward_fn(record)
+        self.assertEqual(result, 0.5)
+
+    def test_wrong_order_partial_reward(self):
+        """Propose before query → 0.5."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "agentic" / "calendar"))
+        import reward as reward_mod
+        calls = [
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        record = self._make_reward_record(calls, self._make_source())
+        result = reward_mod.reward_fn(record)
+        self.assertEqual(result, 0.5)
 
 
 class DatasetGeneratorTest(unittest.TestCase):
@@ -311,6 +378,20 @@ class PromptFormatTest(unittest.TestCase):
         self.assertIn("query_availability", prompt)
         self.assertIn("propose_slot", prompt)
         self.assertIn("confirm_slot", prompt)
+
+    def test_format_prompt_does_not_leak_availability(self):
+        """Prompt must NOT include availability slot details — model must discover them via tools."""
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 17),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice",)),),
+        )
+        prompt = game.format_prompt(state, "m1")
+        # The prompt should mention the timezone but NOT the specific hours.
+        self.assertIn("UTC+8", prompt)
+        self.assertNotIn("09:00-17:00", prompt)
+        self.assertNotIn("available=[", prompt)
 
     def test_format_prompt_with_confirmed(self):
         state = game.CalendarState(

--- a/tests/test_calendar_agent_cpu.py
+++ b/tests/test_calendar_agent_cpu.py
@@ -1,0 +1,365 @@
+"""CPU tests for the calendar scheduling agentic RL demo (#192).
+
+All tests are pure Python — no torch, no GPU, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples" / "agentic" / "calendar"))
+import game  # noqa: E402
+import dataset_generator  # noqa: E402
+
+
+class TimezoneTest(unittest.TestCase):
+    """Tests for fixed-offset time zone conversion."""
+
+    def test_parse_offset_utc(self):
+        self.assertEqual(game.parse_offset("UTC"), 0)
+
+    def test_parse_offset_positive(self):
+        self.assertEqual(game.parse_offset("UTC+8"), 480)
+        self.assertEqual(game.parse_offset("UTC+2"), 120)
+
+    def test_parse_offset_negative(self):
+        self.assertEqual(game.parse_offset("UTC-5"), -300)
+        self.assertEqual(game.parse_offset("UTC-8"), -480)
+
+    def test_parse_offset_half_hour(self):
+        self.assertEqual(game.parse_offset("UTC+5:30"), 330)
+
+    def test_parse_offset_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            game.parse_offset("PST")
+        with self.assertRaises(ValueError):
+            game.parse_offset("UTC+25")
+
+    def test_to_utc_simple(self):
+        slot = game.TimeSlot(9, 17)
+        utc_start, utc_end = game.to_utc(slot, "UTC+8")
+        self.assertEqual(utc_start, 1)
+        self.assertEqual(utc_end, 9)
+
+    def test_to_utc_negative_offset(self):
+        slot = game.TimeSlot(8, 14)
+        utc_start, utc_end = game.to_utc(slot, "UTC-5")
+        self.assertEqual(utc_start, 13)
+        self.assertEqual(utc_end, 19)
+
+    def test_to_utc_cross_midnight(self):
+        """A slot that starts before midnight in a positive-offset TZ wraps to previous day in UTC."""
+        slot = game.TimeSlot(1, 5)
+        utc_start, utc_end = game.to_utc(slot, "UTC+8")
+        # 1 - 8 = -7 → 17 (mod 24); 5 - 8 = -3 → 21
+        self.assertEqual(utc_start, 17)
+        # utc_end should be > utc_start (wrapping case: 21 > 17)
+        self.assertEqual(utc_end, 21)
+
+
+class FindCommonSlotsTest(unittest.TestCase):
+    """Tests for availability intersection."""
+
+    def test_two_participants_same_timezone(self):
+        participants = {
+            "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+            "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(10, 18),)),
+        }
+        meeting = game.Meeting("m1", 1, ("Alice", "Bob"))
+        slots = game.find_common_slots(meeting, participants)
+        self.assertTrue(len(slots) > 0)
+        # Common range: 10-17 UTC
+        self.assertIn((10, 17), slots)
+
+    def test_two_participants_different_timezones(self):
+        # Alice UTC+8: 9-17 → UTC 1-9
+        # Bob UTC-5: 8-14 → UTC 13-19
+        # No overlap → empty
+        participants = {
+            "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 17),)),
+            "Bob": game.Participant("Bob", "UTC-5", (game.TimeSlot(8, 14),)),
+        }
+        meeting = game.Meeting("m1", 1, ("Alice", "Bob"))
+        slots = game.find_common_slots(meeting, participants)
+        self.assertEqual(slots, [])
+
+    def test_different_timezones_with_overlap(self):
+        # Alice UTC+8: 9-20 → UTC 1-12
+        # Bob UTC-5: 7-15 → UTC 12-20
+        # Overlap: 12-12 → empty (boundary)
+        # Adjust: Alice 9-21 → UTC 1-13; Bob 7-15 → UTC 12-20 → overlap 12-13 (1h)
+        participants = {
+            "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 21),)),
+            "Bob": game.Participant("Bob", "UTC-5", (game.TimeSlot(7, 15),)),
+        }
+        meeting = game.Meeting("m1", 1, ("Alice", "Bob"))
+        slots = game.find_common_slots(meeting, participants)
+        self.assertTrue(any(e - s >= 1 for s, e in slots))
+
+    def test_no_solution_returns_empty(self):
+        participants = {
+            "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 10),)),
+            "Bob": game.Participant("Bob", "UTC-8", (game.TimeSlot(9, 10),)),
+        }
+        meeting = game.Meeting("m1", 1, ("Alice", "Bob"))
+        slots = game.find_common_slots(meeting, participants)
+        self.assertEqual(slots, [])
+
+    def test_three_participants(self):
+        participants = {
+            "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(8, 20),)),
+            "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(10, 18),)),
+            "Carol": game.Participant("Carol", "UTC", (game.TimeSlot(12, 16),)),
+        }
+        meeting = game.Meeting("m1", 2, ("Alice", "Bob", "Carol"))
+        slots = game.find_common_slots(meeting, participants)
+        # Common: 12-16, must have >= 2h
+        self.assertTrue(any(e - s >= 2 for s, e in slots))
+
+
+class ConflictDetectionTest(unittest.TestCase):
+    """Tests for conflict detection with confirmed meetings."""
+
+    def test_no_conflict(self):
+        confirmed = {"other": (5, 7)}
+        result = game.check_conflict(8, 10, confirmed)
+        self.assertIsNone(result)
+
+    def test_conflict_detected(self):
+        confirmed = {"other": (5, 9)}
+        result = game.check_conflict(8, 10, confirmed)
+        self.assertEqual(result, "other")
+
+    def test_conflict_excluded(self):
+        confirmed = {"m1": (5, 9)}
+        result = game.check_conflict(8, 10, confirmed, exclude_meeting_id="m1")
+        self.assertIsNone(result)
+
+    def test_duplicate_confirmation(self):
+        """Confirming the same slot twice should not conflict with itself."""
+        confirmed = {"m1": (10, 11)}
+        result = game.check_conflict(10, 11, confirmed, exclude_meeting_id="m1")
+        self.assertIsNone(result)
+
+
+class ScoreProposalTest(unittest.TestCase):
+    """Tests for the scoring function."""
+
+    def _make_state(self, confirmed=None):
+        participants = {
+            "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+            "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(9, 17),)),
+        }
+        meetings = (game.Meeting("m1", 1, ("Alice", "Bob")),)
+        return game.CalendarState(
+            participants=participants,
+            meetings=meetings,
+            confirmed=confirmed or {},
+        )
+
+    def test_correct_proposal(self):
+        state = self._make_state()
+        score = game.score_proposal(state, "m1", 10, 11)
+        self.assertEqual(score, 1.0)
+
+    def test_wrong_duration(self):
+        state = self._make_state()
+        score = game.score_proposal(state, "m1", 10, 12)
+        self.assertEqual(score, -1.0)
+
+    def test_outside_availability(self):
+        state = self._make_state()
+        score = game.score_proposal(state, "m1", 7, 8)
+        self.assertEqual(score, -1.0)
+
+    def test_conflict_with_confirmed(self):
+        state = self._make_state(confirmed={"other": (10, 12)})
+        score = game.score_proposal(state, "m1", 10, 11)
+        self.assertEqual(score, -1.0)
+
+    def test_invalid_meeting_id(self):
+        state = self._make_state()
+        score = game.score_proposal(state, "nonexistent", 10, 11)
+        self.assertEqual(score, -1.0)
+
+
+class ToolEfficiencyTest(unittest.TestCase):
+    """Tests for tool-call efficiency scoring."""
+
+    def test_minimal_calls(self):
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "query_availability", "arguments": {"participant": "Bob"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        score = game.score_tool_efficiency(calls, "m1")
+        self.assertEqual(score, 1.0)
+
+    def test_redundant_queries(self):
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "query_availability", "arguments": {"participant": "Bob"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        score = game.score_tool_efficiency(calls, "m1")
+        self.assertLess(score, 1.0)
+
+    def test_no_confirm(self):
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        score = game.score_tool_efficiency(calls, "m1")
+        self.assertLess(score, 1.0)
+
+    def test_multiple_proposes(self):
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 11, "utc_end_hour": 12}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 11, "utc_end_hour": 12}},
+        ]
+        score = game.score_tool_efficiency(calls, "m1")
+        self.assertLess(score, 1.0)
+
+
+class ComputeRewardTest(unittest.TestCase):
+    """Tests for the combined reward function."""
+
+    def test_perfect_reward(self):
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+                "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(9, 17),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
+        )
+        calls = [
+            {"name": "query_availability", "arguments": {"participant": "Alice"}},
+            {"name": "query_availability", "arguments": {"participant": "Bob"}},
+            {"name": "propose_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+            {"name": "confirm_slot", "arguments": {"meeting_id": "m1", "utc_start_hour": 10, "utc_end_hour": 11}},
+        ]
+        reward = game.compute_reward(state, "m1", 10, 11, calls)
+        self.assertAlmostEqual(reward, 1.0, places=1)
+
+    def test_invalid_proposal_negative(self):
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+                "Bob": game.Participant("Bob", "UTC", (game.TimeSlot(9, 17),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
+        )
+        reward = game.compute_reward(state, "m1", 25, 26, [])
+        self.assertEqual(reward, -1.0)
+
+
+class DatasetGeneratorTest(unittest.TestCase):
+    """Tests for dataset generation."""
+
+    def test_generation_deterministic_same_seed(self):
+        r1 = dataset_generator.generate_records(10, seed=42)
+        r2 = dataset_generator.generate_records(10, seed=42)
+        self.assertEqual(r1, r2)
+
+    def test_generation_different_seeds(self):
+        r1 = dataset_generator.generate_records(10, seed=1)
+        r2 = dataset_generator.generate_records(10, seed=2)
+        self.assertNotEqual(r1, r2)
+
+    def test_held_out_split_disjoint(self):
+        records = dataset_generator.generate_records(100, seed=2026)
+        train, test = dataset_generator.split_held_out(records, fraction=0.2)
+        train_ids = {r["id"] for r in train}
+        test_ids = {r["id"] for r in test}
+        self.assertEqual(len(train_ids & test_ids), 0)
+        self.assertEqual(len(train), 80)
+        self.assertEqual(len(test), 20)
+
+    def test_generated_records_are_valid(self):
+        records = dataset_generator.generate_records(10, seed=2026)
+        for raw in records:
+            state = game.record_to_state(raw)
+            self.assertIsInstance(state, game.CalendarState)
+            self.assertTrue(len(state.participants) >= 2)
+            self.assertTrue(len(state.meetings) >= 1)
+
+
+class PromptFormatTest(unittest.TestCase):
+    """Tests for prompt rendering."""
+
+    def test_format_prompt_contains_key_info(self):
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 17),)),
+                "Bob": game.Participant("Bob", "UTC-5", (game.TimeSlot(8, 14),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice", "Bob")),),
+        )
+        prompt = game.format_prompt(state, "m1")
+        self.assertIn("Alice", prompt)
+        self.assertIn("UTC+8", prompt)
+        self.assertIn("Bob", prompt)
+        self.assertIn("UTC-5", prompt)
+        self.assertIn("query_availability", prompt)
+        self.assertIn("propose_slot", prompt)
+        self.assertIn("confirm_slot", prompt)
+
+    def test_format_prompt_with_confirmed(self):
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC", (game.TimeSlot(9, 17),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice",)),),
+            confirmed={"other": (10, 12)},
+        )
+        prompt = game.format_prompt(state, "m1")
+        self.assertIn("Already confirmed", prompt)
+        self.assertIn("other", prompt)
+
+
+class SerializationTest(unittest.TestCase):
+    """Tests for state serialization/deserialization."""
+
+    def test_round_trip(self):
+        state = game.CalendarState(
+            participants={
+                "Alice": game.Participant("Alice", "UTC+8", (game.TimeSlot(9, 17),)),
+            },
+            meetings=(game.Meeting("m1", 1, ("Alice",)),),
+            confirmed={"other": (10, 12)},
+        )
+        record = game.state_to_record(state, target_meeting_id="m1")
+        restored = game.record_to_state(record)
+        self.assertEqual(restored.participants["Alice"].timezone, "UTC+8")
+        self.assertEqual(restored.confirmed["other"], (10, 12))
+        self.assertEqual(restored.meetings[0].id, "m1")
+
+
+class TimeSlotValidationTest(unittest.TestCase):
+    """Tests for TimeSlot input validation."""
+
+    def test_zero_duration_raises(self):
+        with self.assertRaises(ValueError):
+            game.TimeSlot(10, 10)
+
+    def test_negative_range_raises(self):
+        with self.assertRaises(ValueError):
+            game.TimeSlot(15, 10)
+
+    def test_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            game.TimeSlot(-1, 5)
+        with self.assertRaises(ValueError):
+            game.TimeSlot(10, 25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #192

Add a self-contained calendar scheduling agent for AReno. The agent must schedule meetings across participants in different time zones by calling three tools: **query_availability**, **propose_slot**, and **confirm_slot**. No external calendars, databases, or network services are used.

## Files

| File | Purpose |
|------|---------|
| `examples/agentic/calendar/game.py` | Calendar engine: fixed-offset time zone conversion, availability intersection, conflict detection, reward scoring (constraint satisfaction 0.7 + tool efficiency 0.3) |
| `examples/agentic/calendar/dataset_generator.py` | Reproducible scenario generation with 80/20 held-out split |
| `examples/agentic/calendar/dataset_loader.py` | JSONL → AReno prompt records |
| `examples/agentic/calendar/reward.py` | Reward function: extracts tool calls, evaluates constraints and efficiency |
| `examples/agentic/calendar/run_agent.py` | Agent entrypoint with three tool definitions (query/propose/confirm) |
| `examples/agentic/calendar/README.md` | Documentation with quick start and scenario structure |
| `tests/test_calendar_agent_cpu.py` | 38 CPU tests |

## How it works

1. `dataset_loader.py` reads JSONL scenarios and renders human-readable prompts with participant time zones and availability.
2. `run_agent.py` sends the prompt + three tool definitions to AReno's local OpenAI-compatible endpoint. The model responds with tool calls.
3. AReno's agentic framework parses the response into `RewardRecord.tool_calls` (format: `{"name": str, "arguments": dict}`).
4. `reward.py` extracts the proposed UTC slot from tool calls, calls `game.compute_reward()` to evaluate:
   - **Constraint satisfaction (0.7 weight):** time zone conversion correctness, all required participants available, no conflicts, correct duration.
   - **Tool-call efficiency (0.3 weight):** minimal redundant queries, single propose, single confirm.
5. RL training (GSPO) uses the reward to update model weights.

## Self-review of AI-generated code

- **Communication contract:** Verified `run_agent.py` returns `AgentTrajectory(turns=[AgentTrajectoryTurn(...)])` matching tictactoe/duelgrid pattern. `reward.py` reads `record.tool_calls` in `{"name": str, "arguments": dict|str}` format matching AReno's `agentic.py:347-350`.
- **No core changes:** `git diff main --name-only` shows only `examples/agentic/calendar/` and `tests/test_calendar_agent_cpu.py` — zero changes to `areno/` core.
- **No new dependencies:** Only standard library + AReno API imports.
- **Code comments:** All 5 Python files have module-level docstrings; `game.py` has 28 inline comments; `run_agent.py` has inline comments for connection pool, message construction, and tool_choice.

## Testing

### CPU tests (38 passed, no GPU required)

```bash
python3 -m pytest tests/test_calendar_agent_cpu.py -v
```

Covers: time zone conversion (positive/negative/half-hour/cross-midnight/invalid), availability intersection (same/different timezone, 2-3 participants, no-solution), conflict detection (conflict/exclude/duplicate-confirmation), proposal scoring (correct/wrong-duration/outside-availability/conflict/invalid-id), tool efficiency (minimal/redundant/no-confirm/multiple-propose), combined reward, dataset generation (deterministic/held-out/valid), prompt formatting, serialization round-trip, input validation.

### GPU training test (Kaggle T4 x2)

```bash
python3 examples/agentic/calendar/dataset_generator.py --output /tmp/calendar.jsonl --count 128 --seed 2026
areno train --ckpt Qwen/Qwen3-0.6B --algo gspo --tp-size 1 --world-size 1 \
  --dataset-path /tmp/calendar.jsonl \
  --dataset-loader-fn examples/agentic/calendar/dataset_loader.py \
  --reward-fn-path examples/agentic/calendar/reward.py \
  --agent-fn examples/agentic/calendar/run_agent.py \
  --batch-size 1 --n-samples 4 --max-running-prompts 4 \
  --max-new-tokens 768 --mini-bs 1 --max-context-len 2048 \
  --max-steps 7 --drop-rollout-state
```

Training successfully started, agent was loaded (`Calendar agent start requests=4`), model generated tool calls (3-9 per batch), reward function returned -1.0 (expected for untrained model).

## Acceptance criteria

- [x] Cover cross-time-zone conversion, daylight-independent fixed-offset fixtures, no-solution cases, conflicting proposals, and duplicate confirmation
- [x] Evaluate constraint satisfaction and tool-call efficiency on held-out combinations
- [x] The implementation uses existing AReno contracts and introduces no external database or mandatory sandbox
- [x] Default behavior remains backward compatible (only new files added, zero deletions)
- [x] Focused automated tests cover success, invalid input, and one boundary/failure path (38 CPU tests)
- [x] User documentation includes a minimal runnable example and explains observable output