### PR TITLE
feat(cli): add 'areno metrics' command to query TensorBoard metric history

### DIFF
--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -17,6 +17,7 @@ class ArenoCli(click.Group):
     _COMMANDS = {
         "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
+        "metrics": ("areno.cli.metrics", "metrics_command", "Query TensorBoard metric history from a local run."),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),

--- a/areno/cli/metrics.py
+++ b/areno/cli/metrics.py
@@ -130,7 +130,8 @@ def _sparkline(values: list[float], *, width: int = 40) -> str:
 
     if not values:
         return ""
-    if len(values) > width:
+    width = max(1, width)
+    if len(values) > width and width > 1:
         indices = [round(i * (len(values) - 1) / (width - 1)) for i in range(width)]
         sampled = [values[i] for i in indices]
     else:

--- a/areno/cli/metrics.py
+++ b/areno/cli/metrics.py
@@ -1,0 +1,208 @@
+"""CLI command for querying TensorBoard metric history from local run artifacts.
+
+Reads scalar tags and values from TensorBoard event files without starting a
+training run or loading a model.  When no metric name is given, lists all
+available scalar tags.  When a name is given, prints recent values, min/max,
+last value, and a compact sparkline trend.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import click
+
+
+@click.command(name="metrics", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--log-dir", required=True, help="Directory containing TensorBoard event files.")
+@click.option("--name", default=None, help="Metric tag to query. Omit to list available tags.")
+@click.option("--limit", default=50, help="Maximum number of recent points to display.")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON output.")
+def metrics_command(log_dir: str, name: str | None, limit: int, as_json: bool) -> None:
+    """Query TensorBoard scalar metric history from a local run directory."""
+
+    log_path = Path(log_dir)
+    if not log_path.exists():
+        click.echo(f"Error: log directory does not exist: {log_dir}", err=True)
+        raise SystemExit(1)
+
+    tags = _collect_scalar_tags(log_path)
+
+    if name is None:
+        if not tags:
+            click.echo("No TensorBoard scalar tags found in the given directory.")
+            return
+        if as_json:
+            click.echo(json.dumps({"tags": sorted(tags)}, indent=2))
+        else:
+            click.echo("Available metric tags:")
+            for tag in sorted(tags):
+                click.echo(f"  {tag}")
+        return
+
+    if name not in tags:
+        click.echo(f"Error: metric '{name}' not found.", err=True)
+        if tags:
+            click.echo("Available tags:", err=True)
+            for tag in sorted(tags):
+                click.echo(f"  {tag}", err=True)
+        else:
+            click.echo("No scalar tags found in the given directory.", err=True)
+        raise SystemExit(1)
+
+    points = _read_scalar_series(log_path, name, limit=limit)
+    if not points:
+        click.echo(f"Metric '{name}' has no valid data points.")
+        return
+
+    summary = _summarize(name, points)
+    if as_json:
+        click.echo(json.dumps(summary, indent=2, default=str))
+    else:
+        _print_summary(summary)
+
+
+def _collect_scalar_tags(log_dir: Path) -> set[str]:
+    """Return all scalar tags found across TensorBoard event files in *log_dir*."""
+
+    tags: set[str] = set()
+    for accumulator in _iter_accumulators(log_dir):
+        try:
+            tags.update(accumulator.Tags().get("scalars", []))
+        except Exception:
+            continue
+    return tags
+
+
+def _read_scalar_series(log_dir: Path, tag: str, *, limit: int = 50) -> list[dict[str, Any]]:
+    """Read scalar events for *tag*, returning sorted point dicts.
+
+    Each dict has ``step`` (int), ``value`` (float), and ``wall_time`` (float).
+    NaN/Inf values are skipped.  Results are sorted by step and truncated to
+    *limit* most recent points.
+    """
+
+    raw: list[tuple[int, float, float]] = []
+    for accumulator in _iter_accumulators(log_dir):
+        try:
+            events = accumulator.Scalars(tag)
+        except Exception:
+            continue
+        for event in events:
+            value = float(event.value)
+            if math.isnan(value) or math.isinf(value):
+                continue
+            raw.append((int(event.step), value, float(event.wall_time)))
+
+    raw.sort(key=lambda row: row[0])
+    # Deduplicate by step, keeping the last occurrence.
+    by_step: dict[int, tuple[int, float, float]] = {}
+    for step, value, wall_time in raw:
+        by_step[step] = (step, value, wall_time)
+    points = [{"step": step, "value": value, "wall_time": wall_time} for step, value, wall_time in by_step.values()]
+    return points[-max(1, min(limit, 10000)) :]
+
+
+def _summarize(name: str, points: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a summary dict for *name* from *points*."""
+
+    values = [float(p["value"]) for p in points]
+    steps = [int(p["step"]) for p in points]
+    return {
+        "name": name,
+        "count": len(points),
+        "first_step": steps[0] if steps else None,
+        "last_step": steps[-1] if steps else None,
+        "min_value": min(values) if values else None,
+        "max_value": max(values) if values else None,
+        "last_value": values[-1] if values else None,
+        "mean_value": sum(values) / len(values) if values else None,
+        "sparkline": _sparkline(values, width=40),
+        "recent": points[-20:],
+    }
+
+
+def _sparkline(values: list[float], *, width: int = 40) -> str:
+    """Render a compact ASCII sparkline for *values*."""
+
+    if not values:
+        return ""
+    if len(values) > width:
+        indices = [round(i * (len(values) - 1) / (width - 1)) for i in range(width)]
+        sampled = [values[i] for i in indices]
+    else:
+        sampled = values
+    lo = min(sampled)
+    hi = max(sampled)
+    if hi == lo:
+        return "_" * len(sampled)
+    levels = "\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588"
+    chars = []
+    for v in sampled:
+        normalized = (v - lo) / (hi - lo)
+        idx = min(int(normalized * (len(levels) - 1)), len(levels) - 1)
+        chars.append(levels[idx])
+    return "".join(chars)
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    """Print a human-readable metric summary."""
+
+    click.echo(f"Metric: {summary['name']}")
+    click.echo(f"  Points:    {summary['count']}")
+    click.echo(f"  Steps:     {summary['first_step']} -> {summary['last_step']}")
+    click.echo(f"  Min:       {_fmt(summary['min_value'])}")
+    click.echo(f"  Max:       {_fmt(summary['max_value'])}")
+    click.echo(f"  Last:      {_fmt(summary['last_value'])}")
+    click.echo(f"  Mean:      {_fmt(summary['mean_value'])}")
+    click.echo(f"  Trend:     {summary['sparkline']}")
+    recent = summary.get("recent", [])
+    if recent:
+        click.echo("  Recent:")
+        for point in recent:
+            step = point["step"]
+            value = _fmt(point["value"])
+            click.echo(f"    step {step:>6}: {value}")
+
+
+def _fmt(value: float | None) -> str:
+    """Format a numeric value for display."""
+
+    if value is None:
+        return "n/a"
+    if math.isnan(value):
+        return "NaN"
+    if math.isinf(value):
+        return "Inf" if value > 0 else "-Inf"
+    if abs(value) >= 1000 or (abs(value) < 0.001 and value != 0):
+        return f"{value:.4e}"
+    return f"{value:.6g}"
+
+
+def _iter_accumulators(log_dir: Path):
+    """Yield EventAccumulator instances for each event file in *log_dir*."""
+
+    try:
+        from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+    except Exception:
+        return
+
+    event_files = sorted(log_dir.rglob("events.out.tfevents.*"), key=lambda item: item.stat().st_mtime)
+    if event_files:
+        for event_file in event_files:
+            try:
+                accumulator = EventAccumulator(str(event_file), size_guidance={"scalars": 10000})
+                accumulator.Reload()
+                yield accumulator
+            except Exception:
+                continue
+    else:
+        try:
+            accumulator = EventAccumulator(str(log_dir), size_guidance={"scalars": 10000})
+            accumulator.Reload()
+            yield accumulator
+        except Exception:
+            return

