### PR TITLE
Feat/agent overlength safe stop

### DIFF
--- a/.agents/skills/areno-build-agentic-workflow/SKILL.md
+++ b/.agents/skills/areno-build-agentic-workflow/SKILL.md
@@ -24,6 +24,7 @@ python .agents/skills/areno-run-training/scripts/inspect_dataset.py \
 4. Build trajectories using AReno public agentic types. Preserve assistant tool-call and tool-result ordering.
 5. Reward the intended outcome and process separately; test invalid, partial, and optimal paths.
 6. Verify concurrency, timeout, cancellation, context truncation, multimodal content, and loss masks.
-7. Run a bounded agentic rollout, inspect one full transcript, then one real training step.
+7. Treat a proxy `finish_reason == "length"` response as terminal for that item: append the turn, stop the item, and do not nudge the model to retry or execute a (half) tool call. Under `--agent-overlength-policy safe-stop` the proxy already drops half-finished tool calls / oversized tool results and emits `termination_reason` (`generation_limit` / `context_limit` / `oversized_tool_result`) plus `rollout/overlength_*` metrics; `run_agent` must honor the length signal or the loop spins to the turn limit. Default `off` preserves prior behavior.
+8. Run a bounded agentic rollout, inspect one full transcript, then one real training step.
 
 Do not fabricate missing tool calls or alter raw model text to make a trajectory appear valid. Surface parser/capability failures.

--- a/areno/agent/agent_loop.py
+++ b/areno/agent/agent_loop.py
@@ -290,6 +290,13 @@ async def _run_training_tasks_by_turn(
             )
             assistant_message = _assistant_message_from_response(response)
             state["messages"].append(assistant_message)
+            if _response_finish_reason(response) == "length":
+                # The proxy marked this turn terminal (generation/context/oversized
+                # cap reached). Record the turn as the final state and stop the
+                # item without nudging or executing a (potentially half-finished)
+                # tool call, so the loop does not spin to the turn limit.
+                state["done"] = True
+                continue
             call = _first_tool_call(assistant_message)
             if call is None:
                 state["messages"].append(
@@ -385,6 +392,10 @@ async def run_conversation_turns(
         messages.append(assistant_message)
         # The standalone CLI uses this hook to stream model/tool activity as it happens.
         _emit(on_event, "assistant", assistant_message)
+        if _response_finish_reason(response) == "length":
+            # Proxy signaled a terminal overlength stop; keep the turn and end
+            # the loop instead of nudging the model to retry an overlong turn.
+            break
         call = _first_tool_call(assistant_message)
         if call is None:
             if interaction_hook is not None and await interaction_hook(messages, "assistant_no_tool"):
@@ -476,6 +487,26 @@ def _task_prompt(task: dict[str, Any]) -> str:
         "If this is an information request rather than a code-change request, read enough files to answer with evidence "
         "and then call submit with a concise summary."
     )
+
+
+def _response_finish_reason(response: Any) -> str:
+    """Return the OpenAI ``finish_reason`` of the first choice, or ``""`` if absent.
+
+    Accepts both SDK objects (``response.choices[0].finish_reason``) and plain
+    dict responses so the agent loop can treat a terminal overlength stop
+    uniformly regardless of the client shape.
+    """
+
+    choices = getattr(response, "choices", None)
+    if choices is None and isinstance(response, dict):
+        choices = response.get("choices")
+    if not choices:
+        return ""
+    first = choices[0]
+    value = getattr(first, "finish_reason", None)
+    if value is None and isinstance(first, dict):
+        value = first.get("finish_reason")
+    return str(value) if value is not None else ""
 
 
 def _assistant_message_from_response(response: Any) -> dict[str, Any]:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -116,6 +116,9 @@ class AgentTrainBatch:
     rewards: list[float] | None
     records: list[dict[str, Any]]
     reward_records: list[RewardRecord]
+    # Per-reason overlength counts (e.g. {"generation_limit": 2}) for the
+    # batch. Additive: empty by default so non-agentic callers are unaffected.
+    overlength_counts: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -131,6 +134,10 @@ class AgentTrajectoryTurn:
     model: str = "policy"
     tools: list[dict[str, Any]] = field(default_factory=list)
     tool_choice: Any = None
+    # Why this turn ended (``"generation_limit"`` / ``"context_limit"`` /
+    # ``"oversized_tool_result"``) or ``None`` for a clean stop. Additive
+    # observability populated from the proxy ``areno`` metadata block.
+    termination_reason: str | None = None
 
     def __post_init__(self) -> None:
         if self.response is None:
@@ -139,6 +146,7 @@ class AgentTrajectoryTurn:
         self.response_tokens = list(metadata["response_tokens"])
         self.response_logprobs = [float(value) for value in metadata["response_logprobs"]]
         self.parsed_tool_calls = _chat_response_message_tool_calls(self.response)
+        self.termination_reason = metadata.get("termination_reason")
 
 
 @dataclass(slots=True)
@@ -164,6 +172,7 @@ class _AgentSample:
     response_mask_row: list[bool] = field(default_factory=list)
     loss_mask_row: list[bool] = field(default_factory=list)
     rollout_logprobs_row: list[float] = field(default_factory=list)
+    termination_reason: str | None = None
 
 
 @dataclass(slots=True)
@@ -367,7 +376,11 @@ class RolloutSession:
             logprobs=sample.response_logprobs,
             loss_mask=self._response_loss_mask(sample),
             source_record=sample.item.record,
-            metadata={"prompt_index": sample.item.prompt_index, "sample_index": sample.item.sample_index},
+            metadata={
+                "prompt_index": sample.item.prompt_index,
+                "sample_index": sample.item.sample_index,
+                "termination_reason": sample.termination_reason,
+            },
         )
 
     def _response_loss_mask(self, sample: _AgentSample) -> list[bool]:
@@ -503,10 +516,18 @@ class RolloutSession:
             )
             max_context_len = _max_context_len(pending.params)
             if max_context_len is not None and len(pending.input_tokens) > max_context_len:
+                # Pre-generation short-circuit: the rendered context already
+                # exceeds the cap. Classify whether the *last tool result* alone
+                # accounts for the overflow (oversized_tool_result) or whether
+                # the accumulated trajectory simply grew too long (context_limit).
+                termination_reason = _classify_pre_generation_overlength(
+                    tokenizer, pending.messages, max_context_len
+                )
                 response = _filtered_chat_response(
                     model=pending.model,
                     prompt_tokens=len(pending.input_tokens),
                     max_sequence_len=max_context_len,
+                    termination_reason=termination_reason,
                 )
                 self._set_pending_response(pending, response)
                 return
@@ -520,6 +541,7 @@ class RolloutSession:
                     self._build_chat_response(
                         pending,
                         _ResponseData(response_tokens=sequence.resp_tokens, response_logprobs=sequence.resp_logprobs),
+                        engine_finish_reason=getattr(sequence, "finish_reason", "") or "",
                     ),
                 )
         except BaseException as exc:
@@ -548,6 +570,7 @@ class RolloutSession:
             pending,
             _ResponseData(response_tokens=list(turn.response_tokens), response_logprobs=list(turn.response_logprobs)),
             tool_calls=turn.parsed_tool_calls,
+            termination_reason=turn.termination_reason,
         )
 
     def _set_pending_response(self, pending: _PendingChat, response: dict[str, Any]) -> None:
@@ -572,6 +595,7 @@ class RolloutSession:
         response: _ResponseData,
         *,
         tool_calls: list[dict[str, Any]] | None = None,
+        termination_reason: str | None = None,
     ) -> _AgentSample:
         if pending.item is None:
             raise ValueError("explicit agent trajectory turn requires an AgentItem")
@@ -589,10 +613,14 @@ class RolloutSession:
         ]
         if not events:
             events = [RewardEvent(type=response_kind, text=content)]
+        finish_reason = "length" if termination_reason else "stop"
         trace = [
             RewardEvent(type="request", messages=pending.messages),
             *events,
-            RewardEvent(type="finish", metadata={"finish_reason": "stop"}),
+            RewardEvent(
+                type="finish",
+                metadata={"finish_reason": finish_reason, "termination_reason": termination_reason},
+            ),
         ]
         sample = _AgentSample(
             item=pending.item,
@@ -605,6 +633,7 @@ class RolloutSession:
             trace=trace,
             response_kind=response_kind,
             loss_mask_override=_tool_call_loss_mask(tokenizer, response.response_tokens) if tool_calls else None,
+            termination_reason=termination_reason,
         )
         # The prompt tokens are the fully rendered chat context for this turn,
         # including prior assistant/tool messages. Those context tokens are
@@ -612,17 +641,43 @@ class RolloutSession:
         self._set_sample_training_row(sample, pending.input_tokens)
         return sample
 
-    def _build_chat_response(self, pending: _PendingChat, response: _ResponseData) -> dict[str, Any]:
+    def _build_chat_response(
+        self,
+        pending: _PendingChat,
+        response: _ResponseData,
+        *,
+        engine_finish_reason: str = "",
+    ) -> dict[str, Any]:
         tokenizer = self._trainer.get_tokenizer()
         content = tokenizer.decode(response.response_tokens)
         tool_parse = self._tool_call_parser.parse(content, pending.tools, pending.tool_choice)
+        tool_calls = list(tool_parse.tool_calls)
+        termination_reason: str | None = None
+        force_finish_reason: str | None = None
+        if _is_generation_limit(response.response_tokens, engine_finish_reason, pending.params):
+            termination_reason = "generation_limit"
+            # safe-stop: drop a half-finished tool call so the trajectory never
+            # records an un-executable partial call, and surface ``length`` as
+            # the terminal finish reason. ``off`` keeps today's behavior: the
+            # parsed tool_calls survive and finish_reason follows the normal
+            # tool_calls/stop derivation; termination_reason stays observable.
+            if self._agent_overlength_policy() == "safe-stop":
+                tool_calls = []
+                force_finish_reason = "length"
         return self._build_pending_chat_response(
             pending,
             response.response_tokens,
             response_logprobs=response.response_logprobs,
             content=content,
-            tool_calls=tool_parse.tool_calls,
+            tool_calls=tool_calls,
+            termination_reason=termination_reason,
+            force_finish_reason=force_finish_reason,
         )
