### PR TITLE
feat:Unify overlength sample handling across training modes

### DIFF
--- a/areno/api/data.py
+++ b/areno/api/data.py
@@ -4,12 +4,57 @@
 tokenising a dataset row. `PromptBatch` groups a fixed-size set of items
 together and carries diagnostic counters so the trainer can surface how many
 records were skipped for exceeding the prompt-length budget.
+
+The `Overlength*` types below are the unified contract for issue #216: a single
+policy (`reject` / `warn` / `truncate`) and per-reason counters shared by SFT,
+DPO, and agentic trajectories, replacing the ad-hoc reject-only checks that
+used to live in each trainer.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
+
+
+class OverlengthPolicy(str, Enum):
+    """How to handle a sample that exceeds the configured token budget."""
+
+    REJECT = "reject"
+    WARN = "warn"
+    TRUNCATE = "truncate"
+
+
+class OverlengthReason(str, Enum):
+    """Why a sample was flagged by the overlength policy.
+
+    `WITHIN_BUDGET` marks a sample that fit the budgets (no action needed); it
+    exists so callers/tests can assert the non-overlength path deterministically.
+    `EXACT_LIMIT` marks the boundary where a length equals (not exceeds) its cap.
+    """
+
+    WITHIN_BUDGET = "within_budget"
+    EXACT_LIMIT = "exact_limit"
+    PROMPT_TOO_LONG = "prompt_too_long"
+    RESPONSE_TOO_LONG = "response_too_long"
+    SINGLE_MESSAGE_OVERSIZED = "single_message_oversized"
+    TRAJECTORY_TOO_LONG = "trajectory_too_long"
+
+
+@dataclass(slots=True)
+class OverlengthDecision:
+    """The result of classifying one sample (or pair / trajectory) under a policy.
+
+    `detail` carries bounded diagnostics (stage, over-by token count, truncation
+    point) and never the full training-sample text, so logs/metrics stay safe to
+    surface. `truncated` is True only when the policy actually cut the sample.
+    """
+
+    action: OverlengthPolicy
+    reason: OverlengthReason
+    truncated: bool = False
+    detail: dict[str, Any] | None = None
 
 
 @dataclass(slots=True)
@@ -36,12 +81,19 @@ class PromptBatch:
     (including skips), `skipped_long` is how many were dropped this round, and
     `total_skipped_long` accumulates the drop count across the epoch so the
     metric logger can report it as a cumulative counter.
+
+    `overlength_counters` carries per-reason, per-action counts
+    (``{f"{reason}/{action}": count}``) for issue #216's unified diagnostics.
+    The legacy `skipped_long` / `total_skipped_long` fields stay so existing
+    callers and tests keep working; under the default `reject` policy their
+    values match the pre-#216 behavior exactly.
     """
 
     items: list[PromptItem]
     scanned: int
     skipped_long: int
     total_skipped_long: int
+    overlength_counters: dict[str, int] = field(default_factory=dict)
 
     @property
     def prompts(self) -> list[str]:

--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -31,13 +31,24 @@ class MetricsRecorder:
         self._sample_file = self._log_dir / f"rollout_samples.{os.getpid()}.jsonl"
         self._closed = False
 
-    def record_train_step(self, *, step: int, train_result, train_batch, timings: dict[str, float] | None = None):
+    def record_train_step(
+        self,
+        *,
+        step: int,
+        train_result,
+        train_batch,
+        timings: dict[str, float] | None = None,
+        overlength_counters: dict[str, int] | None = None,
+    ):
         """Record rollout, training, and timing metrics for one step."""
 
         # `collect_train_batch_stats` extracts only the response-side numbers
         # (prompt tokens are masked out) so reported means match what the loss
-        # actually trained on.
-        stats = collect_train_batch_stats(train_batch)
+        # actually trained on. `overlength_counters` carries issue #216
+        # per-reason/per-action counts populated by the trainer (e.g. agentic
+        # trajectory filtering); it is injected into the stats accumulator so
+        # `record_training_stats` can emit `rollout/overlength/*` scalars.
+        stats = collect_train_batch_stats(train_batch, overlength_counters=overlength_counters)
         record_training_stats(self._writer, stats, step, train_result, train_batch, timings=timings)
 
     def record_rollout_sample(self, sample: dict) -> None:
@@ -123,16 +134,20 @@ def create_tensorboard_writer(log_dir: str):
     return SummaryWriter(log_dir=log_dir)
 
 
-def collect_train_batch_stats(train_batch) -> dict:
+def collect_train_batch_stats(train_batch, overlength_counters: dict[str, int] | None = None) -> dict:
     """Summarize rewards, advantages, lengths, and rollout logprobs.
 
     Walks every `TrainSequence` and isolates response-only slices using
     `prompt_mask`. Prompt positions carry zeroed advantage/logprob entries by
     construction (see trainer code), so dropping them gives an honest mean
     over the tokens that actually participated in the loss.
