### PR TITLE
feat(dx): add composable local skill-workflow executor (#277)

### DIFF
--- a/.agents/scripts/run_workflow.py
+++ b/.agents/scripts/run_workflow.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env python3
+"""Composable local skill-workflow executor.
+
+Executes a YAML-defined workflow of AReno skill scripts with typed inputs,
+step dependencies, structured output passing, and restart-from-failed-step.
+
+Uses only the Python standard library. The YAML subset supported covers
+mappings, sequences, strings, integers, floats, booleans, and null -- enough
+for workflow definitions without pulling in a YAML dependency.
+
+Script contract: each step's script must be a Python script that accepts
+argparse-style flags and prints a single JSON object to stdout. The executor
+parses that JSON and makes its keys addressable as ``${steps.<id>.<key>}``
+in subsequent steps' ``inputs``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Minimal YAML parser (standard library only)
+# ---------------------------------------------------------------------------
+#
+# Supports the subset needed for workflow files:
+#   - top-level mapping
+#   - nested mappings and sequences
+#   - inline lists ``[a, b]`` and inline scalars
+#   - string / int / float / bool / null values
+#   - ``#`` comments
+#   - simple quoted strings (single or double)
+#
+# This is NOT a full YAML 1.2 parser; it deliberately rejects constructs it
+# does not understand so that invalid workflows fail loudly.
+
+
+class YamlParseError(ValueError):
+    """Raised when the YAML subset parser encounters unsupported syntax."""
+
+
+_BOOL_TRUE = {"true", "yes", "on"}
+_BOOL_FALSE = {"false", "no", "off"}
+_NULL = {"null", "~", ""}
+_INTERP = re.compile(r"\$\{steps\.([a-zA-Z0-9_]+)\.([a-zA-Z0-9_.]+)\}")
+
+
+def _strip_inline_comment(text: str) -> str:
+    """Remove a trailing ``#`` comment that is not inside quotes."""
+    in_single = in_double = False
+    for i, ch in enumerate(text):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            return text[:i]
+    return text
+
+
+def _parse_scalar(raw: str) -> Any:
+    """Convert a raw YAML scalar string to its Python value."""
+    val = raw.strip()
+    if not val:
+        return None
+    # Quoted strings
+    if (val[0] == val[-1]) and val[0] in ('"', "'"):
+        return val[1:-1]
+    # Inline list
+    if val.startswith("[") and val.endswith("]"):
+        inner = val[1:-1].strip()
+        if not inner:
+            return []
+        return [_parse_scalar(part.strip()) for part in inner.split(",")]
+    # Inline mapping (not supported -- keep simple)
+    if val.startswith("{"):
+        raise YamlParseError(f"inline mappings are not supported: {raw!r}")
+    # Interpolation placeholders are kept as strings (resolved later)
+    if "${" in val:
+        return val
+    low = val.lower()
+    if low in _BOOL_TRUE:
+        return True
+    if low in _BOOL_FALSE:
+        return False
+    if low in _NULL:
+        return None
+    # Int
+    try:
+        return int(val)
+    except ValueError:
+        pass
+    # Float
+    try:
+        return float(val)
+    except ValueError:
+        pass
+    return val
+
+
+def _indent_level(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def parse_yaml(text: str) -> dict[str, Any]:
+    """Parse a YAML subset into a Python dict.
+
+    Raises :class:`YamlParseError` on unsupported syntax.
+    """
+    # Pre-process: strip comments, drop blank lines, normalise tabs to spaces.
+    raw_lines: list[tuple[int, str]] = []
+    for line in text.splitlines():
+        stripped = _strip_inline_comment(line).rstrip()
+        if not stripped.strip():
+            continue
+        if "\t" in stripped:
+            raise YamlParseError("tabs are not allowed for indentation")
+        raw_lines.append((_indent_level(stripped), stripped.lstrip(" ")))
+
+    if not raw_lines:
+        return {}
+
+    result, consumed = _parse_block(raw_lines, 0, min_indent=0)
+    # Any leftover lines mean inconsistent indentation / unsupported nesting.
+    if consumed < len(raw_lines):
+        raise YamlParseError(
+            f"unexpected trailing content at line index {consumed}: {raw_lines[consumed]!r}"
+        )
+    if not isinstance(result, dict):
+        raise YamlParseError("top-level YAML must be a mapping")
+    return result
+
+
+def _parse_block(
+    lines: list[tuple[int, str]], start: int, min_indent: int
+) -> tuple[Any, int]:
+    """Parse a block (mapping or sequence) starting at *start*.
+
+    Returns ``(value, next_index)`` where *next_index* is the index of the
+    first line that does not belong to this block.
+    """
+    if start >= len(lines):
+        return None, start
+
+    indent, content = lines[start]
+    if indent < min_indent:
+        return None, start
+
+    # Sequence?
+    if content.startswith("- "):
+        return _parse_sequence(lines, start, indent)
+    if content == "-":
+        # Empty list item -- not supported for our schema.
+        raise YamlParseError("empty sequence items are not supported")
+
+    # Otherwise treat as mapping.
+    return _parse_mapping(lines, start, indent)
+
+
+def _parse_mapping(
+    lines: list[tuple[int, str]], start: int, indent: int
+) -> tuple[dict[str, Any], int]:
+    result: dict[str, Any] = {}
+    i = start
+    while i < len(lines):
+        cur_indent, cur_content = lines[i]
+        if cur_indent < indent:
+            break
+        if cur_indent > indent:
+            raise YamlParseError(
+                f"unexpected over-indentation at line {i}: {cur_content!r}"
+            )
+        if cur_content.startswith("- "):
+            raise YamlParseError("unexpected sequence item in mapping context")
+        # Split "key: value"
+        key, sep, value = cur_content.partition(":")
+        if not sep:
+            raise YamlParseError(f"missing ':' in mapping line: {cur_content!r}")
+        key = key.strip()
+        if not key:
+            raise YamlParseError(f"empty key in mapping line: {cur_content!r}")
+        value = value.strip()
+        if value:
+            result[key] = _parse_scalar(value)
+            i += 1
+        else:
+            # Value is on subsequent indented lines.
+            i += 1
+            if i >= len(lines) or lines[i][0] <= indent:
+                # Empty value -> null
+                result[key] = None
+                continue
+            child_indent = lines[i][0]
+            if child_indent <= indent:
+                result[key] = None
+                continue
+            child_value, i = _parse_block(lines, i, child_indent)
+            result[key] = child_value
+    return result, i
+
+
+def _parse_sequence(
+    lines: list[tuple[int, str]], start: int, indent: int
+) -> tuple[list[Any], int]:
+    result: list[Any] = []
+    i = start
+    while i < len(lines):
+        cur_indent, cur_content = lines[i]
+        if cur_indent < indent:
+            break
+        if cur_indent > indent:
+            raise YamlParseError(
+                f"unexpected over-indentation at line {i}: {cur_content!r}"
+            )
+        if not cur_content.startswith("- "):
+            break
+        item_content = cur_content[2:].strip()
+        if ":" in item_content and not item_content.startswith(("'", '"')):
+            # This is a mapping item like ``- id: foo``.
+            # Re-inject as a single-line mapping at indent+2 and parse.
+            synthetic = (indent + 2, item_content)
+            # Collect all continuation lines for this list item.
+            j = i + 1
+            item_lines = [synthetic]
+            while j < len(lines) and lines[j][0] > indent:
+                item_lines.append(lines[j])
+                j += 1
+            parsed, _ = _parse_mapping(item_lines, 0, indent + 2)
+            result.append(parsed)
+            i = j
+        else:
+            result.append(_parse_scalar(item_content))
+            i += 1
+    return result, i
+
+
+# ---------------------------------------------------------------------------
+# Workflow model
+# ---------------------------------------------------------------------------
+
+
+class WorkflowError(ValueError):
+    """Raised for invalid workflow definitions."""
+
+
+class StepResult:
+    """Result of a single step execution."""
+
+    # Status constants used for reliable classification instead of
+    # string-matching on error messages.
+    STATUS_SUCCESS = "success"
+    STATUS_SKIPPED_RESTART = "skipped_restart"
+    STATUS_SKIPPED_FAILURE = "skipped_failure"
+    STATUS_FAILED = "failed"
+
+    __slots__ = ("step_id", "ok", "output", "error", "returncode", "status")
+
+    def __init__(
+        self,
+        step_id: str,
+        ok: bool,
+        output: dict[str, Any] | None,
+        error: str,
+        returncode: int,
+        status: str = STATUS_SUCCESS,
+    ):
+        self.step_id = step_id
+        self.ok = ok
+        self.output = output
+        self.error = error
+        self.returncode = returncode
+        self.status = status
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "ok": self.ok,
+            "output": self.output,
+            "error": self.error,
+            "returncode": self.returncode,
+            "status": self.status,
+        }
+
+
+def _validate_workflow(wf: dict[str, Any]) -> list[dict[str, Any]]:
+    """Validate the workflow dict and return the normalised steps list."""
+    if not isinstance(wf, dict):
+        raise WorkflowError("workflow root must be a mapping")
+    for required in ("name", "steps"):
+        if required not in wf:
+            raise WorkflowError(f"workflow is missing required key: {required!r}")
+    steps = wf["steps"]
+    if not isinstance(steps, list) or not steps:
+        raise WorkflowError("'steps' must be a non-empty sequence")
+    seen_ids: set[str] = set()
+    normalised: list[dict[str, Any]] = []
+    for idx, step in enumerate(steps):
+        if not isinstance(step, dict):
+            raise WorkflowError(f"step at index {idx} is not a mapping")
+        step_id = step.get("id")
+        if not step_id or not isinstance(step_id, str):
+            raise WorkflowError(f"step at index {idx} lacks a string 'id'")
+        if step_id in seen_ids:
+            raise WorkflowError(f"duplicate step id: {step_id!r}")
+        seen_ids.add(step_id)
+        script = step.get("script")
+        if not script or not isinstance(script, str):
+            raise WorkflowError(f"step {step_id!r} lacks a string 'script' path")
+        depends_on = step.get("depends_on", [])
+        if depends_on is None:
+            depends_on = []
+        if not isinstance(depends_on, list):
+            raise WorkflowError(f"step {step_id!r} 'depends_on' must be a list")
+        for dep in depends_on:
+            if not isinstance(dep, str):
+                raise WorkflowError(f"step {step_id!r} has a non-string dependency")
+        inputs = step.get("inputs", {})
+        if inputs is None:
+            inputs = {}
+        if not isinstance(inputs, dict):
+            raise WorkflowError(f"step {step_id!r} 'inputs' must be a mapping")
+        normalised.append(
+            {
+                "id": step_id,
+                "script": script,
+                "inputs": inputs,
+                "depends_on": list(depends_on),
+            }
+        )
+    # Validate dependency references exist.
+    for step in normalised:
+        for dep in step["depends_on"]:
+            if dep not in seen_ids:
+                raise WorkflowError(
+                    f"step {step['id']!r} depends on unknown step {dep!r}"
+                )
+    return normalised
+
+
+def _topo_sort(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Topologically sort steps; raise on cycles."""
+    by_id = {s["id"]: s for s in steps}
+    visited: dict[str, int] = {}  # 0 = visiting, 1 = done
+    order: list[dict[str, Any]] = []
+
+    def visit(sid: str, path: list[str]) -> None:
+        state = visited.get(sid)
+        if state == 1:
+            return
+        if state == 0:
+            cycle = " -> ".join(path + [sid])
+            raise WorkflowError(f"dependency cycle detected: {cycle}")
+        visited[sid] = 0
+        for dep in by_id[sid]["depends_on"]:
+            visit(dep, path + [sid])
+        visited[sid] = 1
+        order.append(by_id[sid])
+
+    for s in steps:
+        visit(s["id"], [])
+    return order
+
+
+def _collect_deps(
+    steps: list[dict[str, Any]], targets: set[str], collected: set[str]
+) -> None:
+    """Recursively collect all transitive dependencies of *targets* into *collected*."""
+    by_id = {s["id"]: s for s in steps}
+    queue = list(targets)
+    while queue:
+        sid = queue.pop()
+        if sid in collected:
+            continue
+        collected.add(sid)
+        for dep in by_id[sid]["depends_on"]:
+            if dep not in collected:
+                queue.append(dep)
+
+
+def _resolve_value(
+    value: Any, outputs: dict[str, dict[str, Any]], tolerant: bool = False
+) -> Any:
+    """Resolve ``${steps.<id>.<key>}`` placeholders in a value.
+
+    If the entire string is a single placeholder, the referenced Python object
+    is returned directly (preserving type). If the placeholder is embedded in a
+    larger string, it is stringified and substituted.
+
+    When *tolerant* is true (e.g. dry-run), unresolved placeholders are kept
+    as-is instead of raising.
+    """
+    if not isinstance(value, str) or "${" not in value:
+        return value
+
+    def lookup(step_id: str, key_path: str) -> Any:
+        if step_id not in outputs:
+            if tolerant:
+                return None
+            raise WorkflowError(
+                f"placeholder references unknown or unexecuted step: {step_id!r}"
+            )
+        obj: Any = outputs[step_id]
+        for part in key_path.split("."):
+            if isinstance(obj, dict) and part in obj:
+                obj = obj[part]
+            else:
+                if tolerant:
+                    return None
+                raise WorkflowError(
+                    f"placeholder ${{steps.{step_id}.{key_path}}} references "
+                    f"missing key '{part}'"
+                )
+        return obj
+
+    def replace(m: re.Match[str]) -> str:
+        result = lookup(m.group(1), m.group(2))
+        return value if result is None else str(result)
+
+    # Full-string placeholder -> return typed object (or original if tolerant).
+    m = _INTERP.fullmatch(value.strip())
+    if m is not None:
+        result = lookup(m.group(1), m.group(2))
+        if result is None and tolerant:
+            return value
+        return result
+
+    # Embedded placeholder -> stringify substitution.
+    return _INTERP.sub(replace, value)
+
+
+def _resolve_inputs(
+    raw_inputs: dict[str, Any],
+    outputs: dict[str, dict[str, Any]],
+    tolerant: bool = False,
+) -> dict[str, Any]:
+    resolved: dict[str, Any] = {}
+    for key, val in raw_inputs.items():
+        resolved[key] = _resolve_value(val, outputs, tolerant=tolerant)
+    return resolved
+
+
+def _build_command(
+    script_path: Path, inputs: dict[str, Any]
+) -> list[str]:
+    """Build the command list for a step's script invocation.
+
+    Boolean ``True`` values emit only the flag (``--flag``) without a value,
+    matching argparse ``store_true`` semantics. ``False`` and ``None`` omit
+    the flag entirely.
+    """
+    cmd: list[str] = [sys.executable, str(script_path)]
+    for key, val in inputs.items():
+        if val is None or val is False:
+            continue
+        if val is True:
+            cmd.append(key)
+            continue
+        cmd.append(key)
+        cmd.append(str(val))
+    return cmd
+
+
+def _run_step(
+    step: dict[str, Any],
+    outputs: dict[str, dict[str, Any]],
+    cwd: Path,
+    dry_run: bool = False,
+) -> StepResult:
+    """Execute a single workflow step."""
+    sid = step["id"]
+    try:
+        resolved_inputs = _resolve_inputs(
+            step["inputs"], outputs, tolerant=dry_run
+        )
+    except WorkflowError as exc:
+        return StepResult(sid, False, None, str(exc), 1)
+
+    script_path = cwd / step["script"]
+
+    if dry_run:
+        cmd = _build_command(script_path, resolved_inputs)
+        exists = script_path.is_file()
+        # Dry-run always succeeds; missing scripts are reported as a warning.
+        return StepResult(
+            sid,
+            True,
+            {"dry_run": True, "command": cmd, "script_exists": exists},
+            "" if exists else f"warning: script not found: {step['script']}",
+            0,
+        )
+
+    if not script_path.is_file():
+        return StepResult(
+            sid, False, None, f"script not found: {step['script']}", 1
+        )
+
+    cmd = _build_command(script_path, resolved_inputs)
+
+    try:
+        process = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return StepResult(sid, False, None, "step timed out after 300s", 1)
+    except Exception as exc:
+        return StepResult(sid, False, None, f"{type(exc).__name__}: {exc}", 1)
+
+    if process.returncode != 0:
+        return StepResult(
+            sid,
+            False,
+            None,
+            f"exit code {process.returncode}: {process.stderr.strip()[:500]}",
+            process.returncode,
+        )
+
+    # Parse JSON output.
+    stdout = process.stdout.strip()
+    if not stdout:
+        return StepResult(
+            sid, False, None, "script produced no stdout output", process.returncode
+        )
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return StepResult(
+            sid,
+            False,
+            None,
+            f"script stdout is not valid JSON: {exc}: {stdout[:200]}",
+            process.returncode,
+        )
+    if not isinstance(parsed, dict):
+        return StepResult(
+            sid,
+            False,
+            None,
+            f"script stdout JSON is not an object: {type(parsed).__name__}",
+            process.returncode,
+        )
+
+    outputs[sid] = parsed
+    return StepResult(sid, True, parsed, "", process.returncode)
+
+
+def run_workflow(
+    workflow_path: Path,
+    start_from: str | None = None,
+    dry_run: bool = False,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Execute a workflow file and return a structured summary.
+
+    Parameters
+    ----------
+    workflow_path:
+        Path to the YAML workflow file.
+    start_from:
+        If given, skip the named step itself but re-execute all steps that
+        the named step depends on (transitively) so their outputs are
+        available for the resumed step and its downstream siblings.  This
+        ensures placeholders referencing prior steps resolve correctly.
+    dry_run:
+        If true, resolve and print commands without executing scripts.
+    cwd:
+        Working directory for resolving relative script paths. Defaults to
+        the workflow file's parent directory.
+    """
+    base_dir = cwd or workflow_path.parent.resolve()
+    text = workflow_path.read_text(encoding="utf-8")
+
+    try:
+        wf = parse_yaml(text)
+    except YamlParseError as exc:
+        return {
+            "ok": False,
+            "error": f"YAML parse error: {exc}",
+            "workflow": str(workflow_path),
+        }
+
+    try:
+        steps = _validate_workflow(wf)
+        ordered = _topo_sort(steps)
+    except WorkflowError as exc:
+        return {
+            "ok": False,
+            "error": f"workflow validation error: {exc}",
+            "workflow": str(workflow_path),
+        }
+
+    # Determine which steps to re-execute vs. skip for restart.
+#
+# When --start-from is given, the named step and all steps that come *after*
+# it in topological order are executed normally. Steps that come *before* it
+# are re-executed only if they are (transitively) depended upon by the
+# start-from step or any step after it -- this ensures their outputs are
+# available for placeholder resolution. Steps that no downstream step needs
+# are marked skipped.
+    executed_ids: set[str] = set()
+    if start_from is not None:
+        ids = [s["id"] for s in ordered]
+        if start_from not in ids:
+            return {
+                "ok": False,
+                "error": f"--start-from step not found: {start_from!r}",
+                "workflow": str(workflow_path),
+                "available_steps": ids,
+            }
+        start_idx = ids.index(start_from)
+        # Collect all step ids from start_idx onward (the "resume" set).
+        resume_ids = {s["id"] for s in ordered[start_idx:]}
+        # Transitively collect dependencies of the resume set.
+        needed: set[str] = set()
+        _collect_deps(ordered, resume_ids, needed)
+        executed_ids = resume_ids | needed
+    else:
+        start_idx = 0
+        executed_ids = {s["id"] for s in ordered}
+
+    outputs: dict[str, dict[str, Any]] = {}
+    results: list[StepResult] = []
+
+    failed = False
+    for step in ordered:
+        sid = step["id"]
+        if sid not in executed_ids:
+            results.append(
+                StepResult(
+                    sid, True, None, "skipped (not needed for restart)", 0,
+                    status=StepResult.STATUS_SKIPPED_RESTART,
+                )
+            )
+            continue
+        if failed:
+            results.append(
+                StepResult(
+                    sid, False, None, "skipped (prior failure)", 0,
+                    status=StepResult.STATUS_SKIPPED_FAILURE,
+                )
+            )
+            continue
+        result = _run_step(step, outputs, base_dir, dry_run=dry_run)
+        if not result.ok:
+            result.status = StepResult.STATUS_FAILED
+        results.append(result)
+        if not result.ok:
+            failed = True
+
+    summary = {
+        "ok": not failed,
+        "workflow": str(workflow_path),
+        "name": wf.get("name", ""),
+        "description": wf.get("description", ""),
+        "steps_total": len(ordered),
+        "steps_executed": sum(
+            1 for r in results
+            if r.status in (StepResult.STATUS_SUCCESS, StepResult.STATUS_FAILED)
+        ),
+        "results": [r.to_dict() for r in results],
+        "outputs": outputs,
+    }
+    if failed:
+        summary["error"] = next(
+            (r.error for r in results if r.status == StepResult.STATUS_FAILED and r.error),
+            "one or more steps failed",
+        )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Execute a composable local skill-workflow from a YAML file."
+    )
+    parser.add_argument("workflow", type=Path, help="Path to the workflow YAML file.")
+    parser.add_argument(
+        "--start-from",
+        metavar="STEP_ID",
+        help="Resume execution from the step after the given id (restart from failure).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print commands without executing scripts.",
+    )
+    args = parser.parse_args()
+
+    if not args.workflow.is_file():
+        print(
+            json.dumps(
+                {"ok": False, "error": f"workflow file not found: {args.workflow}"},
+                indent=2,
+            )
+        )
+        return 1
+
+    summary = run_workflow(
+        args.workflow,
+        start_from=args.start_from,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,132 @@
+# Composable Local Skill-Workflow Executor
+
+A lightweight YAML-based workflow executor for AReno skill scripts. It lets
+you chain multiple skill scripts into a reproducible pipeline with typed
+inputs, step dependencies, structured output passing, and restart from a
+failed step — all using the Python standard library, with no external
+database or mandatory sandbox.
+
+## Quick start
+
+```bash
+# Run the recipe -> tiny run -> summary example
+python3 .agents/scripts/run_workflow.py examples/workflows/recipe_to_summary.yaml
+
+# Run the serve -> probe -> summary example
+python3 .agents/scripts/run_workflow.py examples/workflows/serve_to_summary.yaml
+
+# Dry run (resolve and print commands without executing)
+python3 .agents/scripts/run_workflow.py examples/workflows/recipe_to_summary.yaml --dry-run
+
+# Restart from a specific step (skip all steps up to and including the given id)
+python3 .agents/scripts/run_workflow.py examples/workflows/recipe_to_summary.yaml --start-from run
+```
+
+## Workflow YAML format
+
+```yaml
+name: my-workflow              # required, string
+description: What it does      # optional, string
+
+steps:                          # required, non-empty list
+  - id: step1                   #   required, unique string
+    script: scripts/foo.py      #   required, path relative to the YAML file
+    inputs:                     #   optional, mapping of CLI flag -> value
+      --arg1: value1
+      --flag: true              #   boolean true -> --flag (store_true)
+    depends_on: []              #   optional, list of step ids this step needs
+
+  - id: step2
+    script: scripts/bar.py
+    inputs:
+      --input: ${steps.step1.output_key}  # reference step1's JSON output
+    depends_on: [step1]
+```
+
+### Input contract
+
+| Type in YAML      | Behaviour                                                |
+|-------------------|----------------------------------------------------------|
+| String            | Passed as `--flag value`                                 |
+| Integer / Float   | Stringified and passed as `--flag value`                 |
+| `true`            | Passed as `--flag` only (matches argparse `store_true`)  |
+| `false` / `null`  | Flag is omitted entirely                                 |
+| `${steps.X.Y}`    | Resolved to the JSON output `Y` from step `X`. If the    |
+|                   | placeholder is the entire value, the typed object is     |
+|                   | returned; if embedded in a string, it is stringified.   |
+
+### Output fields
+
+The executor prints a single JSON object to stdout:
+
+```json
+{
+  "ok": true,
+  "workflow": "path/to/workflow.yaml",
+  "name": "my-workflow",
+  "description": "...",
+  "steps_total": 2,
+  "steps_executed": 2,
+  "results": [
+    {
+      "step_id": "step1",
+      "ok": true,
+      "output": { ... },        // parsed JSON from the script's stdout
+      "error": "",
+      "returncode": 0
+    }
+  ],
+  "outputs": {                   // accumulated JSON outputs by step id
+    "step1": { ... },
+    "step2": { ... }
+  }
+}
+```
+
+On failure, `ok` is `false` and an `error` field is added at the top level.
+Subsequent steps after a failure are marked `skipped (prior failure)`.
+
+## Script contract
+
+Each step's `script` must:
+
+1. Be a Python script invoked as `python3 script.py --flags ...`.
+2. Print a single JSON object to stdout on success.
+3. Exit with a non-zero code on failure.
+
+This matches the convention already used by all scripts under
+`.agents/skills/*/scripts/` (e.g. `probe_server.py`, `read_metrics.py`).
+
+## Limitations
+
+- The YAML parser supports a deliberate subset (mappings, sequences,
+  scalars, comments). It does not support anchors, aliases, multi-line
+  block scalars, or inline mappings `{...}`.
+- Step outputs are kept in memory; there is no persistent checkpoint
+  file. Restart (`--start-from`) re-executes the named step and all steps
+  it transitively depends on, so their outputs are available for
+  placeholder resolution. Steps not needed by the resume point are
+  skipped. There is no file-based checkpoint — if the process exits you
+  must re-run from the beginning or use `--start-from` which re-executes
+  dependencies as needed.
+- Scripts are executed with a 300-second timeout per step.
+
+## Examples
+
+Two deterministic, self-contained examples ship under `examples/workflows/`:
+
+1. **`recipe_to_summary.yaml`** — builds a tiny training recipe, simulates
+   a training run, and summarises the result.
+2. **`serve_to_summary.yaml`** — mocks a serving endpoint, probes it, and
+   summarises the probe result.
+
+Neither requires a GPU, network, or external database.
+
+## Tests
+
+```bash
+pytest tests/test_workflow_executor_cpu.py -v
+```
+
+Covers success paths, invalid input, dependency cycles, missing output
+keys, restart-from-failed-step, dry-run, and boundary conditions.

--- a/examples/workflows/real_inspect_workflow.yaml
+++ b/examples/workflows/real_inspect_workflow.yaml
@@ -1,0 +1,31 @@
+# Example workflow using REAL AReno skill scripts (no mock scripts).
+#
+# Chains: dataset inspection -> summary of inspection result.
+# Runs entirely on CPU with a local JSONL file. No GPU, no network.
+#
+# Prerequisites:
+#   The inspect step reads /tmp/test_dataset.jsonl. Create a tiny test file first:
+#     echo '{"question":"1+1=?","answer":"2"}' > /tmp/test_dataset.jsonl
+#   Without this file the inspect step will fail.
+#
+# Run with:
+#   python3 .agents/scripts/run_workflow.py examples/workflows/real_inspect_workflow.yaml
+
+name: real-inspect-workflow
+description: Inspect a local dataset using the real AReno skill script, then summarise.
+
+steps:
+  - id: inspect
+    script: ../../.agents/skills/areno-run-training/scripts/inspect_dataset.py
+    inputs:
+      --dataset-path: /tmp/test_dataset.jsonl
+      --algo: gspo
+    depends_on: []
+
+  - id: summary
+    script: scripts/summarize.py
+    inputs:
+      --algo: gspo
+      --steps-completed: ${steps.inspect.count}
+      --source: run
+    depends_on: [inspect]

--- a/examples/workflows/recipe_to_summary.yaml
+++ b/examples/workflows/recipe_to_summary.yaml
@@ -1,0 +1,40 @@
+# Example workflow: recipe -> tiny run -> summary
+#
+# Fully deterministic, no external database, no network, no GPU required.
+# Run with:
+#   python .agents/scripts/run_workflow.py examples/workflows/recipe_to_summary.yaml
+
+name: recipe-to-summary
+description: Build a tiny recipe, simulate a training run, and summarise the result.
+
+steps:
+  - id: recipe
+    script: scripts/make_recipe.py
+    inputs:
+      --algo: gspo
+      --model: Qwen/Qwen3-0.6B
+      --dataset: gsm8k:main
+    depends_on: []
+
+  - id: run
+    script: scripts/tiny_run.py
+    inputs:
+      --algo: ${steps.recipe.algo}
+      --model: ${steps.recipe.model}
+      --dataset: ${steps.recipe.dataset}
+      --batch-size: ${steps.recipe.batch_size}
+      --n-samples: ${steps.recipe.n_samples}
+      --max-new-tokens: ${steps.recipe.max_new_tokens}
+    depends_on: [recipe]
+
+  - id: summary
+    script: scripts/summarize.py
+    inputs:
+      --algo: ${steps.run.algo}
+      --model: ${steps.run.model}
+      --dataset: ${steps.run.dataset}
+      --steps-completed: ${steps.run.steps_completed}
+      --final-reward: ${steps.run.final_reward}
+      --final-loss: ${steps.run.final_loss}
+      --source: run
+    depends_on: [run]

--- a/examples/workflows/scripts/make_recipe.py
+++ b/examples/workflows/scripts/make_recipe.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Generate a tiny deterministic training recipe (no network, no GPU).
+
+Part of the ``recipe_to_summary`` example workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Produce a tiny training recipe.")
+    parser.add_argument("--algo", default="gspo", help="Algorithm name.")
+    parser.add_argument("--model", default="Qwen/Qwen3-0.6B", help="Model checkpoint.")
+    parser.add_argument("--dataset", default="gsm8k:main", help="Dataset reference.")
+    args = parser.parse_args()
+
+    recipe = {
+        "ok": True,
+        "algo": args.algo,
+        "model": args.model,
+        "dataset": args.dataset,
+        "batch_size": 2,
+        "n_samples": 4,
+        "max_new_tokens": 64,
+    }
+    print(json.dumps(recipe, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workflows/scripts/mock_probe.py
+++ b/examples/workflows/scripts/mock_probe.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Deterministic mock probe of a serving endpoint (no network).
+
+Part of the ``serve_to_summary`` example workflow. Instead of issuing real
+HTTP requests, it checks that the upstream ``base_url`` and ``model_id``
+are present and non-empty, simulating a probe result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Mock-probe a serving endpoint.")
+    parser.add_argument("--base-url", required=True, help="Base URL of the endpoint.")
+    parser.add_argument("--model-id", required=True, help="Model ID to check.")
+    args = parser.parse_args()
+
+    probe_ok = bool(args.base_url) and bool(args.model_id)
+    probe = {
+        "ok": probe_ok,
+        "base_url": args.base_url,
+        "model_id": args.model_id,
+        "latency_ms": 12,
+    }
+    print(json.dumps(probe, indent=2))
+    return 0 if probe_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workflows/scripts/mock_serve.py
+++ b/examples/workflows/scripts/mock_serve.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Produce a deterministic mock serving endpoint description (no network).
+
+Part of the ``serve_to_summary`` example workflow. Instead of starting a real
+server, it returns a mock ``base_url`` and ``model_id`` that the downstream
+probe step can use. This keeps the example fully local and deterministic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Mock a serving endpoint.")
+    parser.add_argument(
+        "--model", default="Qwen/Qwen3-0.6B", help="Model checkpoint to advertise."
+    )
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port for the mock endpoint."
+    )
+    args = parser.parse_args()
+
+    serve = {
+        "ok": True,
+        "base_url": f"http://127.0.0.1:{args.port}",
+        "model_id": args.model,
+        "port": args.port,
+    }
+    print(json.dumps(serve, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workflows/scripts/summarize.py
+++ b/examples/workflows/scripts/summarize.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Summarise a training run into a compact report (no network, no GPU).
+
+Used by both example workflows. Accepts upstream JSON fields via CLI flags
+and prints a structured summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarise a run or probe.")
+    parser.add_argument("--algo", help="Algorithm name.")
+    parser.add_argument("--model", help="Model checkpoint.")
+    parser.add_argument("--dataset", help="Dataset reference.")
+    parser.add_argument("--steps-completed", type=int, help="Steps completed.")
+    parser.add_argument("--final-reward", type=float, help="Final reward value.")
+    parser.add_argument("--final-loss", type=float, help="Final loss value.")
+    parser.add_argument("--source", default="run", help="Source type (run or probe).")
+    parser.add_argument(
+        "--probe-ok", dest="probe_ok", action="store_true", help="Probe succeeded."
+    )
+    parser.add_argument(
+        "--model-advertised", help="Model advertised by the serving endpoint."
+    )
+    args = parser.parse_args()
+
+    summary: dict[str, object] = {"ok": True, "source": args.source}
+    if args.algo:
+        summary["algo"] = args.algo
+    if args.model:
+        summary["model"] = args.model
+    if args.dataset:
+        summary["dataset"] = args.dataset
+    if args.steps_completed is not None:
+        summary["steps_completed"] = args.steps_completed
+    if args.final_reward is not None:
+        summary["final_reward"] = args.final_reward
+    if args.final_loss is not None:
+        summary["final_loss"] = args.final_loss
+    if args.source == "probe":
+        summary["probe_ok"] = args.probe_ok
+        if args.model_advertised:
+            summary["model_advertised"] = args.model_advertised
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workflows/scripts/tiny_run.py
+++ b/examples/workflows/scripts/tiny_run.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Simulate a tiny deterministic training run (no network, no GPU).
+
+Part of the ``recipe_to_summary`` example workflow. Accepts recipe fields
+from :doc:`make_recipe.py` and produces a fake step/metric snapshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Simulate a tiny training run.")
+    parser.add_argument("--algo", required=True, help="Algorithm name.")
+    parser.add_argument("--model", required=True, help="Model checkpoint.")
+    parser.add_argument("--dataset", required=True, help="Dataset reference.")
+    parser.add_argument("--batch-size", type=int, default=2, help="Batch size.")
+    parser.add_argument("--n-samples", type=int, default=4, help="Sample count.")
+    parser.add_argument("--max-new-tokens", type=int, default=64, help="Max new tokens.")
+    args = parser.parse_args()
+
+    run = {
+        "ok": True,
+        "algo": args.algo,
+        "model": args.model,
+        "dataset": args.dataset,
+        "steps_completed": 3,
+        "final_reward": 0.75,
+        "final_loss": 1.2,
+        "batch_size": args.batch_size,
+        "n_samples": args.n_samples,
+    }
+    print(json.dumps(run, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/workflows/serve_to_summary.yaml
+++ b/examples/workflows/serve_to_summary.yaml
@@ -1,0 +1,32 @@
+# Example workflow: serve -> probe -> summary
+#
+# Fully deterministic, no external database, no network, no GPU required.
+# Run with:
+#   python .agents/scripts/run_workflow.py examples/workflows/serve_to_summary.yaml
+
+name: serve-to-summary
+description: Mock a serving endpoint, probe it, and summarise the probe result.
+
+steps:
+  - id: serve
+    script: scripts/mock_serve.py
+    inputs:
+      --model: Qwen/Qwen3-0.6B
+      --port: 8000
+    depends_on: []
+
+  - id: probe
+    script: scripts/mock_probe.py
+    inputs:
+      --base-url: ${steps.serve.base_url}
+      --model-id: ${steps.serve.model_id}
+    depends_on: [serve]
+
+  - id: summary
+    script: scripts/summarize.py
+    inputs:
+      --model: ${steps.serve.model_id}
+      --source: probe
+      --probe-ok: ${steps.probe.ok}
+      --model-advertised: ${steps.probe.model_id}
+    depends_on: [probe]

--- a/tests/test_workflow_executor_cpu.py
+++ b/tests/test_workflow_executor_cpu.py
@@ -1,0 +1,741 @@
+"""CPU tests for the composable local skill-workflow executor.
+
+Covers success paths, invalid input, dependency cycles, missing outputs,
+restart-from-failed-step, dry-run, and boundary conditions. No GPU, network,
+or external database is required.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Import the executor as a module so we can unit-test internal functions.
+_SCRIPT = Path(__file__).resolve().parents[1] / ".agents" / "scripts" / "run_workflow.py"
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location("run_workflow", _SCRIPT)
+run_workflow_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(run_workflow_mod)
+
+parse_yaml = run_workflow_mod.parse_yaml
+run_workflow = run_workflow_mod.run_workflow
+YamlParseError = run_workflow_mod.YamlParseError
+WorkflowError = run_workflow_mod.WorkflowError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wf_dir(tmp_path: Path) -> Path:
+    """Create a temp directory with echo/echo scripts for workflow tests."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+
+    # A script that echoes its args as JSON.
+    (scripts / "echo.py").write_text(
+        textwrap.dedent(
+            """
+            #!/usr/bin/env python3
+            from __future__ import annotations
+            import argparse, json, sys
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--value", default="default")
+            parser.add_argument("--flag", action="store_true")
+            args = parser.parse_args()
+            out = {"ok": True, "value": args.value, "flag_set": args.flag}
+            print(json.dumps(out))
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # A script that always fails (non-zero exit).
+    (scripts / "fail.py").write_text(
+        textwrap.dedent(
+            """
+            #!/usr/bin/env python3
+            from __future__ import annotations
+            import json
+            print(json.dumps({"ok": False, "error": "intentional failure"}))
+            raise SystemExit(1)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # A script that produces no JSON (empty stdout).
+    (scripts / "empty.py").write_text(
+        textwrap.dedent(
+            """
+            #!/usr/bin/env python3
+            print("", end="")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+def _write_wf(path: Path, content: str) -> Path:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# YAML parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseYaml:
+    def test_simple_mapping(self):
+        text = "name: foo\nvalue: 42\n"
+        result = parse_yaml(text)
+        assert result == {"name": "foo", "value": 42}
+
+    def test_nested_mapping(self):
+        text = "outer:\n  inner: val\n  num: 3\n"
+        result = parse_yaml(text)
+        assert result == {"outer": {"inner": "val", "num": 3}}
+
+    def test_sequence_of_scalars(self):
+        text = "items:\n  - a\n  - b\n  - c\n"
+        result = parse_yaml(text)
+        assert result == {"items": ["a", "b", "c"]}
+
+    def test_sequence_of_mappings(self):
+        text = textwrap.dedent(
+            """
+            steps:
+              - id: step1
+                script: a.py
+              - id: step2
+                script: b.py
+            """
+        )
+        result = parse_yaml(text)
+        assert result["steps"] == [
+            {"id": "step1", "script": "a.py"},
+            {"id": "step2", "script": "b.py"},
+        ]
+
+    def test_types(self):
+        text = textwrap.dedent(
+            """
+            str_val: hello
+            int_val: 42
+            float_val: 3.14
+            bool_true: true
+            bool_false: false
+            null_val: null
+            empty_val:
+            quoted: "with spaces"
+            """
+        )
+        result = parse_yaml(text)
+        assert result["str_val"] == "hello"
+        assert result["int_val"] == 42
+        assert result["float_val"] == 3.14
+        assert result["bool_true"] is True
+        assert result["bool_false"] is False
+        assert result["null_val"] is None
+        assert result["empty_val"] is None
+        assert result["quoted"] == "with spaces"
+
+    def test_inline_list(self):
+        text = "items: [1, 2, 3]\n"
+        result = parse_yaml(text)
+        assert result["items"] == [1, 2, 3]
+
+    def test_comments_stripped(self):
+        text = "name: foo  # this is a comment\nvalue: 1\n# full line comment\n"
+        result = parse_yaml(text)
+        assert result == {"name": "foo", "value": 1}
+
+    def test_tabs_rejected(self):
+        text = "name: foo\n\tvalue: 1\n"
+        with pytest.raises(YamlParseError, match="tabs are not allowed"):
+            parse_yaml(text)
+
+    def test_empty(self):
+        assert parse_yaml("") == {}
+
+    def test_interpolation_kept_as_string(self):
+        text = "val: ${steps.foo.bar}\n"
+        result = parse_yaml(text)
+        assert result["val"] == "${steps.foo.bar}"
+
+
+# ---------------------------------------------------------------------------
+# Workflow validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowValidation:
+    def test_missing_name(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            steps:
+              - id: a
+                script: scripts/echo.py
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "missing required key: 'name'" in result["error"]
+
+    def test_missing_steps(self, wf_dir: Path):
+        wf = _write_wf(wf_dir / "wf.yaml", "name: test\n")
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "missing required key: 'steps'" in result["error"]
+
+    def test_duplicate_step_id(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+              - id: a
+                script: scripts/echo.py
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "duplicate step id" in result["error"]
+
+    def test_missing_script(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "lacks a string 'script'" in result["error"]
+
+    def test_dependency_on_unknown_step(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                depends_on: [nonexistent]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "depends on unknown step" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestCycleDetection:
+    def test_simple_cycle(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                depends_on: [b]
+              - id: b
+                script: scripts/echo.py
+                depends_on: [a]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "cycle" in result["error"].lower()
+
+    def test_self_cycle(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                depends_on: [a]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "cycle" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Execution tests
+# ---------------------------------------------------------------------------
+
+
+class TestExecution:
+    def test_success_basic(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            description: A basic success workflow
+            steps:
+              - id: step1
+                script: scripts/echo.py
+                inputs:
+                  --value: hello
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is True
+        assert result["steps_executed"] == 1
+        assert result["results"][0]["ok"] is True
+        assert result["results"][0]["output"]["value"] == "hello"
+
+    def test_output_passing(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: first
+                script: scripts/echo.py
+                inputs:
+                  --value: passed-value
+                depends_on: []
+              - id: second
+                script: scripts/echo.py
+                inputs:
+                  --value: ${steps.first.value}
+                depends_on: [first]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is True
+        assert result["results"][1]["output"]["value"] == "passed-value"
+
+    def test_boolean_flag_passthrough(self, wf_dir: Path):
+        """A True value should emit --flag without a value (store_true)."""
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: first
+                script: scripts/echo.py
+                inputs:
+                  --value: x
+                depends_on: []
+              - id: second
+                script: scripts/echo.py
+                inputs:
+                  --value: y
+                  --flag: ${steps.first.ok}
+                depends_on: [first]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is True
+        assert result["results"][1]["output"]["flag_set"] is True
+
+    def test_step_failure_stops_pipeline(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: fail_step
+                script: scripts/fail.py
+                depends_on: []
+              - id: after
+                script: scripts/echo.py
+                depends_on: [fail_step]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert result["results"][0]["ok"] is False
+        assert result["results"][1]["ok"] is False
+        assert "skipped (prior failure)" in result["results"][1]["error"]
+
+    def test_missing_output_key(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: first
+                script: scripts/echo.py
+                inputs:
+                  --value: x
+                depends_on: []
+              - id: second
+                script: scripts/echo.py
+                inputs:
+                  --value: ${steps.first.nonexistent_key}
+                depends_on: [first]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert result["results"][1]["ok"] is False
+        assert "missing key" in result["results"][1]["error"]
+
+    def test_script_not_found(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/nonexistent.py
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "script not found" in result["results"][0]["error"]
+
+    def test_empty_stdout(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/empty.py
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "no stdout output" in result["results"][0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Restart-from-failed-step tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestart:
+    def test_start_from_skips_earlier(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                inputs:
+                  --value: aaa
+                depends_on: []
+              - id: b
+                script: scripts/echo.py
+                inputs:
+                  --value: bbb
+                depends_on: [a]
+              - id: c
+                script: scripts/echo.py
+                inputs:
+                  --value: ccc
+                depends_on: [b]
+            """,
+        )
+        result = run_workflow(wf, start_from="b")
+        assert result["ok"] is True
+        # 'a' is re-executed (b depends on it), 'b' and 'c' are executed.
+        assert result["results"][0]["ok"] is True
+        assert result["results"][0]["status"] == "success"
+        assert result["results"][1]["ok"] is True
+        assert result["results"][1]["output"]["value"] == "bbb"
+        assert result["results"][2]["output"]["value"] == "ccc"
+
+    def test_start_from_resolves_deps(self, wf_dir: Path):
+        """--start-from must re-execute dependencies so their outputs are available."""
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: recipe
+                script: scripts/echo.py
+                inputs:
+                  --value: gspo
+                depends_on: []
+              - id: run
+                script: scripts/echo.py
+                inputs:
+                  --value: ${steps.recipe.value}
+                depends_on: [recipe]
+              - id: summary
+                script: scripts/echo.py
+                inputs:
+                  --value: ${steps.run.value}
+                depends_on: [run]
+            """,
+        )
+        result = run_workflow(wf, start_from="run")
+        assert result["ok"] is True
+        # recipe is re-executed because run depends on it.
+        assert result["results"][0]["ok"] is True
+        assert result["results"][0]["output"]["value"] == "gspo"
+        # run successfully resolves recipe's output.
+        assert result["results"][1]["ok"] is True
+        assert result["results"][1]["output"]["value"] == "gspo"
+        # summary resolves run's output.
+        assert result["results"][2]["ok"] is True
+        assert result["results"][2]["output"]["value"] == "gspo"
+
+    def test_start_from_skips_unneeded_steps(self, wf_dir: Path):
+        """Steps not needed by the resume point should be skipped."""
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: standalone
+                script: scripts/echo.py
+                inputs:
+                  --value: xxx
+                depends_on: []
+              - id: main
+                script: scripts/echo.py
+                inputs:
+                  --value: yyy
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf, start_from="main")
+        assert result["ok"] is True
+        # standalone is not depended upon by main, so it's skipped.
+        assert result["results"][0]["status"] == "skipped_restart"
+        assert result["results"][1]["ok"] is True
+        assert result["results"][1]["output"]["value"] == "yyy"
+
+    def test_start_from_unknown_step(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf, start_from="nonexistent")
+        assert result["ok"] is False
+        assert "start-from step not found" in result["error"]
+        assert "nonexistent" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run tests
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_does_not_execute(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                inputs:
+                  --value: dry
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf, dry_run=True)
+        assert result["ok"] is True
+        assert result["results"][0]["output"]["dry_run"] is True
+        assert "--value" in result["results"][0]["output"]["command"]
+        assert "dry" in result["results"][0]["output"]["command"]
+
+
+# ---------------------------------------------------------------------------
+# Boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    def test_empty_inputs(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is True
+        assert result["results"][0]["output"]["value"] == "default"
+
+    def test_none_value_omitted(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                inputs:
+                  --value: null
+                depends_on: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is True
+        # --value is null -> omitted -> argparse default "default"
+        assert result["results"][0]["output"]["value"] == "default"
+
+    def test_empty_steps_list(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps: []
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is False
+        assert "non-empty sequence" in result["error"]
+
+    def test_interpolation_in_larger_string(self, wf_dir: Path):
+        """An embedded placeholder (not full-string) should be stringified."""
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: first
+                script: scripts/echo.py
+                inputs:
+                  --value: 42
+                depends_on: []
+              - id: second
+                script: scripts/echo.py
+                inputs:
+                  --value: "prefix-${steps.first.value}-suffix"
+                depends_on: [first]
+            """,
+        )
+        result = run_workflow(wf)
+        assert result["ok"] is True
+        assert result["results"][1]["output"]["value"] == "prefix-42-suffix"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_cli_runs_example_workflow(self):
+        """The CLI should successfully execute the recipe_to_summary example."""
+        root = Path(__file__).resolve().parents[1]
+        wf_path = root / "examples" / "workflows" / "recipe_to_summary.yaml"
+        process = subprocess.run(
+            [sys.executable, str(root / ".agents" / "scripts" / "run_workflow.py"), str(wf_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert process.returncode == 0, process.stdout + process.stderr
+        result = json.loads(process.stdout)
+        assert result["ok"] is True
+        assert result["steps_executed"] == 3
+
+    def test_cli_runs_serve_example(self):
+        """The CLI should successfully execute the serve_to_summary example."""
+        root = Path(__file__).resolve().parents[1]
+        wf_path = root / "examples" / "workflows" / "serve_to_summary.yaml"
+        process = subprocess.run(
+            [sys.executable, str(root / ".agents" / "scripts" / "run_workflow.py"), str(wf_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        assert process.returncode == 0, process.stdout + process.stderr
+        result = json.loads(process.stdout)
+        assert result["ok"] is True
+        assert result["steps_executed"] == 3
+
+    def test_cli_dry_run(self, wf_dir: Path):
+        wf = _write_wf(
+            wf_dir / "wf.yaml",
+            """
+            name: test
+            steps:
+              - id: a
+                script: scripts/echo.py
+                inputs:
+                  --value: x
+                depends_on: []
+            """,
+        )
+        root = Path(__file__).resolve().parents[1]
+        process = subprocess.run(
+            [
+                sys.executable,
+                str(root / ".agents" / "scripts" / "run_workflow.py"),
+                str(wf),
+                "--dry-run",
+            ],
+            cwd=wf_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert process.returncode == 0, process.stdout + process.stderr
+        result = json.loads(process.stdout)
+        assert result["ok"] is True
+        assert result["results"][0]["output"]["dry_run"] is True
+
+    def test_cli_nonexistent_file(self, tmp_path: Path):
+        root = Path(__file__).resolve().parents[1]
+        process = subprocess.run(
+            [
+                sys.executable,
+                str(root / ".agents" / "scripts" / "run_workflow.py"),
+                str(tmp_path / "nonexistent.yaml"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert process.returncode == 1
+        result = json.loads(process.stdout)
+        assert result["ok"] is False
+        assert "not found" in result["error"]


### PR DESCRIPTION
## What does this PR do?

Add a composable local YAML skill-workflow executor for AReno. The executor reads a YAML workflow definition, runs steps in dependency order (topological sort), passes structured JSON outputs between steps via `${steps.<id>.<key>}` placeholders, and supports restart-from-failed-step (`--start-from`) and dry-run (`--dry-run`).

This addresses the need to chain multiple AReno skill scripts (e.g. recipe → train → summary, serve → probe → summary) into a reproducible pipeline without one-off shell scripts.

**New files:**
- `.agents/scripts/run_workflow.py` — core executor (YAML parser, validation, topo sort, step execution, CLI)
- `examples/workflows/recipe_to_summary.yaml` — example: recipe → tiny run → summary
- `examples/workflows/serve_to_summary.yaml` — example: serve → probe → summary
- `examples/workflows/real_inspect_workflow.yaml` — example using real AReno skill scripts
- `examples/workflows/scripts/` — mock scripts for the examples (make_recipe, tiny_run, summarize, mock_serve, mock_probe)
- `examples/workflows/README.md` — user documentation
- `tests/test_workflow_executor_cpu.py` — 37 CPU tests

**Key design decisions:**
- Pure Python standard library (no PyYAML dependency) — includes a minimal YAML subset parser
- Script contract: argparse flags in, single JSON object to stdout out (matches existing `.agents/skills/` convention)
- `--start-from` re-executes transitive dependencies so their outputs are available for placeholder resolution
- `StepResult.status` enum for reliable step classification

## Related issue

Fixes #277

## Type of change

- [x] ✨ New feature

## How was it tested?

Test environment: macOS, Python 3.12.13, no GPU.

```
# Workflow executor tests
python3.12 -m pytest tests/test_workflow_executor_cpu.py -v
# Result: 37 passed in 1.54s

# Full CPU test suite (no regression)
python3.12 -m pytest tests/ -k cpu
# Result: 404 passed, 0 failed in 10.56s
```

Tests cover: YAML parsing, workflow validation, cycle detection, step execution, output passing, boolean flags, failure handling, missing output keys, script not found, empty stdout, restart-from-step, dry-run, boundary conditions, and CLI integration.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (Fixes #277).
- [x] Existing tests pass (`pytest tests/ -k cpu` — 404 passed, 0 failed).
- [x] New behavior is covered by tests (37 CPU tests).
- [x] Described the test commands run and any hardware limitations (no GPU, Python 3.12.13).
- [x] Public API / CLI changes are additive and backward-compatible (new script, no changes to existing code).