+
+    def _agent_overlength_policy(self) -> str:
+        """Return the configured overlength policy (``off`` when unset)."""
+
+        return str(getattr(self._trainer.config, "agent_overlength_policy", "off") or "off")
 
     def _append_sample_response(self, existing: _AgentSample, new_sample: _AgentSample) -> None:
         """Append another model response to an existing multi-call trajectory."""
@@ -641,6 +696,10 @@ class RolloutSession:
         existing.response_logprobs.extend(new_sample.response_logprobs)
         existing.trace.extend(new_sample.trace)
         existing.messages = new_sample.messages
+        # The last turn's termination reason wins so a multi-turn trajectory
+        # that ends on a generation-limit cutoff reports that reason, not an
+        # earlier clean stop.
+        existing.termination_reason = new_sample.termination_reason
         # Each later turn is rendered as: previous messages + new assistant.
         # Append only the suffix so the training row becomes one trajectory
         # instead of duplicating the shared prefix for every tool call.
@@ -683,6 +742,8 @@ class RolloutSession:
         response_logprobs: list[float] | None = None,
         content: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        termination_reason: str | None = None,
+        force_finish_reason: str | None = None,
     ) -> dict[str, Any]:
         del content
         finish_reason = "tool_calls" if tool_calls else "stop"
@@ -699,6 +760,8 @@ class RolloutSession:
             response_logprobs=[list(response_logprobs or [])],
             include_areno_metadata=True,
             input_tokens=pending.input_tokens,
+            termination_reason=termination_reason,
+            force_finish_reason=force_finish_reason,
         )
 
 
@@ -816,7 +879,20 @@ def _max_context_len(params: Any) -> int | None:
     return int(max_prompt_len)
 
 
-def _filtered_chat_response(*, model: str, prompt_tokens: int, max_sequence_len: int) -> dict[str, Any]:
+def _filtered_chat_response(
+    *,
+    model: str,
+    prompt_tokens: int,
+    max_sequence_len: int,
+    termination_reason: str | None = None,
+) -> dict[str, Any]:
+    areno_meta: dict[str, Any] = {
+        "input_tokens": [],
+        "response_tokens": [],
+        "response_logprobs": [],
+    }
+    if termination_reason is not None:
+        areno_meta["termination_reason"] = termination_reason
     return {
         "id": f"chatcmpl-{uuid.uuid4().hex}",
         "object": "chat.completion",
@@ -835,12 +911,51 @@ def _filtered_chat_response(*, model: str, prompt_tokens: int, max_sequence_len:
             "total_tokens": prompt_tokens,
             "max_sequence_len": max_sequence_len,
         },
-        "areno": {
-            "input_tokens": [],
-            "response_tokens": [],
-            "response_logprobs": [],
-        },
+        "areno": areno_meta,
     }
+
+
+def _is_generation_limit(response_tokens: list[int], engine_finish_reason: str, params: Any) -> bool:
+    """Classify a generation-limit overlength from the propagated engine signal.
+
+    The engine ``finish_reason`` is authoritative when present (``"length"`` →
+    True, ``"stop"`` → False), so a clean stop at the last token is never
+    misclassified. When the backend did not fill the signal (empty/unset) we
+    fall back to a deterministic length heuristic against ``max_new_tokens``.
+    """
+
+    if engine_finish_reason == "length":
+        return True
+    if engine_finish_reason == "stop":
+        return False
+    max_new_tokens = int(getattr(params, "max_new_tokens", 0) or 0)
+    return max_new_tokens > 0 and len(response_tokens) >= max_new_tokens
+
+
+def _classify_pre_generation_overlength(
+    tokenizer: Any, messages: list[dict[str, Any]], max_context_len: int
+) -> str:
+    """Split a pre-generation context overflow into its cause.
+
+    Returns ``"oversized_tool_result"`` when the last ``role == "tool"``
+    message *on its own* already exceeds ``max_context_len`` tokens (the
+    trajectory is fine but a single tool result blew the cap); otherwise
+    ``"context_limit"`` (the accumulated trajectory simply grew too long).
+    """
+
+    for message in reversed(messages):
+        if message.get("role") != "tool":
+            continue
+        content = message.get("content")
+        text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+        try:
+            tool_tokens = tokenizer.encode(text)
+        except Exception:
+            return "context_limit"
+        if len(tool_tokens) > max_context_len:
+            return "oversized_tool_result"
+        return "context_limit"
+    return "context_limit"
 
 
 def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -260,10 +260,18 @@ class RolloutSession:
         max_running_prompts: int | None = None,
         timeout_s: float = 300.0,
         proxy: bool = True,
+        agent_overlength_policy: str | None = None,
     ) -> None:
         self._trainer = trainer
         self._sampling_params = sampling_params
         self._loss_mask_policy = loss_mask_policy or LossMaskPolicy()
+        # ``agent_overlength_policy`` lives on ``TrainerConfig`` which the
+        # ``Trainer`` instance we hold does not expose, so callers thread the
+        # resolved value in here; ``_agent_overlength_policy`` reads this rather
+        # than reaching for ``self._trainer.config`` (which does not exist).
+        # ``None`` means "not threaded in": fall back to ``trainer.config`` if a
+        # caller set it, else ``off``.
+        self._agent_overlength_policy_value = agent_overlength_policy
         self._tool_call_parser = get_tool_call_parser(infer_tool_call_parser_name(trainer))
         self._dp_size = max(_trainer_dp_size(trainer), 1)
         self._max_running_prompts = (
@@ -675,9 +683,21 @@ class RolloutSession:
         )
 
     def _agent_overlength_policy(self) -> str:
-        """Return the configured overlength policy (``off`` when unset)."""
+        """Return the configured overlength policy (``off`` when unset).
 
-        return str(getattr(self._trainer.config, "agent_overlength_policy", "off") or "off")
+        Prefers the value threaded in at construction (the path real agentic
+        trainers use, since ``Trainer`` does not expose ``TrainerConfig``); falls
+        back to ``self._trainer.config.agent_overlength_policy`` for callers that
+        set it directly on the trainer, and finally to ``off``. Never reaches for
+        ``trainer.config`` unguarded -- the ``Trainer`` object has no such
+        attribute and a bare access raises ``AttributeError`` mid-rollout.
+        """
+
+        value = self._agent_overlength_policy_value
+        if value in ("", None):
+            config = getattr(self._trainer, "config", None)
+            value = getattr(config, "agent_overlength_policy", "off")
+        return str(value or "off")
 
     def _append_sample_response(self, existing: _AgentSample, new_sample: _AgentSample) -> None:
         """Append another model response to an existing multi-call trajectory."""
@@ -1066,7 +1086,9 @@ def _trainer_dp_size(trainer: Any) -> int:
     try:
         return max(int(trainer.dp_size()), 1)
     except (AttributeError, RuntimeError):
-        config = trainer.config
+        config = getattr(trainer, "config", None)
+        if config is None:
+            return 1
         world_size = int(config.world_size or 1)
         tp_size = int(config.tp_size or 1)
         if tp_size <= 0:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -32,6 +32,7 @@ from areno.api.openai_chat import (
     messages_to_prompt_tokens,
     messages_to_text,
     normalize_messages,
+    single_message_token_count,
 )
 from areno.api.rewards import RewardEvent, RewardRecord
 from areno.api.tokenizer import apply_chat_template_with_options
@@ -957,24 +958,19 @@ def _classify_pre_generation_overlength(
 ) -> str:
     """Split a pre-generation context overflow into its cause.
 
-    Returns ``"oversized_tool_result"`` when the last ``role == "tool"``
-    message *on its own* already exceeds ``max_context_len`` tokens (the
-    trajectory is fine but a single tool result blew the cap); otherwise
-    ``"context_limit"`` (the accumulated trajectory simply grew too long).
+    Returns ``"oversized_tool_result"`` when *any* ``role == "tool"`` message
+    rendered on its own already exceeds ``max_context_len`` tokens (a single
+    tool result blew the cap, so trimming older turns cannot help); otherwise
+    ``"context_limit"`` (the accumulated trajectory simply grew too long). The
+    per-message count uses ``single_message_token_count`` so it is measured on
+    the same chat-template-aware scale as the full prompt, not raw ``encode``.
     """
 
-    for message in reversed(messages):
+    for message in messages:
         if message.get("role") != "tool":
             continue
-        content = message.get("content")
-        text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
-        try:
-            tool_tokens = tokenizer.encode(text)
-        except Exception:
-            return "context_limit"
-        if len(tool_tokens) > max_context_len:
+        if single_message_token_count(tokenizer, message) > max_context_len:
             return "oversized_tool_result"
-        return "context_limit"
     return "context_limit"
 
 

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -208,6 +208,11 @@ class ArenoBackend(Backend):
         )
         # Repack the flat result into per-prompt groups of `n_samples`
         # completions so downstream code can iterate `for item, result`.
+        # `rollout.finish_reason` is flat-aligned with `rollout.response_ids`,
+        # so the same flat index `i` (= prompt_idx * n_samples + offset) selects
+        # the per-sequence termination signal; fall back to "" when the engine
+        # did not emit one (short / stubbed lists).
+        finish_reasons = getattr(rollout, "finish_reason", None) or []
         results = []
         for prompt_idx in range(len(prompt_tokens)):
             start = prompt_idx * n_samples
@@ -218,6 +223,7 @@ class ArenoBackend(Backend):
                         RolloutSequence(
                             resp_tokens=tokens,
                             resp_logprobs=rollout.logprobs[i, : len(tokens)].tolist(),
+                            finish_reason=finish_reasons[i] if i < len(finish_reasons) else "",
                         )
                         for i, tokens in enumerate(rollout.response_ids[start:end], start=start)
                     ]
@@ -311,6 +317,7 @@ class ArenoBackend(Backend):
             sampling_params=options["sampling_params"],
         )
         results = []
+        finish_reasons = getattr(rollout, "finish_reason", None) or []
         for prompt_idx in range(len(prompt_tokens)):
             start = prompt_idx * n_samples
             end = start + n_samples