--- a/areno/cli/metrics.py
+++ b/areno/cli/metrics.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -183,8 +184,12 @@ def _fmt(value: float | None) -> str:
     return f"{value:.6g}"
 
 
-def _iter_accumulators(log_dir: Path):
-    """Yield EventAccumulator instances for each event file in *log_dir*."""
+def _iter_accumulators(log_dir: Path) -> Iterator[Any]:
+    """Yield EventAccumulator instances for each event file in *log_dir*.
+
+    ``Any`` is used because ``EventAccumulator`` is imported lazily inside the
+    function to avoid a hard dependency on tensorboard at module import time.
+    """
 
     try:
         from tensorboard.backend.event_processing.event_accumulator import EventAccumulator

--- a/docs/cli/metrics.rst
+++ b/docs/cli/metrics.rst
@@ -82,4 +82,6 @@ Limitations
 * Reads only TensorBoard scalar tags; text, images, and histograms are not
   supported.
 * NaN and Inf values are silently skipped.
+* When the same step appears in multiple event files (e.g. after a training
+  restart), the value from the last file is kept.
 * The command does not modify stored data; it is read-only.

--- a/docs/cli/metrics.rst
+++ b/docs/cli/metrics.rst
@@ -1,0 +1,85 @@
+:orphan:
+
+Metrics CLI reference
+=====================
+
+``areno metrics`` reads scalar tags and values from local TensorBoard event
+files without starting a training run or loading a model.  When no metric name
+is given, it lists all available scalar tags.  When a name is given, it prints
+recent values, min/max, last value, mean, and a compact sparkline trend.
+
+.. code-block:: bash
+
+   areno metrics --log-dir /tmp/areno/tfevent
+
+Example output:
+
+.. code-block:: text
+
+   Available metric tags:
+     rollout/rewards_mean
+     train/policy_loss
+
+To query a specific metric:
+
+.. code-block:: bash
+
+   areno metrics --log-dir /tmp/areno/tfevent --name train/policy_loss
+
+Example output:
+
+.. code-block:: text
+
+   Metric: train/policy_loss
+     Points:    3
+     Steps:     0 -> 2
+     Min:       0.25
+     Max:       1
+     Last:      0.25
+     Mean:      0.583333
+     Trend:     ▆▃▁
+     Recent:
+       step      0: 1
+       step      1: 0.5
+       step      2: 0.25
+
+For machine-readable output:
+
+.. code-block:: bash
+
+   areno metrics --log-dir /tmp/areno/tfevent --name train/policy_loss --json
+
+The JSON output includes:
+
+* ``name`` — metric tag
+* ``count`` — number of valid data points
+* ``first_step`` / ``last_step`` — step range
+* ``min_value`` / ``max_value`` / ``last_value`` / ``mean_value`` — summary statistics
+* ``sparkline`` — compact ASCII trend
+* ``recent`` — list of recent ``{step, value, wall_time}`` points
+
+Options
+-------
+
+``--log-dir`` (required)
+    Directory containing TensorBoard event files.  The command searches
+    recursively for ``events.out.tfevents.*`` files.
+
+``--name``
+    Metric tag to query.  Omit to list all available tags.  When the tag is not
+    found, the command exits with an error and lists available tag names.
+
+``--limit`` (default: 50)
+    Maximum number of recent points to display.  Memory is bounded by this
+    limit and the TensorBoard ``size_guidance`` setting.
+
+``--json``
+    Emit machine-readable JSON output instead of a human-readable table.
+
+Limitations
+-----------
+
+* Reads only TensorBoard scalar tags; text, images, and histograms are not
+  supported.
+* NaN and Inf values are silently skipped.
+* The command does not modify stored data; it is read-only.

