### PR TITLE
feat(agentic): add 6x6 Othello agentic RL demo

### DIFF
--- a/docs/cookbook/othello-agentic-rl.rst
+++ b/docs/cookbook/othello-agentic-rl.rst
@@ -1,0 +1,31 @@
+Othello agentic RL
+===================
+
+Othello is a two-player board game on a 6x6 grid.  This recipe trains a policy
+to choose one Othello move from a rendered board using AReno's agentic
+file-callback contracts.
+
+.. code-block:: bash
+
+   areno train \
+     --agent-fn examples/agentic/othello/run_agent.py \
+     --reward-fn-path examples/agentic/othello/reward.py \
+     --dataset-loader-fn examples/agentic/othello/dataset_loader.py \
+     --algo gspo
+
+The environment implements 8-direction disc flipping, pass handling (including
+double-pass termination), and terminal disc scoring.  The dataset generator
+produces deterministic reachable opening positions from the standard 6x6
+starting board.
+
+Key adaptation points:
+
+* Replace the game logic in ``game.py`` with your own environment rules.
+* The reward function scores moves: -1.0 for illegal, 0.0 for legal
+  non-terminal, 1.0 for a terminal winning move.
+* The ``play_episode`` helper runs full games against a seeded random opponent
+  and reports win rate and illegal-move rate.
+* All new code lives under ``examples/agentic/othello/`` — no core changes
+  required, preserving backward compatibility.
+
+See :doc:`/reference/agentic-rollout-api` for the agentic rollout API contract.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ AReno documentation
    cookbook/math-rlvr
    cookbook/tictactoe-agentic-rl
    cookbook/duelgrid-visual-agent
+   cookbook/othello-agentic-rl
 
 .. toctree::
    :hidden:

--- a/docs/troubleshooting/agentic-rollout.rst
+++ b/docs/troubleshooting/agentic-rollout.rst
@@ -21,4 +21,6 @@ Common symptoms:
 * Runs hang: check external tool or environment calls before model calls.
 * Tool calls fail to parse: inspect raw assistant turns and schema format.
 
-Use :doc:`/cookbook/tictactoe-agentic-rl` as the smallest reference recipe.
+Use :doc:`/cookbook/tictactoe-agentic-rl` as the smallest reference recipe,
+or :doc:`/cookbook/othello-agentic-rl` for a two-player board-game example with
+pass handling.

--- a/examples/agentic/othello/README.md
+++ b/examples/agentic/othello/README.md
@@ -39,6 +39,45 @@ areno train \
   --max-new-tokens 64
 ```
 
+## Train on Kaggle (Dual T4 GPU)
+
+Kaggle provides free dual T4 GPUs for verified accounts. The following
+commands are tuned for the 2x16 GB VRAM budget on that platform.
+
+```bash
+# 1. Generate boards into Kaggle persistent storage
+python examples/agentic/othello/dataset_generator.py \
+  --output /kaggle/working/othello-boards.jsonl \
+  --count 2048 --seed 2026
+
+# 2. Train with GSPO on dual T4
+areno train \
+  --ckpt Qwen/Qwen3-1.7B \
+  --model-hub modelscope \
+  --dataset-path /kaggle/working/othello-boards.jsonl \
+  --dataset-loader-fn examples/agentic/othello/dataset_loader.py \
+  --reward-fn-path examples/agentic/othello/reward.py \
+  --agent-fn examples/agentic/othello/run_agent.py \
+  --algo gspo --tp-size 2 --world-size 2 \
+  --batch-size 2 --n-samples 4 --max-new-tokens 64 \
+  --mini-bs 2 --max-running-prompts 8 \
+  --save-path /kaggle/working/othello-ckpt --save-interval 50
+```
+
+Key parameter choices for Kaggle T4 x2:
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `--tp-size 2` | 2 | Tensor-parallel across both T4 GPUs |
+| `--world-size 2` | 2 | Must equal GPU count; divisible by `--tp-size` |
+| `--batch-size 2` | 2 | Conservative for 16 GB VRAM per card |
+| `--n-samples 4` | 4 | GSPO group size; needs >= 2 for advantage estimation |
+| `--max-running-prompts 8` | 8 | = batch_size * n_samples; controls rollout concurrency |
+| `--max-new-tokens 64` | 64 | `choose_move` tool-call response is very short |
+| `--model-hub modelscope` | modelscope | Faster in CN; use `hf` internationally |
+
+If you hit OOM, reduce `--batch-size` to 1 or `--n-samples` to 2, or add
+`--drop-rollout-state` to trade speed for lower VRAM usage.
 ## Observable Output
 
 - **Reward**: -1.0 for illegal moves, 0.0 for legal non-terminal moves, 1.0

--- a/examples/agentic/othello/README.md
+++ b/examples/agentic/othello/README.md
@@ -78,6 +78,7 @@ Key parameter choices for Kaggle T4 x2:
 
 If you hit OOM, reduce `--batch-size` to 1 or `--n-samples` to 2, or add
 `--drop-rollout-state` to trade speed for lower VRAM usage.
+
 ## Observable Output
 
 - **Reward**: -1.0 for illegal moves, 0.0 for legal non-terminal moves, 1.0

--- a/examples/agentic/othello/README.md
+++ b/examples/agentic/othello/README.md
@@ -1,0 +1,64 @@
+# Agentic 6x6 Othello Example
+
+This example trains a policy to choose one Othello move from a rendered 6x6
+board. The environment implements legal-move enumeration with 8-direction
+flipping, pass handling, double-pass termination, and terminal disc scoring.
+It is deterministic and self-contained with no external dependencies beyond
+AReno's existing contracts.
+
+## Files
+
+- `game.py` contains board validation, 8-direction flip logic, legal-move
+  enumeration, pass handling, terminal scoring, and move evaluation.
+- `dataset_generator.py` generates reproducible reachable opening positions
+  from the standard 6x6 Othello starting board.
+- `dataset_loader.py`, `run_agent.py`, and `reward.py` define the tool-call
+  agentic variant using AReno's file-callback contracts.
+
+## Generate Boards
+
+```bash
+python examples/agentic/othello/dataset_generator.py \
+  --output /tmp/areno-othello-boards.jsonl \
+  --count 2048 \
+  --seed 2026
+```
+
+## Train with Tool Calls
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-1.7B \
+  --dataset-path /tmp/areno-othello-boards.jsonl \
+  --dataset-loader-fn examples/agentic/othello/dataset_loader.py \
+  --reward-fn-path examples/agentic/othello/reward.py \
+  --agent-fn examples/agentic/othello/run_agent.py \
+  --algo gspo \
+  --batch-size 2 \
+  --n-samples 4 \
+  --max-new-tokens 64
+```
+
+## Observable Output
+
+- **Reward**: -1.0 for illegal moves, 0.0 for legal non-terminal moves, 1.0
+  for a move that ends the game with the player having more discs.
+- **Win rate and illegal-move rate**: computed by playing full episodes
+  against a seeded random opponent (see `game.play_episode` and the test
+  suite).
+- **Training logs and metrics**: surfaced through AReno's existing logging,
+  TensorBoard, and dashboard infrastructure.
+
+## Minimal Runnable Example
+
+```bash
+# Generate a small dataset
+python examples/agentic/othello/dataset_generator.py \
+  --output /tmp/othello-demo.jsonl --count 16 --seed 2026
+
+# Verify the generator output
+head -3 /tmp/othello-demo.jsonl
+
+# Run CPU tests
+python -m pytest tests/test_agentic_othello_example_cpu.py -v
+```