@@ -320,6 +327,7 @@ class ArenoBackend(Backend):
                         RolloutSequence(
                             resp_tokens=tokens,
                             resp_logprobs=rollout.logprobs[i, : len(tokens)].tolist(),
+                            finish_reason=finish_reasons[i] if i < len(finish_reasons) else "",
                         )
                         for i, tokens in enumerate(rollout.response_ids[start:end], start=start)
                     ]

--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -31,13 +31,22 @@ class MetricsRecorder:
         self._sample_file = self._log_dir / f"rollout_samples.{os.getpid()}.jsonl"
         self._closed = False
 
-    def record_train_step(self, *, step: int, train_result, train_batch, timings: dict[str, float] | None = None):
+    def record_train_step(
+        self,
+        *,
+        step: int,
+        train_result,
+        train_batch,
+        timings: dict[str, float] | None = None,
+        overlength_counts: dict[str, int] | None = None,
+    ):
         """Record rollout, training, and timing metrics for one step."""
 
         # `collect_train_batch_stats` extracts only the response-side numbers
         # (prompt tokens are masked out) so reported means match what the loss
         # actually trained on.
         stats = collect_train_batch_stats(train_batch)
+        merge_overlength_counts(stats, overlength_counts)
         record_training_stats(self._writer, stats, step, train_result, train_batch, timings=timings)
 
     def record_rollout_sample(self, sample: dict) -> None:
@@ -164,7 +173,30 @@ def init_rollout_stats(skipped_long: int = 0, total_skipped_long: int = 0) -> di
         "response_len": [],
         "skipped_long": skipped_long,
         "total_skipped_long": total_skipped_long,
+        "overlength_generation_limit": 0,
+        "overlength_context_limit": 0,
+        "overlength_oversized_tool_result": 0,
+        "overlength_total": 0,
     }
+
+
+_OVERLENGTH_REASONS = ("generation_limit", "context_limit", "oversized_tool_result")
+
+
+def merge_overlength_counts(stats: dict, counts: dict[str, int] | None) -> dict:
+    """Fold per-reason overlength counts from an agentic batch into stats.
+
+    ``counts`` maps a termination reason (``generation_limit`` /
+    ``context_limit`` / ``oversized_tool_result``) to the number of affected
+    samples. Unknown keys are ignored so future reasons do not corrupt totals.
+    """
+
+    if not counts:
+        return stats
+    for reason in _OVERLENGTH_REASONS:
+        stats[f"overlength_{reason}"] = int(stats.get(f"overlength_{reason}", 0)) + int(counts.get(reason, 0))
+    stats["overlength_total"] = sum(int(stats.get(f"overlength_{reason}", 0)) for reason in _OVERLENGTH_REASONS)
+    return stats
 
 
 def record_rollout_sequence_stats(stats, *, prefix_len: int, response_logprobs, response_len: int):
@@ -210,6 +242,12 @@ def record_training_stats(writer, stats, step, train_res, train_batch, timings: 
     for key in ("skipped_long", "total_skipped_long"):
         if key in stats:
             writer.add_scalar(f"rollout/{key}", stats[key], step)
+    for reason in _OVERLENGTH_REASONS:
+        key = f"overlength_{reason}"
+        if key in stats:
+            writer.add_scalar(f"rollout/{key}", int(stats[key]), step)
+    if "overlength_total" in stats:
+        writer.add_scalar("rollout/overlength_total", int(stats["overlength_total"]), step)
 
     # Backend-supplied training metrics (loss, policy_loss, ratio_mean, ...).
     for key, value in train_res.items():

--- a/areno/api/models.py
+++ b/areno/api/models.py
@@ -51,10 +51,16 @@ class RolloutSequence(BaseModel):
     `resp_logprobs[i]` is the log-probability of `resp_tokens[i]` under the
     rollout policy and becomes the "old logprobs" reference signal in
     importance-weighted losses (PPO/GSPO/GRPO).
+
+    `finish_reason` mirrors the engine-level termination signal (``"stop"`` or
+    ``"length"``) for this sequence. It defaults to ``""`` (unset) so legacy
+    consumers that never read it are unaffected; the agentic proxy uses it to
+    distinguish generation-limit overlength from clean stops.
     """
 
     resp_tokens: list[int] = Field(default_factory=list)
     resp_logprobs: list[float] = Field(default_factory=list)
+    finish_reason: str = Field(default="")
 
 
 class RolloutResult(BaseModel):

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -129,8 +129,19 @@ def build_chat_completion_response(
     include_areno_metadata: bool = False,
     input_tokens: list[int] | None = None,
     stop_strings: list[str] | None = None,
+    termination_reason: str | None = None,
+    force_finish_reason: str | None = None,
 ) -> dict[str, Any]:
-    """Build an OpenAI chat-completion response and parse tool calls if asked."""
+    """Build an OpenAI chat-completion response and parse tool calls if asked.
+
+    ``termination_reason`` is an additive Areno-only signal (carried in the
+    ``areno`` metadata block, never in the OpenAI ``finish_reason`` surface) so
+    the agentic proxy can distinguish overlength causes without changing the
+    wire shape seen by agent code. ``force_finish_reason`` overrides the derived
+    ``finish_reason`` *only* when the choice has no tool calls (e.g. the
+    safe-stop policy drops a half-finished tool call and wants to surface
+    ``"length"``); it never converts a ``tool_calls`` finish reason.
+    """
 
     tools = list(tools or [])
     stop_strings = list(stop_strings or [])
@@ -145,13 +156,19 @@ def build_chat_completion_response(
         tool_calls = (
             parsed_tool_calls[index] if parsed_tool_calls is not None and index < len(parsed_tool_calls) else []
         )
-        if not tool_calls and tools and tool_call_parser is not None:
+        # Only fall back to parsing from the decoded text when the caller did not
+        # pre-parse. The agentic proxy always passes ``parsed_tool_calls`` (even
+        # an empty list, e.g. after the safe-stop policy drops a half tool call),
+        # so re-parsing here would silently re-introduce the dropped call.
+        if not tool_calls and tools and tool_call_parser is not None and parsed_tool_calls is None:
             tool_calls = tool_call_parser.parse(raw_text, tools, tool_choice).tool_calls
         finish_reason = "stop" if stop_hit or finish_reasons[index] == "stop" else "length"
         message: dict[str, Any] = {"role": "assistant", "content": display_text}
         if tool_calls:
             message = {"role": "assistant", "content": None, "tool_calls": tool_calls}
             finish_reason = "tool_calls"
+        elif force_finish_reason is not None:
+            finish_reason = force_finish_reason
         choices.append({"index": index, "message": message, "finish_reason": finish_reason})
 
     response: dict[str, Any] = {
@@ -167,11 +184,14 @@ def build_chat_completion_response(
         },
     }
     if include_areno_metadata:
-        response["areno"] = {
+        areno_meta: dict[str, Any] = {
             "input_tokens": list(input_tokens or []),
             "response_tokens": list(response_ids[0] if response_ids else []),
             "response_logprobs": list(response_logprobs[0] if response_logprobs else []),
         }
+        if termination_reason is not None:
+            areno_meta["termination_reason"] = termination_reason
+        response["areno"] = areno_meta
     return response
 
 

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -105,6 +105,41 @@ def messages_to_text(messages: list[dict[str, Any]]) -> str:
     return "\n".join(parts)
 
 
+def single_message_token_count(tokenizer, message: dict[str, Any]) -> int:
+    """Template-aware token count of one message rendered alone.
+
+    Renders the single message through the model's chat template with
+    ``add_generation_prompt=False`` so the count is on the same scale the full
+    prompt is measured (template/special-token aware), which is what the agentic
+    overlength classifier needs to decide whether a single tool result already
+    exceeds the context cap. Falls back to raw ``tokenizer.encode(text)`` when
+    the tokenizer has no chat template or the template cannot render the
+    message alone; returns ``0`` if even the fallback errors so the caller
+    treats the message as not-decidably-oversized.
+    """
+
+    content = message.get("content")
+    text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+    if getattr(tokenizer, "chat_template", None):
+        try:
+            return len(
+                normalize_token_ids(
+                    apply_chat_template_with_options(
+                        tokenizer,
+                        normalize_messages([message]),
+                        tokenize=True,
+                        add_generation_prompt=False,
+                    )
+                )
+            )
+        except Exception:
+            pass
+    try:
+        return len(tokenizer.encode(text))
+    except Exception:
+        return 0
+
+
 def first_user_text(messages: list[dict[str, Any]]) -> str:
     """Return the first user text, falling back to all text messages."""
 

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -308,8 +308,15 @@ class Trainer:
         max_running_prompts: int | None = None,
         timeout_s: float = 300.0,
         proxy: bool = True,
+        agent_overlength_policy: str | None = None,
     ) -> RolloutSession:
-        """Create an async rollout session, optionally with an OpenAI-compatible proxy."""
+        """Create an async rollout session, optionally with an OpenAI-compatible proxy.
+
+        ``agent_overlength_policy`` is threaded in by agentic callers that hold
+        the ``TrainerConfig`` (the ``Trainer`` itself does not) so the proxy can
+        honor ``safe-stop`` without reaching for a ``config`` attribute it does
+        not expose; defaults to ``off`` to preserve prior behavior.
+        """
 
         return RolloutSession(
             self,
@@ -318,6 +325,7 @@ class Trainer:
             max_running_prompts=max_running_prompts,
             timeout_s=timeout_s,
             proxy=proxy,
+            agent_overlength_policy=agent_overlength_policy,
         )
 
     def train(

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -326,12 +326,16 @@ class Trainer:
         loss_fn: Callable,
         mini_bs: int = 8,
         gradient_accumulation_steps: int | None = None,
+        overlength_counts: dict[str, int] | None = None,
     ) -> dict[str, float]:
         """Run one backend training step with a caller-provided loss function.
 
         Returns whatever scalar metric dict the backend produces; when a
         `MetricsRecorder` is attached the dict and the accumulated step timings
-        are also dispatched to TensorBoard.
+        are also dispatched to TensorBoard. ``overlength_counts`` is an optional
+        agentic-only per-reason tally forwarded to the recorder so
+        ``rollout/overlength_*`` scalars reflect the rollout that produced this
+        batch; non-agentic callers leave it ``None``.
         """
 
         if not callable(loss_fn):
@@ -352,6 +356,7 @@ class Trainer:
                 train_result=result,
                 train_batch=batch_data,
                 timings=self._metric_timings,
+                overlength_counts=overlength_counts,
             )
         self.finish_step()
         return result

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -60,12 +60,20 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     chat_template_enable_thinking: bool | None = None
+    # Agentic overlength policy: ``off`` preserves today's behavior (parse and
+    # keep tool calls even when generation hit the token limit; whole-trajectory
+    # filter still drops oversized samples). ``safe-stop`` drops half-finished
+    # tool calls / oversized tool results and marks the item terminal while
+    # retaining the trajectory up to that turn. See docs overlength handling.
+    agent_overlength_policy: str = "off"
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:
             raise ValueError("attn_backend must be one of: flash, native")
         if self.model_hub not in {"hf", "modelscope"}:
             raise ValueError("model_hub must be one of: hf, modelscope")
+        if self.agent_overlength_policy not in {"off", "safe-stop"}:
+            raise ValueError("agent_overlength_policy must be one of: off, safe-stop")
 
     def optimizer_config(self) -> dict:
         """Build the optimizer dict consumed by the backend config."""

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 
 from areno.api.dashboard import record_dashboard_state
+from areno.api.openai_chat import single_message_token_count
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
@@ -232,8 +233,9 @@ class PolicyOnlyTrainer:
                     samples.append(sample)
                 else:
                     ctx._append_sample_response(existing, sample)
+            tokenizer = self.areno.get_tokenizer()
             samples, filtered_count, filter_diagnostics = self._filter_overlong_agent_samples(
-                ctx, samples, sampling_params
+                ctx, samples, sampling_params, tokenizer
             )
             overlength_counts = _aggregate_overlength_counts(samples)
             expected = len(agent_batch)
@@ -271,7 +273,7 @@ class PolicyOnlyTrainer:
                 overlength_counts=overlength_counts,
             )
 
-    def _filter_overlong_agent_samples(self, ctx, samples, sampling_params):
+    def _filter_overlong_agent_samples(self, ctx, samples, sampling_params, tokenizer=None):
         # Whole-trajectory backstop: under the safe-stop policy the proxy already
         # stops items at the overlength turn, so this filter should rarely drop
         # anything. It is retained for the ``off`` policy (which keeps partial
@@ -286,7 +288,7 @@ class PolicyOnlyTrainer:
         for sample in samples:
             rows = ctx._train_rows_from_samples([sample])
             token_len = len(rows.token_rows[0]) if rows.token_rows else 0
-            detail = self._agent_sample_filter_detail(sample, token_len)
+            detail = self._agent_sample_filter_detail(sample, token_len, tokenizer)
             all_details.append(detail)
             if token_len <= max_context_len:
                 kept.append(sample)
@@ -302,7 +304,7 @@ class PolicyOnlyTrainer:
             self.logger.warning("agentic trajectory filtered: %s", self._format_agent_filter_diagnostics(diagnostics))
         return kept, len(filtered_details), diagnostics
 
-    def _agent_sample_filter_detail(self, sample, token_len):
+    def _agent_sample_filter_detail(self, sample, token_len, tokenizer=None):
         tool_result_count = sum(1 for message in sample.messages if message.get("role") == "tool")
         assistant_count = sum(1 for message in sample.messages if message.get("role") == "assistant")
         return {
@@ -315,8 +317,29 @@ class PolicyOnlyTrainer:
             "response_tokens": len(sample.response_tokens),
             "trace_events": len(sample.trace),
             "termination_reason": sample.termination_reason,
+            "oversized_tool": self._oversized_tool_detail(sample, tokenizer),
             "prompt": str(sample.item.prompt).replace("\n", "\\n")[:120],
         }
+
+    def _oversized_tool_detail(self, sample, tokenizer) -> dict | None:
+        """Identify the largest tool result on an ``oversized_tool_result`` sample.
+
+        Populated only when the sample terminated on ``oversized_tool_result``
+        and a tokenizer is available; returns ``{"name", "tokens"}`` for the
+        tool message with the largest token count (without exposing its text)
+        so operators can see which tool result blew the cap. ``None`` otherwise.
+        """
+
+        if tokenizer is None or getattr(sample, "termination_reason", None) != "oversized_tool_result":
+            return None
+        largest: dict | None = None
+        for message in sample.messages:
+            if message.get("role") != "tool":
+                continue
+            tokens = single_message_token_count(tokenizer, message)
+            if largest is None or tokens > largest["tokens"]:
+                largest = {"name": message.get("name"), "tokens": int(tokens)}
+        return largest
 
     def _agent_filter_diagnostics(self, all_details, filtered_details, *, max_context_len, kept_count):
         token_lengths = sorted(detail["tokens"] for detail in all_details)
@@ -336,12 +359,7 @@ class PolicyOnlyTrainer:
         if not diagnostics:
             return "no context-length diagnostics available"
         top = "; ".join(
-            "prompt_idx={prompt_idx} sample_idx={sample_idx} tokens={tokens} messages={messages} "
-            "assistant_messages={assistant_messages} tool_results={tool_results} response_tokens={response_tokens} "
-            "trace_events={trace_events} termination_reason={termination_reason} prompt='{prompt}'".format(
-                **{"termination_reason": "none", **detail}
-            )
-            for detail in diagnostics.get("top", [])
+            self._format_agent_filter_top_entry(detail) for detail in diagnostics.get("top", [])
         )
         return (
             "max_context_len={max_context_len} total={total} kept={kept} filtered={filtered} "
@@ -357,6 +375,19 @@ class PolicyOnlyTrainer:
             max_tokens=diagnostics["max_tokens"],
             top=top,
         )
+
+    def _format_agent_filter_top_entry(self, detail: dict) -> str:
+        base = (
+            "prompt_idx={prompt_idx} sample_idx={sample_idx} tokens={tokens} messages={messages} "
+            "assistant_messages={assistant_messages} tool_results={tool_results} response_tokens={response_tokens} "
+            "trace_events={trace_events} termination_reason={termination_reason} prompt='{prompt}'"
+        ).format(**{"termination_reason": "none", "prompt": "", **detail})
+        oversized_tool = detail.get("oversized_tool")
+        if oversized_tool:
+            base += " oversized_tool=name:{name} tokens:{tokens}".format(
+                name=oversized_tool.get("name"), tokens=oversized_tool.get("tokens")
+            )
+        return base
 
     def _percentile_value(self, sorted_values, fraction):
         if not sorted_values:

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -218,6 +218,7 @@ class PolicyOnlyTrainer:
             loss_mask_policy=self._loss_mask_policy(),
             max_running_prompts=self.config.resolved_max_running_prompts(),
             timeout_s=self.config.agent_timeout_s,
+            agent_overlength_policy=self.config.agent_overlength_policy,
         ) as ctx:
             await ctx.sync_rollout_session_async()
             trajectories = await maybe_await(self._get_agent_run_fn()(ctx, agent_batch))

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -89,6 +89,7 @@ class PolicyOnlyTrainer:
                     train_batch, rewards_all, rollout_logprobs = self._materialize_agentic_train_batch(
                         tokenizer, prompt_batch, agent_batch
                     )
+                    overlength_counts = dict(agent_batch.overlength_counts)
                 else:
                     # 1) Sample n_samples completions per prompt; ordering
                     #    matches `prompt_batch.items` so we can zip downstream.
@@ -102,6 +103,7 @@ class PolicyOnlyTrainer:
                     train_batch, rewards_all, rollout_logprobs = self._materialize_train_batch(
                         tokenizer, prompt_batch, rollout_results
                     )
+                    overlength_counts = None
 
                 if rewards_all:
                     self.logger.info(
@@ -141,6 +143,7 @@ class PolicyOnlyTrainer:
                         self.loss_fn,
                         mini_bs=self.config.mini_bs,
                         gradient_accumulation_steps=self.config.gradient_accumulation_steps,
+                        overlength_counts=overlength_counts,
                     )
                     train_time_s = time.perf_counter() - train_start
                     if isinstance(result, dict):
@@ -231,6 +234,7 @@ class PolicyOnlyTrainer:
             samples, filtered_count, filter_diagnostics = self._filter_overlong_agent_samples(
                 ctx, samples, sampling_params
             )
+            overlength_counts = _aggregate_overlength_counts(samples)
             expected = len(agent_batch)
             if len(samples) + filtered_count != expected:
                 raise RuntimeError(
@@ -263,9 +267,15 @@ class PolicyOnlyTrainer:
                 rewards=rewards,
                 records=[sample.item.record for sample in samples],
                 reward_records=reward_records,
+                overlength_counts=overlength_counts,
             )
 
     def _filter_overlong_agent_samples(self, ctx, samples, sampling_params):
+        # Whole-trajectory backstop: under the safe-stop policy the proxy already
+        # stops items at the overlength turn, so this filter should rarely drop
+        # anything. It is retained for the ``off`` policy (which keeps partial
+        # tool calls) and as a defensive guard when user ``run_agent`` code
+        # ignores the ``finish_reason="length"`` terminal signal.
         max_context_len = self._agent_model_context_len()
         if max_context_len is None:
             return samples, 0, {}
@@ -303,6 +313,7 @@ class PolicyOnlyTrainer:
             "tool_results": tool_result_count,
             "response_tokens": len(sample.response_tokens),
             "trace_events": len(sample.trace),
+            "termination_reason": sample.termination_reason,
             "prompt": str(sample.item.prompt).replace("\n", "\\n")[:120],
         }
 
@@ -326,7 +337,9 @@ class PolicyOnlyTrainer:
         top = "; ".join(
             "prompt_idx={prompt_idx} sample_idx={sample_idx} tokens={tokens} messages={messages} "
             "assistant_messages={assistant_messages} tool_results={tool_results} response_tokens={response_tokens} "
-            "trace_events={trace_events} prompt='{prompt}'".format(**detail)
+            "trace_events={trace_events} termination_reason={termination_reason} prompt='{prompt}'".format(
+                **{"termination_reason": "none", **detail}
+            )
             for detail in diagnostics.get("top", [])
         )
         return (
@@ -581,3 +594,20 @@ class PolicyOnlyTrainer:
         record_dashboard_state(
             self.areno, stage="save_checkpoint_end", epoch=epoch, step=step, role=self._policy_role_name()
         )
+
+
+def _aggregate_overlength_counts(samples) -> dict[str, int]:
+    """Tally per-sample termination reasons into a per-reason count dict.
+
+    Only agentic overlength reasons (``generation_limit`` / ``context_limit`` /
+    ``oversized_tool_result``) are counted; ``None`` (clean stop) samples are
+    skipped so the dict stays empty for batches that never hit a cap.
+    """
+
+    reasons = ("generation_limit", "context_limit", "oversized_tool_result")
+    counts = {reason: 0 for reason in reasons}
+    for sample in samples:
+        reason = getattr(sample, "termination_reason", None)
+        if reason in counts:
+            counts[reason] += 1
+    return {reason: counts[reason] for reason in reasons if counts[reason]}

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -90,6 +90,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "agent_fn",
             "agent_timeout_s",
             "train_tool_results",
+            "agent_overlength_policy",
             "reward_fn_path",
             "reward_ckpt",
         ),
@@ -243,6 +244,10 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--max-running-prompts must be positive")
     if args.agent_timeout_s <= 0:
         raise click.UsageError("--agent-timeout-s must be positive")
+    agent_overlength_policy = getattr(args, "agent_overlength_policy", "off")
+    if agent_overlength_policy not in {"off", "safe-stop"}:
+        raise click.UsageError("--agent-overlength-policy must be one of: off, safe-stop")
+    args.agent_overlength_policy = agent_overlength_policy
     _require_positive_float(args.lr, "--lr")
     if args.min_lr < 0:
         raise click.UsageError("--min-lr must be non-negative")
@@ -435,6 +440,7 @@ def _rollout_summary_rows(config: TrainerConfig) -> list[tuple[str, str]]:
         ("max_prompt_tokens", str(config.max_prompt_tokens)),
         ("max_new_tokens", str(config.max_new_tokens)),
         ("max_context_len", _format_optional(config.max_context_len, default="model limit")),
+        ("overlength_policy", str(config.agent_overlength_policy)),
     ]
     if not isinstance(config, RolloutTrainerConfig):
         return [
@@ -598,6 +604,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     args.model_hub = getattr(args, "model_hub", "modelscope")
+    args.agent_overlength_policy = getattr(args, "agent_overlength_policy", "off")
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
@@ -638,6 +645,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            agent_overlength_policy=args.agent_overlength_policy,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
         )
@@ -679,6 +687,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            agent_overlength_policy=args.agent_overlength_policy,
         )
     if algorithm.name != "ppo":
         return PolicyTrainerConfig(
@@ -727,6 +736,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            agent_overlength_policy=args.agent_overlength_policy,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -788,6 +798,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
+        agent_overlength_policy=args.agent_overlength_policy,
     )
 
 
@@ -902,6 +913,7 @@ def _training_config_settings(config: TrainerConfig) -> dict:
                 "agent_fn",
                 "agent_timeout_s",
                 "train_tool_results",
+                "agent_overlength_policy",
                 "reward_fn_path",
                 "reward_ckpt",
             ],
@@ -1300,6 +1312,16 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--agent-timeout-s", type=float, default=300.0, show_default=True, help="Agentic rollout proxy request timeout."
 )
 @click.option("--train-tool-results", is_flag=True, help="Include tool-result spans in agentic policy loss.")
+@click.option(
+    "--agent-overlength-policy",
+    type=click.Choice(["off", "safe-stop"], case_sensitive=False),
+    default="off",
+    show_default=True,
+    help=(
+        "Agentic overlength handling: off keeps current behavior; safe-stop drops half-finished "
+        "tool calls / oversized tool results and stops the item while retaining the trajectory."
+    ),
+)
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."
 )

--- a/docs/troubleshooting/agentic-rollout.rst
+++ b/docs/troubleshooting/agentic-rollout.rst
@@ -22,3 +22,60 @@ Common symptoms:
 * Tool calls fail to parse: inspect raw assistant turns and schema format.
 
 Use :doc:`/cookbook/tictactoe-agentic-rl` as the smallest reference recipe.
+
+Overlength handling
+-------------------
+
+A multi-turn trajectory can blow past the context cap in three distinct ways.
+AReno classifies them so you can act on the real cause instead of a generic
+"trajectory too long":
+
+* ``generation_limit`` — the model hit ``--max-new-tokens`` mid tool call (the
+  engine reports ``finish_reason="length"``).
+* ``context_limit`` — the next turn's rendered prompt exceeds
+  ``--max-context-len`` because the accumulated trajectory grew too long.
+* ``oversized_tool_result`` — a single ``role == "tool"`` message *on its own*
+  already exceeds ``--max-context-len``.
+
+Select a policy with ``--agent-overlength-policy`` (default ``off``):
+
+* ``off`` preserves today's behavior: parsed tool calls are kept even when
+  generation hit the token limit, and a post-rollout whole-trajectory filter
+  drops samples that still exceed the cap (with a warning). The
+  ``termination_reason`` is still recorded for observability only.
+* ``safe-stop`` treats each overlength as terminal for that item:
+
+  * ``generation_limit`` — the half-finished tool call is **dropped** (never
+    recorded or executed) and the proxy surfaces ``finish_reason="length"``.
+  * ``context_limit`` — the turn returns an empty response and the item stops.
+  * ``oversized_tool_result`` — the oversized result is **not appended**; the
+    item stops before corrupting the trajectory.
+
+  The trajectory up to and including the terminal turn is kept for training
+  (partial credit) instead of being discarded wholesale.
+
+Observable output:
+
+* Per-turn: the proxy ``areno`` metadata block carries
+  ``termination_reason``; ``RewardRecord.metadata`` and the trace ``finish``
+  event carry it too. The OpenAI ``finish_reason`` surface is ``"length"`` for
+  overlength turns under ``safe-stop`` and unchanged under ``off``.
+* Per-step metrics: ``rollout/overlength_generation_limit``,
+  ``rollout/overlength_context_limit``,
+  ``rollout/overlength_oversized_tool_result``, and ``rollout/overlength_total``.
+* Diagnostics: the whole-trajectory filter "top" list includes
+  ``termination_reason`` per dropped sample.
+
+Copyable minimal example (CPU-only, no sandbox)::
+
+    areno train --ckpt Qwen/Qwen3-0.6B --dataset-path myagent:main \
+      --reward-fn-path examples/agentic/myagent/reward.py \
+      --algo gspo --agent-fn examples/agentic/myagent/run_agent.py \
+      --max-context-len 8192 --max-new-tokens 2048 \
+      --agent-overlength-policy safe-stop
+
+Contract for ``run_agent``: a response with ``finish_reason == "length"`` is
+terminal. Stop the item, record the turn, and do **not** nudge the model to
+retry or execute a (half) tool call — otherwise the loop spins to the turn
+limit and the post-rollout backstop discards the trajectory anyway. The
+bundled ``areno/agent/agent_loop.py`` example already honors this signal.

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -392,7 +392,7 @@ def test_explicit_trajectory_helper_builds_train_rows_without_prompt_claiming():
     assert rows.token_rows == [[len("same prompt"), 100]]
     assert rows.response_masks == [[False, True]]
     assert rows.rollout_logprobs == [[0.0, -0.25]]
-    assert record.metadata == {"prompt_index": 0, "sample_index": 0}
+    assert record.metadata == {"prompt_index": 0, "sample_index": 0, "termination_reason": None}
 
 
 def test_openai_chat_completion_preserves_proxy_trajectory_metadata():

--- a/tests/test_agentic_overlength_cpu.py
+++ b/tests/test_agentic_overlength_cpu.py
@@ -402,3 +402,54 @@ def test_overlength_exact_max_context_len_not_triggered():
     assert trainer.rollout_batches == [([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]], 1)]  # rollout called
     assert "termination_reason" not in response["areno"]  # no overlength classification
     assert response["choices"][0]["finish_reason"] == "stop"
+
+
+# ---------------------------------------------------------------------------
+# 10. regression: Trainer without a .config attribute must not raise
+#     (the real Trainer does not expose TrainerConfig; agent_overlength_policy
+#      is threaded in via rollout_session, not read off trainer.config)
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_policy_trainer_without_config_attr_defaults_off():
+    """A trainer with no ``config`` attribute (like the real ``Trainer``) must
+    not raise ``AttributeError`` when the overlength policy is read -- the prior
+    implementation reached for ``self._trainer.config`` unguarded."""
+
+    trainer = _LengthFakeTrainer(finish_reason="length", resp_tokens=[101, 102, 103], world_size=1, tp_size=1)
+    del trainer.config  # mimic the real Trainer, which has no .config
+    trainer.tokenizer = _LiteralTokenizer('{"name":"foo","arguments":')
+    session = _session(trainer)  # no agent_overlength_policy threaded -> off
+
+    # _agent_overlength_policy() must not raise and must report "off".
+    assert session._agent_overlength_policy() == "off"
+
+    # A generation-limit rollout under "off" keeps the parsed tool call and does
+    # not raise mid-rollout (this is the 500 the bug produced in production).
+    response = _complete(session, {"model": "policy", "messages": [{"role": "user", "content": "go"}]})
+    assert response["areno"]["termination_reason"] == "generation_limit"
+    assert response["choices"][0]["finish_reason"] == "stop"  # off -> normal derivation, not "length"
+
+
+def test_overlength_policy_threaded_safe_stop_overrides_missing_config():
+    """When the policy is threaded in explicitly (the real agentic trainer
+    path), ``safe-stop`` takes effect even though the trainer has no ``.config``.
+    """
+
+    trainer = _LengthFakeTrainer(finish_reason="length", resp_tokens=[101, 102, 103], world_size=1, tp_size=1)
+    del trainer.config
+    trainer.tokenizer = _LiteralTokenizer('{"name":"foo","arguments":')
+    session = RolloutSession(
+        trainer,
+        sampling_params=_FakeSamplingParams(),
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+        agent_overlength_policy="safe-stop",
+    )
+
+    assert session._agent_overlength_policy() == "safe-stop"
+
+    response = _complete(session, {"model": "policy", "messages": [{"role": "user", "content": "go"}]})
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert response["areno"]["termination_reason"] == "generation_limit"
+    assert response["choices"][0]["message"].get("tool_calls") in (None, [])  # half tool call dropped

--- a/tests/test_agentic_overlength_cpu.py
+++ b/tests/test_agentic_overlength_cpu.py
@@ -11,6 +11,7 @@ remaining GPU validation is documented in the troubleshooting page.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -453,3 +454,133 @@ def test_overlength_policy_threaded_safe_stop_overrides_missing_config():
     assert response["choices"][0]["finish_reason"] == "length"
     assert response["areno"]["termination_reason"] == "generation_limit"
     assert response["choices"][0]["message"].get("tool_calls") in (None, [])  # half tool call dropped
+
+
+# ---------------------------------------------------------------------------
+# 11. an oversized tool result that is NOT the last tool message is not missed
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_earlier_oversized_tool_not_missed():
+    """An oversized tool result that is *not* the last tool message must still
+    classify as ``oversized_tool_result``. The prior short-circuiting classifier
+    only inspected the last tool message and would have mislabelled this
+    ``context_limit``."""
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = _CharTokenizer()
+    params = _FakeSamplingParams()
+    params.max_context_len = 10
+    session = _session(trainer, params=params)
+
+    messages = [
+        {"role": "user", "content": "a" * 15},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "f", "content": "b" * 20},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_2", "type": "function", "function": {"name": "g", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_2", "name": "g", "content": "b" * 3},
+    ]
+
+    response = _complete(session, {"model": "policy", "messages": messages})
+
+    assert response["areno"]["termination_reason"] == "oversized_tool_result"
+    assert trainer.rollout_batches == []  # pre-generation short-circuit, no rollout
+
+
+# ---------------------------------------------------------------------------
+# 12. single_message_token_count is template-aware (口径 aligned with the total)
+# ---------------------------------------------------------------------------
+
+
+class _TemplateTokenizer(_FakeTokenizer):
+    """A tokenizer with a chat template: wraps each message with role-tag
+    markers so the rendered count exceeds the raw content length."""
+
+    chat_template = "fake"
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
+        ids = [100]  # opening role-tag marker
+        for message in messages:
+            content = message.get("content")
+            text = content if isinstance(content, str) else json.dumps(content)
+            ids.extend(range(len(text)))
+        ids.append(101)  # closing role-tag marker
+        return ids
+
+    def encode(self, text):
+        return list(range(len(text)))
+
+
+def test_single_message_token_count_template_aware():
+    from areno.api.openai_chat import single_message_token_count
+
+    message = {"role": "tool", "tool_call_id": "c1", "name": "f", "content": "hello"}
+    # Template-bearing tokenizer wraps the content with role-tag markers, so the
+    # count exceeds the raw content length -- same scale the full prompt render
+    # uses, not raw ``encode``.
+    assert single_message_token_count(_TemplateTokenizer(), message) == len("hello") + 2
+    # A tokenizer without a chat template falls back to raw content encode.
+    assert single_message_token_count(_CharTokenizer(), message) == len("hello")
+
+
+# ---------------------------------------------------------------------------
+# 13. filter diagnostics identify the oversized tool result (name + tokens)
+# ---------------------------------------------------------------------------
+
+
+def _policy_only_for_diagnostics():
+    from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+    return PolicyOnlyTrainer(
+        config=SimpleNamespace(), instance=object(), dataset=None, reward_fn=None, loss_fn=None
+    )
+
+
+def test_agent_filter_detail_includes_oversized_tool():
+    policy = _policy_only_for_diagnostics()
+    tokenizer = _CharTokenizer()
+
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = tokenizer
+    params = _FakeSamplingParams()
+    params.max_context_len = 10
+    session = _session(trainer, params=params)
+
+    over_messages = _tool_messages("b" * 25)
+    over_response = _complete(session, {"model": "policy", "messages": over_messages})
+    over_sample = _sample_from_response(session, over_response, messages=over_messages)
+    assert over_sample.termination_reason == "oversized_tool_result"
+
+    over_detail = policy._agent_sample_filter_detail(over_sample, token_len=999, tokenizer=tokenizer)
+    assert over_detail["oversized_tool"] == {"name": "f", "tokens": 25}
+
+    ctx_messages = [{"role": "user", "content": "a" * 15}]
+    ctx_response = _complete(session, {"model": "policy", "messages": ctx_messages})
+    ctx_sample = _sample_from_response(session, ctx_response, messages=ctx_messages)
+    assert ctx_sample.termination_reason == "context_limit"
+    ctx_detail = policy._agent_sample_filter_detail(ctx_sample, token_len=999, tokenizer=tokenizer)
+    assert ctx_detail["oversized_tool"] is None
+
+    diag = {
+        "max_context_len": 10,
+        "total": 2,
+        "kept": 0,
+        "filtered": 2,
+        "min_tokens": 999,
+        "p50_tokens": 999,
+        "p90_tokens": 999,
+        "max_tokens": 999,
+        "top": [over_detail, ctx_detail],
+    }
+    formatted = policy._format_agent_filter_diagnostics(diag)
+    assert "oversized_tool=name:f tokens:25" in formatted
+    assert "oversized_tool=name:none" not in formatted  # context_limit entry carries no suffix

--- a/tests/test_agentic_overlength_cpu.py
+++ b/tests/test_agentic_overlength_cpu.py
@@ -1,0 +1,404 @@
+"""CPU tests for agentic overlength (safe-stop) handling.
+
+These tests reuse the fakes from ``test_agentic_cpu`` (no GPU, no network) and
+exercise the three termination-reason classifications, the ``off`` vs
+``safe-stop`` policy split, per-reason metric emission, multi-turn
+``termination_reason`` propagation, and the exact-limit boundary. GPU /
+distributed rollout behavior is isolated behind the ``_FakeTrainer`` fakes; the
+remaining GPU validation is documented in the troubleshooting page.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Ensure the sibling test module (which owns the shared fakes) is importable
+# when this file is collected standalone.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Reuse the shared fakes/fixtures from the existing agentic CPU suite.
+from test_agentic_cpu import (  # noqa: F401  (re-exports for test ergonomics), E402
+    _FakeSamplingParams,
+    _FakeTokenizer,
+    _FakeTrainer,
+    _FixedTokenizer,
+    _LiteralTokenizer,
+    _pending_chat,
+    agentic,  # noqa: E402  (the module loaded by the existing suite)
+)
+
+from areno.api.agentic import AgentItem, AgentTrajectoryTurn, LossMaskPolicy, RolloutSession  # noqa: E402
+from areno.api.metrics import init_rollout_stats, merge_overlength_counts, record_training_stats  # noqa: E402
+from areno.api.trainer_config import TrainerConfig  # noqa: E402
+from areno.api.trainers.policy_only import _aggregate_overlength_counts  # noqa: E402
+
+
+class _LengthFakeTrainer(_FakeTrainer):
+    """Fake trainer whose rollout sequences carry an engine ``finish_reason``."""
+
+    def __init__(self, *, finish_reason="length", resp_tokens=None, **kwargs):
+        super().__init__(**kwargs)
+        self._finish_reason = finish_reason
+        self._resp_tokens = list(resp_tokens or [101, 102])
+
+    def rollout_token_batch(self, prompt_tokens, n_samples, sampling_params):
+        del sampling_params
+        self.rollout_batches.append((prompt_tokens, n_samples))
+        return [
+            SimpleNamespace(
+                sequences=[
+                    SimpleNamespace(
+                        resp_tokens=list(self._resp_tokens),
+                        resp_logprobs=[-0.1] * len(self._resp_tokens),
+                        finish_reason=self._finish_reason,
+                    )
+                ]
+            )
+            for _ in prompt_tokens
+        ]
+
+
+class _CharTokenizer(_FakeTokenizer):
+    """Character-level tokenizer: ``len(encode(text)) == len(text)``."""
+
+    def encode(self, text):
+        return list(range(len(text)))
+
+    def decode(self, tokens):
+        return "x" * len(tokens)
+
+
+def _session(trainer, *, params=None):
+    return RolloutSession(
+        trainer,
+        sampling_params=params or _FakeSamplingParams(),
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+    )
+
+
+def _complete(session, body):
+    async def run():
+        session._loop = asyncio.get_running_loop()
+        return await session._complete_chat(body)
+
+    return asyncio.run(run())
+
+
+def _item(idx=0):
+    return AgentItem(record={}, prompt=f"p{idx}", input_tokens=[idx], prompt_index=idx, sample_index=0)
+
+
+def _sample_from_response(session, response, *, messages=None, item=None):
+    turn = AgentTrajectoryTurn(
+        item=item or _item(),
+        messages=messages or [{"role": "user", "content": "go"}],
+        response=response,
+        tools=[],
+    )
+    return session._sample_from_trajectory_turn(turn)
+
+
+# ---------------------------------------------------------------------------
+# 1. generation_limit + safe-stop drops the half tool call
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_generation_limit_safe_stop_drops_half_tool_call():
+    trainer = _LengthFakeTrainer(finish_reason="length", resp_tokens=[101, 102, 103])
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = _LiteralTokenizer('{"name":"foo","arguments":')
+    session = _session(trainer)
+
+    response = _complete(session, {"model": "policy", "messages": [{"role": "user", "content": "go"}]})
+
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert response["areno"]["termination_reason"] == "generation_limit"
+    assert response["choices"][0]["message"].get("tool_calls") in (None, [])
+    assert trainer.rollout_batches == [([[2]], 1)]  # one rollout call only
+
+    sample = _sample_from_response(session, response)
+    assert sample.termination_reason == "generation_limit"
+    finish_events = [event for event in sample.trace if event.type == "finish"]
+    assert finish_events and finish_events[-1].metadata["finish_reason"] == "length"
+    assert finish_events[-1].metadata["termination_reason"] == "generation_limit"
+
+
+# ---------------------------------------------------------------------------
+# 2. context_limit (pre-generation short-circuit)
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_context_limit_pre_generation_marks_terminal():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = _FixedTokenizer(list(range(10)))  # 10 tokens regardless of text
+    params = _FakeSamplingParams()
+    params.max_context_len = 5
+    session = _session(trainer, params=params)
+
+    response = _complete(session, {"model": "policy", "messages": [{"role": "user", "content": "long prompt"}]})
+
+    assert trainer.rollout_batches == []  # pre-generation short-circuit, no rollout
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert response["areno"]["termination_reason"] == "context_limit"
+    assert response["areno"]["response_tokens"] == []
+
+
+# ---------------------------------------------------------------------------
+# 3. oversized_tool_result classified separately from context_limit
+# ---------------------------------------------------------------------------
+
+
+def _tool_messages(tool_content):
+    return [
+        {"role": "user", "content": "a" * 15},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "f", "content": tool_content},
+    ]
+
+
+def test_overlength_oversized_tool_result_classified_separately():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = _CharTokenizer()
+    params = _FakeSamplingParams()
+    params.max_context_len = 10
+    session = _session(trainer, params=params)
+
+    response = _complete(session, {"model": "policy", "messages": _tool_messages("b" * 15)})
+
+    assert response["areno"]["termination_reason"] == "oversized_tool_result"
+    assert trainer.rollout_batches == []
+
+
+def test_overlength_context_limit_when_last_tool_result_is_small():
+    """Total overlong but the last tool result fits -> context_limit, not oversized."""
+
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = _CharTokenizer()
+    params = _FakeSamplingParams()
+    params.max_context_len = 10
+    session = _session(trainer, params=params)
+
+    # Full trajectory text > 10 (user content alone is 15), but the tool result
+    # is only 3 tokens -> context_limit.
+    response = _complete(session, {"model": "policy", "messages": _tool_messages("b" * 3)})
+
+    assert response["areno"]["termination_reason"] == "context_limit"
+
+
+# ---------------------------------------------------------------------------
+# 4. generation_limit uses engine finish_reason, not the length heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_generation_limit_reason_from_engine_finish_reason():
+    # finish_reason="length" but len(resp_tokens) < max_new_tokens: the engine
+    # signal must win over the length heuristic.
+    trainer = _LengthFakeTrainer(finish_reason="length", resp_tokens=[1])
+    trainer.config = SimpleNamespace(agent_overlength_policy="off", world_size=1, tp_size=1)
+    trainer.tokenizer = _LiteralTokenizer("partial")
+    params = _FakeSamplingParams()
+    params.max_new_tokens = 4  # len(resp_tokens)=1 < 4 -> heuristic alone would say "not length"
+    session = _session(trainer, params=params)
+
+    response = _complete(session, {"model": "policy", "messages": [{"role": "user", "content": "go"}]})
+
+    assert response["areno"]["termination_reason"] == "generation_limit"
+    assert trainer.rollout_batches == [([[2]], 1)]
+
+
+# ---------------------------------------------------------------------------
+# 5. policy=off preserves current behavior (tool_calls kept, observability set)
+# ---------------------------------------------------------------------------
+
+
+_FOO_TOOL = {"type": "function", "function": {"name": "foo", "parameters": {"type": "object", "properties": {}}}}
+_FOO_CALL_JSON = '{"name":"foo","arguments":{"x":1}}'
+
+
+def _generation_limit_response(policy):
+    trainer = _LengthFakeTrainer(finish_reason="length", resp_tokens=[1, 2])
+    trainer.config = SimpleNamespace(agent_overlength_policy=policy, world_size=1, tp_size=1)
+    trainer.tokenizer = _LiteralTokenizer(_FOO_CALL_JSON)
+    session = _session(trainer)
+    response = _complete(
+        session,
+        {"model": "policy", "messages": [{"role": "user", "content": "go"}], "tools": [_FOO_TOOL]},
+    )
+    return response, trainer
+
+
+def test_overlength_policy_off_preserves_current_behavior():
+    response, trainer = _generation_limit_response("off")
+
+    message = response["choices"][0]["message"]
+    assert message.get("tool_calls")  # parsed tool call is preserved
+    assert len(message["tool_calls"]) == 1
+    # OpenAI finish_reason follows the normal tool_calls/stop derivation.
+    assert response["choices"][0]["finish_reason"] == "tool_calls"
+    # termination_reason is still observable in metadata.
+    assert response["areno"]["termination_reason"] == "generation_limit"
+    assert trainer.rollout_batches == [([[2]], 1)]
+
+
+def test_overlength_policy_safe_stop_drops_tool_call_that_off_keeps():
+    response, _ = _generation_limit_response("safe-stop")
+
+    assert response["choices"][0]["message"].get("tool_calls") in (None, [])
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert response["areno"]["termination_reason"] == "generation_limit"
+
+
+# ---------------------------------------------------------------------------
+# 6. invalid policy values rejected
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_policy_invalid_value_rejected():
+    assert TrainerConfig(algo="gspo", ckpt="x", dataset_path="x").agent_overlength_policy == "off"
+    with pytest.raises(ValueError, match="agent_overlength_policy must be one of"):
+        TrainerConfig(algo="gspo", ckpt="x", dataset_path="x", agent_overlength_policy="bogus")
+
+
+def test_overlength_policy_invalid_cli_value_rejected():
+    from click.testing import CliRunner
+
+    from areno.cli.train import train_command
+
+    result = CliRunner().invoke(train_command, ["--agent-overlength-policy", "bogus"])
+    assert result.exit_code != 0
+    assert "agent-overlength-policy" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 7. per-reason metrics emitted (proxy -> sample -> aggregate -> writer)
+# ---------------------------------------------------------------------------
+
+
+class _MockWriter:
+    def __init__(self):
+        self.scalars: list[tuple[str, float, int]] = []
+
+    def add_scalar(self, name, value, step):
+        self.scalars.append((name, float(value), int(step)))
+
+    def flush(self):
+        pass
+
+
+def _reason_sample(session, response):
+    return _sample_from_response(session, response)
+
+
+def test_overlength_per_reason_metrics_emitted():
+    # generation_limit sample (safe-stop path)
+    gen_trainer = _LengthFakeTrainer(finish_reason="length", resp_tokens=[1, 2])
+    gen_trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    gen_trainer.tokenizer = _LiteralTokenizer("partial")
+    gen_response = _complete(_session(gen_trainer), {"model": "policy", "messages": [{"role": "user", "content": "go"}]})
+    gen_sample = _reason_sample(_session(gen_trainer), gen_response)
+
+    # context_limit sample
+    ctx_trainer = _FakeTrainer(world_size=1, tp_size=1)
+    ctx_trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    ctx_trainer.tokenizer = _FixedTokenizer(list(range(10)))
+    ctx_params = _FakeSamplingParams()
+    ctx_params.max_context_len = 5
+    ctx_response = _complete(_session(ctx_trainer, params=ctx_params), {"model": "policy", "messages": [{"role": "user", "content": "long"}]})
+    # Rebuild the turn against a session bound to the ctx trainer so the sample
+    # is materialized with its tokenizer/context.
+    ctx_sample = _sample_from_response(_session(ctx_trainer, params=ctx_params), ctx_response)
+
+    # oversized_tool_result sample
+    over_trainer = _FakeTrainer(world_size=1, tp_size=1)
+    over_trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    over_trainer.tokenizer = _CharTokenizer()
+    over_params = _FakeSamplingParams()
+    over_params.max_context_len = 10
+    over_response = _complete(_session(over_trainer, params=over_params), {"model": "policy", "messages": _tool_messages("b" * 15)})
+    over_sample = _sample_from_response(_session(over_trainer, params=over_params), over_response)
+
+    samples = [gen_sample, ctx_sample, over_sample]
+    counts = _aggregate_overlength_counts(samples)
+    assert counts == {"generation_limit": 1, "context_limit": 1, "oversized_tool_result": 1}
+
+    writer = _MockWriter()
+    stats = merge_overlength_counts(init_rollout_stats(), counts)
+    record_training_stats(writer, stats, step=0, train_res={}, train_batch=[])
+
+    overlength_scalars = [name for name, _value, _step in writer.scalars if name.startswith("rollout/overlength_")]
+    assert "rollout/overlength_generation_limit" in overlength_scalars
+    assert "rollout/overlength_context_limit" in overlength_scalars
+    assert "rollout/overlength_oversized_tool_result" in overlength_scalars
+    assert "rollout/overlength_total" in overlength_scalars
+    assert len(overlength_scalars) == 4
+
+
+# ---------------------------------------------------------------------------
+# 8. multi-turn propagates the last termination reason
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_multi_turn_propagates_last_reason():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    session = _session(trainer)
+    params = _FakeSamplingParams()
+    item = _item()
+
+    first = _pending_chat(0, params)
+    first.item = item
+    first.input_tokens = [1, 2]
+    first.messages = [{"role": "user", "content": "step 1"}]
+    sample_one = session._sample_from_pending_chat(
+        first, agentic._ResponseData(response_tokens=[10], response_logprobs=[-0.1]),
+    )
+
+    second = _pending_chat(0, params)
+    second.item = item
+    second.input_tokens = [1, 2, 10]
+    second.messages = [{"role": "user", "content": "step 2"}]
+    sample_two = session._sample_from_pending_chat(
+        second, agentic._ResponseData(response_tokens=[20], response_logprobs=[-0.2]),
+        termination_reason="generation_limit",
+    )
+
+    session._append_sample_response(sample_one, sample_two)
+
+    assert sample_one.termination_reason == "generation_limit"
+    finish_events = [event for event in sample_one.trace if event.type == "finish"]
+    assert finish_events and finish_events[-1].metadata["finish_reason"] == "length"
+
+
+# ---------------------------------------------------------------------------
+# 9. exact max_context_len boundary does not trigger
+# ---------------------------------------------------------------------------
+
+
+def test_overlength_exact_max_context_len_not_triggered():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.config = SimpleNamespace(agent_overlength_policy="safe-stop", world_size=1, tp_size=1)
+    trainer.tokenizer = _FixedTokenizer(list(range(10)))  # 10 tokens
+    params = _FakeSamplingParams()
+    params.max_context_len = 10  # equal, not greater -> rollout proceeds
+    session = _session(trainer, params=params)
+
+    response = _complete(session, {"model": "policy", "messages": [{"role": "user", "content": "edge"}]})
+
+    assert trainer.rollout_batches == [([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]], 1)]  # rollout called
+    assert "termination_reason" not in response["areno"]  # no overlength classification
+    assert response["choices"][0]["finish_reason"] == "stop"

--- a/tests/test_coding_agent_loop_cpu.py
+++ b/tests/test_coding_agent_loop_cpu.py
@@ -38,6 +38,25 @@ class _NoToolClient:
         self.chat = type("Chat", (), {"completions": _NoToolCompletions()})()
 
 
+class _LengthFinishCompletions:
+    def __init__(self):
+        self.calls = 0
+
+    async def create(self, **kwargs):
+        del kwargs
+        self.calls += 1
+        message = type("Message", (), {"content": "partial tool call", "tool_calls": None})()
+        choice = type("Choice", (), {"message": message, "finish_reason": "length"})()
+        # AgentTrajectoryTurn.__post_init__ reads Areno trajectory metadata off
+        # the response, so the fake must carry a minimal ``areno`` block.
+        return type("Response", (), {"choices": [choice], "areno": {"response_tokens": [], "response_logprobs": []}})()
+
+
+class _LengthFinishClient:
+    def __init__(self):
+        self.chat = type("Chat", (), {"completions": _LengthFinishCompletions()})()
+
+
 def test_chat_completion_retry_recovers_after_transient_failures(monkeypatch):
     sleeps = []
 
@@ -93,6 +112,34 @@ def test_no_tool_assistant_can_delegate_to_interaction_hook(tmp_path):
 
     assert phases == ["before_turn", "assistant_no_tool"]
     assert messages[-1] == {"role": "user", "content": "User runtime hint:\n128"}
+
+
+def test_agent_loop_honors_length_finish_reason_as_terminal(tmp_path):
+    """A ``finish_reason="length"`` response must end the loop without nudging."""
+
+    task = {"instance_id": "local", "repo": str(tmp_path)}
+    item = type("Item", (), {"record": task, "prompt": "run"})()
+    workspace = type("Workspace", (), {"task": task})()
+    client = _LengthFinishClient()
+    messages = [{"role": "user", "content": "run"}]
+
+    turns = asyncio.run(
+        agent_loop.run_conversation_turns(
+            client=client,
+            item=item,
+            workspace=workspace,
+            model="policy",
+            messages=messages,
+            max_turns=3,
+            record_trajectory=True,
+        )
+    )
+
+    # One model call, one recorded turn, and the loop stopped without nudging.
+    assert client.chat.completions.calls == 1
+    assert len(turns) == 1
+    assert messages[-1]["role"] == "assistant"
+    assert messages[-1]["content"] == "partial tool call"
 
 
 def test_run_command_streams_output_before_process_exits(tmp_path):

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -15,12 +15,41 @@ from areno.cli.train import (
     _format_summary_section,
     _format_training_config_summary,
     _trainer_config_from_options,
+    _training_config_settings,
 )
 
 
 def test_train_config_requires_ckpt():
     with pytest.raises(UsageError, match="--ckpt is required"):
         _trainer_config_from_options(**_options(ckpt=None, algo="sft"))