--- a/tests/test_cli_metrics_cpu.py
+++ b/tests/test_cli_metrics_cpu.py
@@ -143,6 +143,43 @@ class CliMetricsTest(unittest.TestCase):
         self.assertEqual(parsed["count"], 10)
         self.assertEqual(parsed["last_step"], 99)
 
+    def test_limit_zero_returns_one_point(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0), (1, 0.5), (2, 0.25)]})
+            result = CliRunner().invoke(
+                main, ["metrics", "--log-dir", tmp, "--name", "train/loss", "--limit", "0", "--json"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        # limit=0 is clamped to max(1, 0) = 1
+        self.assertEqual(parsed["count"], 1)
+
+    def test_limit_negative_returns_one_point(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0), (1, 0.5), (2, 0.25)]})
+            result = CliRunner().invoke(
+                main, ["metrics", "--log-dir", tmp, "--name", "train/loss", "--limit", "-1", "--json"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        # limit=-1 is clamped to max(1, -1) = 1
+        self.assertEqual(parsed["count"], 1)
+
+    def test_limit_exceeds_cap_returns_all(self):
+        points = [(i, float(i)) for i in range(100)]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": points})
+            result = CliRunner().invoke(
+                main, ["metrics", "--log-dir", tmp, "--name", "train/loss", "--limit", "99999", "--json"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        # limit=99999 is capped to min(99999, 10000) = 10000, but only 100 points exist
+        self.assertEqual(parsed["count"], 100)
+
     def test_sparkline_renders_for_constant_values(self):
         self.assertEqual(metrics_module._sparkline([5.0, 5.0, 5.0]), "___")
 

--- a/tests/test_cli_metrics_cpu.py
+++ b/tests/test_cli_metrics_cpu.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+
+from click.testing import CliRunner
+
+from areno.cli import metrics as metrics_module
+from areno.cli.main import main
+
+
+def _write_test_events(log_dir: str, *, tags: dict[str, list[tuple[int, float]]]) -> None:
+    """Write TensorBoard event files with the given scalar tags and values."""
+
+    from torch.utils.tensorboard import SummaryWriter
+
+    writer = SummaryWriter(log_dir=log_dir)
+    for tag, points in tags.items():
+        for step, value in points:
+            writer.add_scalar(tag, value, step)
+    writer.flush()
+    writer.close()
+
+
+class CliMetricsTest(unittest.TestCase):
+    def test_top_level_cli_lists_metrics(self):
+        result = CliRunner().invoke(main, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("metrics", result.output)
+
+    def test_metrics_help_lists_options(self):
+        result = CliRunner().invoke(main, ["metrics", "--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--log-dir", result.output)
+        self.assertIn("--name", result.output)
+        self.assertIn("--json", result.output)
+        self.assertIn("--limit", result.output)
+
+    def test_list_tags_prints_available_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0), (1, 0.5)], "rollout/reward": [(0, 0.1)]})
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("train/loss", result.output)
+        self.assertIn("rollout/reward", result.output)
+
+    def test_list_tags_json_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0)]})
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp, "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertIn("tags", parsed)
+        self.assertIn("train/loss", parsed["tags"])
+
+    def test_query_metric_prints_summary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0), (1, 0.5), (2, 0.25)]})
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp, "--name", "train/loss"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Metric: train/loss", result.output)
+        self.assertIn("Min:", result.output)
+        self.assertIn("Max:", result.output)
+        self.assertIn("Last:", result.output)
+        self.assertIn("step", result.output)
+
+    def test_query_metric_json_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0), (1, 0.5), (2, 0.25)]})
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp, "--name", "train/loss", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["name"], "train/loss")
+        self.assertEqual(parsed["count"], 3)
+        self.assertEqual(parsed["min_value"], 0.25)
+        self.assertEqual(parsed["max_value"], 1.0)
+        self.assertEqual(parsed["last_value"], 0.25)
+        self.assertIsNotNone(parsed["first_step"])
+        self.assertIsNotNone(parsed["last_step"])
+        self.assertIn("sparkline", parsed)
+
+    def test_metric_not_found_lists_available(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": [(0, 1.0)]})
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp, "--name", "nonexistent"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("not found", result.output)
+        self.assertIn("train/loss", result.output)
+
+    def test_nonexistent_log_dir_errors(self):
+        result = CliRunner().invoke(main, ["metrics", "--log-dir", "/definitely/nonexistent/path"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output)
+
+    def test_empty_directory_prints_friendly_message(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No TensorBoard scalar tags", result.output)
+
+    def test_nan_values_are_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(
+                tmp,
+                tags={
+                    "train/loss": [
+                        (0, float("nan")),
+                        (1, 0.5),
+                        (2, float("inf")),
+                        (3, 0.25),
+                    ]
+                },
+            )
+            result = CliRunner().invoke(main, ["metrics", "--log-dir", tmp, "--name", "train/loss", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        # Only the two finite values should appear.
+        self.assertEqual(parsed["count"], 2)
+        self.assertEqual(parsed["min_value"], 0.25)
+        self.assertEqual(parsed["max_value"], 0.5)
+
+    def test_limit_truncates_points(self):
+        points = [(i, float(i)) for i in range(100)]
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_test_events(tmp, tags={"train/loss": points})
+            result = CliRunner().invoke(
+                main, ["metrics", "--log-dir", tmp, "--name", "train/loss", "--limit", "10", "--json"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["count"], 10)
+        self.assertEqual(parsed["last_step"], 99)
+
+    def test_sparkline_renders_for_constant_values(self):
+        self.assertEqual(metrics_module._sparkline([5.0, 5.0, 5.0]), "___")
+
+    def test_sparkline_renders_for_varied_values(self):
+        result = metrics_module._sparkline([0.0, 1.0])
+        self.assertEqual(len(result), 2)
+        self.assertNotEqual(result[0], result[1])
+
+    def test_fmt_handles_special_values(self):
+        self.assertEqual(metrics_module._fmt(None), "n/a")
+        self.assertEqual(metrics_module._fmt(float("nan")), "NaN")
+        self.assertEqual(metrics_module._fmt(float("inf")), "Inf")
+        self.assertEqual(metrics_module._fmt(float("-inf")), "-Inf")
+
+    def test_fmt_preserves_precision(self):
+        self.assertIn("e", metrics_module._fmt(1e-10))
+        self.assertIn("e", metrics_module._fmt(10000.0))
+        self.assertEqual(metrics_module._fmt(0.5), "0.5")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `areno metrics`, a new CLI subcommand for querying TensorBoard scalar metric history from local run artifacts.

Closes #254

## What does this PR do?

Adds `areno metrics`, a read-only CLI subcommand that reads scalar tags and values from local TensorBoard event files without starting a training run or loading a model.

- Without `--name`: lists all available scalar tags
- With `--name`: prints recent values, min/max, last value, mean, sparkline trend, and recent points
- `--json` flag for machine-readable output
- `--limit` to bound memory (default 50, max 10000)
- NaN/Inf values skipped; deduplicates by step
- Lists available tag names on mismatch

**Files changed:**
- `areno/cli/metrics.py` — new CLI command
- `areno/cli/main.py` — register `metrics` in `_COMMANDS`
- `tests/test_cli_metrics_cpu.py` — 18 CPU tests
- `docs/cli/metrics.rst` — user documentation

## Related issue

Fixes #254

## Type of change

- [x] ✨ New feature

## How was it tested?

```
pytest tests/test_cli_metrics_cpu.py -v          # 18 new tests
pytest tests/ -k cpu                              # 382 total CPU tests
ruff check areno/cli/metrics.py tests/test_cli_metrics_cpu.py
ruff format --check areno/cli/metrics.py tests/test_cli_metrics_cpu.py
```

Unit tests on macOS (Python 3.12, CPU-only PyTorch). Also verified on Kaggle with dual T4 GPUs: ran SFT training on Qwen/Qwen3.5-0.8B, then queried metrics with `areno metrics --log-dir /tmp/areno/tfevent --name train/loss` — successfully read 50 data points with correct min/max/mean values.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (Fixes #254).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests (18 CPU tests).
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible.