### PR TITLE
feat: add periodic evaluation during SFT and DPO training

### DIFF
--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -400,6 +400,78 @@ class ArenoBackend(Backend):
             result["step_e2e_time_s"] = step_e2e_time_s
         return result
 
+    def evaluate(
+        self,
+        ctx: Context,
+        batch_data: list[TrainSequence],
+        loss_fn: Callable,
+        mini_bs: int,
+        gradient_accumulation_steps: int | None = None,
+    ) -> dict[str, float]:
+        """Forward-only eval pass: build packs, score logprobs, compute loss.
+
+        Uses ``engine.score_logprobs("actor", ...)`` so only the current
+        policy model runs a forward pass — no backward, no optimizer step.
+        Metrics are averaged across microbatches.
+        """
+        engine = self._require_engine()
+        if not callable(loss_fn):
+            raise ValueError("ArenoBackend requires a callable loss_fn")
+
+        # Build data packs (same layout as train so loss_fn works unmodified).
+        packs = []
+        for start in range(0, len(batch_data), mini_bs):
+            seqs = batch_data[start : start + mini_bs]
+            packs.append(_make_train_pack(seqs))
+
+        metrics: dict[str, float] = {}
+        losses = []
+        for pack in packs:
+            # Extract per-row token lists for score_logprobs.
+            tokens = pack["input_ids"]  # (B, max_len) int64
+            lengths = pack["lengths"]   # (B,) int32
+            token_rows = []
+            for b in range(tokens.shape[0]):
+                L = int(lengths[b].item())
+                token_rows.append(tokens[b, :L].tolist())
+
+            # Forward pass on the current policy model (no training).
+            logprob_rows = engine.score_logprobs(
+                "actor",
+                token_rows,
+                pad_token_id=_pad_token_id(ctx),
+                microbatch_size=int(mini_bs),
+            )
+
+            # Reconstruct a (B, max_len-1) tensor matching next_token_logprobs.
+            B, max_len = tokens.shape
+            logprobs = torch.zeros(B, max_len - 1, dtype=torch.float32)
+            for b, row in enumerate(logprob_rows):
+                L = len(row)  # == lengths[b] - 1
+                logprobs[b, :L] = torch.tensor(row, dtype=torch.float32)
+
+            loss_out = loss_fn(pack, logprobs)
+            if isinstance(loss_out, tuple):
+                loss_val, pack_metrics = loss_out
+            else:
+                loss_val = loss_out
+                pack_metrics = {}
+
+            losses.append(float(loss_val.detach() if isinstance(loss_val, torch.Tensor) else loss_val))
+            for key, value in pack_metrics.items():
+                value_float = float(value.detach() if isinstance(value, torch.Tensor) else value)
+                metrics[key] = metrics.get(key, 0.0) + value_float
+
+        # Average per-pack accumulations.
+        num_packs = len(packs)
+        if num_packs > 1:
+            for key in list(metrics.keys()):
+                metrics[key] = metrics[key] / num_packs
+
+        result = {"loss": sum(losses) / max(len(losses), 1)}
+        result.update(metrics)
+        return result
+
     def save_checkpoint(self, ctx: Context, path: str) -> str:
         engine = self._require_engine()
         return engine.save_checkpoint(path)

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -429,7 +429,7 @@ class ArenoBackend(Backend):
         for pack in packs:
             # Extract per-row token lists for score_logprobs.
             tokens = pack["input_ids"]  # (B, max_len) int64
-            lengths = pack["lengths"]   # (B,) int32
+            lengths = pack["lengths"]  # (B,) int32
             token_rows = []
             for b in range(tokens.shape[0]):
                 L = int(lengths[b].item())
@@ -451,7 +451,7 @@ class ArenoBackend(Backend):
             logprobs = torch.zeros(B, max_len - 1, dtype=torch.float32)
             for b, row in enumerate(logprob_rows):
                 nxt = row[1:]  # drop position-0 dummy logprob
-                L = len(nxt)   # == len(row) - 1
+                L = len(nxt)  # == len(row) - 1
                 logprobs[b, :L] = torch.tensor(nxt, dtype=torch.float32)
 
             loss_out = loss_fn(pack, logprobs)

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -443,12 +443,16 @@ class ArenoBackend(Backend):
                 microbatch_size=int(mini_bs),
             )
 
-            # Reconstruct a (B, max_len-1) tensor matching next_token_logprobs.
+            # Reconstruct a (B, max_len-1) next-token logprobs tensor.
+            # score_logprobs returns N values (one per input token, including
+            # position 0). Skip position 0 to produce N-1 next-token logprobs
+            # that align with the loss function's prompt_mask[:, 1:] layout.
             B, max_len = tokens.shape
             logprobs = torch.zeros(B, max_len - 1, dtype=torch.float32)
             for b, row in enumerate(logprob_rows):
-                L = len(row)  # == lengths[b] - 1
-                logprobs[b, :L] = torch.tensor(row, dtype=torch.float32)
+                nxt = row[1:]  # drop position-0 dummy logprob
+                L = len(nxt)   # == len(row) - 1
+                logprobs[b, :L] = torch.tensor(nxt, dtype=torch.float32)
 
             loss_out = loss_fn(pack, logprobs)
             if isinstance(loss_out, tuple):

--- a/areno/api/backend/base.py
+++ b/areno/api/backend/base.py
@@ -94,6 +94,22 @@ class Backend(ABC):
 
         pass
 
+    def evaluate(
+        self,
+        ctx: Context,
+        batch_data: list[TrainSequence],
+        loss_fn: Callable,
+        mini_bs: int,
+        gradient_accumulation_steps: int | None = None,
+    ) -> dict[str, float]:
+        """Run a forward-only evaluation pass; no gradient, no optimizer step.
+
+        Default implementation raises `NotImplementedError` so backends that
+        are not evaluation-capable fail explicitly.
+        """
+
+        raise NotImplementedError(f"{type(self).__name__} does not support evaluation")
+
     def save_checkpoint(self, ctx: Context, path: str) -> str:
         """Persist model weights, or raise when the backend cannot save."""
 

--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -40,6 +40,17 @@ class MetricsRecorder:
         stats = collect_train_batch_stats(train_batch)
         record_training_stats(self._writer, stats, step, train_result, train_batch, timings=timings)
 
+    def record_eval_step(self, *, step: int, eval_result: dict[str, float]) -> None:
+        """Write evaluation metrics under the `eval/` TensorBoard namespace.
+
+        Callers aggregate metrics across eval batches before calling this
+        method so that a single eval step produces one consistent scalar
+        point in TensorBoard.
+        """
+        for key, value in eval_result.items():
+            self._writer.add_scalar(f"eval/{key}", value, step)
+        self._writer.flush()
+
     def record_rollout_sample(self, sample: dict) -> None:
         """Record a representative decoded rollout sample beside TensorBoard events."""
 

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -11,6 +11,8 @@ import time
 from collections.abc import Callable, Iterable
 from typing import Any
 
+import torch
+
 from areno.api.agentic import LossMaskPolicy, RolloutSession
 from areno.api.backend.base import Backend, get_backend_cls
 from areno.api.config import BackendConfig, coerce_backend_config, resolve_backend_type
@@ -355,6 +357,30 @@ class Trainer:
             )
         self.finish_step()
         return result
+
+    def evaluate(
+        self,
+        batch_data: list[TrainSequence],
+        loss_fn: Callable,
+        mini_bs: int = 8,
+        gradient_accumulation_steps: int | None = None,
+    ) -> dict[str, float]:
+        """Run a forward-only evaluation pass on a held-out dataset.
+
+        Wraps the backend call in ``torch.no_grad()``. Does **not** advance
+        ``global_step``, does **not** record TensorBoard metrics, and does
+        **not** touch the optimizer. The backend is responsible for switching
+        the model to ``eval()`` and back to ``train()`` before returning.
+        """
+
+        if not self._initialized:
+            raise RuntimeError("Trainer is not initialized")
+        if not callable(loss_fn):
+            raise TypeError("loss_fn must be callable")
+        with torch.no_grad():
+            return self._backend.evaluate(
+                self._ctx, batch_data, loss_fn, mini_bs, gradient_accumulation_steps
+            )
 
     def record_rollout_sample(self, sample: dict[str, Any]) -> None:
         """Persist a representative rollout sample when metrics recording is enabled."""

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -378,9 +378,7 @@ class Trainer:
         if not callable(loss_fn):
             raise TypeError("loss_fn must be callable")
         with torch.no_grad():
-            return self._backend.evaluate(
-                self._ctx, batch_data, loss_fn, mini_bs, gradient_accumulation_steps
-            )
+            return self._backend.evaluate(self._ctx, batch_data, loss_fn, mini_bs, gradient_accumulation_steps)
 
     def record_rollout_sample(self, sample: dict[str, Any]) -> None:
         """Persist a representative rollout sample when metrics recording is enabled."""

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -60,6 +60,9 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     chat_template_enable_thinking: bool | None = None
+    eval_dataset_path: str | None = None
+    eval_interval: int = 0
+    eval_batches: int = 0
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -273,7 +273,8 @@ class DPOTrainer:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
                     # End-of-training evaluation triggered before exiting at max_steps.
-                    if self._eval_enabled:
+                    # Skip when the interval eval already ran at this step.
+                    if self._eval_enabled and not (self.config.eval_interval > 0 and step % self.config.eval_interval == 0):
                         self._run_eval(step)
                     return
             # End-of-epoch evaluation: triggers regardless of interval alignment.

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -124,10 +124,10 @@ class DPOTrainer:
 
                 # Pre-compute reference logprobs for all sequences.
                 tokens = [seq.tokens for seq in eval_batch]
-                ref_logprob_rows = self.areno.score_logprobs(
-                    "ref", tokens, microbatch_size=self.config.score_micro_bs
-                )
+                ref_logprob_rows = self.areno.score_logprobs("ref", tokens, microbatch_size=self.config.score_micro_bs)
                 for seq, ref_lp in zip(eval_batch, ref_logprob_rows):
+                    if len(ref_lp) != len(seq.tokens):
+                        raise ValueError("reference role returned misaligned logprobs")
                     seq.ref_logprobs = [float(v) for v in ref_lp]
                     seq.values = [0.0] * len(seq.tokens)
                     seq.returns = [0.0] * len(seq.tokens)
@@ -154,10 +154,10 @@ class DPOTrainer:
                 eval_batch.extend(p)
 
             tokens = [seq.tokens for seq in eval_batch]
-            ref_logprob_rows = self.areno.score_logprobs(
-                "ref", tokens, microbatch_size=self.config.score_micro_bs
-            )
+            ref_logprob_rows = self.areno.score_logprobs("ref", tokens, microbatch_size=self.config.score_micro_bs)
             for seq, ref_lp in zip(eval_batch, ref_logprob_rows):
+                if len(ref_lp) != len(seq.tokens):
+                    raise ValueError("reference role returned misaligned logprobs")
                 seq.ref_logprobs = [float(v) for v in ref_lp]
                 seq.values = [0.0] * len(seq.tokens)
                 seq.returns = [0.0] * len(seq.tokens)
@@ -274,7 +274,9 @@ class DPOTrainer:
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
                     # End-of-training evaluation triggered before exiting at max_steps.
                     # Skip when the interval eval already ran at this step.
-                    if self._eval_enabled and not (self.config.eval_interval > 0 and step % self.config.eval_interval == 0):
+                    if self._eval_enabled and not (
+                        self.config.eval_interval > 0 and step % self.config.eval_interval == 0
+                    ):
                         self._run_eval(step)
                     return
             # End-of-epoch evaluation: triggers regardless of interval alignment.

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -47,6 +47,27 @@ class DPOTrainer:
             "ref": ModelRole("ref", config.ref_ckpt or config.ckpt, trainable=False),
         }
 
+    @property
+    def _eval_enabled(self) -> bool:
+        return self.config.eval_dataset_path is not None
+
+    def _load_eval_dataset(self) -> list:
+        """Lazily load the evaluation dataset, caching on first call."""
+        if hasattr(self, "_eval_dataset"):
+            return self._eval_dataset
+        from datasets import load_dataset, load_from_disk
+
+        from areno.cli.train import _load_dataset_for_training
+
+        self._eval_dataset = _load_dataset_for_training(
+            self.config.eval_dataset_path,
+            dataset_loader_fn=getattr(self.config, "dataset_loader_fn", None),
+            model_hub=self.config.model_hub,
+            load_dataset=load_dataset,
+            load_from_disk=load_from_disk,
+        )
+        return self._eval_dataset
+
     def fit(self) -> None:
         self.areno.init()
         self._ensure_roles()
@@ -61,6 +82,126 @@ class DPOTrainer:
         self.areno.ensure_roles(self.roles)
         for role in self.roles.values():
             self.logger.info("role=%s stage=init_end trainable=%s", role.name, role.trainable)
+
+    def _run_eval(self, step: int) -> None:
+        """Execute one DPO evaluation pass: load data, tokenize pairs, pre-compute
+        reference logprobs, batch evaluate with ``dpo_loss_fn``, and record
+        aggregated metrics under the ``eval/`` TensorBoard namespace.
+
+        Each pair (chosen/rejected) is converted to two ``TrainSequence`` rows.
+        Before calling ``trainer.evaluate()``, the frozen reference policy
+        scores all token rows so ``dpo_loss_fn`` can compare chosen-vs-rejected
+        logprob margins against the reference margins.
+        """
+        import time
+
+        eval_dataset = self._load_eval_dataset()
+        if len(eval_dataset) == 0:
+            raise ValueError("eval dataset is empty")
+
+        tokenizer = self.areno.get_tokenizer()
+        max_seq_len = self.config.max_prompt_tokens + self.config.max_new_tokens
+
+        total_loss = 0.0
+        total_accuracy_sum = 0.0
+        total_margin_sum = 0.0
+        total_pairs = 0
+        eval_start = time.perf_counter()
+
+        eval_pairs: list = []
+        num_batches = 0
+        for record in eval_dataset:
+            pair = _record_to_train_pair(record, tokenizer, max_seq_len=max_seq_len)
+            if pair is None:
+                continue
+            # pair is [chosen_seq, rejected_seq]
+            eval_pairs.append(pair)
+            if len(eval_pairs) >= self.config.batch_size:
+                # Flatten pairs into [chosen, rejected, chosen, rejected, ...].
+                eval_batch = []
+                for p in eval_pairs:
+                    eval_batch.extend(p)
+
+                # Pre-compute reference logprobs for all sequences.
+                tokens = [seq.tokens for seq in eval_batch]
+                ref_logprob_rows = self.areno.score_logprobs(
+                    "ref", tokens, microbatch_size=self.config.score_micro_bs
+                )
+                for seq, ref_lp in zip(eval_batch, ref_logprob_rows):
+                    seq.ref_logprobs = [float(v) for v in ref_lp]
+                    seq.values = [0.0] * len(seq.tokens)
+                    seq.returns = [0.0] * len(seq.tokens)
+
+                result = self.areno.evaluate(
+                    eval_batch,
+                    self.loss_fn,
+                    mini_bs=self.config.mini_bs,
+                    gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+                )
+                total_loss += result.get("dpo_loss", 0.0)
+                total_accuracy_sum += result.get("dpo_accuracy", 0.0)
+                total_margin_sum += result.get("dpo_margin", 0.0)
+                total_pairs += len(eval_pairs)
+                num_batches += 1
+                eval_pairs = []
+                if self.config.eval_batches > 0 and num_batches >= self.config.eval_batches:
+                    break
+
+        # Process any remaining incomplete batch.
+        if eval_pairs and (self.config.eval_batches == 0 or num_batches < self.config.eval_batches):
+            eval_batch = []
+            for p in eval_pairs:
+                eval_batch.extend(p)
+
+            tokens = [seq.tokens for seq in eval_batch]
+            ref_logprob_rows = self.areno.score_logprobs(
+                "ref", tokens, microbatch_size=self.config.score_micro_bs
+            )
+            for seq, ref_lp in zip(eval_batch, ref_logprob_rows):
+                seq.ref_logprobs = [float(v) for v in ref_lp]
+                seq.values = [0.0] * len(seq.tokens)
+                seq.returns = [0.0] * len(seq.tokens)
+
+            result = self.areno.evaluate(
+                eval_batch,
+                self.loss_fn,
+                mini_bs=self.config.mini_bs,
+                gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+            )
+            total_loss += result.get("dpo_loss", 0.0)
+            total_accuracy_sum += result.get("dpo_accuracy", 0.0)
+            total_margin_sum += result.get("dpo_margin", 0.0)
+            total_pairs += len(eval_pairs)
+            num_batches += 1
+
+        if total_pairs == 0:
+            raise ValueError("eval dataset produced no valid pairs")
+
+        final_metrics: dict[str, float] = {}
+        if num_batches > 0:
+            final_metrics["dpo_loss"] = total_loss / num_batches
+            final_metrics["dpo_accuracy"] = total_accuracy_sum / num_batches
+            final_metrics["dpo_margin"] = total_margin_sum / num_batches
+        else:
+            final_metrics["dpo_loss"] = 0.0
+            final_metrics["dpo_accuracy"] = 0.0
+            final_metrics["dpo_margin"] = 0.0
+        final_metrics["sample_count"] = float(total_pairs * 2)
+        final_metrics["duration_s"] = time.perf_counter() - eval_start
+
+        if self.areno._metrics is not None:
+            self.areno._metrics.record_eval_step(step=step, eval_result=final_metrics)
+
+        self.logger.info(
+            "step=%d stage=eval_end eval_loss=%.4f accuracy=%.4f margin=%.4f sample_count=%d duration_s=%.3f",
+            step,
+            final_metrics["dpo_loss"],
+            final_metrics["dpo_accuracy"],
+            final_metrics["dpo_margin"],
+            int(final_metrics["sample_count"]),
+            final_metrics["duration_s"],
+        )
+        record_dashboard_state(self.areno, stage="eval_end", step=step)
 
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
@@ -125,10 +266,19 @@ class DPOTrainer:
                 self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
                 self._maybe_save(epoch, step)
                 step += 1
+                # Interval evaluation: triggered every eval_interval training steps.
+                if self._eval_enabled and self.config.eval_interval > 0 and step % self.config.eval_interval == 0:
+                    self._run_eval(step)
                 if self.config.max_steps is not None and step >= self.config.max_steps:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
+                    # End-of-training evaluation triggered before exiting at max_steps.
+                    if self._eval_enabled:
+                        self._run_eval(step)
                     return
+            # End-of-epoch evaluation: triggers regardless of interval alignment.
+            if self._eval_enabled:
+                self._run_eval(step)
             self.logger.info("epoch=%d stage=epoch_end", epoch)
             record_dashboard_state(self.areno, stage="epoch_end", epoch=epoch, step=step, role="policy")
 

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -143,10 +143,8 @@ class SFTTrainer:
         final_metrics: dict[str, float] = {}
         if total_target_tokens > 0:
             final_metrics["sft_loss"] = total_weighted_loss / total_target_tokens
-            final_metrics["sft_logprob_mean"] = -final_metrics["sft_loss"]
         else:
             final_metrics["sft_loss"] = 0.0
-            final_metrics["sft_logprob_mean"] = 0.0
         final_metrics["sft_target_tokens"] = float(total_target_tokens)
         final_metrics["sample_count"] = float(total_samples)
         final_metrics["duration_s"] = time.perf_counter() - eval_start

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -44,12 +44,124 @@ class SFTTrainer:
         self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
+    @property
+    def _eval_enabled(self) -> bool:
+        return self.config.eval_dataset_path is not None
+
+    def _load_eval_dataset(self) -> list:
+        """Lazily load the evaluation dataset, caching on first call."""
+        if hasattr(self, "_eval_dataset"):
+            return self._eval_dataset
+        from datasets import load_dataset, load_from_disk
+
+        from areno.cli.train import _load_dataset_for_training
+
+        self._eval_dataset = _load_dataset_for_training(
+            self.config.eval_dataset_path,
+            dataset_loader_fn=getattr(self.config, "dataset_loader_fn", None),
+            model_hub=self.config.model_hub,
+            load_dataset=load_dataset,
+            load_from_disk=load_from_disk,
+        )
+        return self._eval_dataset
+
     def fit(self) -> None:
         self.areno.init()
         try:
             self._fit_initialized()
         finally:
             self.areno.close()