+
+
+def test_agent_overlength_policy_defaults_to_off():
+    cfg = TrainerConfig(algo="gspo", ckpt="x", dataset_path="x")
+    assert cfg.agent_overlength_policy == "off"
+
+
+def test_agent_overlength_policy_rejects_invalid_value():
+    with pytest.raises(ValueError, match="agent_overlength_policy must be one of"):
+        TrainerConfig(algo="gspo", ckpt="x", dataset_path="x", agent_overlength_policy="bogus")
+
+
+def test_agent_overlength_policy_rejects_invalid_cli_value():
+    result = CliRunner().invoke(train_cli.train_command, ["--agent-overlength-policy", "bogus"])
+    assert result.exit_code != 0
+    assert "agent-overlength-policy" in result.output
+
+
+def test_agent_overlength_policy_safe_stop_flows_into_config_summary_and_settings():
+    cfg = _trainer_config_from_options(**_options(algo="gspo", agent_overlength_policy="safe-stop"))
+    assert cfg.agent_overlength_policy == "safe-stop"
+
+    settings = _training_config_settings(cfg)
+    rollout_items = next(section["items"] for section in settings["sections"] if section["title"] == "Rollout")
+    assert next(item for item in rollout_items if item["key"] == "agent_overlength_policy")["value"] == "safe-stop"
+
+    summary = unstyle(_format_training_config_summary(cfg, reward_ckpt="reward-model"))
+    assert "safe-stop" in summary
 
 
 def test_train_config_requires_dataset_path():