+
+    `overlength_counters` (issue #216) is forwarded into the accumulator so
+    `record_training_stats` can emit `rollout/overlength/{reason}/{action}`
+    scalars for counts the trainer populated during rollout filtering.
     """
 
-    stats = init_rollout_stats()
+    stats = init_rollout_stats(overlength_counters=overlength_counters)
     for seq in train_batch:
         prompt_mask = list(seq.prompt_mask)
         # `prompt_mask[i] == True` marks a prompt token; rollout signals only

--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -152,8 +152,17 @@ def collect_train_batch_stats(train_batch) -> dict:
     return stats
 
 
-def init_rollout_stats(skipped_long: int = 0, total_skipped_long: int = 0) -> dict:
-    """Create the mutable stats accumulator used by metric helpers."""
+def init_rollout_stats(
+    skipped_long: int = 0,
+    total_skipped_long: int = 0,
+    overlength_counters: dict[str, int] | None = None,
+) -> dict:
+    """Create the mutable stats accumulator used by metric helpers.
+
+    `overlength_counters` carries the issue #216 per-reason, per-action counts
+    (``{f"{reason}/{action}": count}``). It defaults to an empty dict so callers
+    that do not feed it in keep the pre-#216 behavior.
+    """
 
     return {
         "rewards": [],
@@ -164,6 +173,7 @@ def init_rollout_stats(skipped_long: int = 0, total_skipped_long: int = 0) -> di
         "response_len": [],
         "skipped_long": skipped_long,
         "total_skipped_long": total_skipped_long,
+        "overlength_counters": dict(overlength_counters) if overlength_counters else {},
     }
 
 
@@ -210,6 +220,11 @@ def record_training_stats(writer, stats, step, train_res, train_batch, timings: 
     for key in ("skipped_long", "total_skipped_long"):
         if key in stats:
             writer.add_scalar(f"rollout/{key}", stats[key], step)
+    # Issue #216: emit one scalar per (reason, action) so operators can see why
+    # and how samples were dropped/kept/truncated across training modes.
+    overlength_counters = stats.get("overlength_counters") or {}
+    for counter_key, count in overlength_counters.items():
+        writer.add_scalar(f"rollout/overlength/{counter_key}", count, step)
 
     # Backend-supplied training metrics (loss, policy_loss, ratio_mean, ...).
     for key, value in train_res.items():

--- a/areno/api/overlength.py
+++ b/areno/api/overlength.py
@@ -1,0 +1,189 @@
+"""Unified overlength-sample handling across training modes.
+
+Issue #216 asks AReno to replace its scattered, reject-only "sample exceeds the
+token budget" checks with one explicit contract that supports three policies
+(``reject``, ``warn``, ``truncate``) for SFT, DPO pairs, and agentic
+trajectories. This module owns the policy decision and the per-mode safe
+truncation helpers; the dataclasses live in :mod:`areno.api.data` and the
+metric counters flow through :mod:`areno.api.metrics`.
+
+Phase 1 introduced the contract and ``decide_overlength``. Phase 2 added the
+SFT safe-truncation helper. Phase 3 adds the DPO pair helper that keeps
+chosen/rejected comparable; the agentic helper arrives in a later phase.
+"""
+
+from __future__ import annotations
+
+from areno.api.data import OverlengthDecision, OverlengthPolicy, OverlengthReason
+
+__all__ = ["decide_overlength", "truncate_sft_response", "truncate_dpo_pair"]
+
+
+def decide_overlength(
+    *,
+    prompt_len: int,
+    max_prompt_tokens: int,
+    response_len: int | None = None,
+    max_new_tokens: int | None = None,
+    policy: OverlengthPolicy = OverlengthPolicy.REJECT,
+) -> OverlengthDecision:
+    """Classify one sample against the token budgets under ``policy``.
+
+    The decision is pure and deterministic: identical inputs always yield the
+    same :class:`OverlengthDecision`. ``response_len``/``max_new_tokens`` are
+    optional because the RL prompt-side path only inspects the prompt budget.
+
+    A prompt that exactly matches ``max_prompt_tokens`` is *not* overlength;
+    callers rely on this boundary so ``max_prompt_tokens`` is an inclusive cap.
+    """
+
+    if max_prompt_tokens <= 0:
+        raise ValueError("max_prompt_tokens must be positive")
+    if max_new_tokens is not None and max_new_tokens <= 0:
+        raise ValueError("max_new_tokens must be positive when provided")
+    if not isinstance(policy, OverlengthPolicy):
+        raise ValueError(f"policy must be an OverlengthPolicy, got {type(policy).__name__}")
+
+    over_by = 0
+    reason: OverlengthReason | None = None
+
+    if prompt_len > max_prompt_tokens:
+        # A prompt that already exceeds the budget cannot be safely truncated
+        # when it is a single base-prompt string (no chat-turn boundary to cut
+        # on). Later phases refine this for chat-message prompts; for now it is
+        # reported as a single oversized message.
+        reason = OverlengthReason.SINGLE_MESSAGE_OVERSIZED
+        over_by = prompt_len - max_prompt_tokens
+    elif response_len is not None and max_new_tokens is not None and response_len > max_new_tokens:
+        reason = OverlengthReason.RESPONSE_TOO_LONG
+        over_by = response_len - max_new_tokens
+
+    if reason is None:
+        # Within budget. `EXACT_LIMIT` marks the inclusive boundary (length ==
+        # cap, not exceeding it); otherwise the sample simply fit, reported as
+        # WITHIN_BUDGET. Neither case triggers an action.
+        within_reason = (
+            OverlengthReason.EXACT_LIMIT if prompt_len == max_prompt_tokens else OverlengthReason.WITHIN_BUDGET
+        )
+        return OverlengthDecision(action=policy, reason=within_reason, truncated=False, detail=None)
+
+    truncated = policy is OverlengthPolicy.TRUNCATE
+    return OverlengthDecision(
+        action=policy,
+        reason=reason,
+        truncated=truncated,
+        detail={"over_by_tokens": over_by},
+    )
+
+
+def truncate_sft_response(
+    *,
+    prompt_ids: list[int],
+    response_ids: list[int],
+    max_new_tokens: int,
+    eos_token_ids: tuple[int, ...] | None = None,
+) -> tuple[list[int], list[bool], bool]:
+    """Cut an SFT response to ``max_new_tokens`` at a token boundary, keeping EOS.
+
+    Operates on already-tokenized ids so the result is deterministic and never
+    re-pieces text. If the response already fits, it is returned unchanged with
+    ``truncated=False``. When the cut drops the trailing EOS, the first available
+    EOS id (from ``eos_token_ids``) is re-appended so the sequence still
+    terminates correctly; if no EOS ids are supplied the cut stands as-is.
+
+    Returns ``(tokens, prompt_mask, truncated)`` where ``prompt_mask`` masks the
+    prompt prefix (``True``) and leaves the response trainable (``False``).
+    """
+
+    if max_new_tokens <= 0:
+        raise ValueError("max_new_tokens must be positive")
+
+    if len(response_ids) <= max_new_tokens:
+        tokens = list(prompt_ids) + list(response_ids)
+        mask = [True] * len(prompt_ids) + [False] * len(response_ids)
+        return tokens, mask, False
+
+    cut = list(response_ids[:max_new_tokens])
+    # Re-append an EOS if the cut removed it. We only append when there is at
+    # least one response token to train on after the prompt; otherwise the
+    # sequence cannot produce a next-token loss and the caller should reject it.
+    if cut and eos_token_ids and cut[-1] not in eos_token_ids:
+        cut.append(eos_token_ids[0])
+    tokens = list(prompt_ids) + cut
+    mask = [True] * len(prompt_ids) + [False] * len(cut)
+    return tokens, mask, True
+
+
+def truncate_dpo_pair(
+    *,
+    chosen_tokens: list[int],
+    chosen_mask: list[bool],
+    rejected_tokens: list[int],
+    rejected_mask: list[bool],
+    prefix_len: int,
+    max_seq_len: int,
+    eos_token_ids: tuple[int, ...] | None = None,
+) -> tuple[list[int], list[bool], list[int], list[bool], bool] | None:
+    """Truncate a DPO chosen/rejected pair to a common budget, keeping it comparable.
+
+    The shared prefix (first ``prefix_len`` tokens) is never touched, so both
+    branches keep the same prompt context. Each divergent suffix is cut to
+    ``budget = max_seq_len - prefix_len`` at a token boundary; if the cut drops
+    the trailing EOS, the first available EOS id is re-appended. Both sides use
+    the *same* budget, so after truncation chosen and rejected are still aligned
+    on the prefix and directly comparable for the DPO margin loss.
+
+    Returns ``(chosen_tokens, chosen_mask, rejected_tokens, rejected_mask,
+    truncated)`` on success, or ``None`` when either side cannot fit even at the
+    minimum (prefix + EOS) — the caller should then reject the whole pair rather
+    than keep an incomparable single side. When neither side exceeds
+    ``max_seq_len`` the pair is returned unchanged with ``truncated=False``.
+    """
+
+    if max_seq_len <= 0:
+        raise ValueError("max_seq_len must be positive")
+    if prefix_len < 0 or prefix_len > min(len(chosen_tokens), len(rejected_tokens)):
+        raise ValueError("prefix_len must fit within both token sequences")
+
+    # Fast path: both sides already fit.
+    if len(chosen_tokens) <= max_seq_len and len(rejected_tokens) <= max_seq_len:
+        return (
+            list(chosen_tokens),
+            list(chosen_mask),
+            list(rejected_tokens),
+            list(rejected_mask),
+            False,
+        )
+
+    eos_id = eos_token_ids[0] if eos_token_ids else None
+
+    def _cut_side(tokens: list[int], mask: list[bool]) -> tuple[list[int], list[bool]] | None:
+        if len(tokens) <= max_seq_len:
+            return list(tokens), list(mask)
+        # Keep the prefix, trim the divergent suffix to the budget.
+        suffix = list(tokens[prefix_len:max_seq_len])
+        # Re-append EOS if the cut removed it. The cut already lands at
+        # max_seq_len, so appending would exceed it; instead replace the last
+        # cut token with EOS so the total stays within budget. When there is no
+        # suffix room beyond the prefix, the side is untrainable -> return None.
+        if eos_id is not None and (not suffix or suffix[-1] != eos_id):
+            if len(suffix) >= 1:
+                suffix[-1] = eos_id
+            else:
+                # No suffix room beyond prefix; this side is un-trainable.
+                return None
+        new_tokens = list(tokens[:prefix_len]) + suffix
+        new_mask = list(mask[:prefix_len]) + [False] * len(suffix)
+        if len(new_tokens) > max_seq_len:
+            return None
+        return new_tokens, new_mask
+
+    cut_chosen = _cut_side(chosen_tokens, chosen_mask)
+    cut_rejected = _cut_side(rejected_tokens, rejected_mask)
+    if cut_chosen is None or cut_rejected is None:
+        # Either side cannot fit even at minimum; reject the whole pair to keep
+        # chosen/rejected comparable (never keep only one side).
+        return None
+    if len(cut_chosen[0]) < 2 or len(cut_rejected[0]) < 2:
+        return None
+    return cut_chosen[0], cut_chosen[1], cut_rejected[0], cut_rejected[1], True

--- a/areno/api/overlength.py
+++ b/areno/api/overlength.py
@@ -104,11 +104,15 @@ def truncate_sft_response(
         return tokens, mask, False
 
     cut = list(response_ids[:max_new_tokens])
-    # Re-append an EOS if the cut removed it. We only append when there is at
-    # least one response token to train on after the prompt; otherwise the
-    # sequence cannot produce a next-token loss and the caller should reject it.
+    # Re-append an EOS if the cut removed it. Appending would make the cut one
+    # token longer than `max_new_tokens`, breaking the budget; instead replace
+    # the last cut token with EOS so the total stays within budget. This matches
+    # `truncate_dpo_pair`'s EOS handling so both truncators obey the same length
+    # contract. We only replace when there is at least one response token to
+    # train on after the prompt; otherwise the sequence cannot produce a
+    # next-token loss and the caller should reject it.
     if cut and eos_token_ids and cut[-1] not in eos_token_ids:
-        cut.append(eos_token_ids[0])
+        cut[-1] = eos_token_ids[0]
     tokens = list(prompt_ids) + cut
     mask = [True] * len(prompt_ids) + [False] * len(cut)
     return tokens, mask, True

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -369,6 +369,19 @@ class Trainer:
         if self._metrics is not None:
             self._metrics.record_rollout_sample(sample)
 
+    def record_overlength_counters(self, counters: dict[str, int]) -> None:
+        """Surface per-reason/per-action overlength counts for the current step.
+
+        Issue #216: trainers (SFT/DPO/agentic) call this with the counts they
+        collected during rollout filtering so `record_train_step` can emit
+        ``rollout/overlength/{reason}/{action}`` scalars. The counts replace
+        the step accumulator and are flushed on the next ``train()`` call;
+        ``_begin_step`` resets them so counts never leak across steps.
+        """
+
+        if counters:
+            self._step_overlength_counters = dict(counters)
+
     def record_dashboard_state(
         self,
         *,

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -60,6 +60,11 @@ class Trainer:
         self._metric_timings: dict[str, float] = {}
         self._step_active = False
         self._step_wall_start: float | None = None
+        # Issue #216: per-step overlength counters populated by the trainer
+        # (e.g. agentic trajectory filtering) and flushed by `record_train_step`
+        # alongside the rollout/train scalars. Reset every step like
+        # `_metric_timings` so counts never leak across steps.
+        self._step_overlength_counters: dict[str, int] = {}
         self._rollout_session_depth = 0
         self._rollout_wall_start: float | None = None
 
@@ -92,6 +97,7 @@ class Trainer:
             return
         self._ctx.step()
         self._metric_timings = {}
+        self._step_overlength_counters = {}
         self._step_active = True
         self._step_wall_start = time.perf_counter()
 
@@ -352,6 +358,7 @@ class Trainer:
                 train_result=result,
                 train_batch=batch_data,
                 timings=self._metric_timings,
+                overlength_counters=self._step_overlength_counters,
             )
         self.finish_step()
         return result

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -60,12 +60,20 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     chat_template_enable_thinking: bool | None = None
+    # Issue #216: how to handle samples that exceed the token budget. Default
+    # "reject" preserves the pre-#216 behavior exactly; "warn" keeps overlength
+    # samples and counts them; "truncate" cuts at a semantically safe boundary
+    # (for agentic trajectories, truncate degrades to reject because per-turn
+    # token offsets are not available yet).
+    overlength_policy: str = "reject"
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:
             raise ValueError("attn_backend must be one of: flash, native")
         if self.model_hub not in {"hf", "modelscope"}:
             raise ValueError("model_hub must be one of: hf, modelscope")
+        if self.overlength_policy not in {"reject", "warn", "truncate"}:
+            raise ValueError("overlength_policy must be one of: reject, warn, truncate")
 
     def optimizer_config(self) -> dict:
         """Build the optimizer dict consumed by the backend config."""

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -20,7 +20,9 @@ from typing import Any
 
 import areno.api
 from areno.api.dashboard import record_dashboard_state
+from areno.api.data import OverlengthPolicy
 from areno.api.data_utils import apply_chat_template, encode_prompt_value, response_to_tokens_and_mask
+from areno.api.overlength import truncate_dpo_pair
 from areno.api.roles import ModelRole
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
@@ -135,19 +137,35 @@ class DPOTrainer:
     def _iter_train_batches(self, tokenizer, *, max_seq_len: int):
         # `batch_size` counts preference pairs; the emitted train batch has two
         # rows per pair and always preserves chosen/rejected adjacency.
+        policy = getattr(self.config, "overlength_policy", "reject")
         batch = []
-        skipped = 0
+        skipped_invalid = 0
+        overlength_counters: dict[str, int] = {}
         for index in range(len(self.dataset)):
-            pair = _record_to_train_pair(self.dataset[index], tokenizer, max_seq_len=max_seq_len)
+            # `overlength_counters` is mutated as a side effect when a pair is
+            # dropped/truncated for being over budget; an invalid pair leaves it
+            # untouched so the two drop reasons can be distinguished.
+            before = sum(overlength_counters.values())
+            pair = _record_to_train_pair(
+                self.dataset[index],
+                tokenizer,
+                max_seq_len=max_seq_len,
+                policy=policy,
+                counters=overlength_counters,
+            )
             if pair is None:
-                skipped += 1
+                if sum(overlength_counters.values()) == before:
+                    skipped_invalid += 1
                 continue
             batch.extend(pair)
             if len(batch) >= self.config.batch_size * 2:
                 yield batch
                 batch = []
-        if skipped:
-            self.logger.info("stage=dpo_dataset_filter skipped_invalid_or_long=%d", skipped)
+        if skipped_invalid or overlength_counters:
+            parts = [f"skipped_invalid={skipped_invalid}"]
+            for key, count in sorted(overlength_counters.items()):
+                parts.append(f"{key}={count}")
+            self.logger.info("stage=dpo_dataset_filter %s", " ".join(parts))
         if batch:
             yield batch
 
@@ -162,12 +180,24 @@ class DPOTrainer:
         record_dashboard_state(self.areno, stage="save_checkpoint_end", epoch=epoch, step=step, role="policy")
 
 
-def _record_to_train_pair(record: Any, tokenizer, *, max_seq_len: int):
+def _record_to_train_pair(
+    record: Any,
+    tokenizer,
+    *,
+    max_seq_len: int,
+    policy: str = "reject",
+    counters: dict[str, int] | None = None,
+):
     record = dict(record)
     eos_token_id = tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 0
     if "chosen" not in record or "rejected" not in record:
         raise ValueError("DPO dataset row must contain `chosen` and `rejected`")
     chosen, rejected = record["chosen"], record["rejected"]
+
+    def _count(reason_value: str) -> None:
+        if counters is not None:
+            key = f"{reason_value}/{policy}"
+            counters[key] = counters.get(key, 0) + 1
 
     if isinstance(chosen, list) and isinstance(rejected, list):
         # Preference datasets sometimes store full chosen/rejected chats. The
@@ -187,18 +217,71 @@ def _record_to_train_pair(record: Any, tokenizer, *, max_seq_len: int):
         prompt_ids = encode_prompt_value(tokenizer, prompt)
         chosen_tokens, chosen_mask = response_to_tokens_and_mask(prompt_ids, str(chosen), tokenizer, eos_token_id)
         rejected_tokens, rejected_mask = response_to_tokens_and_mask(prompt_ids, str(rejected), tokenizer, eos_token_id)
+        prefix_len = len(prompt_ids)
 
-    chosen_seq = _make_sequence(chosen_tokens, chosen_mask, eos_token_id, max_seq_len)
-    rejected_seq = _make_sequence(rejected_tokens, rejected_mask, eos_token_id, max_seq_len)
-    if chosen_seq is None or rejected_seq is None:
+    # Pair-level overlength check: if either side exceeds the budget, the whole
+    # pair is handled together so chosen/rejected stay comparable.
+    chosen_over = len(chosen_tokens) > max_seq_len
+    rejected_over = len(rejected_tokens) > max_seq_len
+    if not chosen_over and not rejected_over:
+        # Both sides fit; still validate each is trainable, else reject as invalid.
+        chosen_seq = _make_sequence(chosen_tokens, chosen_mask, eos_token_id)
+        rejected_seq = _make_sequence(rejected_tokens, rejected_mask, eos_token_id)
+        if chosen_seq is None or rejected_seq is None:
+            return None
+        return [chosen_seq, rejected_seq]
+
+    overlength_policy = OverlengthPolicy(policy)
+    # DPO overlength is response/pair-level: at least one divergent suffix
+    # pushed the pair past the shared sequence budget.
+    reason = "response_too_long"
+
+    if overlength_policy is OverlengthPolicy.REJECT:
+        _count(reason)
         return None
+    if overlength_policy is OverlengthPolicy.WARN:
+        # Keep the original pair unchanged but count it.
+        chosen_seq = _make_sequence(chosen_tokens, chosen_mask, eos_token_id)
+        rejected_seq = _make_sequence(rejected_tokens, rejected_mask, eos_token_id)
+        if chosen_seq is None or rejected_seq is None:
+            # Untrainable even when kept; reject instead of emitting broken rows.
+            _count(reason)
+            return None
+        _count(reason)
+        return [chosen_seq, rejected_seq]
+
+    # TRUNCATE: cut both sides to a common budget over the shared prefix.
+    cut = truncate_dpo_pair(
+        chosen_tokens=chosen_tokens,
+        chosen_mask=chosen_mask,
+        rejected_tokens=rejected_tokens,
+        rejected_mask=rejected_mask,
+        prefix_len=prefix_len,
+        max_seq_len=max_seq_len,
+        eos_token_ids=(eos_token_id,) if eos_token_id is not None else None,
+    )
+    if cut is None:
+        # Either side cannot fit even at minimum; reject the whole pair rather
+        # than keep an incomparable single side.
+        _count("single_message_oversized")
+        return None
+    cut_chosen_tokens, cut_chosen_mask, cut_rejected_tokens, cut_rejected_mask, _truncated = cut
+    chosen_seq = _make_sequence(cut_chosen_tokens, cut_chosen_mask, eos_token_id)
+    rejected_seq = _make_sequence(cut_rejected_tokens, cut_rejected_mask, eos_token_id)
+    if chosen_seq is None or rejected_seq is None:
+        _count("single_message_oversized")
+        return None
+    _count(reason)
     return [chosen_seq, rejected_seq]
 
 
-def _make_sequence(tokens: list[int], prompt_mask: list[bool], eos_token_id: int, max_seq_len: int):
+def _make_sequence(tokens: list[int], prompt_mask: list[bool], eos_token_id: int, max_seq_len: int | None = None):
     # Drop examples that cannot produce a next-token loss or exceed the shared
-    # max sequence budget.
-    if len(tokens) < 2 or len(tokens) > max_seq_len or not any(not item for item in prompt_mask[1:]):
+    # max sequence budget. When `max_seq_len` is None the caller has already
+    # validated/truncated the length (e.g. the truncate policy path).
+    if len(tokens) < 2 or not any(not item for item in prompt_mask[1:]):
+        return None
+    if max_seq_len is not None and len(tokens) > max_seq_len:
         return None
     zeros = [0.0] * len(tokens)
     # Dummy rollout fields keep the TrainSequence shape contract shared with

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -159,6 +159,13 @@ class DPOTrainer:
                 continue
             batch.extend(pair)
             if len(batch) >= self.config.batch_size * 2:
+                # Surface this batch's overlength counts to the metrics recorder
+                # so they emit `rollout/overlength/*` scalars for this step, then
+                # reset so the next batch only carries its own counts (mirrors
+                # the per-step semantics of the agentic path).
+                if overlength_counters:
+                    self.areno.record_overlength_counters(overlength_counters)
+                    overlength_counters = {}
                 yield batch
                 batch = []
         if skipped_invalid or overlength_counters:
@@ -167,6 +174,8 @@ class DPOTrainer:
                 parts.append(f"{key}={count}")
             self.logger.info("stage=dpo_dataset_filter %s", " ".join(parts))
         if batch:
+            if overlength_counters:
+                self.areno.record_overlength_counters(overlength_counters)
             yield batch
 
     def _maybe_save(self, epoch: int, step: int) -> None:

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -238,7 +238,7 @@ class PolicyOnlyTrainer:
             # filter actually counted something.
             overlength_counters = filter_diagnostics.get("overlength_counters") or {}
             if overlength_counters:
-                self.areno._step_overlength_counters = dict(overlength_counters)
+                self.areno.record_overlength_counters(overlength_counters)
             expected = len(agent_batch)
             if len(samples) + filtered_count != expected:
                 raise RuntimeError(
@@ -296,8 +296,14 @@ class PolicyOnlyTrainer:
                 continue
             # Overlength sample.
             filtered_details.append(detail)
-            overlength_counters[f"trajectory_too_long/{policy}"] = (
-                overlength_counters.get(f"trajectory_too_long/{policy}", 0) + 1
+            # `truncate` is not implemented for agentic trajectories (the
+            # flattened token row carries no per-turn offsets, so cutting it
+            # could split a tool_call/result pair). It degrades to reject here;
+            # label the counter accordingly so operators are not misled into
+            # thinking samples were safely truncated when they were dropped.
+            counter_policy = "truncate_degraded_to_reject" if policy == "truncate" else policy
+            overlength_counters[f"trajectory_too_long/{counter_policy}"] = (
+                overlength_counters.get(f"trajectory_too_long/{counter_policy}", 0) + 1
             )
             if policy == "warn":
                 # Keep the overlength sample unchanged but count it.
@@ -310,6 +316,14 @@ class PolicyOnlyTrainer:
         )
         if overlength_counters:
             diagnostics["overlength_counters"] = overlength_counters
+        if policy == "truncate" and filtered_details:
+            # Explicitly warn that truncate degraded to reject so an operator
+            # monitoring the `truncate` policy is not left assuming truncation happened.
+            self.logger.warning(
+                "agentic truncate not implemented (no per-turn offsets); dropped %d overlength "
+                "trajectory(ies) as reject instead of truncating",
+                len(filtered_details),
+            )
         if filtered_details:
             self.logger.warning("agentic trajectory filtered: %s", self._format_agent_filter_diagnostics(diagnostics))
         # `warn` keeps overlength samples, so the filtered_count (dropped) must

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -269,9 +269,15 @@ class PolicyOnlyTrainer:
         max_context_len = self._agent_model_context_len()
         if max_context_len is None:
             return samples, 0, {}
+        # Resolve the overlength policy from config (default reject keeps the
+        # pre-#216 behavior). Agentic turn-level truncation is not implemented
+        # yet because the flattened token row does not carry per-turn offsets,
+        # so `truncate` degrades to `reject` here with an explicit log line.
+        policy = getattr(self.config, "overlength_policy", "reject")
         kept = []
         filtered_details = []
         all_details = []
+        overlength_counters: dict[str, int] = {}
         for sample in samples:
             rows = ctx._train_rows_from_samples([sample])
             token_len = len(rows.token_rows[0]) if rows.token_rows else 0
@@ -280,16 +286,30 @@ class PolicyOnlyTrainer:
             if token_len <= max_context_len:
                 kept.append(sample)
                 continue
+            # Overlength sample.
             filtered_details.append(detail)
+            overlength_counters[f"trajectory_too_long/{policy}"] = (
+                overlength_counters.get(f"trajectory_too_long/{policy}", 0) + 1
+            )
+            if policy == "warn":
+                # Keep the overlength sample unchanged but count it.
+                kept.append(sample)
         diagnostics = self._agent_filter_diagnostics(
             all_details,
             filtered_details,
             max_context_len=max_context_len,
             kept_count=len(kept),
         )
+        if overlength_counters:
+            diagnostics["overlength_counters"] = overlength_counters
         if filtered_details:
             self.logger.warning("agentic trajectory filtered: %s", self._format_agent_filter_diagnostics(diagnostics))
-        return kept, len(filtered_details), diagnostics
+        # `warn` keeps overlength samples, so the filtered_count (dropped) must
+        # exclude them to preserve the caller's `len(samples)+filtered==expected`
+        # invariant. Under reject/truncate-degraded-to-reject, every overlength
+        # sample is dropped.
+        dropped = len(filtered_details) if policy != "warn" else 0
+        return kept, dropped, diagnostics
 
     def _agent_sample_filter_detail(self, sample, token_len):
         tool_result_count = sum(1 for message in sample.messages if message.get("role") == "tool")

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -231,6 +231,14 @@ class PolicyOnlyTrainer:
             samples, filtered_count, filter_diagnostics = self._filter_overlong_agent_samples(
                 ctx, samples, sampling_params
             )
+            # Issue #216: surface the per-reason/per-action overlength counts to
+            # the metrics recorder so they are emitted as `rollout/overlength/*`
+            # scalars alongside the rollout/train stats. The counters are reset
+            # every step by `Trainer._begin_step`, so we only set them when the
+            # filter actually counted something.
+            overlength_counters = filter_diagnostics.get("overlength_counters") or {}
+            if overlength_counters:
+                self.areno._step_overlength_counters = dict(overlength_counters)
             expected = len(agent_batch)
             if len(samples) + filtered_count != expected:
                 raise RuntimeError(

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -23,7 +23,9 @@ from typing import Any
 
 import areno.api
 from areno.api.dashboard import record_dashboard_state
+from areno.api.data import OverlengthPolicy, OverlengthReason
 from areno.api.data_utils import prompt_response_to_tokens_and_mask
+from areno.api.overlength import decide_overlength, truncate_sft_response
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
@@ -97,33 +99,46 @@ class SFTTrainer:
     def _iter_train_batches(self, tokenizer, *, max_prompt_tokens: int, max_new_tokens: int):
         # Dataset rows are converted lazily so large HF datasets do not need an
         # up-front tokenized copy. Rows that are empty, all-prompt, or exceed
-        # the configured prompt or supervised-response budgets are dropped.
+        # the configured prompt or supervised-response budgets are dropped or
+        # truncated according to the configured overlength policy.
+        policy = getattr(self.config, "overlength_policy", "reject")
         batch = []
-        skipped = 0
+        skipped_empty = 0
+        overlength_counters: dict[str, int] = {}
         accepted = 0
         total_rows = len(self.dataset)
         for index in range(total_rows):
-            # Normalize each supported row schema into one TrainSequence.
+            # `overlength_counters` is mutated as a side effect when a row is
+            # dropped/truncated for being over budget; an empty/invalid row
+            # leaves it untouched so we can tell the two drop reasons apart.
+            before = sum(overlength_counters.values())
             seq = _record_to_train_sequence(
                 self.dataset[index],
                 tokenizer,
                 max_prompt_tokens=max_prompt_tokens,
                 max_new_tokens=max_new_tokens,
+                policy=policy,
+                counters=overlength_counters,
             )
             if seq is None:
-                skipped += 1
+                if sum(overlength_counters.values()) == before:
+                    skipped_empty += 1
                 continue
             accepted += 1
             batch.append(seq)
             if len(batch) >= self.config.batch_size:
                 yield batch
                 batch = []
-        if skipped:
-            self.logger.info("stage=sft_dataset_filter skipped_long_or_empty=%d", skipped)
+        if skipped_empty or overlength_counters:
+            parts = [f"skipped_empty={skipped_empty}"]
+            for key, count in sorted(overlength_counters.items()):
+                parts.append(f"{key}={count}")
+            self.logger.info("stage=sft_dataset_filter %s", " ".join(parts))
         if accepted == 0:
             raise ValueError(
                 "SFT dataset produced no valid training rows after filtering: "
-                f"scanned {total_rows} row(s), skipped {skipped} as empty, over-budget, or all-prompt examples. "
+                f"scanned {total_rows} row(s), skipped {skipped_empty} as empty, "
+                f"overlength {sum(overlength_counters.values())}, or all-prompt examples. "
                 "Check dataset quality, --max-prompt-tokens, and --max-new-tokens."
             )
         if batch:
@@ -141,14 +156,35 @@ class SFTTrainer:
         record_dashboard_state(self.areno, stage="save_checkpoint_end", epoch=epoch, step=step, role="policy")
 
 
-def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int, max_new_tokens: int):
+def _record_to_train_sequence(
+    record: Any,
+    tokenizer,
+    *,
+    max_prompt_tokens: int,
+    max_new_tokens: int,
+    policy: str = "reject",
+    counters: dict[str, int] | None = None,
+):
     """Normalize one loader-produced SFT row into backend training format.
 
     `prompt_mask=True` means "do not train this source token"; the backend loss
     is next-token aligned, so the loss function later uses positions after the
     prompt prefix. RL-only fields are filled with zeros to satisfy the shared
     `TrainSequence` packing contract.
+
+    Returns a ``TrainSequence`` or ``None``. When a row is dropped because it
+    exceeds a budget, the per-reason, per-action count is recorded into
+    ``counters`` (as ``{f"{reason}/{policy}": count}``) so callers can surface
+    per-reason diagnostics; empty/invalid rows return ``None`` without touching
+    ``counters``. Under ``warn`` the original sequence is kept and counted;
+    under ``truncate`` the response is cut to ``max_new_tokens`` with a trailing
+    EOS preserved.
     """
+
+    def _count(reason_value: str) -> None:
+        if counters is not None:
+            key = f"{reason_value}/{policy}"
+            counters[key] = counters.get(key, 0) + 1
 
     record = dict(record)
     eos_token_id = tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 0
@@ -169,8 +205,61 @@ def _record_to_train_sequence(record: Any, tokenizer, *, max_prompt_tokens: int,
         return None
     prompt_tokens = prompt_mask.count(True)
     response_tokens = prompt_mask[1:].count(False)
-    if prompt_tokens > max_prompt_tokens or response_tokens > max_new_tokens or response_tokens == 0:
+    if response_tokens == 0:
         return None
+
+    overlength_policy = OverlengthPolicy(policy)
+    decision = decide_overlength(
+        prompt_len=prompt_tokens,
+        max_prompt_tokens=max_prompt_tokens,
+        response_len=response_tokens,
+        max_new_tokens=max_new_tokens,
+        policy=overlength_policy,
+    )
+
+    # Within budget: keep as-is (no overlength reason to count).
+    if not decision.truncated and decision.reason.value in ("within_budget", "exact_limit"):
+        return _build_train_sequence(tokens, prompt_mask, eos_token_id)
+
+    reason_value = decision.reason.value
+
+    # Prompt overlength: SFT prompts are plain strings with no chat-turn
+    # boundary to cut on, so truncate degrades to reject for this path.
+    if decision.reason is OverlengthReason.SINGLE_MESSAGE_OVERSIZED:
+        if overlength_policy is OverlengthPolicy.WARN:
+            _count(reason_value)
+            return _build_train_sequence(tokens, prompt_mask, eos_token_id)
+        _count(reason_value)
+        return None
+
+    # Response overlength.
+    if overlength_policy is OverlengthPolicy.REJECT:
+        _count(reason_value)
+        return None
+    if overlength_policy is OverlengthPolicy.WARN:
+        _count(reason_value)
+        return _build_train_sequence(tokens, prompt_mask, eos_token_id)
+
+    # TRUNCATE: cut the response at max_new_tokens, preserve trailing EOS.
+    prompt_ids = tokens[:prompt_tokens]
+    response_ids = tokens[prompt_tokens:]
+    cut_tokens, cut_mask, _truncated = truncate_sft_response(
+        prompt_ids=prompt_ids,
+        response_ids=response_ids,
+        max_new_tokens=max_new_tokens,
+        eos_token_ids=(eos_token_id,) if eos_token_id is not None else None,
+    )
+    if len(cut_tokens) < 2 or cut_mask[1:].count(False) == 0:
+        # Trimming produced an un-trainable sequence; reject instead.
+        _count(reason_value)
+        return None
+    _count(reason_value)
+    return _build_train_sequence(cut_tokens, cut_mask, eos_token_id)
+
+
+def _build_train_sequence(tokens: list[int], prompt_mask: list[bool], eos_token_id: int):
+    """Wrap token/mask rows into a TrainSequence with zeroed RL-only fields."""
+
     zeros = [0.0] * len(tokens)
     # Dummy rollout fields keep the backend packer shared with RL trainers.
     return areno.api.TrainSequence(

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -127,6 +127,13 @@ class SFTTrainer:
             accepted += 1
             batch.append(seq)
             if len(batch) >= self.config.batch_size:
+                # Surface the overlength counts accumulated for this batch to the
+                # metrics recorder so they emit `rollout/overlength/*` scalars
+                # for this step, then reset so the next batch only carries its
+                # own counts (mirrors the per-step semantics of the agentic path).
+                if overlength_counters:
+                    self.areno.record_overlength_counters(overlength_counters)
+                    overlength_counters = {}
                 yield batch
                 batch = []
         if skipped_empty or overlength_counters:
@@ -142,6 +149,8 @@ class SFTTrainer:
                 "Check dataset quality, --max-prompt-tokens, and --max-new-tokens."
             )
         if batch:
+            if overlength_counters:
+                self.areno.record_overlength_counters(overlength_counters)
             yield batch
 
     def _maybe_save(self, epoch: int, step: int) -> None:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -90,6 +90,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "agent_fn",
             "agent_timeout_s",
             "train_tool_results",
+            "overlength_policy",
             "reward_fn_path",
             "reward_ckpt",
         ),
@@ -637,6 +638,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            overlength_policy=getattr(args, "overlength_policy", "reject"),
             chat_template_enable_thinking=chat_template_enable_thinking,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
@@ -678,6 +680,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            overlength_policy=getattr(args, "overlength_policy", "reject"),
             chat_template_enable_thinking=chat_template_enable_thinking,
         )
     if algorithm.name != "ppo":
@@ -726,6 +729,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            overlength_policy=getattr(args, "overlength_policy", "reject"),
             chat_template_enable_thinking=chat_template_enable_thinking,
         )
     return PPOTrainerConfig(
@@ -902,6 +906,7 @@ def _training_config_settings(config: TrainerConfig) -> dict:
                 "agent_fn",
                 "agent_timeout_s",
                 "train_tool_results",
+                "overlength_policy",
                 "reward_fn_path",
                 "reward_ckpt",
             ],
@@ -1300,6 +1305,15 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--agent-timeout-s", type=float, default=300.0, show_default=True, help="Agentic rollout proxy request timeout."
 )
 @click.option("--train-tool-results", is_flag=True, help="Include tool-result spans in agentic policy loss.")
+@click.option(
+    "--overlength-policy",
+    type=click.Choice(["reject", "warn", "truncate"], case_sensitive=False),
+    default="reject",
+    show_default=True,
+    help="How to handle samples exceeding the token budget: reject (drop), warn (keep and count), "
+    "or truncate (cut at a semantically safe boundary). Default preserves current behavior. "
+    "For agentic trajectories, truncate degrades to reject until per-turn truncation lands.",
+)
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."
 )

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -183,6 +183,24 @@ but are masked from policy loss unless ``--train-tool-results`` is set.
 When ``--max-context-len`` is set, filtering uses the full concatenated token
 row for the whole agentic trajectory, not only the latest chat-completion turn.
 
+``--overlength-policy {reject,warn,truncate}``
+   How to handle samples that exceed the configured token budget
+   (``--max-prompt-tokens`` / ``--max-new-tokens`` / ``--max-context-len``):
+
+   - ``reject`` (default) drops the sample and counts it. This preserves the
+     pre-existing behavior exactly.
+   - ``warn`` keeps the overlength sample unchanged but logs and counts it.
+   - ``truncate`` cuts the sample at a semantically safe boundary: SFT
+     responses are cut to ``--max-new-tokens`` with a trailing EOS preserved;
+     DPO chosen/rejected pairs are cut to a common budget over the shared
+     prompt prefix so the two branches stay comparable.
+
+   Per-reason, per-action counters are emitted as ``rollout/overlength/{reason}/{action}``
+   TensorBoard scalars. For agentic trajectories, ``truncate`` currently
+   degrades to ``reject`` because per-turn token offsets are not yet available;
+   overlength trajectories are dropped rather than risk splitting a tool-call /
+   tool-result pair.
+
 ``--reward-fn-path TEXT``
    Python file defining ``reward_fn(record)``.
 

--- a/tests/test_overlength_cpu.py
+++ b/tests/test_overlength_cpu.py
@@ -144,6 +144,26 @@ class OverlengthMetricsTest(unittest.TestCase):
         overlength_tags = [call[0] for call in writer.scalars if call[0].startswith("rollout/overlength/")]
         self.assertEqual(overlength_tags, [])
 
+    def test_collect_train_batch_stats_forwards_overlength_counters(self):
+        # The agentic path populates counters on the trainer and hands them to
+        # `collect_train_batch_stats`, which must inject them into the stats
+        # accumulator so `record_training_stats` emits the scalars.
+        from areno.api.metrics import collect_train_batch_stats
+
+        counters = {"trajectory_too_long/warn": 2}
+        stats = collect_train_batch_stats([], overlength_counters=counters)
+        self.assertEqual(stats["overlength_counters"], counters)
+        writer = _FakeWriter()
+        record_training_stats(writer, stats, step=0, train_res={}, train_batch=[])
+        tags = {call[0] for call in writer.scalars}
+        self.assertIn("rollout/overlength/trajectory_too_long/warn", tags)
+
+    def test_collect_train_batch_stats_without_counters_is_empty(self):
+        from areno.api.metrics import collect_train_batch_stats
+
+        stats = collect_train_batch_stats([])
+        self.assertEqual(stats["overlength_counters"], {})
+
 
 class _FakeWriter:
     """Minimal TensorBoard writer substitute that records add_scalar calls."""

--- a/tests/test_overlength_cpu.py
+++ b/tests/test_overlength_cpu.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import unittest
+
+from areno.api.data import OverlengthPolicy, OverlengthReason, PromptBatch, PromptItem
+from areno.api.metrics import init_rollout_stats, record_training_stats
+from areno.api.overlength import decide_overlength, truncate_dpo_pair, truncate_sft_response
+
+
+class OverlengthDecisionTest(unittest.TestCase):
+    """Decision matrix, boundaries, malformed input, determinism."""
+
+    def test_within_budget_returns_no_action(self):
+        decision = decide_overlength(prompt_len=10, max_prompt_tokens=20, policy=OverlengthPolicy.REJECT)
+        self.assertEqual(decision.reason, OverlengthReason.WITHIN_BUDGET)
+        self.assertFalse(decision.truncated)
+        self.assertIsNone(decision.detail)
+
+    def test_exact_limit_is_not_overlength(self):
+        # prompt_len == max_prompt_tokens is the inclusive cap, not a violation.
+        decision = decide_overlength(prompt_len=20, max_prompt_tokens=20, policy=OverlengthPolicy.REJECT)
+        self.assertEqual(decision.reason, OverlengthReason.EXACT_LIMIT)
+        self.assertFalse(decision.truncated)
+
+    def test_prompt_overlength_one_token_over(self):
+        decision = decide_overlength(prompt_len=21, max_prompt_tokens=20, policy=OverlengthPolicy.REJECT)
+        self.assertEqual(decision.reason, OverlengthReason.SINGLE_MESSAGE_OVERSIZED)
+        self.assertEqual(decision.action, OverlengthPolicy.REJECT)
+        self.assertFalse(decision.truncated)
+        self.assertEqual(decision.detail, {"over_by_tokens": 1})
+
+    def test_response_overlength(self):
+        decision = decide_overlength(
+            prompt_len=5,
+            max_prompt_tokens=20,
+            response_len=60,
+            max_new_tokens=50,
+            policy=OverlengthPolicy.REJECT,
+        )
+        self.assertEqual(decision.reason, OverlengthReason.RESPONSE_TOO_LONG)
+        self.assertEqual(decision.detail, {"over_by_tokens": 10})
+
+    def test_prompt_overlength_takes_precedence_over_response(self):
+        # If the prompt itself is already over budget, that is the reported
+        # reason even when the response is also too long.
+        decision = decide_overlength(
+            prompt_len=25,
+            max_prompt_tokens=20,
+            response_len=60,
+            max_new_tokens=50,
+            policy=OverlengthPolicy.REJECT,
+        )
+        self.assertEqual(decision.reason, OverlengthReason.SINGLE_MESSAGE_OVERSIZED)
+
+    def test_truncate_policy_marks_truncated(self):
+        decision = decide_overlength(
+            prompt_len=5,
+            max_prompt_tokens=20,
+            response_len=60,
+            max_new_tokens=50,
+            policy=OverlengthPolicy.TRUNCATE,
+        )
+        self.assertEqual(decision.action, OverlengthPolicy.TRUNCATE)
+        self.assertTrue(decision.truncated)
+
+    def test_warn_policy_keeps_sample_not_truncated(self):
+        decision = decide_overlength(
+            prompt_len=5,
+            max_prompt_tokens=20,
+            response_len=60,
+            max_new_tokens=50,
+            policy=OverlengthPolicy.WARN,
+        )
+        self.assertEqual(decision.action, OverlengthPolicy.WARN)
+        self.assertFalse(decision.truncated)
+
+    def test_invalid_max_prompt_tokens_raises(self):
+        with self.assertRaises(ValueError):
+            decide_overlength(prompt_len=1, max_prompt_tokens=0, policy=OverlengthPolicy.REJECT)
+
+    def test_invalid_max_new_tokens_raises(self):
+        with self.assertRaises(ValueError):
+            decide_overlength(
+                prompt_len=1, max_prompt_tokens=10, response_len=1, max_new_tokens=0, policy=OverlengthPolicy.REJECT
+            )
+
+    def test_invalid_policy_type_raises(self):
+        with self.assertRaises(ValueError):
+            decide_overlength(prompt_len=1, max_prompt_tokens=10, policy="reject")  # type: ignore[arg-type]
+
+    def test_decision_is_deterministic(self):
+        kwargs = dict(prompt_len=25, max_prompt_tokens=20, response_len=60, max_new_tokens=50)
+        first = decide_overlength(policy=OverlengthPolicy.REJECT, **kwargs)
+        for _ in range(5):
+            self.assertEqual(
+                decide_overlength(policy=OverlengthPolicy.REJECT, **kwargs),
+                first,
+            )
+
+
+class PromptBatchCountersTest(unittest.TestCase):
+    """PromptBatch exposes the new per-reason counter field with a safe default."""
+
+    def test_default_overlength_counters_is_empty_dict(self):
+        batch = PromptBatch(items=[], scanned=0, skipped_long=0, total_skipped_long=0)
+        self.assertEqual(batch.overlength_counters, {})
+
+    def test_each_batch_gets_independent_default_dict(self):
+        # default_factory must give each instance its own dict, not a shared one.
+        batch_a = PromptBatch(items=[], scanned=0, skipped_long=0, total_skipped_long=0)
+        batch_b = PromptBatch(items=[], scanned=0, skipped_long=0, total_skipped_long=0)
+        batch_a.overlength_counters["response_too_long/reject"] = 1
+        self.assertEqual(batch_b.overlength_counters, {})
+
+    def test_legacy_fields_still_accepted(self):
+        item = PromptItem(prompt="hi", solutions=None, input_tokens=[1, 2], record={})
+        batch = PromptBatch(items=[item], scanned=1, skipped_long=0, total_skipped_long=0)
+        self.assertEqual(batch.skipped_long, 0)
+        self.assertEqual(batch.items, [item])
+
+
+class OverlengthMetricsTest(unittest.TestCase):
+    """record_training_stats emits one scalar per (reason, action) counter."""
+
+    def test_overlength_counters_emitted_as_scalars(self):
+        writer = _FakeWriter()
+        stats = init_rollout_stats(
+            skipped_long=2,
+            total_skipped_long=5,
+            overlength_counters={"response_too_long/reject": 3, "single_message_oversized/warn": 1},
+        )
+        record_training_stats(writer, stats, step=0, train_res={}, train_batch=[])
+
+        tags = {call[0] for call in writer.scalars}
+        self.assertIn("rollout/overlength/response_too_long/reject", tags)
+        self.assertIn("rollout/overlength/single_message_oversized/warn", tags)
+        self.assertIn("rollout/skipped_long", tags)
+        self.assertIn("rollout/total_skipped_long", tags)
+
+    def test_empty_overlength_counters_emits_nothing_extra(self):
+        writer = _FakeWriter()
+        stats = init_rollout_stats()
+        record_training_stats(writer, stats, step=0, train_res={}, train_batch=[])
+        overlength_tags = [call[0] for call in writer.scalars if call[0].startswith("rollout/overlength/")]
+        self.assertEqual(overlength_tags, [])
+
+
+class _FakeWriter:
+    """Minimal TensorBoard writer substitute that records add_scalar calls."""
+
+    def __init__(self):
+        self.scalars: list[tuple] = []
+
+    def add_scalar(self, tag, value, step):
+        self.scalars.append((tag, value, step))
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class TruncateSftResponseTest(unittest.TestCase):
+    """SFT response truncation preserves EOS and keeps mask length consistent."""
+
+    def test_short_response_returned_unchanged(self):
+        prompt_ids = [1, 2, 3]
+        response_ids = [4, 5, 7]  # 7 is EOS
+        tokens, mask, truncated = truncate_sft_response(
+            prompt_ids=prompt_ids, response_ids=response_ids, max_new_tokens=10, eos_token_ids=(7,)
+        )
+        self.assertFalse(truncated)
+        self.assertEqual(tokens, [1, 2, 3, 4, 5, 7])
+        self.assertEqual(mask, [True, True, True, False, False, False])
+
+    def test_long_response_cut_to_limit_with_eos_reappended(self):
+        prompt_ids = [1, 2]
+        response_ids = [4, 5, 6, 8, 9]  # last token 9 is not EOS
+        tokens, mask, truncated = truncate_sft_response(
+            prompt_ids=prompt_ids, response_ids=response_ids, max_new_tokens=3, eos_token_ids=(7,)
+        )
+        self.assertTrue(truncated)
+        # cut = [4,5,6] then EOS re-appended -> [4,5,6,7]
+        self.assertEqual(tokens, [1, 2, 4, 5, 6, 7])
+        self.assertEqual(mask, [True, True, False, False, False, False])
+        self.assertEqual(len(tokens), len(mask))
+
+    def test_cut_keeps_existing_eos_at_boundary(self):
+        prompt_ids = [1]
+        response_ids = [4, 5, 7, 8, 9]  # 7 is EOS at position 2
+        tokens, mask, truncated = truncate_sft_response(
+            prompt_ids=prompt_ids, response_ids=response_ids, max_new_tokens=3, eos_token_ids=(7,)
+        )
+        # cut = [4,5,7], last is EOS -> no re-append
+        self.assertTrue(truncated)
+        self.assertEqual(tokens, [1, 4, 5, 7])
+        self.assertEqual(tokens[-1], 7)
+
+    def test_no_eos_ids_no_reappend(self):
+        prompt_ids = [1]
+        response_ids = [4, 5, 6, 8]
+        tokens, mask, truncated = truncate_sft_response(
+            prompt_ids=prompt_ids, response_ids=response_ids, max_new_tokens=2, eos_token_ids=None
+        )
+        self.assertTrue(truncated)
+        self.assertEqual(tokens, [1, 4, 5])
+
+    def test_invalid_max_new_tokens_raises(self):
+        with self.assertRaises(ValueError):
+            truncate_sft_response(prompt_ids=[1], response_ids=[2], max_new_tokens=0, eos_token_ids=(7,))
+
+    def test_prompt_mask_length_matches_tokens(self):
+        # mask length must always equal tokens length (backend asserts this).
+        prompt_ids = [1, 2, 3, 4]
+        response_ids = list(range(10, 40))
+        tokens, mask, _ = truncate_sft_response(
+            prompt_ids=prompt_ids, response_ids=response_ids, max_new_tokens=5, eos_token_ids=(99,)
+        )
+        self.assertEqual(len(tokens), len(mask))
+        self.assertEqual(sum(1 for m in mask if m), len(prompt_ids))
+
+
+class TruncateDpoPairTest(unittest.TestCase):
+    """DPO pair truncation keeps chosen/rejected comparable over the shared prefix."""
+
+    def test_both_fit_returned_unchanged(self):
+        # prefix=[1,2], chosen suffix=[3,7], rejected suffix=[4,7]; 7 is EOS.
+        chosen = [1, 2, 3, 7]
+        cmask = [True, True, False, False]
+        rejected = [1, 2, 4, 7]
+        rmask = [True, True, False, False]
+        result = truncate_dpo_pair(
+            chosen_tokens=chosen,
+            chosen_mask=cmask,
+            rejected_tokens=rejected,
+            rejected_mask=rmask,
+            prefix_len=2,
+            max_seq_len=10,
+            eos_token_ids=(7,),
+        )
+        self.assertIsNotNone(result)
+        ct, cm, rt, rm, truncated = result
+        self.assertFalse(truncated)
+        self.assertEqual(ct, chosen)
+        self.assertEqual(rt, rejected)
+
+    def test_chosen_overlong_both_truncated_to_common_budget(self):
+        # prefix=[1,2]; chosen suffix long, rejected short. max_seq_len=5.
+        chosen = [1, 2, 3, 4, 5, 6, 7]  # len 7 > 5
+        cmask = [True, True, False, False, False, False, False]
+        rejected = [1, 2, 8, 7]  # len 4 <= 5
+        rmask = [True, True, False, False]
+        result = truncate_dpo_pair(
+            chosen_tokens=chosen,
+            chosen_mask=cmask,
+            rejected_tokens=rejected,
+            rejected_mask=rmask,
+            prefix_len=2,
+            max_seq_len=5,
+            eos_token_ids=(7,),
+        )
+        self.assertIsNotNone(result)
+        ct, cm, rt, rm, truncated = result
+        self.assertTrue(truncated)
+        # chosen cut to budget=3 suffix -> [1,2,?,7], last replaced with EOS
+        self.assertLessEqual(len(ct), 5)
+        self.assertEqual(ct[:2], [1, 2])  # prefix preserved
+        self.assertEqual(ct[-1], 7)  # EOS preserved/re-appended
+        # rejected already fit; unchanged
+        self.assertEqual(rt, rejected)
+        # comparability: shared prefix identical
+        self.assertEqual(ct[:2], rt[:2])
+
+    def test_both_overlong_truncated_comparable(self):
+        chosen = [1, 2, 3, 4, 5, 6, 7]
+        cmask = [True, True, False, False, False, False, False]
+        rejected = [1, 2, 8, 9, 10, 11, 7]
+        rmask = [True, True, False, False, False, False, False]
+        result = truncate_dpo_pair(
+            chosen_tokens=chosen,
+            chosen_mask=cmask,
+            rejected_tokens=rejected,
+            rejected_mask=rmask,
+            prefix_len=2,
+            max_seq_len=4,
+            eos_token_ids=(7,),
+        )
+        self.assertIsNotNone(result)
+        ct, cm, rt, rm, truncated = result
+        self.assertTrue(truncated)
+        self.assertLessEqual(len(ct), 4)
+        self.assertLessEqual(len(rt), 4)
+        self.assertEqual(ct[:2], rt[:2])  # shared prefix identical -> comparable
+        self.assertEqual(ct[-1], 7)
+        self.assertEqual(rt[-1], 7)
+        self.assertEqual(len(ct), len(cm))
+        self.assertEqual(len(rt), len(rm))
+
+    def test_too_small_to_fit_returns_none(self):
+        # prefix=4, max_seq_len=4 -> budget=0, cannot keep any response token.
+        chosen = [1, 2, 3, 4, 5, 6, 7]
+        cmask = [True, True, True, True, False, False, False]
+        rejected = [1, 2, 3, 4, 8, 7]
+        rmask = [True, True, True, True, False, False]
+        result = truncate_dpo_pair(
+            chosen_tokens=chosen,
+            chosen_mask=cmask,
+            rejected_tokens=rejected,
+            rejected_mask=rmask,
+            prefix_len=4,
+            max_seq_len=4,
+            eos_token_ids=(7,),
+        )
+        self.assertIsNone(result)
+
+    def test_invalid_max_seq_len_raises(self):
+        with self.assertRaises(ValueError):
+            truncate_dpo_pair(
+                chosen_tokens=[1],
+                chosen_mask=[True],
+                rejected_tokens=[1],
+                rejected_mask=[True],
+                prefix_len=0,
+                max_seq_len=0,
+                eos_token_ids=(7,),
+            )
+
+    def test_invalid_prefix_len_raises(self):
+        with self.assertRaises(ValueError):
+            truncate_dpo_pair(
+                chosen_tokens=[1, 2],
+                chosen_mask=[True, False],
+                rejected_tokens=[1],
+                rejected_mask=[True],
+                prefix_len=2,
+                max_seq_len=5,
+                eos_token_ids=(7,),
+            )
+
+
+class AgentOverlengthFilterTest(unittest.TestCase):
+    """Agentic overlength filter: reject drops, warn keeps, truncate degrades to reject.
+
+    The real `_filter_overlong_agent_samples` lives on `PolicyOnlyTrainer` and
+    needs a backend; here we drive the method on a tiny fake trainer + fake ctx
+    so the policy branching is covered without a GPU.
+    """
+
+    def _make_fake_sample(self, token_len: int):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            messages=[{"role": "assistant", "content": "x"}],
+            item=SimpleNamespace(prompt="p", prompt_index=0, sample_index=0, input_tokens=[1] * token_len),
+            response_tokens=[1] * token_len,
+            response_logprobs=[0.0] * token_len,
+            trace=[],
+            response_kind="assistant_text",
+            last_tool_calls=[],
+            token_row=[1] * token_len,
+            response_mask_row=[True] * token_len,
+            loss_mask_row=[True] * token_len,
+            rollout_logprobs_row=[0.0] * token_len,
+        )
+
+    def _make_fake_trainer(self, policy: str):
+        import logging
+        from types import SimpleNamespace
+
+        trainer = SimpleNamespace()
+        trainer.config = SimpleNamespace(overlength_policy=policy, max_context_len=10)
+        trainer.logger = logging.getLogger("test")
+        # Bind the real method under test.
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        trainer._filter_overlong_agent_samples = PolicyOnlyTrainer._filter_overlong_agent_samples.__get__(trainer)
+        trainer._agent_sample_filter_detail = PolicyOnlyTrainer._agent_sample_filter_detail.__get__(trainer)
+        trainer._agent_filter_diagnostics = PolicyOnlyTrainer._agent_filter_diagnostics.__get__(trainer)
+        trainer._format_agent_filter_diagnostics = PolicyOnlyTrainer._format_agent_filter_diagnostics.__get__(trainer)
+        trainer._percentile_value = PolicyOnlyTrainer._percentile_value.__get__(trainer)
+        trainer._agent_model_context_len = lambda: 10
+        return trainer
+
+    class _FakeCtx:
+        def _train_rows_from_samples(self, samples):
+            from types import SimpleNamespace
+
+            row = samples[0].token_row
+            return SimpleNamespace(
+                token_rows=[list(row)],
+                response_masks=[[]],
+                loss_masks=[[]],
+                rollout_logprobs=[[]],
+                total_tokens=len(row),
+            )
+
+    def test_reject_drops_overlong(self):
+        trainer = self._make_fake_trainer("reject")
+        samples = [self._make_fake_sample(5), self._make_fake_sample(20)]  # 20 > 10
+        kept, dropped, diag = trainer._filter_overlong_agent_samples(self._FakeCtx(), samples, None)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(dropped, 1)
+        self.assertEqual(diag["overlength_counters"]["trajectory_too_long/reject"], 1)
+
+    def test_warn_keeps_overlong(self):
+        trainer = self._make_fake_trainer("warn")
+        samples = [self._make_fake_sample(5), self._make_fake_sample(20)]
+        kept, dropped, diag = trainer._filter_overlong_agent_samples(self._FakeCtx(), samples, None)
+        # warn keeps both; dropped stays 0 to preserve caller invariant.
+        self.assertEqual(len(kept), 2)
+        self.assertEqual(dropped, 0)
+        self.assertEqual(diag["overlength_counters"]["trajectory_too_long/warn"], 1)
+
+    def test_truncate_degrades_to_reject(self):
+        # truncate is not implemented for agentic yet; it must degrade to reject
+        # (drop the overlong sample) rather than split a tool call/result pair.
+        trainer = self._make_fake_trainer("truncate")
+        samples = [self._make_fake_sample(5), self._make_fake_sample(20)]
+        kept, dropped, diag = trainer._filter_overlong_agent_samples(self._FakeCtx(), samples, None)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(dropped, 1)
+        self.assertEqual(diag["overlength_counters"]["trajectory_too_long/truncate"], 1)
+
+    def test_all_within_budget_no_counters(self):
+        trainer = self._make_fake_trainer("reject")
+        samples = [self._make_fake_sample(5), self._make_fake_sample(8)]
+        kept, dropped, diag = trainer._filter_overlong_agent_samples(self._FakeCtx(), samples, None)
+        self.assertEqual(len(kept), 2)
+        self.assertEqual(dropped, 0)
+        self.assertNotIn("overlength_counters", diag)
+
+
+class OverlengthConfigTest(unittest.TestCase):
+    """TrainerConfig exposes overlength_policy with a safe default and validation."""
+
+    def test_default_policy_is_reject(self):
+        from areno.api.trainer_config import TrainerConfig
+
+        config = TrainerConfig(algo="sft", ckpt="x", dataset_path="x")
+        self.assertEqual(config.overlength_policy, "reject")
+
+    def test_valid_policies_accepted(self):
+        from areno.api.trainer_config import TrainerConfig
+
+        for policy in ("reject", "warn", "truncate"):
+            config = TrainerConfig(algo="sft", ckpt="x", dataset_path="x", overlength_policy=policy)
+            self.assertEqual(config.overlength_policy, policy)
+
+    def test_invalid_policy_rejected(self):
+        from areno.api.trainer_config import TrainerConfig
+
+        with self.assertRaises(ValueError):
+            TrainerConfig(algo="sft", ckpt="x", dataset_path="x", overlength_policy="bogus")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_overlength_cpu.py
+++ b/tests/test_overlength_cpu.py
@@ -164,6 +164,31 @@ class OverlengthMetricsTest(unittest.TestCase):
         stats = collect_train_batch_stats([])
         self.assertEqual(stats["overlength_counters"], {})
 
+    def test_record_overlength_counters_writes_step_accumulator(self):
+        # Issue #216 CR fix: trainers call the public `record_overlength_counters`
+        # method instead of reaching into the private `_step_overlength_counters`
+        # attribute. The method must copy the counters onto the step accumulator
+        # so `record_train_step` flushes them as `rollout/overlength/*` scalars.
+        from types import SimpleNamespace
+
+        trainer = SimpleNamespace(_step_overlength_counters={}, _metrics=None)
+        # Bind the real method under test.
+        from areno.api.trainer import Trainer
+
+        Trainer.record_overlength_counters(trainer, {"response_too_long/warn": 3})
+        self.assertEqual(trainer._step_overlength_counters, {"response_too_long/warn": 3})
+
+    def test_record_overlength_counters_ignores_empty(self):
+        # Empty counters must not overwrite a previous step's accumulator (the
+        # caller guards this too, but the method must be a no-op regardless).
+        from types import SimpleNamespace
+
+        trainer = SimpleNamespace(_step_overlength_counters={"existing/reject": 1}, _metrics=None)
+        from areno.api.trainer import Trainer
+
+        Trainer.record_overlength_counters(trainer, {})
+        self.assertEqual(trainer._step_overlength_counters, {"existing/reject": 1})
+
 
 class _FakeWriter:
     """Minimal TensorBoard writer substitute that records add_scalar calls."""
@@ -201,10 +226,12 @@ class TruncateSftResponseTest(unittest.TestCase):
             prompt_ids=prompt_ids, response_ids=response_ids, max_new_tokens=3, eos_token_ids=(7,)
         )
         self.assertTrue(truncated)
-        # cut = [4,5,6] then EOS re-appended -> [4,5,6,7]
-        self.assertEqual(tokens, [1, 2, 4, 5, 6, 7])
-        self.assertEqual(mask, [True, True, False, False, False, False])
+        # cut = [4,5,6]; the last token is replaced with EOS so the cut stays
+        # within max_new_tokens -> [4,5,7]. Total length never exceeds the budget.
+        self.assertEqual(tokens, [1, 2, 4, 5, 7])
+        self.assertEqual(mask, [True, True, False, False, False])
         self.assertEqual(len(tokens), len(mask))
+        self.assertEqual(len(tokens), len(prompt_ids) + 3)  # respects max_new_tokens
 
     def test_cut_keeps_existing_eos_at_boundary(self):
         prompt_ids = [1]
@@ -435,12 +462,14 @@ class AgentOverlengthFilterTest(unittest.TestCase):
     def test_truncate_degrades_to_reject(self):
         # truncate is not implemented for agentic yet; it must degrade to reject
         # (drop the overlong sample) rather than split a tool call/result pair.
+        # The counter is labeled `truncate_degraded_to_reject` so operators are
+        # not misled into thinking samples were safely truncated.
         trainer = self._make_fake_trainer("truncate")
         samples = [self._make_fake_sample(5), self._make_fake_sample(20)]
         kept, dropped, diag = trainer._filter_overlong_agent_samples(self._FakeCtx(), samples, None)
         self.assertEqual(len(kept), 1)
         self.assertEqual(dropped, 1)
-        self.assertEqual(diag["overlength_counters"]["trajectory_too_long/truncate"], 1)
+        self.assertEqual(diag["overlength_counters"]["trajectory_too_long/truncate_degraded_to_reject"], 1)
 
     def test_all_within_budget_no_counters(self):
         trainer = self._make_fake_trainer("reject")


### PR DESCRIPTION
**Resolves #216**

## Summary

Replaces AReno's scattered, reject-only "sample exceeds the token budget" checks with one explicit, observable contract — `OverlengthPolicy {reject, warn, truncate}` — shared by SFT, DPO pairs, and agentic trajectories, with per-reason `rollout/overlength/{reason}/{action}` scalars. Default `reject` is byte-equivalent to today; `warn`/`truncate` are opt-in.

## Background

Before #216, each trainer re-implemented the same `if len > max: skip` check with inconsistent counters: only the RL prompt path reached TensorBoard (`rollout/skipped_long`), SFT/DPO only `logger.info` and conflated `long` with `empty`/`invalid`, and the agentic path used a separate diagnostics dict. There was no `warn`/`truncate` policy and no per-reason breakdown.

## What this PR changes

| Area | File(s) | Change |
| --- | --- | --- |
| Contract | `areno/api/data.py` | `OverlengthPolicy`, `OverlengthReason`, `OverlengthDecision`; `PromptBatch` gains per-reason `overlength_counters` (legacy `skipped_long` kept) |
| Decision core | `areno/api/overlength.py` (new) | Pure-CPU `decide_overlength()` (deterministic, validates inputs) + `truncate_sft_response()` + `truncate_dpo_pair()` |
| Metrics | `areno/api/metrics.py` | Per-reason scalars `rollout/overlength/{reason}/{action}` via existing `record_training_stats`; `Trainer.record_overlength_counters()` public method wires all three modes |
| SFT adapter | `areno/api/trainers/sft.py` | Cuts response at `max_new_tokens`, replaces last token with EOS (stays within budget), recomputes prompt mask |
| DPO adapter | `areno/api/trainers/dpo.py` | Truncates chosen/rejected to a common budget over the shared prefix; rejects the whole pair if either side can't fit (never single-sided) |
| Agentic adapter | `areno/api/trainers/policy_only.py` | `reject`/`warn` fully supported; `truncate` degrades to `reject` (no per-turn offsets — never splits a tool_call/result pair), labeled `truncate_degraded_to_reject` + WARNING |
| CLI / config | `areno/cli/train.py`, `areno/api/trainer_config.py` | `--overlength-policy {reject,warn,truncate}`, default `reject`, validated before model/worker init |
| Tests / docs | `tests/test_overlength_cpu.py`, `docs/cli/training.rst` | 28 CPU tests; CLI docs with policies, output fields, and agentic limitation |

## Key design decisions

1. **Default `reject` is byte-equivalent to today** — backward compatible, opt-in for `warn`/`truncate`.
2. **No new subsystem** — reuses `eos_token_ids`, `prompt_response_to_tokens_and_mask`, `apply_chat_template`, the existing Click preflight, and the existing metrics writer. One small pure-CPU module added; no new dependencies.
3. **DPO never single-sided** — if either side can't fit even at minimum, the whole pair is rejected, keeping chosen/rejected comparable.
4. **Agentic `truncate` is an honest degrade** — the flattened token row has no per-turn offsets, so it degrades to `reject` (labeled `truncate_degraded_to_reject` + WARNING) rather than risk splitting a tool_call/result pair.
5. **No sample leakage** — `OverlengthDecision.detail` carries only `over_by_tokens`, never full training text.

## How it's verified

- `pytest tests/ -k cpu` — **406 passed** (378 existing + 28 new overlength tests).
- `ruff check . && ruff format --check .` — clean.
- End-to-end on a Kaggle T4 GPU (Qwen3-0.6B):
  - Default `reject` regression: `areno train --algo gspo --dataset-path gsm8k:main --max-steps 2` runs to `train_stats` without error — backward compatible.
  - `warn` + agentic filtering: `areno train --algo gspo --agent-fn examples/agentic/tictactoe/run_agent.py --overlength-policy warn --max-context-len 64 --max-steps 2` logs `agentic trajectory filtered: ... filtered=2` and runs to completion.
  - TensorBoard scalar confirmed via `EventAccumulator`: `rollout/overlength/trajectory_too_long/warn = 2.0` — the full channel (filter → counter → scalar) is wired end-to-end.

## Acceptance criteria coverage

| Criterion | Where it is satisfied |
| --- | --- |
| Covers chat template, EOS position, mask, exact-limit input, single oversized message, per-reason counting | Chat template: `sft.py`/`dpo.py` call `configure_chat_template_enable_thinking` + `apply_chat_template`. EOS: `overlength.py` SFT replaces last token with EOS on cut, DPO re-appends EOS over the shared prefix. Mask: both truncators recompute `prompt_mask`. Exact-limit: `decide_overlength` treats `len == cap` as `EXACT_LIMIT` (not overlength). Single oversized message: prompt-overlength returns `SINGLE_MESSAGE_OVERSIZED`. Per-reason counting: `overlength_counters` keyed by `{reason}/{action}`, emitted as `rollout/overlength/{reason}/{action}` scalars. |
| Preserve current default behavior unless intentionally migrated and recorded | `overlength_policy` defaults to `reject` in `TrainerConfig` and CLI; default `reject` is byte-equivalent to the pre-PR skip path. Legacy `skipped_long`/`total_skipped_long` fields retained on `PromptBatch`. |
| Reuses existing AReno contracts; no external DB or forced sandbox | Reuses `prompt_response_to_tokens_and_mask`, `apply_chat_template`, `eos_token_ids`, `record_training_stats`, and the existing Click preflight. One new pure-CPU module (`overlength.py`); no new dependencies in `pyproject.toml`; no DB, no sandbox. |
| Default behavior stays backward compatible | Verified end-to-end: default `reject` on gsm8k GSPO runs to `train_stats` without error (Kaggle T4). |
| Automated tests cover success, invalid input, and a boundary/failure path | `tests/test_overlength_cpu.py` (28 tests): success (`within_budget`, `both_fit_unchanged`), invalid input (`invalid_max_prompt_tokens_raises`, `invalid_policy_type_raises`), boundary (`exact_limit_is_not_overlength`, `too_small_to_fit_returns_none`), failure path (`truncate_degrades_to_reject`, `long_response_cut_to_limit_with_eos_reappended`). |
| User docs include a minimal runnable example and explain observable output | `docs/cli/training.rst` documents `--overlength-policy`, the three policies, the `rollout/overlength/{reason}/{action}` output fields, and the agentic truncate limitation; the Kaggle run above is the minimal runnable example. |

## Known limitations & follow-ups

These were found in a pre-submit self-review and are intentionally deferred to keep this PR focused; happy to address them in follow-ups if preferred:

- **DPO bypasses `decide_overlength`** — it hand-rolls the length check and hardcodes reason strings instead of using `OverlengthReason.X.value`. A rename of the enum value would silently split the metric series.
- **`OverlengthReason.PROMPT_TOO_LONG` is currently dead code** — `decide_overlength` returns `SINGLE_MESSAGE_OVERSIZED` for prompt overlength.
- **`_count()` helper and the `before/after` counter-diff protocol** are duplicated across SFT/DPO/agentic; a shared `bump_overlength_counter()` helper would centralize the `{reason}/{policy}` key convention.
- **Agentic true turn-level truncation** needs per-turn offsets on the token row, which is a larger change; tracked as a future enhancement.

## Compatibility

No public API removed; `PromptBatch` only adds a field with a default. Default behavior unchanged unless the user explicitly passes `--overlength-policy`.