+
+    def _run_eval(self, step: int) -> None:
+        """Execute one evaluation pass: load data, tokenize, batch, evaluate, record.
+
+        Metrics are aggregated across eval batches: loss is weighted by
+        ``sft_target_tokens``, sample counts are summed, and the final dict is
+        written via ``MetricsRecorder.record_eval_step`` under the ``eval/``
+        TensorBoard namespace.
+        """
+        import time
+
+        eval_dataset = self._load_eval_dataset()
+        if len(eval_dataset) == 0:
+            raise ValueError("eval dataset is empty")
+
+        tokenizer = self.areno.get_tokenizer()
+        max_prompt_tokens = self.config.max_prompt_tokens
+        max_new_tokens = self.config.max_new_tokens
+
+        total_weighted_loss = 0.0
+        total_target_tokens = 0
+        total_samples = 0
+        eval_start = time.perf_counter()
+
+        eval_batch: list = []
+        num_batches = 0
+        for record in eval_dataset:
+            seq = _record_to_train_sequence(
+                record,
+                tokenizer,
+                max_prompt_tokens=max_prompt_tokens,
+                max_new_tokens=max_new_tokens,
+            )
+            if seq is None:
+                continue
+            eval_batch.append(seq)
+            if len(eval_batch) >= self.config.batch_size:
+                result = self.areno.evaluate(
+                    eval_batch,
+                    self.loss_fn,
+                    mini_bs=self.config.mini_bs,
+                    gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+                )
+                batch_tokens = result.get("sft_target_tokens", len(eval_batch))
+                total_weighted_loss += result.get("sft_loss", 0.0) * batch_tokens
+                total_target_tokens += batch_tokens
+                total_samples += len(eval_batch)
+                num_batches += 1
+                eval_batch = []
+                if self.config.eval_batches > 0 and num_batches >= self.config.eval_batches:
+                    break
+
+        # Process any remaining incomplete batch.
+        if eval_batch and (self.config.eval_batches == 0 or num_batches < self.config.eval_batches):
+            result = self.areno.evaluate(
+                eval_batch,
+                self.loss_fn,
+                mini_bs=self.config.mini_bs,
+                gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+            )
+            batch_tokens = result.get("sft_target_tokens", len(eval_batch))
+            total_weighted_loss += result.get("sft_loss", 0.0) * batch_tokens
+            total_target_tokens += batch_tokens
+            total_samples += len(eval_batch)
+            num_batches += 1
+
+        if total_samples == 0:
+            raise ValueError("eval dataset produced no valid rows")
+
+        final_metrics: dict[str, float] = {}
+        if total_target_tokens > 0:
+            final_metrics["sft_loss"] = total_weighted_loss / total_target_tokens
+            final_metrics["sft_logprob_mean"] = -final_metrics["sft_loss"]
+        else:
+            final_metrics["sft_loss"] = 0.0
+            final_metrics["sft_logprob_mean"] = 0.0
+        final_metrics["sft_target_tokens"] = float(total_target_tokens)
+        final_metrics["sample_count"] = float(total_samples)
+        final_metrics["duration_s"] = time.perf_counter() - eval_start
+
+        if self.areno._metrics is not None:
+            self.areno._metrics.record_eval_step(step=step, eval_result=final_metrics)
+
+        self.logger.info(
+            "step=%d stage=eval_end eval_loss=%.4f sample_count=%d duration_s=%.3f",
+            step,
+            final_metrics["sft_loss"],
+            total_samples,
+            final_metrics["duration_s"],
+        )
+        record_dashboard_state(self.areno, stage="eval_end", step=step)
 
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
@@ -87,10 +199,19 @@ class SFTTrainer:
                 self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
                 self._maybe_save(epoch, step)
                 step += 1
+                # Interval evaluation: triggered every eval_interval training steps.
+                if self._eval_enabled and self.config.eval_interval > 0 and step % self.config.eval_interval == 0:
+                    self._run_eval(step)
                 if self.config.max_steps is not None and step >= self.config.max_steps:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
+                    # End-of-training evaluation triggered before exiting at max_steps.
+                    if self._eval_enabled:
+                        self._run_eval(step)
                     return
+            # End-of-epoch evaluation: triggers regardless of interval alignment.
+            if self._eval_enabled:
+                self._run_eval(step)
             self.logger.info("epoch=%d stage=epoch_end", epoch)
             record_dashboard_state(self.areno, stage="epoch_end", epoch=epoch, step=step, role="policy")
 

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -205,7 +205,9 @@ class SFTTrainer:
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
                     # End-of-training evaluation triggered before exiting at max_steps.
                     # Skip when the interval eval already ran at this step.
-                    if self._eval_enabled and not (self.config.eval_interval > 0 and step % self.config.eval_interval == 0):
+                    if self._eval_enabled and not (
+                        self.config.eval_interval > 0 and step % self.config.eval_interval == 0
+                    ):
                         self._run_eval(step)
                     return
             # End-of-epoch evaluation: triggers regardless of interval alignment.

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -206,7 +206,8 @@ class SFTTrainer:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
                     # End-of-training evaluation triggered before exiting at max_steps.
-                    if self._eval_enabled:
+                    # Skip when the interval eval already ran at this step.
+                    if self._eval_enabled and not (self.config.eval_interval > 0 and step % self.config.eval_interval == 0):
                         self._run_eval(step)
                     return
             # End-of-epoch evaluation: triggers regardless of interval alignment.

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -129,7 +129,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
         ),
     ),
     ("Checkpoint", ("save_path", "save_interval")),
-    ("Observability", ("metrics_log_dir",)),
+    ("Observability", ("metrics_log_dir", "eval_dataset_path", "eval_interval", "eval_batches")),
 )
 
 
@@ -176,6 +176,9 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     args.model_hub = getattr(args, "model_hub", "modelscope")
+    args.eval_dataset_path = getattr(args, "eval_dataset_path", None)
+    args.eval_interval = getattr(args, "eval_interval", 0)
+    args.eval_batches = getattr(args, "eval_batches", 0)
     smoke_infer = bool(getattr(args, "smoke_infer", False))
     smoke_train = bool(getattr(args, "smoke_train", False))
     if smoke_infer or smoke_train:
@@ -273,6 +276,17 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         _require_positive_float(args.lam, "--lam")
     if args.critic_warmup_steps < 0:
         raise click.UsageError("--critic-warmup-steps must be non-negative")
+    if args.eval_dataset_path is not None:
+        path = Path(args.eval_dataset_path).expanduser().resolve()
+        if not path.exists():
+            raise click.UsageError(
+                f"--eval-dataset-path does not exist: {path}"
+            )
+        args.eval_dataset_path = str(path)
+    if args.eval_interval < 0:
+        raise click.UsageError("--eval-interval must be non-negative")
+    if args.eval_batches < 0:
+        raise click.UsageError("--eval-batches must be non-negative")
     _preflight_task_hooks(args, algorithm)
     return _trainer_config_from_args(args)
 
@@ -598,6 +612,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     args.model_hub = getattr(args, "model_hub", "modelscope")
+    args.eval_dataset_path = getattr(args, "eval_dataset_path", None)
+    args.eval_interval = getattr(args, "eval_interval", 0)
+    args.eval_batches = getattr(args, "eval_batches", 0)
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
@@ -638,6 +655,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            eval_dataset_path=args.eval_dataset_path,
+            eval_interval=args.eval_interval,
+            eval_batches=args.eval_batches,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
         )
@@ -679,6 +699,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            eval_dataset_path=args.eval_dataset_path,
+            eval_interval=args.eval_interval,
+            eval_batches=args.eval_batches,
         )
     if algorithm.name != "ppo":
         return PolicyTrainerConfig(
@@ -1187,6 +1210,13 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 @click.option("--save-interval", type=int, default=100, show_default=True, help="Save checkpoint every N train steps.")
 @click.option(
     "--metrics-log-dir", default=DEFAULT_METRICS_LOG_DIR, show_default=True, help="TensorBoard metrics log directory."
+)
+@click.option("--eval-dataset-path", default=None, help="Optional evaluation dataset path.")
+@click.option(
+    "--eval-interval", type=int, default=0, show_default=True, help="Evaluate every N training steps. 0 disables periodic eval."
+)
+@click.option(
+    "--eval-batches", type=int, default=0, show_default=True, help="Max eval batches per evaluation. 0 means full dataset."
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
 @click.option("--max-steps", type=int, default=None, help="Stop after this many trainer steps.")

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -279,9 +279,7 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if args.eval_dataset_path is not None:
         path = Path(args.eval_dataset_path).expanduser().resolve()
         if path.suffix.lower() in _SUPPORTED_DATASET_SUFFIXES and not path.exists():
-            raise click.UsageError(
-                f"--eval-dataset-path does not exist: {path}"
-            )
+            raise click.UsageError(f"--eval-dataset-path does not exist: {path}")
         if path.exists():
             args.eval_dataset_path = str(path)
     if args.eval_interval < 0:
@@ -1225,10 +1223,18 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option("--eval-dataset-path", default=None, help="Optional evaluation dataset path.")
 @click.option(
-    "--eval-interval", type=int, default=0, show_default=True, help="Evaluate every N training steps. 0 disables periodic eval."
+    "--eval-interval",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Evaluate every N training steps. 0 disables periodic eval.",
 )
 @click.option(
-    "--eval-batches", type=int, default=0, show_default=True, help="Max eval batches per evaluation. 0 means full dataset."
+    "--eval-batches",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Max eval batches per evaluation. 0 means full dataset.",
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
 @click.option("--max-steps", type=int, default=None, help="Stop after this many trainer steps.")

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -374,6 +374,17 @@ def _format_training_config_summary(
             ],
         ),
     ]
+    if getattr(config, "eval_dataset_path", None) is not None:
+        sections.append(
+            (
+                "Evaluation",
+                [
+                    ("eval_dataset_path", str(config.eval_dataset_path)),
+                    ("eval_interval", str(config.eval_interval)),
+                    ("eval_batches", _format_optional(config.eval_batches, default="full dataset")),
+                ],
+            )
+        )
     lines = [_style("AReno training config", fg="bright_white", bold=True, color=color)]
     if attn_warning is not None:
         lines.append(_style("WARNING", fg="yellow", bold=True, color=color) + f": {attn_warning}")
@@ -975,7 +986,7 @@ def _training_config_settings(config: TrainerConfig) -> dict:
             ],
         ),
         section("Checkpoint", ["save_path", "save_interval"]),
-        section("Observability", ["metrics_log_dir"]),
+        section("Observability", ["metrics_log_dir", "eval_dataset_path", "eval_interval", "eval_batches"]),
     ]
     extras = []
     for field in fields(config):

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -278,11 +278,12 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--critic-warmup-steps must be non-negative")
     if args.eval_dataset_path is not None:
         path = Path(args.eval_dataset_path).expanduser().resolve()
-        if not path.exists():
+        if path.suffix.lower() in _SUPPORTED_DATASET_SUFFIXES and not path.exists():
             raise click.UsageError(
                 f"--eval-dataset-path does not exist: {path}"
             )