### PR DESCRIPTION
## Summary

Closes #241 

This PR adds an opt-in, bounded overlength safe-stop policy to agentic multi-turn rollout (`--algo gspo/grpo/ppo` with `--agent-fn`) so that a trajectory that would be dropped wholesale can instead be retained up to the offending turn for partial credit, without placing parsing burden on the next turn.

- add `--agent-overlength-policy {off, safe-stop}`, default `off`
- distinguish `generation_limit` (hit `--max-new-tokens`, stopped mid tool call), `context_limit` (next-turn prompt exceeds `--max-context-len`), and `oversized_tool_result` (a single tool message alone exceeds `--max-context-len`)
- under `safe-stop`, drop the offending half-finished tool call / oversized tool result and retain the trajectory up to that turn; the item terminates instead of spinning to the step limit
- surface `rollout/overlength_{generation_limit,context_limit,oversized_tool_result,total}` TensorBoard scalars
- thread `termination_reason` through proxy `areno_meta`, `RewardRecord.metadata`, trace finish events, and post-filter diagnostics
- keep the feature disabled by default; non-agentic and sft/dpo paths are unaffected (additive-only changes to shared code)
- fix a main-path regression introduced in the initial implementation: `Trainer` has no `config` attribute, so any agentic rollout hitting `generation_limit` raised `AttributeError`, surfaced as `openai.InternalServerError: 500 'Trainer' object has no attribute 'config'`. Fixed by threading `agent_overlength_policy` from `PolicyOnlyTrainer.config` through `Trainer.rollout_session()` into `RolloutSession`; `_agent_overlength_policy()` never reads `trainer.config` unguarded, and the `_trainer_dp_size` legacy fallback is hardened the same way

## Usage

```bash
areno train \
  --ckpt Qwen/Qwen3-0.6B --model-hub modelscope \
  --algo gspo \
  --dataset-path tictactoe.jsonl \
  --dataset-loader-fn examples/agentic/tictactoe/dataset_loader.py \
  --reward-fn-path examples/agentic/tictactoe/reward.py \
  --agent-fn examples/agentic/tictactoe/run_agent.py \
  --batch-size 2 --n-samples 4 \
  --max-new-tokens 8 --max-context-len 512 --max-steps 2 \
  --agent-overlength-policy safe-stop \
  --metrics-log-dir /tmp/areno/metrics
```

`--agent-overlength-policy off` (default) preserves today's behavior byte-for-byte: half-finished tool calls parse as today, and overlength trajectories are still dropped by the post-filter with a warning. With `safe-stop`, the offending partial tool call / oversized tool result is dropped and the trajectory is retained up to that turn.

## Output

Under `--metrics-log-dir`, TensorBoard gains four scalars:

- `rollout/overlength_generation_limit` — samples cut at `--max-new-tokens`
- `rollout/overlength_context_limit` — samples whose next-turn prompt exceeded `--max-context-len`
- `rollout/overlength_oversized_tool_result` — samples with a single tool message exceeding `--max-context-len`
- `rollout/overlength_total` — sum of the above

`termination_reason` is also attached to `RewardRecord.metadata`, trace finish events, post-filter diagnostics, and the proxy `areno_meta` for client-side observability.

## Validation

Automated validation:

- full CPU test suite: `pytest tests/ -k cpu` → 386 passed
- focused overlength tests in `tests/test_agentic_overlength_cpu.py` (14 tests), including: `Trainer` without `.config` returns `off` without raising; threaded `safe-stop` honored when `.config` is absent; three-way reason classification; per-reason metrics; `off` preserves current behavior; invalid CLI value rejected
- related suites (`test_agentic_cpu` / `test_coding_agent_loop_cpu` / `test_train_cli_config_cpu`) → 124 passed
- ruff / strict Sphinx build: not run in this session — not claimed

Kaggle GPU validation:

- 2 × Tesla T4 (cc 7.5), CUDA, PyTorch; flash-attn / torch.compile fall back to native on T4 (expected)
- Qwen3-0.6B, tictactoe agentic, `world_size=2 --tp-size 1`, `--max-new-tokens 8 --max-context-len 512 --max-steps 2 --agent-overlength-policy safe-stop`
- no `500` across 2 rollout+train steps; finished via `max_steps_reached` (not a crash)
- `rollout/overlength_generation_limit=8, context_limit=0, oversized_tool_result=0, total=8` — all 8 samples classified as `generation_limit`, no second-turn accumulation so the other two reasons stay 0
- (`loss=0 / grad_norm=0` is expected under the 8-token cutoff: no legal move → no reward variance → zero GSPO advantage; this verifies the safe-stop plumbing, not effective training.)

## Files

Core: `areno/api/agentic.py`, `areno/api/trainer.py`, `areno/api/trainers/policy_only.py`, `areno/api/trainer_config.py`, `areno/api/metrics.py`, `areno/api/models.py`, `areno/api/openai_chat.py`, `areno/api/backend/areno/backend.py`, `areno/agent/agent_loop.py`, `areno/cli/train.py`.

Tests & docs: `tests/test_agentic_overlength_cpu.py` (new), `tests/test_coding_agent_loop_cpu.py`, `tests/test_train_cli_config_cpu.py`, `tests/test_agentic_cpu.py`, `docs/troubleshooting/agentic-rollout.rst`, `.agents/skills/areno-build-agentic-workflow/SKILL.md`.