### PR TITLE
feat: add areno-profile-performance command for two-run comparison

### DIFF
--- a/.agents/skills/areno-profile-performance/SKILL.md
+++ b/.agents/skills/areno-profile-performance/SKILL.md
@@ -26,6 +26,8 @@ python .agents/skills/areno-profile-performance/scripts/probe_openai_latency.py 
   --base-url http://127.0.0.1:8000 --model <model> --requests 16 --concurrency 4
 python .agents/skills/areno-profile-performance/scripts/build_nsys_command.py \
   --output /tmp/areno-profile -- <bounded-command> [args...]
+python .agents/skills/areno-profile-performance/scripts/compare_runs.py \
+  <baseline-metrics-dir> <candidate-metrics-dir>
 ```
 
 ## Workflow
@@ -39,5 +41,26 @@ python .agents/skills/areno-profile-performance/scripts/build_nsys_command.py \
 7. Use `py-spy record -p <pid> -o /tmp/areno.svg --duration 30` for Python scheduling, data processing, serialization, blocking I/O, or compilation orchestration.
 8. Use a bounded Nsight Systems capture for GPU compute, communication, synchronization, allocator activity, or launch gaps. Read [references/profile-policy.md](references/profile-policy.md).
 9. Compare baseline and candidate with identical workloads and multiple steady-state observations, then re-run correctness validation after optimization.
+
+Use `compare_runs.py` to produce a structured comparison of throughput, phase
+timing, peak memory, and configuration between two run directories. The script
+reads `areno_run_config`, `dashboard_state`, TensorBoard `time/*` and
+`throughput`/`tokens_per_second` scalars, and monitor JSONL artifacts from each
+directory. Missing values are reported as null, never converted to zero.
+Configuration mismatches are highlighted in both the terminal report (stderr)
+and the JSON report (stdout). Active runs (status="running") produce a warning
+that metrics may be incomplete.
+
+Example:
+
+```bash
+python .agents/skills/areno-profile-performance/scripts/compare_runs.py \
+  /tmp/run-baseline/metrics /tmp/run-candidate/metrics --json-only
+```
+
+Output fields: `ok`, `baseline` (status/stage/step/kind/pid), `candidate`,
+`metrics` (per-key baseline/candidate/pct_change), `peak_memory`,
+`settings_comparison` (matched/mismatched/only_baseline/only_candidate),
+`extremes` (largest_improvement/largest_regression), `warnings`.
 
 Report raw workload metadata, selected window, GPU peak/average memory and utilization, process CPU/RSS, stage breakdown or TTFT/latency, bottleneck evidence, profiler overhead, and before/after metrics. A single warmup step is not a benchmark.

--- a/.agents/skills/areno-profile-performance/references/profile-policy.md
+++ b/.agents/skills/areno-profile-performance/references/profile-policy.md
@@ -10,3 +10,4 @@
 - TensorBoard event directories are job-specific. List available tags and select the target job's files; never combine unrelated runs into one conclusion.
 - Serve comparisons report warmup policy, request concurrency, prompt/output lengths, TTFT, total latency, and throughput.
 - Profile overhead is not production throughput; validate the change without the profiler.
+- Run comparisons report percentage change per metric, highlight configuration mismatches, and never convert missing values to zero; use `compare_runs.py` for a structured diff of two run directories.

--- a/.agents/skills/areno-profile-performance/scripts/compare_runs.py
+++ b/.agents/skills/areno-profile-performance/scripts/compare_runs.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python3
+"""Compare throughput, phase timing, peak memory, and settings between two AReno runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# Metric keys whose *increase* indicates a regression (higher = slower).
+_TIMING_PREFIXES = ("time/", "step_")
+
+# Metric keys whose *increase* indicates an improvement (higher = faster).
+_THROUGHPUT_KEYWORDS = ("throughput", "tokens_per_second")
+
+
+# ---------------------------------------------------------------------------
+# Pure functions (importable and testable without any external dependency)
+# ---------------------------------------------------------------------------
+
+
+def percent_change(baseline: float | None, candidate: float | None) -> float | None:
+    """Return percentage change from baseline to candidate, or None when undefined."""
+    if baseline is None or candidate is None:
+        return None
+    if baseline == 0:
+        return None
+    return (candidate - baseline) / abs(baseline) * 100.0
+
+
+def _is_timing_metric(key: str) -> bool:
+    return key.startswith(_TIMING_PREFIXES) and not any(
+        kw in key for kw in _THROUGHPUT_KEYWORDS
+    )
+
+
+def _stat_keys() -> tuple[str, ...]:
+    return ("mean", "median", "min", "max", "last")
+
+
+def compare_metric_pair(
+    baseline: dict | None, candidate: dict | None
+) -> dict:
+    """Compare two statistic dictionaries and return per-stat pct_change."""
+    result: dict = {"baseline": baseline, "candidate": candidate, "pct_change": {}}
+    for stat in _stat_keys():
+        b_val = baseline.get(stat) if baseline else None
+        c_val = candidate.get(stat) if candidate else None
+        result["pct_change"][stat] = percent_change(
+            b_val if isinstance(b_val, (int, float)) else None,
+            c_val if isinstance(c_val, (int, float)) else None,
+        )
+    return result
+
+
+def _flatten_settings(settings: dict | None) -> dict[str, object]:
+    """Flatten the nested areno_run_config settings into {key: value}."""
+    if not settings or not isinstance(settings, dict):
+        return {}
+    flat: dict[str, object] = {}
+    for section in settings.values():
+        if not isinstance(section, dict):
+            continue
+        for item in section.get("items", []):
+            if isinstance(item, dict) and "key" in item:
+                flat[str(item["key"])] = item.get("value")
+    return flat
+
+
+def compare_settings(
+    baseline_settings: dict | None, candidate_settings: dict | None
+) -> dict:
+    """Compare flattened settings from two run configs."""
+    base = _flatten_settings(baseline_settings)
+    cand = _flatten_settings(candidate_settings)
+    base_keys = set(base)
+    cand_keys = set(cand)
+    matched = sorted(base_keys & cand_keys)
+    mismatched: list[dict] = []
+    for key in matched:
+        if base[key] != cand[key]:
+            mismatched.append(
+                {"key": key, "baseline": base[key], "candidate": cand[key]}
+            )
+    return {
+        "matched": [k for k in matched if base[k] == cand[k]],
+        "mismatched": mismatched,
+        "only_baseline": sorted(base_keys - cand_keys),
+        "only_candidate": sorted(cand_keys - base_keys),
+    }
+
+
+def identify_extremes(comparisons: dict[str, dict]) -> dict:
+    """Find the largest improvement and largest regression by pct_change mean.
+
+    For timing metrics (time/*, step_* without throughput keywords), an
+    *increase* is a regression and a *decrease* is an improvement. For
+    throughput metrics, the opposite holds. The returned pct_change is
+    the raw signed value.
+    """
+    improvements: list[tuple[str, float, float]] = []  # (metric, raw_pct, magnitude)
+    regressions: list[tuple[str, float, float]] = []
+    for metric, data in comparisons.items():
+        pct = data.get("pct_change", {}).get("mean")
+        if pct is None:
+            continue
+        is_timing = _is_timing_metric(metric)
+        if is_timing:
+            if pct > 0:
+                regressions.append((metric, pct, pct))
+            elif pct < 0:
+                improvements.append((metric, pct, abs(pct)))
+        else:
+            if pct > 0:
+                improvements.append((metric, pct, pct))
+            elif pct < 0:
+                regressions.append((metric, pct, abs(pct)))
+    best_imp = max(improvements, key=lambda x: x[2]) if improvements else None
+    worst_reg = max(regressions, key=lambda x: x[2]) if regressions else None
+    return {
+        "largest_improvement": {"metric": best_imp[0], "pct_change": best_imp[1]}
+        if best_imp
+        else None,
+        "largest_regression": {"metric": worst_reg[0], "pct_change": worst_reg[1]}
+        if worst_reg
+        else None,
+    }
+
+
+def _extract_peak_mib(monitor: dict | None) -> float | None:
+    """Extract peak memory in MiB from a monitor summary dict."""
+    if not monitor:
+        return None
+    peaks: list[float] = []
+    gpus = monitor.get("gpus", {})
+    if isinstance(gpus, dict):
+        for gpu_stats in gpus.values():
+            if isinstance(gpu_stats, dict):
+                mem = gpu_stats.get("memory_used_mib")
+                if isinstance(mem, dict):
+                    peak = mem.get("max")
+                    if isinstance(peak, (int, float)):
+                        peaks.append(float(peak))
+    proc_mem = monitor.get("target_process_memory_mib", {})
+    if isinstance(proc_mem, dict):
+        for proc_stats in proc_mem.values():
+            if isinstance(proc_stats, dict):
+                peak = proc_stats.get("max")
+                if isinstance(peak, (int, float)):
+                    peaks.append(float(peak))
+    return max(peaks) if peaks else None
+
+
+def compare_peak_memory(
+    baseline_monitor: dict | None, candidate_monitor: dict | None
+) -> dict:
+    """Compare peak memory between two monitor summaries."""
+    base_peak = _extract_peak_mib(baseline_monitor)
+    cand_peak = _extract_peak_mib(candidate_monitor)
+    return {
+        "baseline_peak_mib": base_peak,
+        "candidate_peak_mib": cand_peak,
+        "pct_change": percent_change(base_peak, cand_peak),
+    }
+
+
+def build_run_summary(status: dict | None, config: dict | None) -> dict:
+    """Extract run metadata from dashboard_state and run_config JSON."""
+    summary: dict = {
+        "status": None,
+        "stage": None,
+        "step": None,
+        "kind": None,
+        "pid": None,
+    }
+    if isinstance(status, dict):
+        summary["status"] = status.get("status")
+        summary["stage"] = status.get("stage")
+        step = status.get("step")
+        if isinstance(step, int):
+            summary["step"] = step
+        pid = status.get("pid")
+        if isinstance(pid, int):
+            summary["pid"] = pid
+    if isinstance(config, dict):
+        summary["kind"] = config.get("kind")
+        cpid = config.get("pid")
+        if isinstance(cpid, int) and summary["pid"] is None:
+            summary["pid"] = cpid
+    return summary
+
+
+def build_result(baseline_data: dict, candidate_data: dict) -> dict:
+    """Assemble the full comparison result from loaded run artifacts."""
+    base_summary = build_run_summary(
+        baseline_data.get("status"), baseline_data.get("config")
+    )
+    cand_summary = build_run_summary(
+        candidate_data.get("status"), candidate_data.get("config")
+    )
+    base_summary["log_dir"] = baseline_data.get("log_dir")
+    cand_summary["log_dir"] = candidate_data.get("log_dir")
+
+    base_metrics = {k: v for k, v in (baseline_data.get("time_metrics") or {}).items() if v is not None}
+    cand_metrics = {k: v for k, v in (candidate_data.get("time_metrics") or {}).items() if v is not None}
+
+    common_keys = sorted(set(base_metrics) & set(cand_metrics))
+    only_base = sorted(set(base_metrics) - set(cand_metrics))
+    only_cand = sorted(set(cand_metrics) - set(base_metrics))
+
+    comparisons: dict[str, dict] = {}
+    for key in common_keys:
+        comparisons[key] = compare_metric_pair(base_metrics[key], cand_metrics[key])
+
+    extremes = identify_extremes(comparisons)
+
+    peak_memory = compare_peak_memory(
+        baseline_data.get("monitor_summary"), candidate_data.get("monitor_summary")
+    )
+
+    settings_comp = compare_settings(
+        baseline_data.get("config", {}).get("settings") if baseline_data.get("config") else None,
+        candidate_data.get("config", {}).get("settings") if candidate_data.get("config") else None,
+    )
+
+    warnings: list[str] = []
+    if base_summary.get("status") == "running":
+        warnings.append(
+            f"baseline status is 'running'; baseline metrics may be incomplete"
+        )
+    if cand_summary.get("status") == "running":
+        warnings.append(
+            f"candidate status is 'running'; candidate metrics may be incomplete"
+        )
+    if not common_keys and not only_base and not only_cand:
+        warnings.append("no common time/throughput metrics found between runs")
+    if only_base:
+        warnings.append(
+            f"metrics only in baseline (excluded from comparison): {', '.join(only_base)}"
+        )
+    if only_cand:
+        warnings.append(
+            f"metrics only in candidate (excluded from comparison): {', '.join(only_cand)}"
+        )
+    if settings_comp["mismatched"]:
+        keys = ", ".join(m["key"] for m in settings_comp["mismatched"])
+        warnings.append(f"configuration mismatch on keys: {keys}")
+    if peak_memory["baseline_peak_mib"] is None and peak_memory["candidate_peak_mib"] is not None:
+        warnings.append("baseline peak memory unavailable; candidate peak memory present")
+    if peak_memory["candidate_peak_mib"] is None and peak_memory["baseline_peak_mib"] is not None:
+        warnings.append("candidate peak memory unavailable; baseline peak memory present")
+
+    return {
+        "ok": True,
+        "baseline": base_summary,
+        "candidate": cand_summary,
+        "metrics": comparisons,
+        "peak_memory": peak_memory,
+        "settings_comparison": settings_comp,
+        "extremes": extremes,
+        "warnings": warnings,
+    }
+
+
+def format_terminal_report(result: dict) -> str:
+    """Generate a human-readable multi-line report string."""
+    lines: list[str] = []
+    lines.append("=== AReno Run Comparison ===")
+    lines.append("")
+
+    base = result.get("baseline", {})
+    cand = result.get("candidate", {})
+
+    def _run_line(label: str, info: dict) -> str:
+        log_dir = info.get("log_dir") or "?"
+        status = info.get("status") or "unknown"
+        step = info.get("step")
+        step_str = f", step {step}" if step is not None else ""
+        return f"{label}: {log_dir}  [{status}{step_str}]"
+
+    lines.append(_run_line("Baseline ", base))
+    lines.append(_run_line("Candidate", cand))
+    lines.append("")
+
+    # Metrics section
+    metrics = result.get("metrics", {})
+    if metrics:
+        lines.append("--- Throughput & Timing Metrics ---")
+        lines.append("")
+        header = f"{'Metric':<30s} {'Baseline (mean)':>16s} {'Candidate (mean)':>16s} {'Change':>12s}"
+        lines.append(header)
+        lines.append("-" * len(header))
+        for key in sorted(metrics):
+            entry = metrics[key]
+            b_mean = entry.get("baseline", {}).get("mean") if entry.get("baseline") else None
+            c_mean = entry.get("candidate", {}).get("mean") if entry.get("candidate") else None
+            pct = entry.get("pct_change", {}).get("mean")
+            b_str = f"{b_mean:.2f}" if isinstance(b_mean, (int, float)) else "N/A"
+            c_str = f"{c_mean:.2f}" if isinstance(c_mean, (int, float)) else "N/A"
+            if pct is not None:
+                sign = "+" if pct >= 0 else ""
+                pct_str = f"{sign}{pct:.2f}%"
+                is_timing = _is_timing_metric(key)
+                if pct > 0:
+                    tag = "REGRESSION" if is_timing else "IMPROVEMENT"
+                elif pct < 0:
+                    tag = "IMPROVEMENT" if is_timing else "REGRESSION"
+                else:
+                    tag = ""
+                pct_str = f"{pct_str} {tag}".strip()
+            else:
+                pct_str = "N/A"
+            metric_name = key[:30]
+            lines.append(f"{metric_name:<30s} {b_str:>16s} {c_str:>16s} {pct_str:>12s}")
+        lines.append("")
+
+    # Peak memory section
+    peak = result.get("peak_memory", {})
+    if peak.get("baseline_peak_mib") is not None or peak.get("candidate_peak_mib") is not None:
+        lines.append("--- Peak Memory ---")
+        lines.append("")
+        b_peak = peak.get("baseline_peak_mib")
+        c_peak = peak.get("candidate_peak_mib")
+        b_str = f"{b_peak:.2f} MiB" if isinstance(b_peak, (int, float)) else "N/A"
+        c_str = f"{c_peak:.2f} MiB" if isinstance(c_peak, (int, float)) else "N/A"
+        lines.append(f"Baseline peak: {b_str}")
+        lines.append(f"Candidate peak: {c_str}")
+        pct = peak.get("pct_change")
+        if pct is not None:
+            sign = "+" if pct >= 0 else ""
+            lines.append(f"Change: {sign}{pct:.2f}%")
+        else:
+            lines.append("Change: N/A")
+        lines.append("")
+
+    # Configuration section
+    settings = result.get("settings_comparison", {})
+    if settings.get("matched") or settings.get("mismatched") or settings.get("only_baseline") or settings.get("only_candidate"):
+        lines.append("--- Configuration ---")
+        lines.append("")
+        if settings.get("matched"):
+            lines.append(f"Matched: {', '.join(settings['matched'])}")
+        for m in settings.get("mismatched", []):
+            lines.append(
+                f"MISMATCH: {m['key']} (baseline={m['baseline']}, candidate={m['candidate']})"
+            )
+        if settings.get("only_baseline"):
+            lines.append(f"Only in baseline: {', '.join(settings['only_baseline'])}")
+        if settings.get("only_candidate"):
+            lines.append(f"Only in candidate: {', '.join(settings['only_candidate'])}")
+        lines.append("")
+
+    # Summary section
+    extremes = result.get("extremes", {})
+    improvements = extremes.get("largest_improvement")
+    regressions = extremes.get("largest_regression")
+    if improvements or regressions:
+        lines.append("--- Summary ---")
+        lines.append("")
+        if improvements:
+            lines.append(
+                f"Largest improvement: {improvements['metric']} ({improvements['pct_change']:+.2f}%)"
+            )
+        if regressions:
+            lines.append(
+                f"Largest regression:  {regressions['metric']} ({regressions['pct_change']:+.2f}%)"
+            )
+        lines.append("")
+
+    # Warnings
+    warnings = result.get("warnings", [])
+    if warnings:
+        lines.append("Warnings:")
+        for w in warnings:
+            lines.append(f"  - {w}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O layer (deferred imports, file system access)
+# ---------------------------------------------------------------------------
+
+
+def _latest_glob(directory: Path, pattern: str) -> Path | None:
+    """Return the most recently modified file matching pattern, or None."""
+    files = sorted(directory.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    return files[0] if files else None
+
+
+def _load_json(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _load_monitor_peak(directory: Path) -> dict | None:
+    """Load monitor JSONL files and extract a simplified GPU/process memory summary."""
+    jsonl_files = sorted(
+        [f for f in directory.glob("*.jsonl") if not f.name.startswith("rollout_samples")],
+        key=lambda p: p.name,
+    )
+    if not jsonl_files:
+        return None
+    monitor_file = jsonl_files[-1]
+    try:
+        records = [
+            json.loads(line)
+            for line in monitor_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except Exception:
+        return None
+    if not records:
+        return None
+    first = records[0]
+    if "gpus" not in first and "processes" not in first:
+        return None
+    if "gpus" in first:
+        return _summarize_gpu_monitor(records)
+    if "processes" in first:
+        return _summarize_process_monitor(records)
+    return None
+
+
+def _summarize_gpu_monitor(records: list[dict]) -> dict:
+    """Extract peak GPU and target-process memory from GPU monitor JSONL."""
+    from collections import defaultdict
+
+    gpu_mem: dict[int, list[float]] = defaultdict(list)
+    proc_mem: dict[int, list[float]] = defaultdict(list)
+    for record in records:
+        for gpu in record.get("gpus", []):
+            idx = gpu.get("index")
+            mem = gpu.get("memory_used_mib")
+            if idx is not None and isinstance(mem, (int, float)):
+                gpu_mem[idx].append(float(mem))
+        for proc in record.get("target_processes", []):
+            pid = proc.get("pid")
+            mem = proc.get("memory_used_mib")
+            if pid is not None and isinstance(mem, (int, float)):
+                proc_mem[pid].append(float(mem))
+    gpus_out = {}
+    for idx, values in sorted(gpu_mem.items()):
+        gpus_out[str(idx)] = {"memory_used_mib": {"max": max(values)}}
+    proc_out = {}
+    for pid, values in sorted(proc_mem.items()):
+        proc_out[str(pid)] = {"max": max(values)}
+    return {"gpus": gpus_out, "target_process_memory_mib": proc_out}
+
+
+def _summarize_process_monitor(records: list[dict]) -> dict:
+    """Extract peak RSS from process monitor JSONL (as a peek_memory surrogate)."""
+    from collections import defaultdict
+
+    rss_values: list[float] = []
+    for record in records:
+        for proc in record.get("processes", []):
+            rss = proc.get("rss_bytes")
+            if isinstance(rss, (int, float)):
+                rss_values.append(float(rss))
+    if not rss_values:
+        return {"gpus": {}, "target_process_memory_mib": {}}
+    # Convert bytes to MiB for consistency with GPU monitor
+    peak_mib = max(rss_values) / (1024 * 1024)
+    return {
+        "gpus": {},
+        "target_process_memory_mib": {"0": {"max": peak_mib}},
+    }
+
+
+def _load_time_metrics(log_dir: Path, drop_first: int) -> dict | None:
+    """Load TensorBoard time/* and throughput scalars (deferred import)."""
+    try:
+        from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+    except Exception:
+        return None
+    try:
+        accumulator = EventAccumulator(str(log_dir), size_guidance={"scalars": 0})
+        accumulator.Reload()
+        keys = sorted(accumulator.Tags().get("scalars", []))
+        selected = [
+            key
+            for key in keys
+            if key.startswith("time/")
+            or "throughput" in key
+            or "tokens_per_second" in key
+        ]
+        summaries = {}
+        for key in selected:
+            events = accumulator.Scalars(key)[max(drop_first, 0):]
+            values = [event.value for event in events]
+            if values:
+                summaries[key] = {
+                    "count": len(values),
+                    "mean": statistics.fmean(values),
+                    "median": statistics.median(values),
+                    "min": min(values),
+                    "max": max(values),
+                    "last": values[-1],
+                }
+        return summaries if summaries else None
+    except Exception:
+        return None
+
+
+def load_run_artifacts(log_dir: Path, drop_first: int, load_monitor: bool = True) -> dict:
+    """Load all available artifacts from a run directory."""
+    data: dict = {"log_dir": str(log_dir)}
+
+    # Dashboard state (glob for *.<pid>.json, then plain .json)
+    state_path = _latest_glob(log_dir, "dashboard_state.*.json")
+    if state_path is None:
+        plain = log_dir / "dashboard_state.json"
+        state_path = plain if plain.exists() else None
+    data["status"] = _load_json(state_path) if state_path else None
+
+    # Run config (glob for *.<pid>.json, then plain .json)
+    config_path = _latest_glob(log_dir, "areno_run_config.*.json")
+    if config_path is None:
+        plain = log_dir / "areno_run_config.json"
+        config_path = plain if plain.exists() else None
+    data["config"] = _load_json(config_path) if config_path else None
+
+    # TensorBoard time metrics
+    data["time_metrics"] = _load_time_metrics(log_dir, drop_first)
+
+    # Monitor data
+    data["monitor_summary"] = _load_monitor_peak(log_dir) if load_monitor else None
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare throughput, phase timing, peak memory, and settings between two AReno runs."
+    )
+    parser.add_argument("baseline", type=Path, help="Baseline run metrics_log_dir")
+    parser.add_argument("candidate", type=Path, help="Candidate run metrics_log_dir")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json-only", action="store_true", help="Output only JSON to stdout")
+    output_group.add_argument(
+        "--terminal-only", action="store_true", help="Output only terminal report to stdout"
+    )
+    parser.add_argument("--drop-first", type=int, default=1, help="Drop first N warmup steps (default 1)")
+    parser.add_argument("--no-monitor", action="store_true", help="Skip monitor JSONL loading")
+    args = parser.parse_args()
+
+    # --- Input validation (before any expensive import) ---
+    inputs = {"baseline": str(args.baseline), "candidate": str(args.candidate)}
+    for label, path in (("baseline", args.baseline), ("candidate", args.candidate)):
+        if not path.exists():
+            result = {
+                "ok": False,
+                "error": f"{label} directory does not exist: {path}",
+                "stage": "input_validation",
+                "inputs": inputs,
+            }
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 1
+        if not path.is_dir():
+            result = {
+                "ok": False,
+                "error": f"{label} path is not a directory: {path}",
+                "stage": "input_validation",
+                "inputs": inputs,
+            }
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 1
+
+    # --- Load artifacts ---
+    try:
+        baseline_data = load_run_artifacts(
+            args.baseline, args.drop_first, load_monitor=not args.no_monitor
+        )
+    except Exception as exc:
+        result = {
+            "ok": False,
+            "error": f"failed to load baseline: {type(exc).__name__}: {exc}",
+            "stage": "load_baseline",
+            "inputs": inputs,
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1
+
+    try:
+        candidate_data = load_run_artifacts(
+            args.candidate, args.drop_first, load_monitor=not args.no_monitor
+        )
+    except Exception as exc:
+        result = {
+            "ok": False,
+            "error": f"failed to load candidate: {type(exc).__name__}: {exc}",
+            "stage": "load_candidate",
+            "inputs": inputs,
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1
+
+    # --- Build comparison result ---
+    result = build_result(baseline_data, candidate_data)
+
+    # --- Output ---
+    json_str = json.dumps(result, indent=2, sort_keys=True)
+    terminal_str = format_terminal_report(result)
+
+    if args.json_only:
+        print(json_str)
+    elif args.terminal_only:
+        print(terminal_str)
+    else:
+        # Default: JSON to stdout, terminal report to stderr
+        print(json_str)
+        print(terminal_str, file=sys.stderr)
+
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compare_runs_cpu.py
+++ b/tests/test_compare_runs_cpu.py
@@ -1,0 +1,569 @@
+"""CPU tests for the compare_runs.py two-run comparison script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Module loading helper -- load the script as an importable module
+# ---------------------------------------------------------------------------
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / ".agents/skills/areno-profile-performance/scripts/compare_runs.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("compare_runs", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Inline fixtures
+# ---------------------------------------------------------------------------
+
+
+def _metric_stats(mean, median=None, min_val=None, max_val=None, last=None, count=10):
+    """Build a metric stats dict similar to summarize_time_metrics output."""
+    return {
+        "count": count,
+        "mean": mean,
+        "median": median if median is not None else mean,
+        "min": min_val if min_val is not None else mean,
+        "max": max_val if max_val is not None else mean,
+        "last": last if last is not None else mean,
+    }
+
+
+def _baseline_data():
+    return {
+        "log_dir": "/fake/baseline",
+        "status": {"pid": 12345, "stage": "train", "status": "completed", "step": 100},
+        "config": {
+            "kind": "train",
+            "pid": 12345,
+            "settings": {
+                "Basic": {
+                    "title": "Basic",
+                    "items": [
+                        {"key": "algo", "value": "grpo"},
+                        {"key": "batch_size", "value": 32},
+                        {"key": "max_new_tokens", "value": 1024},
+                    ],
+                }
+            },
+        },
+        "time_metrics": {
+            "throughput": _metric_stats(1000.0, count=99),
+            "time/rollout": _metric_stats(5.0),
+            "time/train": _metric_stats(10.0),
+        },
+        "monitor_summary": {
+            "gpus": {"0": {"memory_used_mib": {"max": 40000.0}}},
+            "target_process_memory_mib": {"12345": {"max": 38000.0}},
+        },
+    }
+
+
+def _candidate_data():
+    return {
+        "log_dir": "/fake/candidate",
+        "status": {"pid": 67890, "stage": "train", "status": "running", "step": 50},
+        "config": {
+            "kind": "train",
+            "pid": 67890,
+            "settings": {
+                "Basic": {
+                    "title": "Basic",
+                    "items": [
+                        {"key": "algo", "value": "grpo"},
+                        {"key": "batch_size", "value": 32},
+                        {"key": "max_new_tokens", "value": 2048},
+                        {"key": "custom_key", "value": "new_val"},
+                    ],
+                }
+            },
+        },
+        "time_metrics": {
+            "throughput": _metric_stats(1200.0, count=49),
+            "time/rollout": _metric_stats(4.0),
+            "time/train": _metric_stats(11.55),
+        },
+        "monitor_summary": {
+            "gpus": {"0": {"memory_used_mib": {"max": 38000.0}}},
+            "target_process_memory_mib": {"67890": {"max": 36000.0}},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+
+def test_percent_change_basic():
+    mod = _load_module()
+    assert mod.percent_change(100.0, 120.0) == 20.0
+    assert mod.percent_change(100.0, 80.0) == -20.0
+
+
+def test_percent_change_with_none():
+    mod = _load_module()
+    assert mod.percent_change(None, 100.0) is None
+    assert mod.percent_change(100.0, None) is None
+    assert mod.percent_change(None, None) is None
+
+
+def test_percent_change_zero_baseline():
+    mod = _load_module()
+    assert mod.percent_change(0.0, 100.0) is None
+    assert mod.percent_change(0, 0) is None
+
+
+def test_compare_metric_pair_complete():
+    mod = _load_module()
+    base = _metric_stats(100.0)
+    cand = _metric_stats(120.0)
+    result = mod.compare_metric_pair(base, cand)
+    assert result["pct_change"]["mean"] == 20.0
+    assert result["pct_change"]["median"] == 20.0
+    assert result["baseline"] == base
+    assert result["candidate"] == cand
+
+
+def test_compare_metric_pair_one_missing():
+    mod = _load_module()
+    base = _metric_stats(100.0)
+    result = mod.compare_metric_pair(base, None)
+    assert result["candidate"] is None
+    for stat in ("mean", "median", "min", "max", "last"):
+        assert result["pct_change"][stat] is None
+
+    result2 = mod.compare_metric_pair(None, base)
+    assert result2["baseline"] is None
+    assert result2["pct_change"]["mean"] is None
+
+
+def test_compare_settings_finds_mismatch():
+    mod = _load_module()
+    base_settings = {"S": {"items": [{"key": "algo", "value": "grpo"}, {"key": "lr", "value": 1e-4}]}}
+    cand_settings = {"S": {"items": [{"key": "algo", "value": "grpo"}, {"key": "lr", "value": 5e-5}]}}
+    result = mod.compare_settings(base_settings, cand_settings)
+    mismatched_keys = [m["key"] for m in result["mismatched"]]
+    assert "lr" in mismatched_keys
+    assert "algo" in result["matched"]
+
+
+def test_compare_settings_only_in_one_run():
+    mod = _load_module()
+    base_settings = {"S": {"items": [{"key": "a", "value": 1}, {"key": "b", "value": 2}]}}
+    cand_settings = {"S": {"items": [{"key": "a", "value": 1}, {"key": "c", "value": 3}]}}
+    result = mod.compare_settings(base_settings, cand_settings)
+    assert result["only_baseline"] == ["b"]
+    assert result["only_candidate"] == ["c"]
+
+
+def test_identify_extremes_both_directions():
+    mod = _load_module()
+    comparisons = {
+        "throughput": {"pct_change": {"mean": 20.0}},
+        "time/train": {"pct_change": {"mean": -15.0}},
+        "time/rollout": {"pct_change": {"mean": 5.0}},
+    }
+    extremes = mod.identify_extremes(comparisons)
+    # throughput +20% = improvement (throughput metric, positive = good)
+    assert extremes["largest_improvement"]["metric"] == "throughput"
+    assert extremes["largest_improvement"]["pct_change"] == 20.0
+    # time/rollout +5% = regression (timing metric, positive = bad)
+    # time/train -15% = improvement (timing metric, negative = good, magnitude 15 < 20)
+    assert extremes["largest_regression"]["metric"] == "time/rollout"
+    assert extremes["largest_regression"]["pct_change"] == 5.0
+
+
+def test_identify_extremes_no_valid_entries():
+    mod = _load_module()
+    comparisons = {"metric": {"pct_change": {"mean": None}}}
+    extremes = mod.identify_extremes(comparisons)
+    assert extremes["largest_improvement"] is None
+    assert extremes["largest_regression"] is None
+
+
+def test_identify_extremes_only_positive():
+    mod = _load_module()
+    comparisons = {
+        "throughput": {"pct_change": {"mean": 20.0}},
+        "throughput2": {"pct_change": {"mean": 10.0}},
+    }
+    extremes = mod.identify_extremes(comparisons)
+    assert extremes["largest_improvement"]["pct_change"] == 20.0
+    assert extremes["largest_regression"] is None
+
+
+def test_compare_peak_memory():
+    mod = _load_module()
+    base_monitor = {"gpus": {"0": {"memory_used_mib": {"max": 40000.0}}}}
+    cand_monitor = {"gpus": {"0": {"memory_used_mib": {"max": 38000.0}}}}
+    result = mod.compare_peak_memory(base_monitor, cand_monitor)
+    assert result["baseline_peak_mib"] == 40000.0
+    assert result["candidate_peak_mib"] == 38000.0
+    assert result["pct_change"] == -5.0
+
+
+def test_compare_peak_memory_none():
+    mod = _load_module()
+    result = mod.compare_peak_memory(None, None)
+    assert result["baseline_peak_mib"] is None
+    assert result["candidate_peak_mib"] is None
+    assert result["pct_change"] is None
+
+
+def test_compare_peak_memory_from_process_memory():
+    mod = _load_module()
+    monitor = {"gpus": {}, "target_process_memory_mib": {"123": {"max": 35000.0}}}
+    result = mod.compare_peak_memory(monitor, None)
+    assert result["baseline_peak_mib"] == 35000.0
+    assert result["candidate_peak_mib"] is None
+    assert result["pct_change"] is None
+
+
+def test_build_result_full_fixture():
+    mod = _load_module()
+    result = mod.build_result(_baseline_data(), _candidate_data())
+    assert result["ok"] is True
+    assert result["baseline"]["status"] == "completed"
+    assert result["candidate"]["status"] == "running"
+    assert result["baseline"]["step"] == 100
+    assert result["candidate"]["step"] == 50
+    # Throughput improved 20%
+    assert "throughput" in result["metrics"]
+    assert result["metrics"]["throughput"]["pct_change"]["mean"] == 20.0
+    # Time/train increased (+15.5%) = regression for timing metric
+    # time/rollout decreased (-20%) = improvement for timing metric
+    # throughput increased (+20%) = improvement
+    assert result["extremes"]["largest_regression"]["metric"] == "time/train"
+    # Settings: max_new_tokens mismatch
+    mismatched_keys = [m["key"] for m in result["settings_comparison"]["mismatched"]]
+    assert "max_new_tokens" in mismatched_keys
+    # only_candidate has custom_key
+    assert "custom_key" in result["settings_comparison"]["only_candidate"]
+    # Peak memory
+    assert result["peak_memory"]["baseline_peak_mib"] is not None
+    assert result["peak_memory"]["pct_change"] is not None
+    # Warnings: candidate running + config mismatch
+    warnings_text = " ".join(result["warnings"])
+    assert "candidate status is 'running'" in warnings_text
+    assert "configuration mismatch" in warnings_text
+
+
+def test_format_terminal_report_contains_sections():
+    mod = _load_module()
+    result = mod.build_result(_baseline_data(), _candidate_data())
+    report = mod.format_terminal_report(result)
+    assert "=== AReno Run Comparison ===" in report
+    assert "Throughput & Timing Metrics" in report
+    assert "Peak Memory" in report
+    assert "Configuration" in report
+    assert "Summary" in report
+    assert "Warnings" in report
+
+
+def test_format_terminal_report_highlights_mismatch():
+    mod = _load_module()
+    result = mod.build_result(_baseline_data(), _candidate_data())
+    report = mod.format_terminal_report(result)
+    assert "MISMATCH" in report
+    assert "max_new_tokens" in report
+
+
+def test_format_terminal_report_shows_regression():
+    mod = _load_module()
+    result = mod.build_result(_baseline_data(), _candidate_data())
+    report = mod.format_terminal_report(result)
+    assert "REGRESSION" in report
+    assert "IMPROVEMENT" in report
+
+
+def test_format_terminal_report_shows_na_for_missing():
+    mod = _load_module()
+    result = mod.build_result(_baseline_data(), _candidate_data())
+    # Force a None metric
+    result["metrics"]["missing_metric"] = {
+        "baseline": None,
+        "candidate": _metric_stats(50.0),
+        "pct_change": {"mean": None, "median": None, "min": None, "max": None, "last": None},
+    }
+    report = mod.format_terminal_report(result)
+    assert "N/A" in report
+
+
+def test_none_values_never_converted_to_zero():
+    """Ensure that None stays None throughout the pipeline."""
+    mod = _load_module()
+    base = _baseline_data()
+    base["time_metrics"]["throughput"] = None  # simulate missing
+    base["monitor_summary"] = None
+    result = mod.build_result(base, _candidate_data())
+    # throughput should not appear in metrics (baseline has None)
+    assert "throughput" not in result["metrics"]
+    # peak_memory should have None for baseline
+    assert result["peak_memory"]["baseline_peak_mib"] is None
+    assert result["peak_memory"]["pct_change"] is None
+    # Warnings should mention missing peak
+    warnings_text = " ".join(result["warnings"])
+    assert "baseline peak memory unavailable" in warnings_text
+
+
+def test_missing_metric_in_one_run_goes_to_warnings():
+    mod = _load_module()
+    base = _baseline_data()
+    base["time_metrics"]["time/reward"] = _metric_stats(2.0)
+    result = mod.build_result(base, _candidate_data())
+    warnings_text = " ".join(result["warnings"])
+    assert "time/reward" in warnings_text
+    assert "only in baseline" in warnings_text
+
+
+def test_active_run_status_in_warnings():
+    mod = _load_module()
+    base = _baseline_data()
+    base["status"]["status"] = "running"
+    result = mod.build_result(base, _candidate_data())
+    warnings_text = " ".join(result["warnings"])
+    assert "baseline status is 'running'" in warnings_text
+    assert "candidate status is 'running'" in warnings_text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests (subprocess + tmp_path)
+# ---------------------------------------------------------------------------
+
+
+def _create_run_dir(tmp_path, name, status="completed", step=100, settings_extra=None, pid=12345):
+    """Create a minimal run directory with config and state files."""
+    run_dir = tmp_path / name
+    run_dir.mkdir()
+    settings_items = [
+        {"key": "algo", "value": "grpo"},
+        {"key": "batch_size", "value": 32},
+    ]
+    if settings_extra:
+        settings_items.extend(settings_extra)
+    config = {
+        "kind": "train",
+        "pid": pid,
+        "summary_text": "test run",
+        "settings": {"Basic": {"title": "Basic", "items": settings_items}},
+    }
+    (run_dir / f"areno_run_config.{pid}.json").write_text(
+        json.dumps(config, indent=2), encoding="utf-8"
+    )
+    state = {
+        "pid": pid,
+        "stage": "train",
+        "status": status,
+        "step": step,
+        "updated_at": 1700000000,
+    }
+    (run_dir / f"dashboard_state.{pid}.json").write_text(
+        json.dumps(state, indent=2), encoding="utf-8"
+    )
+    return run_dir
+
+
+def test_subprocess_end_to_end_success(tmp_path):
+    base_dir = _create_run_dir(tmp_path, "baseline", status="completed", step=100, pid=12345)
+    cand_dir = _create_run_dir(
+        tmp_path, "candidate", status="completed", step=80, pid=67890,
+        settings_extra=[{"key": "max_new_tokens", "value": 2048}],
+    )
+    # Add a matching setting to baseline so it's not only_candidate
+    base_config = json.loads((base_dir / "areno_run_config.12345.json").read_text())
+    base_config["settings"]["Basic"]["items"].append({"key": "max_new_tokens", "value": 1024})
+    (base_dir / "areno_run_config.12345.json").write_text(json.dumps(base_config), encoding="utf-8")
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(cand_dir), "--json-only"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 0, process.stdout + process.stderr
+    result = json.loads(process.stdout)
+    assert result["ok"] is True
+    assert result["baseline"]["status"] == "completed"
+    assert result["candidate"]["status"] == "completed"
+    # Config mismatch detected
+    mismatched_keys = [m["key"] for m in result["settings_comparison"]["mismatched"]]
+    assert "max_new_tokens" in mismatched_keys
+    # No time metrics (no TensorBoard files), but no crash
+    assert result["metrics"] == {}
+
+
+def test_subprocess_nonexistent_dir(tmp_path):
+    base_dir = _create_run_dir(tmp_path, "baseline")
+    fake_dir = tmp_path / "does_not_exist"
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(fake_dir)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 1
+    result = json.loads(process.stdout)
+    assert result["ok"] is False
+    assert "stage" in result
+    assert result["stage"] == "input_validation"
+    assert "does not exist" in result["error"]
+    assert result["inputs"]["candidate"] == str(fake_dir)
+
+
+def test_subprocess_not_a_directory(tmp_path):
+    base_dir = _create_run_dir(tmp_path, "baseline")
+    not_a_dir = tmp_path / "a_file.txt"
+    not_a_dir.write_text("hello", encoding="utf-8")
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(not_a_dir)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 1
+    result = json.loads(process.stdout)
+    assert result["ok"] is False
+    assert result["stage"] == "input_validation"
+    assert "not a directory" in result["error"]
+
+
+def test_subprocess_help_works():
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert process.returncode == 0
+    assert "baseline" in process.stdout
+    assert "candidate" in process.stdout
+
+
+def test_subprocess_default_outputs_json_and_terminal(tmp_path):
+    """Default mode should output JSON to stdout and terminal to stderr."""
+    base_dir = _create_run_dir(tmp_path, "baseline", pid=11111)
+    cand_dir = _create_run_dir(tmp_path, "candidate", pid=22222)
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(cand_dir)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 0
+    # stdout should be valid JSON
+    result = json.loads(process.stdout)
+    assert result["ok"] is True
+    # stderr should contain the terminal report
+    assert "=== AReno Run Comparison ===" in process.stderr
+
+
+def test_subprocess_terminal_only(tmp_path):
+    base_dir = _create_run_dir(tmp_path, "baseline", pid=11111)
+    cand_dir = _create_run_dir(tmp_path, "candidate", pid=22222)
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(cand_dir), "--terminal-only"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 0
+    assert "=== AReno Run Comparison ===" in process.stdout
+    # stdout should NOT be JSON
+    assert not process.stdout.strip().startswith("{")
+
+
+def test_subprocess_running_status_warning(tmp_path):
+    base_dir = _create_run_dir(tmp_path, "baseline", status="completed", pid=11111)
+    cand_dir = _create_run_dir(tmp_path, "candidate", status="running", pid=22222)
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(cand_dir), "--json-only"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 0
+    result = json.loads(process.stdout)
+    warnings_text = " ".join(result["warnings"])
+    assert "candidate status is 'running'" in warnings_text
+
+
+def test_subprocess_monitor_jsonl(tmp_path):
+    """Test that monitor JSONL files are loaded and peak memory extracted."""
+    base_dir = _create_run_dir(tmp_path, "baseline", pid=11111)
+    cand_dir = _create_run_dir(tmp_path, "candidate", pid=22222)
+
+    # Write a GPU monitor JSONL
+    monitor_lines = [
+        json.dumps({"timestamp": 1, "gpus": [{"index": 0, "memory_used_mib": 30000.0}], "target_processes": [{"pid": 11111, "memory_used_mib": 28000.0}]}),
+        json.dumps({"timestamp": 2, "gpus": [{"index": 0, "memory_used_mib": 40000.0}], "target_processes": [{"pid": 11111, "memory_used_mib": 35000.0}]}),
+    ]
+    (base_dir / "gpu_monitor.11111.jsonl").write_text("\n".join(monitor_lines), encoding="utf-8")
+
+    monitor_lines_cand = [
+        json.dumps({"timestamp": 1, "gpus": [{"index": 0, "memory_used_mib": 32000.0}], "target_processes": [{"pid": 22222, "memory_used_mib": 30000.0}]}),
+        json.dumps({"timestamp": 2, "gpus": [{"index": 0, "memory_used_mib": 38000.0}], "target_processes": [{"pid": 22222, "memory_used_mib": 36000.0}]}),
+    ]
+    (cand_dir / "gpu_monitor.22222.jsonl").write_text("\n".join(monitor_lines_cand), encoding="utf-8")
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(cand_dir), "--json-only"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 0
+    result = json.loads(process.stdout)
+    assert result["peak_memory"]["baseline_peak_mib"] is not None
+    assert result["peak_memory"]["candidate_peak_mib"] is not None
+    # Baseline peak should be 40000 (max GPU memory)
+    assert result["peak_memory"]["baseline_peak_mib"] == 40000.0
+    assert result["peak_memory"]["candidate_peak_mib"] == 38000.0
+
+
+def test_subprocess_no_monitor_flag(tmp_path):
+    """--no-monitor should skip monitor loading and produce None peak memory."""
+    base_dir = _create_run_dir(tmp_path, "baseline", pid=11111)
+    cand_dir = _create_run_dir(tmp_path, "candidate", pid=22222)
+    (base_dir / "gpu_monitor.11111.jsonl").write_text(
+        json.dumps({"gpus": [{"index": 0, "memory_used_mib": 40000.0}]}), encoding="utf-8"
+    )
+
+    process = subprocess.run(
+        [sys.executable, str(_SCRIPT), str(base_dir), str(cand_dir), "--json-only", "--no-monitor"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert process.returncode == 0
+    result = json.loads(process.stdout)
+    assert result["peak_memory"]["baseline_peak_mib"] is None
+    assert result["peak_memory"]["candidate_peak_mib"] is None


### PR DESCRIPTION
Fixes #281 

## 摘要

本 PR 引入了 `compare_runs.py`，这是 `areno-profile-performance` 技能中的一个新实用工具，旨在比较两个 AReno 运行目录（基准版 vs. 候选版）。

该工具提供**吞吐量**、**阶段延迟**、**峰值内存**和**配置设置**的结构化差异对比。它计算百分比变化，识别显著的回归/改进，并输出人类可读的终端报告以及机器可解析的 JSON 格式。

### 核心特性
- **严格的空值处理**：缺失值保留为 `null`；**绝不**强制转换为零。
- **语义感知**：正确解释指标的方向性（例如，延迟增加视为回归，吞吐量增加视为改进）。
- **配置差异对比**：突出显示运行之间不匹配、缺失或额外的配置参数。
- **双重输出**：默认模式将 JSON 输出到 `stdout`（用于管道传输），将格式化报告输出到 `stderr`。
- **稳健验证**：在执行昂贵导入（如 TensorBoard）之前进行输入验证，以实现快速失败。

## 架构与设计

遵循 `summarize_monitor.py` 中建立的模式，此脚本 adheres to **纯函数 + I/O 分离** 的架构：

1.  **纯函数层**：核心逻辑（`percent_change`, `compare_metrics`, `identify_extremes` 等）没有外部依赖，使其可以通过简单的 Python 字典轻松测试。
2.  **I/O 层**：处理文件系统访问、TensorBoard 加载（通过延迟导入）和 CLI 参数解析。

```text
┌─────────────────────────────────────────────────────┐
│  纯逻辑层 (可测试, 无副作用)                           │
│  - percent_change / compare_metric_pair             │
│  - compare_settings / identify_extremes             │
│  - build_result / format_terminal_report            │
├─────────────────────────────────────────────────────┤
│  I/O 层 (文件系统 & 外部依赖)                          │
│  - _load_json / _load_monitor_peak                  │
│  - _load_time_metrics (TensorBoard)                 │
│  - main() / argparse                                │
└─────────────────────────────────────────────────────┘
```

## 变更内容

### 新增文件
- `.agents/skills/areno-profile-performance/scripts/compare_runs.py` (629 行)
  - 实现对比逻辑的主脚本。
- `tests/test_compare_runs_cpu.py` (569 行)
  - 包含 30+ 个单元和集成测试的综合测试套件。

### 修改文件
- `.agents/skills/areno-profile-performance/SKILL.md`
  - 添加了新工具的使用示例和工作流说明。
- `.agents/skills/areno-profile-performance/references/profile-policy.md`
  - 更新策略以反映新的对比方法。

## 用法与 CLI 接口

```bash
usage: compare_runs.py [-h] [--json-only | --terminal-only]
                       [--drop-first DROP_FIRST] [--no-monitor]
                       baseline candidate

位置参数:
  baseline              基准运行的 metrics_log_dir
  candidate             候选运行的 metrics_log_dir

可选参数:
  --json-only           仅向 stdout 输出 JSON
  --terminal-only       仅向 stdout 输出终端报告
  --drop-first N        丢弃前 N 个预热步骤 (默认: 1)
  --no-monitor          跳过加载 monitor JSONL 文件
```

### 示例输出 (终端报告)

```text
=== AReno 运行对比 ===

基准版:  /path/to/baseline  [已完成, 第 100 步]
候选版: /path/to/candidate [运行中, 第 50 步]

--- 吞吐量与计时指标 ---

指标                          基准版 (均值)   候选版 (均值)        变化
--------------------------------------------------------------------------------
throughput                          1000.00          1200.00   +20.00% 改进
time/train                            10.00            11.55   +15.50% 回归

--- 配置 ---

不匹配: max_new_tokens (基准版=1024, 候选版=2048)
仅存在于基准版: save_interval

警告:
  - 候选版状态为 'running'；指标可能不完整
```

## 测试

实现包括 **32 个测试**，涵盖单元逻辑、边缘情况和端到端子进程执行。

### 测试覆盖细分
| 类别 | 数量 | 描述 |
| :--- | :---: | :--- |
| **单元测试** | 14 | 百分比计算、指标对比、配置差异、极值识别、内存对比。 |
| **边缘情况** | 5 | `None` 处理（绝不转换为 0）、零基准、缺失指标。 |
| **E2E/子进程** | 9 | 有效运行、无效目录、帮助标志、输出模式、运行状态警告。 |
| **集成测试** | 4 | 终端报告格式化、回归/改进标签。 |

### 验证结果
- ✅ 所有 32 个新测试均通过。
- ✅ `validate_skills.py` 通过，0 错误（共 25 个脚本）。
- ✅ 现有的 `test_agent_skills_cpu.py` 无回归。

```text
============================= test session starts ==============================
platform darwin -- Python 3.9.6, pytest-8.4.2
collected 32 items

tests/test_compare_runs_cpu.py ............................              [ 93%]
tests/test_agent_skills_cpu.py ..                                        [100%]

============================== 32 passed in 2.31s ==============================
```

## 文档更新

1.  **SKILL.md**：添加了专门针对 `compare_runs.py` 的部分，包含可直接复制粘贴的示例和输出字段说明。
2.  **profile-policy.md**：添加要点，规定运行对比必须报告百分比变化并突出配置不匹配，且不强制转换缺失值。

## 审查者备注

- **指标语义**：请验证 `identify_extremes` 中的逻辑。它正确地将吞吐量的正% 变化视为*改进*，而将计时指标的同样变化视为*回归*。
- **延迟导入**：TensorBoard 导入被包裹在函数内的 `try/except` 块中，以确保在加载重型库之前，针对无效输入实现快速失败。
- **JSON 稳定性**：JSON 输出使用 `sort_keys=True` 以确保程序化消费时的确定性输出。