--- a/examples/agentic/othello/dataset_generator.py
+++ b/examples/agentic/othello/dataset_generator.py
@@ -1,0 +1,103 @@
+"""Generate reachable 6x6 Othello boards for the agentic example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = 2026
+
+
+def generate_records(count: int = DEFAULT_COUNT, *, seed: int = DEFAULT_SEED) -> list[dict]:
+    """Generate reproducible reachable boards where B is to move."""
+
+    rng = random.Random(seed)
+    records: list[dict] = []
+    seen: set[tuple[tuple[str, ...], ...]] = set()
+    attempts = 0
+    while len(records) < count:
+        attempts += 1
+        if attempts > count * 200:
+            raise RuntimeError("could not generate enough unique Othello boards")
+        board = _random_board(rng)
+        key = tuple(tuple(row) for row in board)
+        if key in seen or game.is_terminal(board) or game.next_player(board) != "B":
+            continue
+        if not game.has_legal_move(board, "B"):
+            continue
+        seen.add(key)
+        records.append(
+            {
+                "id": f"othello-{len(records):05d}",
+                "board": board,
+                "player": "B",
+            }
+        )
+    return records
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write generated records as JSONL."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def _random_board(rng: random.Random) -> game.Board:
+    """Play random legal moves from the initial board to get a reachable position."""
+
+    board = game.initial_board()
+    player = "B"
+    num_moves = rng.randint(0, 8)
+    for _ in range(num_moves):
+        if game.is_terminal(board):
+            break
+        if not game.has_legal_move(board, player):
+            player = "W" if player == "B" else "B"
+            if not game.has_legal_move(board, player):
+                break
+        moves = game.legal_moves(board, player)
+        if not moves:
+            player = "W" if player == "B" else "B"
+            continue
+        move = rng.choice(moves)
+        board = game.apply_move(board, move[0], move[1], player)
+        player = "W" if player == "B" else "B"
+    # Ensure it is B's turn: if W is to move, play one more W move
+    if game.next_player(board) == "W" and game.has_legal_move(board, "W"):
+        moves = game.legal_moves(board, "W")
+        move = rng.choice(moves)
+        board = game.apply_move(board, move[0], move[1], "W")
+    return board
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate JSONL boards for the Areno 6x6 Othello agentic example.")
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of boards to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise ValueError("--count must be positive")
+
+    records = generate_records(args.count, seed=args.seed)
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/othello/dataset_generator.py
+++ b/examples/agentic/othello/dataset_generator.py
@@ -65,9 +65,6 @@ def _random_board(rng: random.Random) -> game.Board:
             if not game.has_legal_move(board, player):
                 break
         moves = game.legal_moves(board, player)
-        if not moves:
-            player = "W" if player == "B" else "B"
-            continue
         move = rng.choice(moves)
         board = game.apply_move(board, move[0], move[1], player)
         player = "W" if player == "B" else "B"

--- a/examples/agentic/othello/dataset_loader.py
+++ b/examples/agentic/othello/dataset_loader.py
@@ -16,7 +16,7 @@ def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object
 
     del default_loader
     records = _load_records(dataset_path)
-    return [_format_record(raw, idx, xml=False) for idx, raw in enumerate(records, start=1)]
+    return [_format_record(raw, idx) for idx, raw in enumerate(records, start=1)]
 
 
 def _load_records(dataset_path: str) -> list[dict]:
@@ -34,12 +34,12 @@ def _load_records(dataset_path: str) -> list[dict]:
     return records
 
 
-def _format_record(raw: dict, index: int, *, xml: bool) -> dict:
+def _format_record(raw: dict, index: int) -> dict:
     board = game.normalize_board(raw["board"])
     player = raw.get("player", game.next_player(board) or "B")
     return {
         "id": raw.get("id", f"board-{index:05d}"),
-        "prompt": game.format_xml_prompt(board, player) if xml else game.format_prompt(board, player),
+        "prompt": game.format_prompt(board, player),
         "board": board,
         "player": player,
         "valid_moves": game.legal_moves(board, player),

--- a/examples/agentic/othello/dataset_loader.py
+++ b/examples/agentic/othello/dataset_loader.py
@@ -1,0 +1,46 @@
+"""Dataset loader for the 6x6 Othello tool-call example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL boards and convert them to Areno prompt records."""
+
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx, xml=False) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "boards.jsonl"
+    if not path.exists():
+        return dataset_generator.generate_records()
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int, *, xml: bool) -> dict:
+    board = game.normalize_board(raw["board"])
+    player = raw.get("player", game.next_player(board) or "B")
+    return {
+        "id": raw.get("id", f"board-{index:05d}"),
+        "prompt": game.format_xml_prompt(board, player) if xml else game.format_prompt(board, player),
+        "board": board,
+        "player": player,
+        "valid_moves": game.legal_moves(board, player),
+    }

--- a/examples/agentic/othello/game.py
+++ b/examples/agentic/othello/game.py
@@ -1,0 +1,336 @@
+"""Small 6x6 Othello helpers for agentic examples."""
+
+from __future__ import annotations
+
+import random
+import re
+from collections.abc import Callable, Iterable
+
+Board = list[list[str]]
+SIZE = 6
+PLAYERS = ("B", "W")
+EMPTY = "."
+DIRECTIONS = [
+    (-1, -1),
+    (-1, 0),
+    (-1, 1),
+    (0, -1),
+    (0, 1),
+    (1, -1),
+    (1, 0),
+    (1, 1),
+]
+
+_XML_MOVE_RE = re.compile(r'<move\s+row="(\d+)"\s+col="(\d+)"\s*/?>', re.IGNORECASE | re.DOTALL)
+_THINK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
+_CHAT_SPECIAL_RE = re.compile(r"<\|[^>]+?\|>|</?s>", re.IGNORECASE)
+
+
+def normalize_board(board: Iterable[Iterable[str]]) -> Board:
+    """Return a validated 6x6 Othello board."""
+
+    rows = [[str(cell).upper() if str(cell) != EMPTY else EMPTY for cell in row] for row in board]
+    if len(rows) != SIZE or any(len(row) != SIZE for row in rows):
+        raise ValueError(f"Othello board must be {SIZE}x{SIZE}")
+    allowed = {"B", "W", EMPTY}
+    if any(cell not in allowed for row in rows for cell in row):
+        raise ValueError("Othello cells must be B, W, or .")
+    return rows
+
+
+def initial_board() -> Board:
+    """Return the standard 6x6 Othello starting position."""
+
+    board = [[EMPTY for _ in range(SIZE)] for _ in range(SIZE)]
+    mid = SIZE // 2
+    board[mid - 1][mid - 1] = "W"
+    board[mid - 1][mid] = "B"
+    board[mid][mid - 1] = "B"
+    board[mid][mid] = "W"
+    return board
+
+
+def board_to_text(board: Board) -> str:
+    """Render the board as 6 rows of characters."""
+
+    board = normalize_board(board)
+    return "\n".join(" ".join(row) for row in board)
+
+
+def format_prompt(board: Board, player: str = "B") -> str:
+    """Build the one-step prompt for the tool-call agent."""
+
+    player = player.upper()
+    opponent = "W" if player == "B" else "B"
+    moves = legal_moves(board, player)
+    move_str = ", ".join(f"({r},{c})" for r, c in moves) if moves else "(none - must pass)"
+    return (
+        f"You are playing 6x6 Othello as {player} ({'Black' if player == 'B' else 'White'}). "
+        "Choose the best legal next move.\n\n"
+        "Rules:\n"
+        f"- {player} and {opponent} are already-placed discs; . is empty.\n"
+        "- A legal move must flank at least one opponent disc in a straight line "
+        "(horizontal, vertical, or diagonal), with your disc at the far end.\n"
+        "- All flanked opponent discs flip to your colour.\n"
+        "- If you have no legal move you must pass.\n"
+        "- The game ends when neither player can move; the player with more discs wins.\n\n"
+        f"Legal moves for {player}: {move_str}\n\n"
+        f"Board:\n{board_to_text(board)}\n\n"
+        f"Call the choose_move tool with row and col (0-indexed, 0-5) to place {player}."
+    )
+
+
+def format_xml_prompt(board: Board, player: str = "B") -> str:
+    """Build the one-step prompt for the XML no-tool agent."""
+
+    player = player.upper()
+    opponent = "W" if player == "B" else "B"
+    moves = legal_moves(board, player)
+    move_str = ", ".join(f"({r},{c})" for r, c in moves) if moves else "(none - must pass)"
+    return (
+        f"You are playing 6x6 Othello as {player} ({'Black' if player == 'B' else 'White'}). "
+        "Choose the best legal next move.\n\n"
+        "Rules:\n"
+        f"- {player} and {opponent} are already-placed discs; . is empty.\n"
+        "- A legal move must flank at least one opponent disc in a straight line.\n"
+        "- Answer with exactly one XML tag such as "
+        f'<move row="2" col="3"/> to place {player} at row 2, col 3.\n\n'
+        f"Legal moves for {player}: {move_str}\n\n"
+        f"Board:\n{board_to_text(board)}\n\nMove:"
+    )
+
+
+def parse_xml_move(text: str) -> tuple[int, int] | None:
+    """Extract the final XML move from a model response."""
+
+    text = strip_chat_special_tokens(strip_think_tags(text)).strip()
+    matches = list(_XML_MOVE_RE.finditer(text))
+    if not matches:
+        return None
+    row = int(matches[-1].group(1))
+    col = int(matches[-1].group(2))
+    if not (0 <= row < SIZE and 0 <= col < SIZE):
+        return None
+    return (row, col)
+
+
+def strip_think_tags(text: str) -> str:
+    """Remove reasoning spans before parsing the policy action."""
+
+    return _THINK_RE.sub(" ", text)
+
+
+def strip_chat_special_tokens(text: str) -> str:
+    """Remove chat-template sentinels that may trail generated text."""
+
+    return _CHAT_SPECIAL_RE.sub(" ", text)
+
+
+def _flips_for_move(board: Board, row: int, col: int, player: str) -> list[tuple[int, int]]:
+    """Return all discs that would flip if *player* places at (row, col).
+
+    Returns an empty list if the cell is occupied or no discs would flip.
+    """
+
+    board = normalize_board(board)
+    player = player.upper()
+    if board[row][col] != EMPTY:
+        return []
+    opponent = "W" if player == "B" else "B"
+    all_flips: list[tuple[int, int]] = []
+    for dr, dc in DIRECTIONS:
+        flips: list[tuple[int, int]] = []
+        r, c = row + dr, col + dc
+        while 0 <= r < SIZE and 0 <= c < SIZE and board[r][c] == opponent:
+            flips.append((r, c))
+            r += dr
+            c += dc
+        if flips and 0 <= r < SIZE and 0 <= c < SIZE and board[r][c] == player:
+            all_flips.extend(flips)
+    return all_flips
+
+
+def legal_moves(board: Board, player: str) -> list[tuple[int, int]]:
+    """Return all legal moves for *player* as (row, col) tuples."""
+
+    board = normalize_board(board)
+    player = player.upper()
+    if player not in PLAYERS:
+        raise ValueError("player must be B or W")
+    return [
+        (r, c)
+        for r in range(SIZE)
+        for c in range(SIZE)
+        if board[r][c] == EMPTY and _flips_for_move(board, r, c, player)
+    ]
+
+
+def has_legal_move(board: Board, player: str) -> bool:
+    """Return whether *player* has at least one legal move."""
+
+    return len(legal_moves(board, player)) > 0
+
+
+def apply_move(board: Board, row: int, col: int, player: str) -> Board:
+    """Apply a move and return a new board with discs flipped.
+
+    Raises ValueError if the move is illegal.
+    """
+
+    board = normalize_board(board)
+    player = player.upper()
+    if player not in PLAYERS:
+        raise ValueError("player must be B or W")
+    if not (0 <= row < SIZE and 0 <= col < SIZE):
+        raise ValueError(f"move out of bounds: ({row}, {col})")
+    flips = _flips_for_move(board, row, col, player)
+    if not flips:
+        raise ValueError(f"illegal Othello move for {player}: ({row}, {col})")
+    next_board = [list(row_values) for row_values in board]
+    next_board[row][col] = player
+    for fr, fc in flips:
+        next_board[fr][fc] = player
+    return next_board
+
+
+def next_player(board: Board) -> str | None:
+    """Infer the next player from disc counts.
+
+    Returns "B" when black disc count <= white disc count (black moves first
+    and alternates).  Returns None when the board is full.
+    """
+
+    board = normalize_board(board)
+    flat = _flat(board)
+    if EMPTY not in flat:
+        return None
+    return "B" if flat.count("B") <= flat.count("W") else "W"
+
+
+def is_terminal(board: Board) -> bool:
+    """Return whether the game is finished.
+
+    The game ends when the board is full or neither player has a legal move.
+    """
+
+    board = normalize_board(board)
+    flat = _flat(board)
+    if EMPTY not in flat:
+        return True
+    return not has_legal_move(board, "B") and not has_legal_move(board, "W")
+
+
+def score(board: Board) -> dict[str, int]:
+    """Count discs for each player."""
+
+    board = normalize_board(board)
+    flat = _flat(board)
+    return {"B": flat.count("B"), "W": flat.count("W")}
+
+
+def winner(board: Board) -> str | None:
+    """Return "B" or "W" if the game has a winner, None for a tie or ongoing game."""
+
+    board = normalize_board(board)
+    if not is_terminal(board):
+        return None
+    counts = score(board)
+    if counts["B"] > counts["W"]:
+        return "B"
+    if counts["W"] > counts["B"]:
+        return "W"
+    return None
+
+
+def score_move(board: Board, row: int | None, col: int | None, player: str = "B") -> float:
+    """Score one move for *player*.
+
+    Returns -1.0 for an illegal move, 0.0 for a legal non-terminal move, and
+    1.0 if the move results in a terminal board where *player* has more discs.
+    """
+
+    if row is None or col is None:
+        return -1.0
+    try:
+        next_board = apply_move(board, row, col, player)
+    except ValueError:
+        return -1.0
+    if is_terminal(next_board):
+        counts = score(next_board)
+        player_count = counts[player.upper()]
+        opponent = "W" if player.upper() == "B" else "B"
+        return 1.0 if player_count > counts[opponent] else 0.0
+    return 0.0
+
+
+def play_episode(
+    board: Board,
+    policy_fn: Callable[[Board, str], tuple[int, int] | None],
+    opponent_fn: Callable[[Board, str], tuple[int, int] | None],
+    *,
+    first_player: str = "B",
+    max_moves: int = 40,
+    seed: int = 0,
+) -> dict:
+    """Play a full episode alternating *policy_fn* (plays ``first_player``) and *opponent_fn*.
+
+    Handles forced passes and double-pass termination.  Returns a dict with
+    the final board, winner, move history, and statistics.
+    """
+
+    board = normalize_board(board)
+    history: list[dict] = []
+    current = first_player.upper()
+    passes = 0
+    illegal_moves = 0
+    total_moves = 0
+
+    for _step in range(max_moves):
+        if is_terminal(board):
+            break
+        if not has_legal_move(board, current):
+            passes += 1
+            history.append({"player": current, "move": None, "pass": True})
+            current = "W" if current == "B" else "B"
+            if passes >= 2:
+                break
+            continue
+        passes = 0
+        fn = policy_fn if current == first_player.upper() else opponent_fn
+        move = fn(board, current)
+        total_moves += 1
+        if move is None:
+            illegal_moves += 1
+            current = "W" if current == "B" else "B"
+            continue
+        row, col = move
+        flips = _flips_for_move(board, row, col, current)
+        if not flips:
+            illegal_moves += 1
+            current = "W" if current == "B" else "B"
+            continue
+        board = apply_move(board, row, col, current)
+        history.append({"player": current, "move": (row, col), "pass": False})
+        current = "W" if current == "B" else "B"
+
+    return {
+        "board": board,
+        "winner": winner(board),
+        "score": score(board),
+        "history": history,
+        "illegal_moves": illegal_moves,
+        "total_moves": total_moves,
+    }
+
+
+def random_policy(board: Board, player: str, rng: random.Random) -> tuple[int, int] | None:
+    """Return a random legal move for *player*, or None if no legal move exists."""
+
+    moves = legal_moves(board, player)
+    if not moves:
+        return None
+    return rng.choice(moves)
+
+
+def _flat(board: Board) -> list[str]:
+    return [cell for row in board for cell in row]

--- a/examples/agentic/othello/game.py
+++ b/examples/agentic/othello/game.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import random
-import re
 from collections.abc import Callable, Iterable
 
 Board = list[list[str]]
@@ -20,10 +19,6 @@ DIRECTIONS = [
     (1, 0),
     (1, 1),
 ]
-
-_XML_MOVE_RE = re.compile(r'<move\s+row="(\d+)"\s+col="(\d+)"\s*/?>', re.IGNORECASE | re.DOTALL)
-_THINK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
-_CHAT_SPECIAL_RE = re.compile(r"<\|[^>]+?\|>|</?s>", re.IGNORECASE)
 
 
 def normalize_board(board: Iterable[Iterable[str]]) -> Board:
@@ -78,52 +73,6 @@ def format_prompt(board: Board, player: str = "B") -> str:
         f"Board:\n{board_to_text(board)}\n\n"
         f"Call the choose_move tool with row and col (0-indexed, 0-5) to place {player}."
     )
-
-
-def format_xml_prompt(board: Board, player: str = "B") -> str:
-    """Build the one-step prompt for the XML no-tool agent."""
-
-    player = player.upper()
-    opponent = "W" if player == "B" else "B"
-    moves = legal_moves(board, player)
-    move_str = ", ".join(f"({r},{c})" for r, c in moves) if moves else "(none - must pass)"
-    return (
-        f"You are playing 6x6 Othello as {player} ({'Black' if player == 'B' else 'White'}). "
-        "Choose the best legal next move.\n\n"
-        "Rules:\n"
-        f"- {player} and {opponent} are already-placed discs; . is empty.\n"
-        "- A legal move must flank at least one opponent disc in a straight line.\n"
-        "- Answer with exactly one XML tag such as "
-        f'<move row="2" col="3"/> to place {player} at row 2, col 3.\n\n'
-        f"Legal moves for {player}: {move_str}\n\n"
-        f"Board:\n{board_to_text(board)}\n\nMove:"
-    )
-
-
-def parse_xml_move(text: str) -> tuple[int, int] | None:
-    """Extract the final XML move from a model response."""
-
-    text = strip_chat_special_tokens(strip_think_tags(text)).strip()
-    matches = list(_XML_MOVE_RE.finditer(text))
-    if not matches:
-        return None
-    row = int(matches[-1].group(1))
-    col = int(matches[-1].group(2))
-    if not (0 <= row < SIZE and 0 <= col < SIZE):
-        return None
-    return (row, col)
-
-
-def strip_think_tags(text: str) -> str:
-    """Remove reasoning spans before parsing the policy action."""
-
-    return _THINK_RE.sub(" ", text)
-
-
-def strip_chat_special_tokens(text: str) -> str:
-    """Remove chat-template sentinels that may trail generated text."""
-
-    return _CHAT_SPECIAL_RE.sub(" ", text)
 
 
 def _flips_for_move(board: Board, row: int, col: int, player: str) -> list[tuple[int, int]]:
@@ -270,9 +219,8 @@ def play_episode(
     *,
     first_player: str = "B",
     max_moves: int = 40,
-    seed: int = 0,
 ) -> dict:
-    """Play a full episode alternating *policy_fn* (plays ``first_player``) and *opponent_fn*.
+    """Play a full episode alternating *policy_fn* and *opponent_fn*.
 
     Handles forced passes and double-pass termination.  Returns a dict with
     the final board, winner, move history, and statistics.
@@ -303,7 +251,12 @@ def play_episode(
             illegal_moves += 1
             current = "W" if current == "B" else "B"
             continue
-        row, col = move
+        try:
+            row, col = move
+        except (TypeError, ValueError):
+            illegal_moves += 1
+            current = "W" if current == "B" else "B"
+            continue
         flips = _flips_for_move(board, row, col, current)
         if not flips:
             illegal_moves += 1
@@ -323,13 +276,16 @@ def play_episode(
     }
 
 
-def random_policy(board: Board, player: str, rng: random.Random) -> tuple[int, int] | None:
-    """Return a random legal move for *player*, or None if no legal move exists."""
+def random_policy(rng: random.Random) -> Callable[[Board, str], tuple[int, int] | None]:
+    """Return a policy function that picks a random legal move using *rng*."""
 
-    moves = legal_moves(board, player)
-    if not moves:
-        return None
-    return rng.choice(moves)
+    def _policy(board: Board, player: str) -> tuple[int, int] | None:
+        moves = legal_moves(board, player)
+        if not moves:
+            return None
+        return rng.choice(moves)
+
+    return _policy
 
 
 def _flat(board: Board) -> list[str]:

--- a/examples/agentic/othello/reward.py
+++ b/examples/agentic/othello/reward.py
@@ -1,0 +1,42 @@
+"""Reward function for the 6x6 Othello tool-call example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by extracting the choose_move tool call."""
+
+    source = record.source_record
+    board = game.normalize_board(source["board"])
+    player = source.get("player", "B")
+    row, col = _tool_move(record)
+    return game.score_move(board, row, col, player)
+
+
+def _tool_move(record: Any) -> tuple[int | None, int | None]:
+    for call in record.tool_calls:
+        name = call.get("name") if isinstance(call, dict) else None
+        if name != "choose_move":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return None, None
+        if isinstance(arguments, dict):
+            row = arguments.get("row")
+            col = arguments.get("col")
+            try:
+                return int(row), int(col)
+            except (TypeError, ValueError):
+                return None, None
+    return None, None

--- a/examples/agentic/othello/run_agent.py
+++ b/examples/agentic/othello/run_agent.py
@@ -1,0 +1,93 @@
+"""Agent entrypoint for one-step 6x6 Othello tool-call rollouts."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are a careful 6x6 Othello player. "
+    "Choose exactly one legal move by calling the choose_move tool. "
+    "A legal move flanks at least one opponent disc in a straight line "
+    "(horizontal, vertical, or diagonal) with your disc at the far end. "
+    "Row and col are 0-indexed (0-5). If you have no legal move, you must pass."
+)
+
+CHOOSE_MOVE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "choose_move",
+        "description": "Choose the next Othello move (row and col, 0-indexed 0-5).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "row": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 5,
+                    "description": "The row index to place the disc (0-5).",
+                },
+                "col": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 5,
+                    "description": "The column index to place the disc (0-5).",
+                },
+            },
+            "required": ["row", "col"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+async def run_agent(ctx, batch):
+    """Run one tool-call model request for each board."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The Othello agentic example requires `openai` and `httpx`. Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info("Othello agent start requests=%d max_running_prompts=%d", len(items), ctx.max_running_prompts)
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+
+    async def run_one(item):
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+        tool_choice = {"type": "function", "function": {"name": "choose_move"}}
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=messages,
+            tools=[CHOOSE_MOVE_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        return AgentTrajectoryTurn(
+            item=item,
+            messages=messages,
+            response=response,
+            tools=[CHOOSE_MOVE_TOOL],
+            tool_choice=tool_choice,
+        )
+
+    try:
+        return AgentTrajectory(turns=list(await asyncio.gather(*(run_one(item) for item in items))))
+    finally:
+        await client.close()

--- a/tests/test_agentic_othello_example_cpu.py
+++ b/tests/test_agentic_othello_example_cpu.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import random
 from pathlib import Path
 from types import SimpleNamespace
@@ -51,58 +52,37 @@ def test_othello_initial_board_and_normalize():
 def test_othello_legal_moves_and_flips_cover_all_eight_directions():
     game = _load_module("game")
 
-    # Build a board where W is surrounded by B in all 8 directions,
-    # so B can flank W from multiple angles.
-    # Place B at (2,3), W at (2,4), B at (2,5) — horizontal flip
-    # Place B at (3,3), W at (3,4), B at (3,5) — another horizontal
-    # We test each direction independently with a dedicated mini-board.
-    board = game.initial_board()
-
-    # Clear the board and set up a controlled scenario
+    # Set up a board to test horizontal, vertical, and diagonal flips
     board = [["." for _ in range(6)] for _ in range(6)]
-    # Horizontal: B . W . B — B can play at (0,1) to flank W at (0,2) via B at (0,4)? No.
-    # Let's place: B at (0,0), W at (0,1), . at (0,2) — B plays (0,2) if there's a B beyond W.
-    # Setup: B(0,0) W(0,1) .(0,2) .(0,3) W(0,4) B(0,5)
-    # B plays (0,2): flanks W(0,1) between B(0,0) and B(0,2) -> valid
+    # Horizontal flip: B(0,0) W(0,1) .(0,2) -> B plays (0,2) to flip W(0,1)
     board[0][0] = "B"
     board[0][1] = "W"
     board[0][5] = "B"
     board[0][4] = "W"
-
-    # Vertical: B(1,0) W(2,0) .(3,0) — B plays (3,0) if B exists beyond? No. Need B(4,0).
+    # Vertical flip: B(1,0) W(2,0) .(3,0) -> B plays (3,0) to flip W(2,0)
     board[1][0] = "B"
     board[2][0] = "W"
-
-    # Diagonal: B(1,1) W(2,2) .(3,3) — B plays (3,3) if B beyond at (4,4)
+    # Diagonal flip: B(1,1) W(2,2) .(3,3) -> B plays (3,3) to flip W(2,2)
     board[1][1] = "B"
     board[2][2] = "W"
-
-    # Anti-diagonal: B(1,5) W(2,4) .(3,3) — B plays (3,3) if B beyond at (4,2)
+    # Anti-diagonal flip: B(1,5) W(2,4) .(3,3)
     board[2][4] = "W"
 
     moves = game.legal_moves(board, "B")
-    # (0,2) should be legal: B(0,0)-W(0,1)-B(0,2)
-    assert (0, 2) in moves
-    # (3,0) should be legal: B(1,0)-W(2,0)-B(3,0)
-    assert (3, 0) in moves
+    assert (0, 2) in moves  # horizontal flip
+    assert (3, 0) in moves  # vertical flip
 
-    # Test apply_move flips correctly
+    # Verify apply_move flips correctly
     new_board = game.apply_move(board, 0, 2, "B")
     assert new_board[0][1] == "B"  # W flipped to B
 
-    # Test all 8 directions: place a ring of W around a central B
-    # B at (3,3), W at all 8 neighbors (2,2),(2,3),(2,4),(3,2),(3,4),(4,2),(4,3),(4,4)
-    # Then B at the far end of each direction. B plays the far end to flip.
+    # Test all 8 directions: ring of W around central B
     board2 = [["." for _ in range(6)] for _ in range(6)]
     board2[3][3] = "B"
-    # 8 neighbors as W
     for dr, dc in game.DIRECTIONS:
-        r, c = 3 + dr, 3 + dc
-        board2[r][c] = "W"
-    # Far end for each direction: another empty cell beyond W
-    # direction (-1,-1): far end (1,1) -> B plays there to flip (2,2)
-    # direction (-1,0): far end (1,3) -> B plays there to flip (2,3)
-    # etc.
+        board2[3 + dr][3 + dc] = "W"
+
+    # For each direction, B plays the far-end cell to flip the adjacent W
     for dr, dc in game.DIRECTIONS:
         r_far, c_far = 3 + dr * 2, 3 + dc * 2
         if 0 <= r_far < 6 and 0 <= c_far < 6:
@@ -113,15 +93,11 @@ def test_othello_legal_moves_and_flips_cover_all_eight_directions():
 def test_othello_forced_pass_when_no_legal_moves():
     game = _load_module("game")
 
-    # Construct a board where W has no legal moves but B does.
-    # Fill most of the board with B, leaving one empty cell that only B can use.
+    # Construct a board where W has no legal moves but B does
     board = [["B" for _ in range(6)] for _ in range(6)]
-    # Leave (0,0) empty
     board[0][0] = "."
-    # Make sure W exists somewhere adjacent so it's a valid Othello position
     board[0][1] = "W"
-    # B can play (0,0): B(0,0)-W(0,1)-B(0,2)? board[0][2]="B" -> yes, flips W(0,1)
-    # W cannot play (0,0): need W-B-...-W line, but there's no W to close the flank
+    # B can play (0,0) to flank W(0,1); W has no flanking opportunity
     assert game.has_legal_move(board, "B")
     assert not game.has_legal_move(board, "W")
 
@@ -129,17 +105,14 @@ def test_othello_forced_pass_when_no_legal_moves():
 def test_othello_double_pass_ends_game():
     game = _load_module("game")
 
-    # A board where neither player has a legal move -> terminal
-    # Fill the entire board
+    # Full board -> terminal
     board = [["B" for _ in range(6)] for _ in range(6)]
-    # Set a few W cells
     board[0][0] = "W"
     board[1][1] = "W"
     board[2][2] = "W"
     assert game.is_terminal(board)
 
-    # Test play_episode handles double pass
-    # Force a terminal by filling the board
+    # play_episode on a full board terminates immediately
     full_board = [["B" if (r + c) % 2 == 0 else "W" for c in range(6)] for r in range(6)]
     result = game.play_episode(
         full_board,
@@ -153,7 +126,7 @@ def test_othello_double_pass_ends_game():
 def test_othello_terminal_scoring_counts_discs():
     game = _load_module("game")
 
-    # Board with 20 B and 16 W (36 total, full board)
+    # Board with 20 B and 16 W (full board)
     board = [["B" for _ in range(6)] for _ in range(6)]
     for r in range(4):
         for c in range(6):
@@ -177,7 +150,7 @@ def test_othello_illegal_cell_rejected():
     board = game.initial_board()
 
     # Occupied cell -> illegal
-    assert game.score_move(board, 2, 2, "B") == -1.0  # (2,2) is W in initial board
+    assert game.score_move(board, 2, 2, "B") == -1.0
     try:
         game.apply_move(board, 2, 2, "B")
         assert False, "should reject occupied cell"
@@ -185,7 +158,6 @@ def test_othello_illegal_cell_rejected():
         pass
 
     # Empty cell with no flips -> illegal
-    # (0,0) is empty but has no B-W-B line in the initial board
     assert game.score_move(board, 0, 0, "B") == -1.0
     try:
         game.apply_move(board, 0, 0, "B")
@@ -218,12 +190,9 @@ def test_othello_generator_produces_reachable_boards():
         board = game.normalize_board(record["board"])
         assert len(board) == 6
         assert all(len(row) == 6 for row in board)
-        # Must be B's turn
         assert record["player"] == "B"
         assert game.next_player(board) == "B"
-        # Must not be terminal
         assert not game.is_terminal(board)
-        # Must have legal moves for B
         assert game.has_legal_move(board, "B")
 
 
@@ -232,7 +201,6 @@ def test_othello_reward_scores_tool_move_only():
     reward = _load_module("reward")
 
     board = game.initial_board()
-    # Legal first move for B: (2,4) or (3,5) or (4,2) or (5,3) etc.
     legal = game.legal_moves(board, "B")
     assert len(legal) > 0
     legal_row, legal_col = legal[0]
@@ -258,8 +226,6 @@ def test_othello_reward_scores_tool_move_only():
     assert reward.reward_fn(record) == -1.0
 
     # Arguments as JSON string
-    import json
-
     record.tool_calls = [
         {
             "name": "choose_move",
@@ -276,14 +242,8 @@ def test_othello_reward_scores_tool_move_only():
 def test_othello_seeded_random_opponent_evaluation():
     game = _load_module("game")
 
-    rng_policy = random.Random(42)
-    rng_opponent = random.Random(99)
-
-    def policy_fn(board, player):
-        return game.random_policy(board, player, rng_policy)
-
-    def opponent_fn(board, player):
-        return game.random_policy(board, player, rng_opponent)
+    policy_fn = game.random_policy(random.Random(42))
+    opponent_fn = game.random_policy(random.Random(99))
 
     num_games = 20
     wins = 0
@@ -301,7 +261,6 @@ def test_othello_seeded_random_opponent_evaluation():
             max_moves=40,
         )
         if result["winner"] is not None:
-            # policy_fn plays first_player; check if that side won
             if result["winner"] == first_player:
                 wins += 1
         total_illegal += result["illegal_moves"]
@@ -331,6 +290,5 @@ def test_othello_dataset_loader_formats_records():
         assert "player" in record
         assert "valid_moves" in record
         assert isinstance(record["valid_moves"], list)
-        # Each valid move should be a legal move
         for move in record["valid_moves"]:
             assert move in game.legal_moves(record["board"], record["player"])

--- a/tests/test_agentic_othello_example_cpu.py
+++ b/tests/test_agentic_othello_example_cpu.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import importlib.util
+import random
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_module(name: str):
+    path = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "othello" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"agentic_othello_{name}_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_othello_initial_board_and_normalize():
+    game = _load_module("game")
+
+    board = game.initial_board()
+    assert len(board) == 6
+    assert all(len(row) == 6 for row in board)
+    # Standard starting position: center 2x2 cross-placed
+    assert board[2][2] == "W"
+    assert board[2][3] == "B"
+    assert board[3][2] == "B"
+    assert board[3][3] == "W"
+
+    # normalize accepts valid input
+    normalized = game.normalize_board(board)
+    assert normalized == board
+
+    # Invalid size rejected
+    try:
+        game.normalize_board([["."] * 3 for _ in range(3)])
+        assert False, "should reject 3x3"
+    except ValueError:
+        pass
+
+    # Invalid cell rejected
+    try:
+        bad = game.initial_board()
+        bad[0][0] = "X"
+        game.normalize_board(bad)
+        assert False, "should reject X"
+    except ValueError:
+        pass
+
+
+def test_othello_legal_moves_and_flips_cover_all_eight_directions():
+    game = _load_module("game")
+
+    # Build a board where W is surrounded by B in all 8 directions,
+    # so B can flank W from multiple angles.
+    # Place B at (2,3), W at (2,4), B at (2,5) — horizontal flip
+    # Place B at (3,3), W at (3,4), B at (3,5) — another horizontal
+    # We test each direction independently with a dedicated mini-board.
+    board = game.initial_board()
+
+    # Clear the board and set up a controlled scenario
+    board = [["." for _ in range(6)] for _ in range(6)]
+    # Horizontal: B . W . B — B can play at (0,1) to flank W at (0,2) via B at (0,4)? No.
+    # Let's place: B at (0,0), W at (0,1), . at (0,2) — B plays (0,2) if there's a B beyond W.
+    # Setup: B(0,0) W(0,1) .(0,2) .(0,3) W(0,4) B(0,5)
+    # B plays (0,2): flanks W(0,1) between B(0,0) and B(0,2) -> valid
+    board[0][0] = "B"
+    board[0][1] = "W"
+    board[0][5] = "B"
+    board[0][4] = "W"
+
+    # Vertical: B(1,0) W(2,0) .(3,0) — B plays (3,0) if B exists beyond? No. Need B(4,0).
+    board[1][0] = "B"
+    board[2][0] = "W"
+
+    # Diagonal: B(1,1) W(2,2) .(3,3) — B plays (3,3) if B beyond at (4,4)
+    board[1][1] = "B"
+    board[2][2] = "W"
+
+    # Anti-diagonal: B(1,5) W(2,4) .(3,3) — B plays (3,3) if B beyond at (4,2)
+    board[2][4] = "W"
+
+    moves = game.legal_moves(board, "B")
+    # (0,2) should be legal: B(0,0)-W(0,1)-B(0,2)
+    assert (0, 2) in moves
+    # (3,0) should be legal: B(1,0)-W(2,0)-B(3,0)
+    assert (3, 0) in moves
+
+    # Test apply_move flips correctly
+    new_board = game.apply_move(board, 0, 2, "B")
+    assert new_board[0][1] == "B"  # W flipped to B
+
+    # Test all 8 directions: place a ring of W around a central B
+    # B at (3,3), W at all 8 neighbors (2,2),(2,3),(2,4),(3,2),(3,4),(4,2),(4,3),(4,4)
+    # Then B at the far end of each direction. B plays the far end to flip.
+    board2 = [["." for _ in range(6)] for _ in range(6)]
+    board2[3][3] = "B"
+    # 8 neighbors as W
+    for dr, dc in game.DIRECTIONS:
+        r, c = 3 + dr, 3 + dc
+        board2[r][c] = "W"
+    # Far end for each direction: another empty cell beyond W
+    # direction (-1,-1): far end (1,1) -> B plays there to flip (2,2)
+    # direction (-1,0): far end (1,3) -> B plays there to flip (2,3)
+    # etc.
+    for dr, dc in game.DIRECTIONS:
+        r_far, c_far = 3 + dr * 2, 3 + dc * 2
+        if 0 <= r_far < 6 and 0 <= c_far < 6:
+            flips = game._flips_for_move(board2, r_far, c_far, "B")
+            assert (3 + dr, 3 + dc) in flips, f"direction ({dr},{dc}) should flip ({3 + dr},{3 + dc})"
+
+
+def test_othello_forced_pass_when_no_legal_moves():
+    game = _load_module("game")
+
+    # Construct a board where W has no legal moves but B does.
+    # Fill most of the board with B, leaving one empty cell that only B can use.
+    board = [["B" for _ in range(6)] for _ in range(6)]
+    # Leave (0,0) empty
+    board[0][0] = "."
+    # Make sure W exists somewhere adjacent so it's a valid Othello position
+    board[0][1] = "W"
+    # B can play (0,0): B(0,0)-W(0,1)-B(0,2)? board[0][2]="B" -> yes, flips W(0,1)
+    # W cannot play (0,0): need W-B-...-W line, but there's no W to close the flank
+    assert game.has_legal_move(board, "B")
+    assert not game.has_legal_move(board, "W")
+
+
+def test_othello_double_pass_ends_game():
+    game = _load_module("game")
+
+    # A board where neither player has a legal move -> terminal
+    # Fill the entire board
+    board = [["B" for _ in range(6)] for _ in range(6)]
+    # Set a few W cells
+    board[0][0] = "W"
+    board[1][1] = "W"
+    board[2][2] = "W"
+    assert game.is_terminal(board)
+
+    # Test play_episode handles double pass
+    # Force a terminal by filling the board
+    full_board = [["B" if (r + c) % 2 == 0 else "W" for c in range(6)] for r in range(6)]
+    result = game.play_episode(
+        full_board,
+        policy_fn=lambda b, p: None,
+        opponent_fn=lambda b, p: None,
+        max_moves=5,
+    )
+    assert game.is_terminal(result["board"])
+
+
+def test_othello_terminal_scoring_counts_discs():
+    game = _load_module("game")
+
+    # Board with 20 B and 16 W (36 total, full board)
+    board = [["B" for _ in range(6)] for _ in range(6)]
+    for r in range(4):
+        for c in range(6):
+            if r * 6 + c < 16:
+                board[r][c] = "W"
+    counts = game.score(board)
+    assert counts["B"] == 20
+    assert counts["W"] == 16
+    assert game.winner(board) == "B"
+
+    # Tie board
+    tie_board = [["B" if (r * 6 + c) % 2 == 0 else "W" for c in range(6)] for r in range(6)]
+    tie_counts = game.score(tie_board)
+    assert tie_counts["B"] == 18
+    assert tie_counts["W"] == 18
+    assert game.winner(tie_board) is None
+
+
+def test_othello_illegal_cell_rejected():
+    game = _load_module("game")
+    board = game.initial_board()
+
+    # Occupied cell -> illegal
+    assert game.score_move(board, 2, 2, "B") == -1.0  # (2,2) is W in initial board
+    try:
+        game.apply_move(board, 2, 2, "B")
+        assert False, "should reject occupied cell"
+    except ValueError:
+        pass
+
+    # Empty cell with no flips -> illegal
+    # (0,0) is empty but has no B-W-B line in the initial board
+    assert game.score_move(board, 0, 0, "B") == -1.0
+    try:
+        game.apply_move(board, 0, 0, "B")
+        assert False, "should reject no-flip cell"
+    except ValueError:
+        pass
+
+    # Out of bounds
+    try:
+        game.apply_move(board, 6, 0, "B")
+        assert False, "should reject out of bounds"
+    except ValueError:
+        pass
+
+    # None move
+    assert game.score_move(board, None, None, "B") == -1.0
+
+
+def test_othello_generator_produces_reachable_boards():
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+
+    # Determinism: same seed -> same output
+    records1 = generator.generate_records(16, seed=7)
+    records2 = generator.generate_records(16, seed=7)
+    assert records1 == records2
+
+    assert len(records1) == 16
+    for record in records1:
+        board = game.normalize_board(record["board"])
+        assert len(board) == 6
+        assert all(len(row) == 6 for row in board)
+        # Must be B's turn
+        assert record["player"] == "B"
+        assert game.next_player(board) == "B"
+        # Must not be terminal
+        assert not game.is_terminal(board)
+        # Must have legal moves for B
+        assert game.has_legal_move(board, "B")
+
+
+def test_othello_reward_scores_tool_move_only():
+    game = _load_module("game")
+    reward = _load_module("reward")
+
+    board = game.initial_board()
+    # Legal first move for B: (2,4) or (3,5) or (4,2) or (5,3) etc.
+    legal = game.legal_moves(board, "B")
+    assert len(legal) > 0
+    legal_row, legal_col = legal[0]
+
+    # Valid legal move -> 0.0 (non-terminal)
+    record = SimpleNamespace(
+        source_record={"board": board, "player": "B"},
+        completion="",
+        tool_calls=[{"name": "choose_move", "arguments": {"row": legal_row, "col": legal_col}}],
+    )
+    assert reward.reward_fn(record) == 0.0
+
+    # Illegal move (occupied cell) -> -1.0
+    record.tool_calls = [{"name": "choose_move", "arguments": {"row": 2, "col": 2}}]
+    assert reward.reward_fn(record) == -1.0
+
+    # Wrong tool name -> -1.0
+    record.tool_calls = [{"name": "other_tool", "arguments": {"row": 2, "col": 4}}]
+    assert reward.reward_fn(record) == -1.0
+
+    # No tool calls -> -1.0
+    record.tool_calls = []
+    assert reward.reward_fn(record) == -1.0
+
+    # Arguments as JSON string
+    import json
+
+    record.tool_calls = [
+        {
+            "name": "choose_move",
+            "arguments": json.dumps({"row": legal_row, "col": legal_col}),
+        }
+    ]
+    assert reward.reward_fn(record) == 0.0
+
+    # Invalid JSON string arguments -> -1.0
+    record.tool_calls = [{"name": "choose_move", "arguments": "not json"}]
+    assert reward.reward_fn(record) == -1.0
+
+
+def test_othello_seeded_random_opponent_evaluation():
+    game = _load_module("game")
+
+    rng_policy = random.Random(42)
+    rng_opponent = random.Random(99)
+
+    def policy_fn(board, player):
+        return game.random_policy(board, player, rng_policy)
+
+    def opponent_fn(board, player):
+        return game.random_policy(board, player, rng_opponent)
+
+    num_games = 20
+    wins = 0
+    total_illegal = 0
+    total_moves = 0
+
+    for i in range(num_games):
+        board = game.initial_board()
+        first_player = "B" if i % 2 == 0 else "W"
+        result = game.play_episode(
+            board,
+            policy_fn=policy_fn,
+            opponent_fn=opponent_fn,
+            first_player=first_player,
+            max_moves=40,
+        )
+        if result["winner"] is not None:
+            # policy_fn plays first_player; check if that side won
+            if result["winner"] == first_player:
+                wins += 1
+        total_illegal += result["illegal_moves"]
+        total_moves += result["total_moves"]
+
+    win_rate = wins / num_games
+    illegal_rate = total_illegal / max(total_moves, 1)
+
+    # Random vs random: win rate should be in a reasonable range
+    assert 0.0 <= win_rate <= 1.0
+    # Seeded random agent only picks legal moves, so illegal rate should be 0
+    assert illegal_rate == 0.0
+    # Ensure we actually played some games
+    assert total_moves > 0
+
+
+def test_othello_dataset_loader_formats_records():
+    game = _load_module("game")
+    loader = _load_module("dataset_loader")
+
+    # Test with no file -> falls back to generator
+    records = loader.load_training_dataset("/nonexistent/path/boards.jsonl")
+    assert len(records) > 0
+    for record in records:
+        assert "prompt" in record
+        assert "board" in record
+        assert "player" in record
+        assert "valid_moves" in record
+        assert isinstance(record["valid_moves"], list)
+        # Each valid move should be a legal move
+        for move in record["valid_moves"]:
+            assert move in game.legal_moves(record["board"], record["player"])


### PR DESCRIPTION
## What does this PR do?

Implements a 6x6 Othello agentic RL demo (Issue #190).

**Files changed:**

| File | Change |
|------|--------|
| `examples/agentic/othello/game.py` | New — 6x6 Othello engine (8-direction flipping, pass handling, terminal scoring, episode simulation) |
| `examples/agentic/othello/dataset_generator.py` | New — deterministic reachable board generator (seeded RNG from standard initial board) |
| `examples/agentic/othello/dataset_loader.py` | New — AReno file-callback dataset loader |
| `examples/agentic/othello/reward.py` | New — AReno file-callback reward function (illegal=-1.0, legal=0.0, terminal win=1.0) |
| `examples/agentic/othello/run_agent.py` | New — AReno agentic agent entrypoint with choose_move tool |
| `examples/agentic/othello/README.md` | New — documentation with generate/train commands and Kaggle T4 guide |
| `tests/test_agentic_othello_example_cpu.py` | New — 10 CPU tests covering all acceptance criteria |
| `docs/cookbook/othello-agentic-rl.rst` | New — cookbook recipe |
| `docs/index.rst` | Modified — added cookbook toctree entry |
| `docs/troubleshooting/agentic-rollout.rst` | Modified — added Othello recipe reference |

## Related issue

Fixes #190

## Type of change

- [x] New feature
- [x] Test coverage improvement

## How was this tested?

```bash
python -m pytest tests/test_agentic_othello_example_cpu.py -v   # 10 passed
ruff check examples/agentic/othello/ tests/test_agentic_othello_example_cpu.py   # All checks passed
ruff format --check examples/agentic/othello/ tests/test_agentic_othello_example_cpu.py   # 7 files already formatted
```

CPU tests pass on Kaggle (Python 3.12, CPU-only, no GPU required). GPU-specific training validation not yet performed — planned on Kaggle dual-T4.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description.
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible.

## Breaking change details

No breaking changes. All new code lives under `examples/agentic/othello/` with no changes to any AReno core files. The only existing files modified are `docs/index.rst` (added toctree entry) and `docs/troubleshooting/agentic-rollout.rst` (added recipe reference). Default behavior is unchanged when the feature is not used.