-        args.eval_dataset_path = str(path)
+        if path.exists():
+            args.eval_dataset_path = str(path)
     if args.eval_interval < 0:
         raise click.UsageError("--eval-interval must be non-negative")
     if args.eval_batches < 0:

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -366,6 +366,85 @@ Observability
    ``rollout/*``, ``train/*``, and ``time/*`` metric namespaces and debugging
    log examples.
 
+Periodic evaluation
+~~~~~~~~~~~~~~~~~~~
+
+SFT and DPO trainers support periodic evaluation on a held-out dataset. When
+enabled, the trainer pauses every *N* steps, runs a no-gradient forward pass
+on the eval set, records the loss, and resumes training. Parameters, optimizer
+state, and RNG are untouched.
+
+Evaluation is disabled by default. Enable it by passing at least
+``--eval-dataset-path``.
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3.5-0.8B \
+     --algo sft \
+     --dataset-path yahma/alpaca-cleaned \
+     --dataset-loader-fn examples/sft/alpaca/dataset_loader.py \
+     --batch-size 2 --mini-bs 2 --max-steps 1000 \
+     --eval-dataset-path ./eval_data.jsonl \
+     --eval-interval 100 \
+     --eval-batches 10
+
+``--eval-dataset-path TEXT``
+   Path to the evaluation dataset. Same format as the training dataset
+   (SFT: ``prompt`` / ``response``; DPO: ``chosen`` / ``rejected``). Accepts
+   local files (JSONL, Parquet, ...), directories, and remote HF/ModelScope
+   dataset references. When omitted, evaluation is disabled.
+
+``--eval-interval INTEGER``
+   Evaluate every *N* training steps. A value of ``0`` (default) skips
+   interval evaluation but still triggers a final evaluation at the end of
+   each epoch and when ``--max-steps`` is reached.
+
+``--eval-batches INTEGER``
+   Maximum number of batches per evaluation pass. ``0`` (default) means
+   iterate the full eval dataset. Use a positive value to bound eval time
+   on large datasets.
+
+Output
+......
+
+Each evaluation produces one structured log line:
+
+.. code-block:: text
+
+   step=100 stage=eval_end eval_loss=1.1692 sample_count=50 duration_s=1.407
+
+TensorBoard records every scalar under the ``eval/`` namespace, separate from
+``train/`` and ``rollout/``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Metric
+     - Meaning
+   * - ``eval/sft_loss``
+     - Weighted average NLL on eval set (SFT)
+   * - ``eval/dpo_loss``
+     - Preference loss on eval set (DPO)
+   * - ``eval/dpo_accuracy``
+     - Fraction of pairs where chosen > rejected (DPO)
+   * - ``eval/dpo_margin``
+     - Mean chosen-rejected logit margin (DPO)
+   * - ``eval/sample_count``
+     - Number of evaluated examples
+   * - ``eval/duration_s``
+     - Wall-clock seconds of the eval phase
+
+Limitations
+...........
+
+- Supported for SFT and DPO only. GSPO, GRPO, and PPO do not trigger
+  evaluation.
+- Eval and train datasets must have the same schema when using
+  ``--dataset-loader-fn``. The loader is applied to both.
+- Model ``eval()`` mode is restored by the next training step; inserting
+  operations between eval and train may require explicit mode management.
+
 Examples
 --------
 

--- a/examples/eval/dpo_eval_example.py
+++ b/examples/eval/dpo_eval_example.py
@@ -1,0 +1,150 @@
+"""DPO training with periodic evaluation -- runnable example.
+
+This example demonstrates the periodic evaluation feature for DPO training.
+It creates a small synthetic dataset of preference pairs, runs a few training
+steps with eval enabled, and logs the eval metrics to TensorBoard.
+
+Usage::
+
+    python examples/eval/dpo_eval_example.py
+
+Requirements: the ``datasets`` library and a tokenizer-aware model checkpoint.
+Note that DPO eval requires a frozen reference policy role (``"ref"``) to
+pre-compute reference logprobs before each evaluate() call.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from functools import partial
+from types import SimpleNamespace
+
+from areno.api.metrics import MetricsRecorder
+from areno.api.trainers.dpo import DPOTrainer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+
+class _ExampleTokenizer:
+    """Minimal tokeniser for the offline example."""
+
+    eos_token_id = 0
+    chat_template = None
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        return [ord(ch) % 50 + 1 for ch in text]
+
+    def apply_chat_template(self, messages, tokenize, add_generation_prompt=False):
+        del tokenize, add_generation_prompt
+        ids: list[int] = []
+        for message in messages:
+            ids.extend(self.encode(f"{message.get('role')}:{message.get('content')}"))
+        return ids
+
+
+class _ExampleBackend:
+    """Backend double for the offline DPO example.
+
+    Supports all DPOTrainer requirements: train, evaluate, score_logprobs,
+    ensure_roles, save_checkpoint, and get_tokenizer.
+    """
+
+    def __init__(self, metrics=None):
+        self.train_calls = 0
+        self.eval_calls = 0
+        self.ref_score_calls = 0
+        self._metrics = metrics
+
+    def init(self):
+        pass
+
+    def close(self):
+        pass
+
+    def get_tokenizer(self):
+        return _ExampleTokenizer()
+
+    def train(self, _batch, _loss_fn, *, mini_bs, gradient_accumulation_steps):
+        del mini_bs, gradient_accumulation_steps
+        self.train_calls += 1
+        return {"dpo_loss": 0.69, "total_loss": 0.69, "dpo_accuracy": 0.75}
+
+    def evaluate(self, batch_data, _loss_fn, *, mini_bs, gradient_accumulation_steps=None):
+        del mini_bs, gradient_accumulation_steps
+        self.eval_calls += 1
+        return {"dpo_loss": 0.5, "dpo_accuracy": 0.8, "dpo_margin": 0.3}
+
+    def save_checkpoint(self, _ctx, path):
+        return path
+
+    def score_logprobs(self, role, token_rows, microbatch_size=None):
+        del role, microbatch_size
+        self.ref_score_calls += 1
+        return [[-0.1 * float(i + 1) for i in range(len(row))] for row in token_rows]
+
+    def ensure_roles(self, roles):
+        pass
+
+
+def main() -> None:
+    log_dir = tempfile.mkdtemp(prefix="dpo_eval_example_")
+    metrics = MetricsRecorder(log_dir)
+
+    # Build a synthetic training dataset (short texts to fit token budgets).
+    train_data = [
+        {"prompt": "2+2?", "chosen": "4", "rejected": "5"},
+        {"prompt": "1+1?", "chosen": "2", "rejected": "3"},
+        {"prompt": "3+3?", "chosen": "6", "rejected": "7"},
+        {"prompt": "4+4?", "chosen": "8", "rejected": "9"},
+    ]
+
+    # Build a synthetic evaluation dataset.
+    eval_data = [
+        {"prompt": "5+5?", "chosen": "10", "rejected": "11"},
+        {"prompt": "6+6?", "chosen": "12", "rejected": "13"},
+    ]
+
+    config = SimpleNamespace(
+        batch_size=2,
+        epochs=1,
+        gradient_accumulation_steps=1,
+        max_new_tokens=10,
+        max_prompt_tokens=10,
+        mini_bs=2,
+        save_interval=100,
+        save_path=None,
+        max_steps=None,
+        eval_dataset_path="synthetic_dpo_eval",  # non-None enables eval
+        eval_interval=2,
+        eval_batches=0,
+        model_hub="hf",
+        dataset_loader_fn=None,
+        dpo_beta=0.1,
+        score_micro_bs=2,
+        ref_ckpt=None,
+        ckpt="/fake/ckpt",
+    )
+
+    backend = _ExampleBackend(metrics=metrics)
+    loss_fn = partial(lambda _pack, _logprobs, *, beta: None, beta=config.dpo_beta)
+    trainer = DPOTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
+
+    # Inject eval dataset directly to skip file loading.
+    trainer._eval_dataset = eval_data
+
+    print("=== DPO training with periodic evaluation ===")
+    trainer.fit()
+
+    metrics.close()
+
+    print(f"\nTrain calls       : {backend.train_calls}")
+    print(f"Eval calls        : {backend.eval_calls}")
+    print(f"Ref score calls   : {backend.ref_score_calls}")
+    print(f"TensorBoard logs written to: {log_dir}")
+    print("Run: tensorboard --logdir", log_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/eval/dpo_eval_example.py
+++ b/examples/eval/dpo_eval_example.py
@@ -128,7 +128,11 @@ def main() -> None:
     )
 
     backend = _ExampleBackend(metrics=metrics)
-    loss_fn = partial(lambda _pack, _logprobs, *, beta: None, beta=config.dpo_beta)
+
+    def _dpo_loss(_pack, _logprobs, *, beta):
+        return None
+
+    loss_fn = partial(_dpo_loss, beta=config.dpo_beta)
     trainer = DPOTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
 
     # Inject eval dataset directly to skip file loading.

--- a/examples/eval/sft_eval_example.py
+++ b/examples/eval/sft_eval_example.py
@@ -13,10 +13,8 @@ Requirements: the ``datasets`` library and a tokenizer-aware model checkpoint.
 
 from __future__ import annotations
 
-import json
 import logging
 import tempfile
-from pathlib import Path
 from types import SimpleNamespace
 
 from areno.api.metrics import MetricsRecorder
@@ -110,7 +108,11 @@ def main() -> None:
     )
 
     backend = _ExampleBackend(metrics=metrics)
-    loss_fn = lambda _pack, _logprobs: None
+
+    def _loss_fn(_pack, _logprobs):
+        return None
+
+    loss_fn = _loss_fn
     trainer = SFTTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
 
     # Inject eval dataset directly to skip file loading.

--- a/examples/eval/sft_eval_example.py
+++ b/examples/eval/sft_eval_example.py
@@ -1,0 +1,131 @@
+"""SFT training with periodic evaluation — runnable example.
+
+This example demonstrates the periodic evaluation feature for SFT training.
+It creates a small synthetic dataset, runs a few training steps with eval
+enabled, and logs the eval metrics to TensorBoard.
+
+Usage::
+
+    python examples/eval/sft_eval_example.py
+
+Requirements: the ``datasets`` library and a tokenizer-aware model checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from areno.api.metrics import MetricsRecorder
+from areno.api.trainers.sft import SFTTrainer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+
+
+class _ExampleTokenizer:
+    """Minimal tokeniser for the offline example."""
+
+    eos_token_id = 0
+    chat_template = None
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        return [ord(ch) % 50 + 1 for ch in text]
+
+    def apply_chat_template(self, messages, tokenize, add_generation_prompt=False):
+        del tokenize, add_generation_prompt
+        ids: list[int] = []
+        for message in messages:
+            ids.extend(self.encode(f"{message.get('role')}:{message.get('content')}"))
+        return ids
+
+
+class _ExampleBackend:
+    """Backend double for the offline example."""
+
+    def __init__(self, metrics=None):
+        self.train_calls = 0
+        self.eval_calls = 0
+        self._metrics = metrics
+
+    def init(self):
+        pass
+
+    def close(self):
+        pass
+
+    def get_tokenizer(self):
+        return _ExampleTokenizer()
+
+    def train(self, _batch, _loss_fn, *, mini_bs, gradient_accumulation_steps):
+        del mini_bs, gradient_accumulation_steps
+        self.train_calls += 1
+        return {"sft_loss": 1.0, "sft_target_tokens": 4.0}
+
+    def evaluate(self, batch_data, _loss_fn, *, mini_bs, gradient_accumulation_steps=None):
+        del mini_bs, gradient_accumulation_steps
+        self.eval_calls += 1
+        return {"sft_loss": 0.5, "sft_target_tokens": float(len(batch_data) * 4)}
+
+    def save_checkpoint(self, _ctx, path):
+        return path
+
+
+def main() -> None:
+    log_dir = tempfile.mkdtemp(prefix="sft_eval_example_")
+    metrics = MetricsRecorder(log_dir)
+
+    # Build a synthetic training dataset (short texts to fit token budgets).
+    train_data = [
+        {"prompt": "2+2?", "response": "4"},
+        {"prompt": "1+1?", "response": "2"},
+        {"prompt": "3+3?", "response": "6"},
+        {"prompt": "4+4?", "response": "8"},
+    ]
+
+    # Build a synthetic evaluation dataset.
+    eval_data = [
+        {"prompt": "5+5?", "response": "10"},
+        {"prompt": "6+6?", "response": "12"},
+    ]
+
+    config = SimpleNamespace(
+        batch_size=2,
+        epochs=1,
+        gradient_accumulation_steps=1,
+        max_new_tokens=10,
+        max_prompt_tokens=10,
+        mini_bs=1,
+        save_interval=100,
+        save_path=None,
+        max_steps=None,
+        eval_dataset_path="synthetic_eval",  # non-None enables eval
+        eval_interval=2,
+        eval_batches=0,
+        model_hub="hf",
+        dataset_loader_fn=None,
+    )
+
+    backend = _ExampleBackend(metrics=metrics)
+    loss_fn = lambda _pack, _logprobs: None
+    trainer = SFTTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
+
+    # Inject eval dataset directly to skip file loading.
+    trainer._eval_dataset = eval_data
+
+    print("=== SFT training with periodic evaluation ===")
+    trainer.fit()
+
+    metrics.close()
+
+    print(f"\nTrain calls : {backend.train_calls}")
+    print(f"Eval calls  : {backend.eval_calls}")
+    print(f"TensorBoard logs written to: {log_dir}")
+    print("Run: tensorboard --logdir", log_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_eval_cpu.py
+++ b/tests/test_eval_cpu.py
@@ -10,7 +10,6 @@ Task 5: DPO training evaluation integration.
 from __future__ import annotations
 
 import copy
-import importlib.util
 import tempfile
 import unittest
 from pathlib import Path
@@ -279,15 +278,18 @@ class EvalMetricsRecorderTest(unittest.TestCase):
             time_set = {t for t in scalar_tags if t.startswith("time/")}
 
             self.assertEqual(
-                len(eval_set & train_set), 0,
+                len(eval_set & train_set),
+                0,
                 "eval/ and train/ namespaces must not overlap",
             )
             self.assertEqual(
-                len(eval_set & rollout_set), 0,
+                len(eval_set & rollout_set),
+                0,
                 "eval/ and rollout/ namespaces must not overlap",
             )
             self.assertEqual(
-                len(eval_set & time_set), 0,
+                len(eval_set & time_set),
+                0,
                 "eval/ and time/ namespaces must not overlap",
             )
 
@@ -399,7 +401,11 @@ def _make_sft_trainer(config, *, train_data=None, backend=None, _metrics=None):
         backend = _FakeEvalSFTBackend(metrics=_metrics)
     if train_data is None:
         train_data = list(_FIXTURE_TRAIN_DATA)
-    loss_fn = lambda _pack, _logprobs: None
+
+    def _stub_loss_fn(_pack, _logprobs):
+        return None
+
+    loss_fn = _stub_loss_fn
     trainer = SFTTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
     return trainer, backend
 
@@ -561,8 +567,14 @@ class SFTEvalIntegrationTest(unittest.TestCase):
     def test_eval_end_of_max_steps(self):
         """max_steps exit triggers eval before return."""
         train_calls, eval_steps = self._count_eval_calls_from_fit(
-            {"eval_dataset_path": "dummy", "eval_interval": 0, "eval_batches": 0,
-             "batch_size": 1, "epochs": 2, "max_steps": 3},
+            {
+                "eval_dataset_path": "dummy",
+                "eval_interval": 0,
+                "eval_batches": 0,
+                "batch_size": 1,
+                "epochs": 2,
+                "max_steps": 3,
+            },
             train_rows=10,
         )
         self.assertEqual(train_calls, 3)
@@ -742,7 +754,10 @@ def _make_dpo_trainer(config, *, train_data=None, backend=None, _metrics=None):
     if train_data is None:
         train_data = list(_FIXTURE_DPO_TRAIN_DATA)
 
-    loss_fn = partial(lambda _pack, _logprobs, *, beta: None, beta=config.dpo_beta)
+    def _dpo_stub_loss(_pack, _logprobs, *, beta):
+        return None
+
+    loss_fn = partial(_dpo_stub_loss, beta=config.dpo_beta)
     trainer = DPOTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
     return trainer, backend
 
@@ -832,3 +847,76 @@ class DPOEvalIntegrationTest(unittest.TestCase):
             # 6 train rows at batch_size=2 pairs => 3 train batches (each is 4 rows).
             self.assertEqual(backend.train_calls, 3)
             self.assertGreater(backend.eval_calls, 0)
+
+    def test_dpo_eval_batches_limit(self):
+        """DPO eval_batches limits the number of evaluated batches."""
+        from areno.api.metrics import MetricsRecorder
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            metrics = MetricsRecorder(log_dir)
+            config = _dpo_eval_config(
+                eval_dataset_path="dummy",
+                eval_interval=2,
+                eval_batches=1,
+                batch_size=2,
+            )
+            trainer, backend = _make_dpo_trainer(config, _metrics=metrics)
+            trainer._eval_dataset = list(_FIXTURE_DPO_EVAL_DATA)
+            trainer._ensure_roles()
+
+            trainer._run_eval(step=10)
+
+            self.assertEqual(backend.eval_calls, 1)
+            self.assertEqual(backend.ref_score_calls, 1)
+            metrics.close()
+
+            import tensorboard.backend.event_processing.event_accumulator as ea
+
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            eval_tags = [t for t in acc.Tags()["scalars"] if t.startswith("eval/")]
+            self.assertIn("eval/dpo_loss", eval_tags)
+
+    def test_dpo_eval_disabled(self):
+        """DPO eval does not trigger when eval_dataset_path is None."""
+        from areno.api.metrics import MetricsRecorder
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            metrics = MetricsRecorder(log_dir)
+            train_data = [_FIXTURE_DPO_TRAIN_DATA[0].copy() for _ in range(6)]
+            config = _dpo_eval_config(
+                eval_dataset_path=None,
+                eval_interval=2,
+                eval_batches=0,
+                batch_size=2,
+                epochs=1,
+                max_steps=2,
+            )
+            trainer, backend = _make_dpo_trainer(config, train_data=train_data, _metrics=metrics)
+            trainer._eval_dataset = list(_FIXTURE_DPO_EVAL_DATA)
+            trainer.fit()
+            metrics.close()
+
+            import tensorboard.backend.event_processing.event_accumulator as ea
+
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            eval_tags = [t for t in acc.Tags()["scalars"] if t.startswith("eval/")]
+            self.assertEqual(len(eval_tags), 0, "eval/ tags should not exist when disabled")
+            self.assertEqual(backend.eval_calls, 0)
+
+    def test_dpo_eval_ref_logprob_mismatch(self):
+        """DPO eval raises ValueError when ref logprobs don't match token count."""
+        trainer, backend = _make_dpo_trainer(_dpo_eval_config(eval_dataset_path="dummy", batch_size=2))
+
+        def _score_logprobs_mismatch(role, token_rows, microbatch_size=None):
+            del role, microbatch_size
+            return [[-0.1] * (len(row) - 1) for row in token_rows]
+
+        backend.score_logprobs = _score_logprobs_mismatch
+        trainer._eval_dataset = list(_FIXTURE_DPO_EVAL_DATA)
+        trainer._ensure_roles()
+
+        with self.assertRaises(ValueError) as ctx:
+            trainer._run_eval(step=10)
+        self.assertIn("misaligned logprobs", str(ctx.exception))

--- a/tests/test_eval_cpu.py
+++ b/tests/test_eval_cpu.py
@@ -451,7 +451,6 @@ class SFTEvalIntegrationTest(unittest.TestCase):
             acc.Reload()
             eval_tags = [t for t in acc.Tags()["scalars"] if t.startswith("eval/")]
             self.assertIn("eval/sft_loss", eval_tags)
-            self.assertIn("eval/sft_logprob_mean", eval_tags)
             self.assertIn("eval/sft_target_tokens", eval_tags)
             self.assertIn("eval/sample_count", eval_tags)
             self.assertIn("eval/duration_s", eval_tags)
@@ -629,7 +628,6 @@ class SFTEvalIntegrationTest(unittest.TestCase):
             eval_tags = [t for t in scalar_tags if t.startswith("eval/")]
             self.assertGreater(len(eval_tags), 0, "eval/ tags should exist")
             self.assertIn("eval/sft_loss", eval_tags)
-            self.assertIn("eval/sft_logprob_mean", eval_tags)
             self.assertIn("eval/sample_count", eval_tags)
             self.assertIn("eval/duration_s", eval_tags)
 

--- a/tests/test_eval_cpu.py
+++ b/tests/test_eval_cpu.py
@@ -1,0 +1,836 @@
+"""CPU-side unit tests for periodic evaluation during SFT/DPO training.
+
+Task 1: Evaluation config and CLI entrypoint.
+Task 2: Trainer.evaluate() core method.
+Task 3: Evaluation metric recording.
+Task 4: SFT training evaluation integration.
+Task 5: DPO training evaluation integration.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import click
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from areno import Trainer
+from areno.api.context import Context
+from areno.api.models import TrainSequence
+
+
+def _default_sft_options(**overrides):
+    """Return kwargs for _trainer_config_from_options with SFT-safe defaults.
+
+    Every attribute that _trainer_config_from_options reads directly (i.e. not
+    via ``getattr``) must be present; missing values cause an
+    ``AttributeError`` deep inside the validation chain before our eval check
+    ever fires.
+    """
+    base = {
+        "algo": "sft",
+        "ckpt": "/fake/ckpt",
+        "dataset_path": "/fake/train.jsonl",
+        "dataset_loader_fn": "loader.py:load",
+        "model_hub": "modelscope",
+        "save_interval": 100,
+        "epochs": 10,
+        "tp_size": 2,
+        "world_size": 2,
+        "batch_size": 4,
+        "mini_bs": 2,
+        "max_prompt_tokens": 512,
+        "max_new_tokens": 512,
+        "max_context_len": None,
+        "agent_timeout_s": 300.0,
+        "gradient_accumulation_steps": None,
+        "lr": 1.0e-6,
+        "min_lr": 1.0e-7,
+        "lr_decay_steps": 100,
+        "adam_beta1": 0.9,
+        "adam_beta2": 0.999,
+        "weight_decay": 1.0e-2,
+        "grad_clip_norm": 1.0,
+        "critic_warmup_steps": 0,
+        "eval_dataset_path": None,
+        "eval_interval": 0,
+        "eval_batches": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across Task 2 / Task 4 / Task 5
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvalModel(nn.Module):
+    """Minimal module with a trainable parameter for eval safety tests."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(4, 8))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.float() @ self.weight
+
+
+class _EvalBackendStub:
+    """Backend stub: tracks model mode and has a simple evaluate() impl."""
+
+    def __init__(self, model: _FakeEvalModel, optimizer: optim.Optimizer | None = None):
+        self._model = model
+        self._optimizer = optimizer
+        self.eval_calls = 0
+
+    def evaluate(
+        self,
+        ctx: Context,
+        batch_data: list,
+        loss_fn,
+        mini_bs: int,
+        gradient_accumulation_steps: int | None = None,
+    ) -> dict[str, float]:
+        self.eval_calls += 1
+        self._model.eval()
+        try:
+            # Simulate forward pass + loss computation.
+            _ = self._model(torch.zeros(1, 4, dtype=torch.long))
+            return {"loss": 0.5, "sft_loss": 0.5, "sft_target_tokens": 4.0}
+        finally:
+            self._model.train()
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Evaluation config and CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+class EvalCliConfigTest(unittest.TestCase):
+    """Tests for eval CLI options and TrainerConfig fields."""
+
+    # -- _trainer_config_from_options ----------------------------------------
+
+    def test_eval_invalid_dataset_path(self):
+        """Non-existent --eval-dataset-path raises click.UsageError with path info."""
+        from areno.cli.train import _trainer_config_from_options
+
+        with tempfile.TemporaryDirectory() as td:
+            non_existent = Path(td) / "does_not_exist.jsonl"
+            options = _default_sft_options(eval_dataset_path=str(non_existent))
+            with self.assertRaises(click.UsageError) as ctx:
+                _trainer_config_from_options(**options)
+            self.assertIn("--eval-dataset-path", str(ctx.exception))
+            self.assertIn(str(non_existent), str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Trainer.evaluate() core method
+# ---------------------------------------------------------------------------
+
+
+class EvalTrainerCoreTest(unittest.TestCase):
+    """Tests for Trainer.evaluate() — param safety, mode restore, optimizer."""
+
+    def _make_trainer(self) -> tuple[Trainer, _FakeEvalModel, _EvalBackendStub]:
+        model = _FakeEvalModel()
+        optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+        backend = _EvalBackendStub(model, optimizer)
+        trainer = Trainer(world_size=1, model_path="unused")
+        trainer._backend = backend
+        trainer._ctx = Context(1, "unused", object())
+        trainer._initialized = True
+        return trainer, model, backend
+
+    @staticmethod
+    def _dummy_loss_fn(_data_pack, _logprobs):
+        return torch.tensor(0.0), {"loss": torch.tensor(0.0)}
+
+    @staticmethod
+    def _make_simple_batch() -> list[TrainSequence]:
+        seq = TrainSequence(
+            prompt_mask=[True, True, True, False],
+            tokens=[1, 2, 3, 4],
+            logprobs=[-0.1, -0.2, -0.3, -0.4],
+            advantages=[0.0, 0.0, 0.0, 0.0],
+            eos_token_id=0,
+        )
+        return [seq]
+
+    # -- param safety ---------------------------------------------------------
+
+    def test_eval_params_unchanged(self):
+        """All model parameter values must be identical before and after eval."""
+        trainer, model, _ = self._make_trainer()
+        batch = self._make_simple_batch()
+
+        params_before = {name: param.clone() for name, param in model.named_parameters()}
+        trainer.evaluate(batch, self._dummy_loss_fn, mini_bs=4)
+        for name, param in model.named_parameters():
+            self.assertTrue(
+                torch.equal(params_before[name], param),
+                f"parameter '{name}' changed after evaluate()",
+            )
+
+    # -- model mode -----------------------------------------------------------
+
+    def test_eval_model_mode_restored(self):
+        """After evaluate(), model.training must be True."""
+        trainer, model, _ = self._make_trainer()
+        batch = self._make_simple_batch()
+
+        self.assertTrue(model.training, "model should be in train mode before eval")
+        trainer.evaluate(batch, self._dummy_loss_fn, mini_bs=4)
+        self.assertTrue(model.training, "model should be in train mode after eval")
+
+    # -- optimizer safety -----------------------------------------------------
+
+    def test_eval_optimizer_unchanged(self):
+        """Optimizer step count and momentum state must be unchanged by eval."""
+        trainer, model, backend = self._make_trainer()
+
+        # Do one real optimizer step so there is meaningful state to check.
+        opt: optim.SGD = backend._optimizer
+        opt.zero_grad()
+        loss = model(torch.zeros(1, 4, dtype=torch.long)).sum()
+        loss.backward()
+        opt.step()
+        step_after_train = copy.deepcopy(opt.state_dict())["state"]
+
+        batch = self._make_simple_batch()
+        trainer.evaluate(batch, self._dummy_loss_fn, mini_bs=4)
+        step_after_eval = copy.deepcopy(opt.state_dict())["state"]
+
+        # Compare per-parameter momentum buffers — must be identical.
+        for param_id, state_after_train in step_after_train.items():
+            self.assertIn(param_id, step_after_eval, f"param {param_id} missing after eval")
+            state_after_eval = step_after_eval[param_id]
+            for key in state_after_train:
+                if isinstance(state_after_train[key], torch.Tensor):
+                    self.assertTrue(
+                        torch.equal(state_after_train[key], state_after_eval[key]),
+                        f"opt state '{key}' for param {param_id} changed",
+                    )
+                else:
+                    self.assertEqual(state_after_train[key], state_after_eval[key])
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Evaluation metric recording
+# ---------------------------------------------------------------------------
+
+
+class EvalMetricsRecorderTest(unittest.TestCase):
+    """Tests for MetricsRecorder.record_eval_step() — eval/ namespace."""
+
+    def test_eval_metrics_namespace(self):
+        """Verify eval/ and train/ namespaces are independent in TensorBoard events."""
+        import tensorboard.backend.event_processing.event_accumulator as ea
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            from areno.api.metrics import MetricsRecorder
+
+            recorder = MetricsRecorder(log_dir)
+
+            # Record a training step (writes train/*, rollout/* tags).
+            seq = TrainSequence(
+                prompt_mask=[True, False],
+                tokens=[1, 2],
+                logprobs=[-0.1, -0.2],
+                advantages=[0.0, 0.1],
+                reward=1.0,
+            )
+            train_result = {"loss": 0.5, "sft_loss": 0.5}
+            recorder.record_train_step(step=10, train_result=train_result, train_batch=[seq])
+
+            # Record an eval step (writes eval/* tags).
+            eval_result = {"sft_loss": 2.3, "sample_count": 50.0, "duration_s": 1.2}
+            recorder.record_eval_step(step=10, eval_result=eval_result)
+
+            recorder.close()
+
+            # Read back TensorBoard events and verify namespace separation.
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            scalar_tags = acc.Tags()["scalars"]
+
+            # eval/ tags must exist with the expected keys.
+            eval_tags = [t for t in scalar_tags if t.startswith("eval/")]
+            self.assertEqual(len(eval_tags), 3, f"Expected 3 eval tags, got {eval_tags}")
+            self.assertIn("eval/sft_loss", eval_tags)
+            self.assertIn("eval/sample_count", eval_tags)
+            self.assertIn("eval/duration_s", eval_tags)
+
+            # train/ tags exist and were not overwritten.
+            train_tags = [t for t in scalar_tags if t.startswith("train/")]
+            self.assertGreater(len(train_tags), 0, "train/ tags should still exist")
+
+            # No overlap between eval/ and any other namespace (train/, rollout/, time/).
+            eval_set = {t for t in scalar_tags if t.startswith("eval/")}
+            train_set = {t for t in scalar_tags if t.startswith("train/")}
+            rollout_set = {t for t in scalar_tags if t.startswith("rollout/")}
+            time_set = {t for t in scalar_tags if t.startswith("time/")}
+
+            self.assertEqual(
+                len(eval_set & train_set), 0,
+                "eval/ and train/ namespaces must not overlap",
+            )
+            self.assertEqual(
+                len(eval_set & rollout_set), 0,
+                "eval/ and rollout/ namespaces must not overlap",
+            )
+            self.assertEqual(
+                len(eval_set & time_set), 0,
+                "eval/ and time/ namespaces must not overlap",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for Task 4 / Task 5
+# ---------------------------------------------------------------------------
+
+
+class _FakeTextTokenizer:
+    """Tokeniser double that returns small int ids for eval row conversion."""
+
+    eos_token_id = 99
+    chat_template = None
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        return [ord(ch) % 50 + 1 for ch in text]
+
+    def apply_chat_template(self, messages, tokenize, add_generation_prompt=False):
+        del tokenize, add_generation_prompt
+        ids: list[int] = []
+        for message in messages:
+            ids.extend(self.encode(f"{message.get('role')}:{message.get('content')}"))
+        return ids
+
+
+class _FakeEvalSFTBackend:
+    """Backend double for SFT eval integration tests.
+
+    Supports ``init()``, ``close()``, ``get_tokenizer()``, ``train()``,
+    ``evaluate()``, and an optional ``_metrics`` attribute.
+    """
+
+    def __init__(self, metrics=None):
+        self.closed = False
+        self.train_calls = 0
+        self.eval_calls = 0
+        self._metrics = metrics
+        self._saved: list[str] = []
+
+    def init(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+    def get_tokenizer(self):
+        return _FakeTextTokenizer()
+
+    def train(self, _batch, _loss_fn, *, mini_bs, gradient_accumulation_steps):
+        del mini_bs, gradient_accumulation_steps
+        self.train_calls += 1
+        return {"sft_loss": 1.0, "sft_target_tokens": 4.0}
+
+    def evaluate(self, batch_data, _loss_fn, *, mini_bs, gradient_accumulation_steps=None):
+        del mini_bs, gradient_accumulation_steps
+        self.eval_calls += 1
+        return {"sft_loss": 0.5, "sft_target_tokens": float(len(batch_data) * 4)}
+
+    def save_checkpoint(self, _ctx, path):
+        self._saved.append(path)
+        return path
+
+
+_FIXTURE_EVAL_DATA: list[dict] = [
+    {"prompt": "q1", "response": "a1"},
+    {"prompt": "q2", "response": "a2"},
+    {"prompt": "q3", "response": "a3"},
+    {"prompt": "q4", "response": "a4"},
+    {"prompt": "q5", "response": "a5"},
+]
+
+_FIXTURE_TRAIN_DATA: list[dict] = [
+    {"prompt": "q1", "response": "a1"},
+    {"prompt": "q2", "response": "a2"},
+]
+
+
+def _sft_eval_config(**overrides):
+    """Return a SimpleNamespace with the fields SFTTrainer reads."""
+    from types import SimpleNamespace
+
+    defaults = {
+        "batch_size": 2,
+        "epochs": 1,
+        "gradient_accumulation_steps": 1,
+        "max_new_tokens": 10,
+        "max_prompt_tokens": 10,
+        "mini_bs": 1,
+        "save_interval": 100,
+        "save_path": None,
+        "max_steps": None,
+        "eval_dataset_path": None,
+        "eval_interval": 0,
+        "eval_batches": 0,
+        "model_hub": "hf",
+        "dataset_loader_fn": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_sft_trainer(config, *, train_data=None, backend=None, _metrics=None):
+    """Build an SFTTrainer with a controlled backend for eval testing."""
+    from areno.api.trainers.sft import SFTTrainer
+
+    if backend is None:
+        backend = _FakeEvalSFTBackend(metrics=_metrics)
+    if train_data is None:
+        train_data = list(_FIXTURE_TRAIN_DATA)
+    loss_fn = lambda _pack, _logprobs: None
+    trainer = SFTTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
+    return trainer, backend
+
+
+# ---------------------------------------------------------------------------
+# Task 4: SFT training evaluation integration
+# ---------------------------------------------------------------------------
+
+
+class SFTEvalIntegrationTest(unittest.TestCase):
+    """Tests for SFTTrainer eval integration: _run_eval + _fit_initialized hooks."""
+
+    # -- _eval_enabled ---------------------------------------------------------
+
+    def test_eval_disabled_by_default(self):
+        """_eval_enabled is False when eval_dataset_path is None."""
+        config = _sft_eval_config(eval_dataset_path=None)
+        trainer, backend = _make_sft_trainer(config)
+        self.assertFalse(trainer._eval_enabled)
+        self.assertEqual(backend.train_calls, 0)
+        self.assertEqual(backend.eval_calls, 0)
+
+    # -- _run_eval (direct call) ----------------------------------------------
+
+    def test_eval_sft_success(self):
+        """SFT eval returns correct metrics when called directly."""
+        from areno.api.metrics import MetricsRecorder
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            metrics = MetricsRecorder(log_dir)
+            config = _sft_eval_config(
+                eval_dataset_path="dummy",
+                eval_interval=2,
+                eval_batches=0,
+                batch_size=2,
+            )
+            trainer, backend = _make_sft_trainer(config, _metrics=metrics)
+            trainer._eval_dataset = list(_FIXTURE_EVAL_DATA)
+
+            trainer._run_eval(step=10)
+
+            # All 5 fixture rows should be processed (batch_size=2 => 3 batches).
+            self.assertEqual(backend.eval_calls, 3)
+            # Verify metrics were recorded.
+            import tensorboard.backend.event_processing.event_accumulator as ea
+
+            metrics.close()
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            eval_tags = [t for t in acc.Tags()["scalars"] if t.startswith("eval/")]
+            self.assertIn("eval/sft_loss", eval_tags)
+            self.assertIn("eval/sft_logprob_mean", eval_tags)
+            self.assertIn("eval/sft_target_tokens", eval_tags)
+            self.assertIn("eval/sample_count", eval_tags)
+            self.assertIn("eval/duration_s", eval_tags)
+
+    def test_eval_batches_limit(self):
+        """eval_batches=2 processes at most 2 batches."""
+        config = _sft_eval_config(
+            eval_dataset_path="dummy",
+            eval_batches=2,
+            batch_size=1,
+        )
+        trainer, backend = _make_sft_trainer(config)
+        trainer._eval_dataset = list(_FIXTURE_EVAL_DATA)
+
+        trainer._run_eval(step=5)
+
+        self.assertEqual(backend.eval_calls, 2)
+
+    def test_eval_batches_full(self):
+        """eval_batches=0 traverses the full eval dataset."""
+        config = _sft_eval_config(
+            eval_dataset_path="dummy",
+            eval_batches=0,
+            batch_size=1,
+        )
+        trainer, backend = _make_sft_trainer(config)
+        trainer._eval_dataset = list(_FIXTURE_EVAL_DATA)
+
+        trainer._run_eval(step=5)
+
+        # 5 rows / batch_size=1 => 5 batches.
+        self.assertEqual(backend.eval_calls, 5)
+
+    def test_eval_dataset_empty(self):
+        """Empty eval dataset raises ValueError."""
+        config = _sft_eval_config(eval_dataset_path="dummy")
+        trainer, backend = _make_sft_trainer(config)
+        trainer._eval_dataset = []
+
+        with self.assertRaisesRegex(ValueError, "empty"):
+            trainer._run_eval(step=0)
+
+    # -- _fit_initialized integration -----------------------------------------
+
+    def test_eval_interval_trigger(self):
+        """eval_interval=2 triggers eval at steps 2, 4, ..."""
+        train_data = [_FIXTURE_TRAIN_DATA[0].copy() for _ in range(10)]
+        config = _sft_eval_config(
+            eval_dataset_path="dummy",
+            eval_interval=2,
+            eval_batches=1,
+            batch_size=1,
+            epochs=1,
+        )
+        trainer, backend = _make_sft_trainer(config, train_data=train_data)
+        trainer._eval_dataset = list(_FIXTURE_EVAL_DATA)
+
+        eval_steps: list[int] = []
+        _orig = trainer._run_eval
+
+        def _spy(step):
+            eval_steps.append(step)
+            _orig(step)
+
+        trainer._run_eval = _spy  # type: ignore[method-assign]
+        trainer.fit()
+
+        # 10 rows at batch_size=1 => 10 train steps.
+        # interval=2 => evals at steps 2, 4, 6, 8, 10 + epoch-end at step 10.
+        self.assertEqual(backend.train_calls, 10)
+        self.assertEqual(len(eval_steps), 6)
+        self.assertEqual(eval_steps, [2, 4, 6, 8, 10, 10])
+        self.assertTrue(backend.closed)
+
+    def _count_eval_calls_from_fit(self, config_overrides, train_rows=6):
+        """Helper that runs fit() and returns (train_calls, run_eval_steps).
+
+        Uses a spy on ``_run_eval`` so we count full eval passes, not
+        individual batch-evaluate calls.
+        """
+        train_data = [_FIXTURE_TRAIN_DATA[0].copy() for _ in range(train_rows)]
+        config = _sft_eval_config(**config_overrides)
+        trainer, backend = _make_sft_trainer(config, train_data=train_data)
+        trainer._eval_dataset = list(_FIXTURE_EVAL_DATA)
+
+        eval_steps: list[int] = []
+        _orig = trainer._run_eval
+
+        def _spy(step):
+            eval_steps.append(step)
+            _orig(step)
+
+        trainer._run_eval = _spy  # type: ignore[method-assign]
+        trainer.fit()
+        return backend.train_calls, eval_steps
+
+    def test_eval_end_of_epoch(self):
+        """Epoch end triggers eval regardless of interval alignment."""
+        train_calls, eval_steps = self._count_eval_calls_from_fit(
+            {"eval_dataset_path": "dummy", "eval_interval": 100, "eval_batches": 0, "batch_size": 2, "epochs": 1},
+            train_rows=4,
+        )
+        self.assertEqual(train_calls, 2)  # 4 rows / batch_size=2 = 2 batches
+        # Only end-of-epoch eval should fire (interval is too large).
+        self.assertEqual(len(eval_steps), 1)
+        self.assertEqual(eval_steps[0], 2)  # step=2 after 2 batches
+
+    def test_eval_end_of_max_steps(self):
+        """max_steps exit triggers eval before return."""
+        train_calls, eval_steps = self._count_eval_calls_from_fit(
+            {"eval_dataset_path": "dummy", "eval_interval": 0, "eval_batches": 0,
+             "batch_size": 1, "epochs": 2, "max_steps": 3},
+            train_rows=10,
+        )
+        self.assertEqual(train_calls, 3)
+        # max_steps exit eval fires once at step 3.
+        self.assertEqual(len(eval_steps), 1)
+        self.assertEqual(eval_steps[0], 3)
+
+    def test_eval_interval_zero_skips_interval_only(self):
+        """eval_interval=0 only triggers end-of-epoch eval (no interval eval)."""
+        # interval=0, 4 rows, batch_size=1 => 4 train steps, 1 epoch-end eval.
+        train_calls, eval_steps = self._count_eval_calls_from_fit(
+            {"eval_dataset_path": "dummy", "eval_interval": 0, "eval_batches": 0, "batch_size": 1, "epochs": 1},
+            train_rows=4,
+        )
+        self.assertEqual(train_calls, 4)
+        # Only end-of-epoch eval, at step 4.
+        self.assertEqual(len(eval_steps), 1)
+        self.assertEqual(eval_steps[0], 4)
+
+    def test_sft_train_unchanged_without_eval(self):
+        """Training is identical to baseline when eval is disabled."""
+        train_data = [_FIXTURE_TRAIN_DATA[0].copy() for _ in range(4)]
+        config = _sft_eval_config(
+            eval_dataset_path=None,
+            eval_interval=0,
+            eval_batches=0,
+            batch_size=1,
+            epochs=1,
+        )
+        trainer, backend = _make_sft_trainer(config, train_data=train_data)
+        trainer.fit()
+
+        # All 4 rows produced valid training batches; no eval calls.
+        self.assertEqual(backend.train_calls, 4)
+        self.assertEqual(backend.eval_calls, 0)
+        self.assertTrue(backend.closed)
+
+    def test_sft_eval_integration(self):
+        """Full SFT train + eval end-to-end: verify eval/ metrics recorded."""
+        from areno.api.metrics import MetricsRecorder
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            metrics = MetricsRecorder(log_dir)
+            train_data = [_FIXTURE_TRAIN_DATA[0].copy() for _ in range(6)]
+            config = _sft_eval_config(
+                eval_dataset_path="dummy",
+                eval_interval=2,
+                eval_batches=0,
+                batch_size=2,
+                epochs=1,
+            )
+            trainer, backend = _make_sft_trainer(config, train_data=train_data, _metrics=metrics)
+            trainer._eval_dataset = list(_FIXTURE_EVAL_DATA)
+            trainer.fit()
+            metrics.close()
+
+            # Verify eval/ metrics exist in TensorBoard events.
+            import tensorboard.backend.event_processing.event_accumulator as ea
+
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            scalar_tags = acc.Tags()["scalars"]
+            eval_tags = [t for t in scalar_tags if t.startswith("eval/")]
+            self.assertGreater(len(eval_tags), 0, "eval/ tags should exist")
+            self.assertIn("eval/sft_loss", eval_tags)
+            self.assertIn("eval/sft_logprob_mean", eval_tags)
+            self.assertIn("eval/sample_count", eval_tags)
+            self.assertIn("eval/duration_s", eval_tags)
+
+            # Verify backend calls.
+            self.assertEqual(backend.train_calls, 3)  # 6 rows / batch_size=2
+            self.assertGreater(backend.eval_calls, 0)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for Task 5 (DPO)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvalDPOBackend:
+    """Backend double for DPO eval integration tests.
+
+    Supports ``init()``, ``close()``, ``get_tokenizer()``, ``train()``,
+    ``evaluate()``, ``save_checkpoint()``, ``score_logprobs()``, and
+    ``ensure_roles()``.
+    """
+
+    def __init__(self, metrics=None):
+        self.closed = False
+        self.train_calls = 0
+        self.eval_calls = 0
+        self.ref_score_calls = 0
+        self._metrics = metrics
+        self._saved: list[str] = []
+
+    def init(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+    def get_tokenizer(self):
+        return _FakeTextTokenizer()
+
+    def train(self, _batch, _loss_fn, *, mini_bs, gradient_accumulation_steps):
+        del mini_bs, gradient_accumulation_steps
+        self.train_calls += 1
+        return {"dpo_loss": 0.69, "total_loss": 0.69, "dpo_accuracy": 0.75}
+
+    def evaluate(self, batch_data, _loss_fn, *, mini_bs, gradient_accumulation_steps=None):
+        del mini_bs, gradient_accumulation_steps
+        self.eval_calls += 1
+        return {"dpo_loss": 0.5, "dpo_accuracy": 0.8, "dpo_margin": 0.3}
+
+    def save_checkpoint(self, _ctx, path):
+        self._saved.append(path)
+        return path
+
+    def score_logprobs(self, role, token_rows, microbatch_size=None):
+        del role, microbatch_size
+        self.ref_score_calls += 1
+        return [[-0.1 * float(i + 1) for i in range(len(row))] for row in token_rows]
+
+    def ensure_roles(self, roles):
+        pass
+
+
+_FIXTURE_DPO_EVAL_DATA: list[dict] = [
+    {"prompt": "q1", "chosen": "good_a1", "rejected": "bad_a1"},
+    {"prompt": "q2", "chosen": "good_a2", "rejected": "bad_a2"},
+    {"prompt": "q3", "chosen": "good_a3", "rejected": "bad_a3"},
+    {"prompt": "q4", "chosen": "good_a4", "rejected": "bad_a4"},
+]
+
+_FIXTURE_DPO_TRAIN_DATA: list[dict] = [
+    {"prompt": "qt1", "chosen": "gt1", "rejected": "bt1"},
+    {"prompt": "qt2", "chosen": "gt2", "rejected": "bt2"},
+]
+
+
+def _dpo_eval_config(**overrides):
+    """Return a SimpleNamespace with the fields DPOTrainer reads."""
+    from types import SimpleNamespace
+
+    defaults = {
+        "algo": "dpo",
+        "batch_size": 2,
+        "epochs": 1,
+        "gradient_accumulation_steps": 1,
+        "max_new_tokens": 10,
+        "max_prompt_tokens": 10,
+        "mini_bs": 2,
+        "save_interval": 100,
+        "save_path": None,
+        "max_steps": None,
+        "eval_dataset_path": None,
+        "eval_interval": 0,
+        "eval_batches": 0,
+        "model_hub": "hf",
+        "dataset_loader_fn": None,
+        "dpo_beta": 0.1,
+        "score_micro_bs": 2,
+        "ref_ckpt": None,
+        "ckpt": "/fake/ckpt",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_dpo_trainer(config, *, train_data=None, backend=None, _metrics=None):
+    """Build a DPOTrainer with a controlled backend for eval testing."""
+    from functools import partial
+
+    from areno.api.trainers.dpo import DPOTrainer
+
+    if backend is None:
+        backend = _FakeEvalDPOBackend(metrics=_metrics)
+    if train_data is None:
+        train_data = list(_FIXTURE_DPO_TRAIN_DATA)
+
+    loss_fn = partial(lambda _pack, _logprobs, *, beta: None, beta=config.dpo_beta)
+    trainer = DPOTrainer(config, instance=backend, dataset=train_data, reward_fn=None, loss_fn=loss_fn)
+    return trainer, backend
+
+
+# ---------------------------------------------------------------------------
+# Task 5: DPO training evaluation integration
+# ---------------------------------------------------------------------------
+
+
+class DPOEvalIntegrationTest(unittest.TestCase):
+    """Tests for DPOTrainer eval integration: _run_eval + _fit_initialized hooks."""
+
+    # -- _run_eval (direct call) -----------------------------------------------
+
+    def test_eval_dpo_success(self):
+        """DPO eval returns correct metrics when called directly."""
+        from areno.api.metrics import MetricsRecorder
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            metrics = MetricsRecorder(log_dir)
+            config = _dpo_eval_config(
+                eval_dataset_path="dummy",
+                eval_interval=2,
+                eval_batches=0,
+                batch_size=2,
+            )
+            trainer, backend = _make_dpo_trainer(config, _metrics=metrics)
+            trainer._eval_dataset = list(_FIXTURE_DPO_EVAL_DATA)
+
+            # Roles must already be ensured for "ref" score_logprobs to work.
+            trainer._ensure_roles()
+
+            trainer._run_eval(step=10)
+
+            # 4 fixture rows => 4 pairs. batch_size=2 pairs => 2 batches.
+            # Each batch: 2 pairs = 4 sequences. 2 batches * 4 seq = 8 seq total.
+            self.assertEqual(backend.eval_calls, 2)
+            # ref_logprobs scoring: call per batch.
+            self.assertEqual(backend.ref_score_calls, 2)
+
+            # Verify metrics were recorded in TensorBoard.
+            import tensorboard.backend.event_processing.event_accumulator as ea
+
+            metrics.close()
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            eval_tags = [t for t in acc.Tags()["scalars"] if t.startswith("eval/")]
+            self.assertIn("eval/dpo_loss", eval_tags)
+            self.assertIn("eval/dpo_accuracy", eval_tags)
+            self.assertIn("eval/dpo_margin", eval_tags)
+            self.assertIn("eval/sample_count", eval_tags)
+            self.assertIn("eval/duration_s", eval_tags)
+
+    def test_dpo_eval_integration(self):
+        """Full DPO train + eval end-to-end: verify eval/ metrics recorded."""
+        from areno.api.metrics import MetricsRecorder
+
+        with tempfile.TemporaryDirectory() as log_dir:
+            metrics = MetricsRecorder(log_dir)
+            train_data = [_FIXTURE_DPO_TRAIN_DATA[0].copy() for _ in range(6)]
+            config = _dpo_eval_config(
+                eval_dataset_path="dummy",
+                eval_interval=2,
+                eval_batches=0,
+                batch_size=2,
+                epochs=1,
+            )
+            trainer, backend = _make_dpo_trainer(config, train_data=train_data, _metrics=metrics)
+            trainer._eval_dataset = list(_FIXTURE_DPO_EVAL_DATA)
+            trainer.fit()
+            metrics.close()
+
+            # Verify eval/ metrics exist in TensorBoard events.
+            import tensorboard.backend.event_processing.event_accumulator as ea
+
+            acc = ea.EventAccumulator(log_dir)
+            acc.Reload()
+            scalar_tags = acc.Tags()["scalars"]
+            eval_tags = [t for t in scalar_tags if t.startswith("eval/")]
+            self.assertGreater(len(eval_tags), 0, "eval/ tags should exist")
+            self.assertIn("eval/dpo_loss", eval_tags)
+            self.assertIn("eval/dpo_accuracy", eval_tags)
+            self.assertIn("eval/sample_count", eval_tags)
+            self.assertIn("eval/duration_s", eval_tags)
+
+            # Verify backend calls.
+            # 6 train rows at batch_size=2 pairs => 3 train batches (each is 4 rows).
+            self.assertEqual(backend.train_calls, 3)
+            self.assertGreater(backend.eval_calls, 0)


### PR DESCRIPTION
Resolves #202 

## What & Why

这个 PR 在 SFT 和 DPO 训练循环中增加了可配置的无梯度定期评估。训练过程中按 step 间隔在验证集上跑一次纯前向传播计算 loss，指标写入 TensorBoard `eval/` 命名空间，评估完成后继续训练。

背景：AReno 当前只能看 train_loss，用户无法判断模型是在真正学习还是死记硬背训练数据。需要一种轻量的评估手段，不引入新依赖、不替换现有架构。

## Changes

- **评估配置**：`TrainerConfig` 新增 `eval_dataset_path`、`eval_interval`、`eval_batches` 三个字段，默认全部关闭，向后兼容。
- **CLI 入口**：3 个 `--eval-*` 选项，路径校验区分本地文件和远程引用，校验在模型加载前完成。
- **核心评估方法**：`Trainer.evaluate()` 用 `torch.no_grad()` 包裹，委托 `ArenoBackend.evaluate()` 通过 `engine.score_logprobs("actor")` 做前向传播，复用 `_make_train_pack` 保持与训练路径的数据格式一致。
- **指标记录**：`MetricsRecorder.record_eval_step()` 写入 `eval/` 命名空间，与 `train/`、`rollout/` 分离，dashboard 折线图自动拾取。
- **SFT 集成**：`SFTTrainer._run_eval()` 惰性加载 eval 数据集，批次遍历，loss 按 target_tokens 加权聚合。三个触发点：step 间隔、epoch 结束、max_steps 退出。
- **DPO 集成**：同上，额外在 eval 前通过 `score_logprobs("ref")` 预计算 reference logprobs，含 misaligned logprobs 防御性校验。
- **测试**：21 个 CPU 测试，fake backend + 合成数据，覆盖成功路径、边界值、失败路径、参数不变性。
- **文档**：`docs/cli/training.rst` 新增评估章节，含选项说明、输出格式、限制。

## Usage

```bash
# SFT + 评估（本地 eval 文件）
areno train \
  --algo sft \
  --ckpt Qwen/Qwen3.5-0.8B \
  --dataset-path yahma/alpaca-cleaned \
  --dataset-loader-fn examples/sft/alpaca/dataset_loader.py \
  --eval-dataset-path ./eval_data.jsonl \
  --eval-interval 100 \
  --eval-batches 10

# DPO + 评估（远程 eval 数据集）
areno train \
  --algo dpo \
  --ckpt Qwen/Qwen3.5-0.8B \
  --dataset-path trl-lib/ultrafeedback_binarized \
  --eval-dataset-path trl-lib/ultrafeedback_binarized \
  --eval-interval 100 \
  --eval-batches 10
```

三个新选项：

| 选项 | 默认值 | 说明 |
|------|--------|------|
| `--eval-dataset-path` | None | 评估数据集路径（本地文件/目录/远程引用）。不传则不做评估 |
| `--eval-interval` | 0 | 每 N 步评估一次。0 表示跳过间隔评估，仅在 epoch 结束和 max_steps 退出时触发 |
| `--eval-batches` | 0 | 每次评估最多 N 个 batch。0 表示遍历完整评估集 |

每轮评估输出一行日志：
```
step=100 stage=eval_end eval_loss=1.1692 sample_count=50 duration_s=1.407
```

TensorBoard 指标全部在 `eval/` 命名空间下，与 `train/`、`rollout/` 分离显示。

## Design Decisions

- **为什么用 `eval_batches=0` 表示全量而不是 `-1`**：与项目中 `--max-steps` 和 `--gradient-accumulation-steps` 的惯例一致，0 或 None 表示"不限制"。
- **为什么复用 `_make_train_pack` 而不是新建 `_make_eval_pack`**：eval_loss 需要与 train_loss 在同一数据格式下可比。代价是 eval 路径耦合了 train 的 packing 逻辑。
- **为什么 eval 指标写同一个 TensorBoard writer 的 `eval/` 前缀而不是独立 event file**：独立 writer 会导致 eval 和 train 曲线的 step 轴不对齐，TensorBoard 无法叠加对比。代价是 event file 会膨胀。
- **为什么用 `engine.score_logprobs("actor")` 而不是新增 engine API**：`score_logprobs` 已经是 forward-only、inference_mode 的实现，语义匹配。代价是返回格式需要 `row[1:]` 跳过位置 0 的占位 logprob。

## How to Test

```bash
# 单元测试（CPU，不依赖 GPU）
pytest tests/test_eval_cpu.py -v

# 全量回归
pytest tests/ -q

# 代码规范
pre-commit run -a
```

## Test Results

```
tests/test_eval_cpu.py: 21 passed in 2.55s
tests/ (full suite):   385 passed, 0 failed, 12 warnings in 8.06s
```

真机验证（Kaggle T4 × 2 + Qwen3.5-0.8B）：

SFT eval 日志：
```
step=10 stage=eval_end eval_loss=1.1692 sample_count=10 duration_s=1.407
step=20 stage=eval_end eval_loss=1.1130 sample_count=10 duration_s=1.297
step=30 stage=eval_end eval_loss=1.0893 sample_count=10 duration_s=1.312
step=40 stage=eval_end eval_loss=1.0618 sample_count=10 duration_s=1.311
```

## Checklist

- [x] 代码遵循项目风格（pre-commit 全绿）
- [x] 新增 CPU 测试覆盖核心逻辑（21 个）
- [x] 向后兼容：不传 `--eval-dataset-path` 时行为不变（385 回归测试通过）
- [x] 回归测试通过
- [x] 真机 SFT + DPO 实测通过
- [x] 文档已更新