### PR TITLE
feat(engine): record effective trainable tokens per update (#227)

### DIFF
--- a/areno/engine/token_counts.py
+++ b/areno/engine/token_counts.py
@@ -3,10 +3,10 @@
 Computes per-update token statistics using the same masks consumed by the
 loss function.  The four emitted metrics are:
 
-* ``total_input_tokens`` — all tokens in the batch (including padding).
-* ``masked_tokens`` — tokens excluded from loss (prompt positions + padding).
+* ``total_input_tokens`` — all valid tokens in the batch (excluding padding).
+* ``masked_tokens`` — tokens excluded from loss (prompt positions).
 * ``effective_loss_tokens`` — tokens that contribute to the loss gradient.
-* ``mean_effective_length`` — effective tokens per sequence (response length).
+* ``mean_effective_length`` — average effective (response) tokens per sequence.
 
 The module is pure Python and operates on plain lists/ints so it can be
 unit-tested without torch or GPU.  The trainer integration calls
@@ -31,8 +31,7 @@ class TokenCounts:
     """Per-update token statistics.
 
     Attributes:
-        total_input_tokens: All tokens in the batch (valid positions only,
-            excluding padding).
+        total_input_tokens: All valid tokens in the batch (excluding padding).
         masked_tokens: Tokens excluded from loss (prompt positions).
         effective_loss_tokens: Tokens that contribute to the loss gradient.
         mean_effective_length: Average effective (response) tokens per sequence.
@@ -56,66 +55,78 @@ class TokenCounts:
         }
 
 
-def compute_token_counts(
-    lengths: list[int],
-    prompt_mask_rows: list[list[bool]] | None = None,
-    loss_mask_rows: list[list[bool]] | None = None,
-    packed_response_mask: list[bool] | None = None,
-    num_sequences: int | None = None,
+def compute_token_counts_from_packed(
+    response_mask: list[bool],
+    num_sequences: int,
 ) -> TokenCounts:
-    """Compute effective trainable token statistics from loss masks.
+    """Compute token counts from a packed (varlen) response mask.
 
-    Supports both packed (varlen) and padded (rectangular) layouts.
+    In packed layout, the response mask is a flat tensor where each entry
+    corresponds to an action position (token at position t predicts token t+1).
+    Each sequence of length L contributes L-1 actions.
 
-    For **packed** layout, pass ``packed_response_mask`` and ``num_sequences``.
-    For **padded** layout, pass ``lengths``, ``prompt_mask_rows``, and
-    optionally ``loss_mask_rows``.
+    Args:
+        response_mask: Flat mask (True = response token contributing to loss).
+        num_sequences: Number of sequences in the packed batch.
+
+    Returns:
+        A :class:`TokenCounts`.
+    """
+
+    n_seqs = max(num_sequences, 1)
+    effective = sum(1 for m in response_mask if m)
+    total_actions = len(response_mask)
+    # total_input_tokens = sum of sequence lengths = actions + num_sequences
+    # (each seq of length L contributes L-1 actions; sum(L_i) = sum(L_i-1) + n).
+    total_tokens = total_actions + n_seqs
+    masked = total_tokens - effective
+    mean_eff = effective / n_seqs if n_seqs > 0 else 0.0
+    return TokenCounts(
+        total_input_tokens=total_tokens,
+        masked_tokens=masked,
+        effective_loss_tokens=effective,
+        mean_effective_length=mean_eff,
+        num_sequences=n_seqs,
+    )
+
+
+def compute_token_counts_from_padded(
+    lengths: list[int],
+    prompt_mask_rows: list[list[bool]],
+    loss_mask_rows: list[list[bool]] | None = None,
+) -> TokenCounts:
+    """Compute token counts from padded (rectangular) masks.
+
+    In padded layout, each sequence has a length and a per-position prompt
+    mask. Actions are positions 1..length-1 (token at position 0 has no
+    action because there's no previous token to predict it from).
+
+    ``total_input_tokens`` = sum of lengths (valid tokens, excluding padding).
+    For each action position (1..length-1):
+        - If prompt_mask[pos] is True → masked (doesn't contribute to loss).
+        - If loss_mask exists and loss_mask[pos] is False → masked.
+        - Otherwise → effective (contributes to loss).
+    ``masked_tokens`` = total action positions - effective.
+    Note: position 0 of each sequence is not an action position, so it's
+    neither masked nor effective. ``total_input_tokens`` includes it, but
+    ``masked_tokens + effective_loss_tokens`` = total_input_tokens - num_sequences.
 
     Args:
         lengths: Valid token count per sequence (excludes padding).
         prompt_mask_rows: Per-sequence prompt mask (True = prompt token).
-            Required for padded layout; ignored for packed layout.
         loss_mask_rows: Per-sequence loss mask (True = contributes to loss).
-            Optional; if None, only prompt_mask is used.
-        packed_response_mask: Flat response mask for packed layout
-            (True = response token that contributes to loss).
-        num_sequences: Number of sequences for packed layout.
+            If None, only prompt_mask is used (all non-prompt = effective).
 
     Returns:
-        A :class:`TokenCounts` with the four metrics.
-
-    Raises:
-        ValueError: If neither packed nor padded inputs are provided, or
-            if lengths are empty for padded layout.
+        A :class:`TokenCounts`.
     """
 
-    # --- Packed layout ---
-    if packed_response_mask is not None:
-        n_seqs = num_sequences if num_sequences is not None and num_sequences > 0 else 1
-        effective = sum(1 for m in packed_response_mask if m)
-        total_actions = len(packed_response_mask)
-        # In packed layout, total_input_tokens = actions + num_sequences
-        # (each sequence has length L, contributing L-1 actions; total tokens
-        # = sum of lengths = actions + num_sequences).
-        total_tokens = total_actions + n_seqs
-        masked = total_tokens - effective
-        mean_eff = effective / n_seqs if n_seqs > 0 else 0.0
-        return TokenCounts(
-            total_input_tokens=total_tokens,
-            masked_tokens=masked,
-            effective_loss_tokens=effective,
-            mean_effective_length=mean_eff,
-            num_sequences=n_seqs,
-        )
-
-    # --- Padded layout ---
     if not lengths:
         raise ValueError("lengths must be non-empty for padded layout")
     if prompt_mask_rows is None:
         raise ValueError("prompt_mask_rows required for padded layout")
 
     total_tokens = 0
-    masked = 0
     effective = 0
     n_seqs = len(lengths)
 
@@ -125,15 +136,16 @@ def compute_token_counts(
         total_tokens += length
         pm = prompt_mask_rows[i] if i < len(prompt_mask_rows) else []
         lm = loss_mask_rows[i] if loss_mask_rows is not None and i < len(loss_mask_rows) else None
-        # Actions are positions 1..length-1 (token at position 0 has no action).
+        # Actions are positions 1..length-1.
         for pos in range(1, length):
             is_prompt = bool(pm[pos]) if pos < len(pm) else False
             is_loss = bool(lm[pos]) if lm is not None and pos < len(lm) else True
-            if is_prompt or not is_loss:
-                masked += 1
-            else:
+            if not is_prompt and is_loss:
                 effective += 1
 
+    # masked = total_actions - effective = (total_tokens - n_seqs) - effective
+    total_actions = max(total_tokens - n_seqs, 0)
+    masked = max(total_actions - effective, 0)
     mean_eff = effective / n_seqs if n_seqs > 0 else 0.0
     return TokenCounts(
         total_input_tokens=total_tokens,
@@ -141,4 +153,46 @@ def compute_token_counts(
         effective_loss_tokens=effective,
         mean_effective_length=mean_eff,
         num_sequences=n_seqs,
+    )
+
+
+def compute_token_counts(
+    lengths: list[int],
+    prompt_mask_rows: list[list[bool]] | None = None,
+    loss_mask_rows: list[list[bool]] | None = None,
+    packed_response_mask: list[bool] | None = None,
+    num_sequences: int | None = None,
+) -> TokenCounts:
+    """Compute effective trainable token statistics from loss masks.
+
+    Dispatches to packed or padded layout based on which arguments are provided.
+
+    For **packed** layout, pass ``packed_response_mask`` and ``num_sequences``.
+    For **padded** layout, pass ``lengths``, ``prompt_mask_rows``, and
+    optionally ``loss_mask_rows``.
+
+    Args:
+        lengths: Valid token count per sequence (excludes padding).
+        prompt_mask_rows: Per-sequence prompt mask (True = prompt token).
+        loss_mask_rows: Per-sequence loss mask (True = contributes to loss).
+        packed_response_mask: Flat response mask for packed layout.
+        num_sequences: Number of sequences for packed layout.
+
+    Returns:
+        A :class:`TokenCounts`.
+
+    Raises:
+        ValueError: If neither packed nor padded inputs are provided, or
+            if lengths are empty for padded layout.
+    """
+
+    if packed_response_mask is not None:
+        return compute_token_counts_from_packed(
+            response_mask=packed_response_mask,
+            num_sequences=num_sequences if num_sequences is not None else 1,
+        )
+    return compute_token_counts_from_padded(
+        lengths=lengths,
+        prompt_mask_rows=prompt_mask_rows,
+        loss_mask_rows=loss_mask_rows,
     )

--- a/areno/engine/token_counts.py
+++ b/areno/engine/token_counts.py
@@ -1,0 +1,144 @@
+"""Effective trainable token counting (issue #227).
+
+Computes per-update token statistics using the same masks consumed by the
+loss function.  The four emitted metrics are:
+
+* ``total_input_tokens`` — all tokens in the batch (including padding).
+* ``masked_tokens`` — tokens excluded from loss (prompt positions + padding).
+* ``effective_loss_tokens`` — tokens that contribute to the loss gradient.
+* ``mean_effective_length`` — effective tokens per sequence (response length).
+
+The module is pure Python and operates on plain lists/ints so it can be
+unit-tested without torch or GPU.  The trainer integration calls
+:func:`compute_token_counts` after packing and before the loss, reading the
+same ``prompt_mask`` / ``loss_mask`` / ``packed_response_mask`` fields that
+the loss function uses.
+
+Public API:
+
+* :func:`compute_token_counts` — main entry point; returns
+  :class:`TokenCounts`.
+* :class:`TokenCounts` — dataclass with ``to_dict()``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TokenCounts:
+    """Per-update token statistics.
+
+    Attributes:
+        total_input_tokens: All tokens in the batch (valid positions only,
+            excluding padding).
+        masked_tokens: Tokens excluded from loss (prompt positions).
+        effective_loss_tokens: Tokens that contribute to the loss gradient.
+        mean_effective_length: Average effective (response) tokens per sequence.
+        num_sequences: Number of sequences in the batch.
+    """
+
+    total_input_tokens: int
+    masked_tokens: int
+    effective_loss_tokens: int
+    mean_effective_length: float
+    num_sequences: int
+
+    def to_dict(self) -> dict[str, float]:
+        """Return a metrics dict suitable for merging into train stats."""
+
+        return {
+            "total_input_tokens": float(self.total_input_tokens),
+            "masked_tokens": float(self.masked_tokens),
+            "effective_loss_tokens": float(self.effective_loss_tokens),
+            "mean_effective_length": float(self.mean_effective_length),
+        }
+
+
+def compute_token_counts(
+    lengths: list[int],
+    prompt_mask_rows: list[list[bool]] | None = None,
+    loss_mask_rows: list[list[bool]] | None = None,
+    packed_response_mask: list[bool] | None = None,
+    num_sequences: int | None = None,
+) -> TokenCounts:
+    """Compute effective trainable token statistics from loss masks.
+
+    Supports both packed (varlen) and padded (rectangular) layouts.
+
+    For **packed** layout, pass ``packed_response_mask`` and ``num_sequences``.
+    For **padded** layout, pass ``lengths``, ``prompt_mask_rows``, and
+    optionally ``loss_mask_rows``.
+
+    Args:
+        lengths: Valid token count per sequence (excludes padding).
+        prompt_mask_rows: Per-sequence prompt mask (True = prompt token).
+            Required for padded layout; ignored for packed layout.
+        loss_mask_rows: Per-sequence loss mask (True = contributes to loss).
+            Optional; if None, only prompt_mask is used.
+        packed_response_mask: Flat response mask for packed layout
+            (True = response token that contributes to loss).
+        num_sequences: Number of sequences for packed layout.
+
+    Returns:
+        A :class:`TokenCounts` with the four metrics.
+
+    Raises:
+        ValueError: If neither packed nor padded inputs are provided, or
+            if lengths are empty for padded layout.
+    """
+
+    # --- Packed layout ---
+    if packed_response_mask is not None:
+        n_seqs = num_sequences if num_sequences is not None and num_sequences > 0 else 1
+        effective = sum(1 for m in packed_response_mask if m)
+        total_actions = len(packed_response_mask)
+        # In packed layout, total_input_tokens = actions + num_sequences
+        # (each sequence has length L, contributing L-1 actions; total tokens
+        # = sum of lengths = actions + num_sequences).
+        total_tokens = total_actions + n_seqs
+        masked = total_tokens - effective
+        mean_eff = effective / n_seqs if n_seqs > 0 else 0.0
+        return TokenCounts(
+            total_input_tokens=total_tokens,
+            masked_tokens=masked,
+            effective_loss_tokens=effective,
+            mean_effective_length=mean_eff,
+            num_sequences=n_seqs,
+        )
+
+    # --- Padded layout ---
+    if not lengths:
+        raise ValueError("lengths must be non-empty for padded layout")
+    if prompt_mask_rows is None:
+        raise ValueError("prompt_mask_rows required for padded layout")
+
+    total_tokens = 0
+    masked = 0
+    effective = 0
+    n_seqs = len(lengths)
+
+    for i, length in enumerate(lengths):
+        if length <= 0:
+            continue
+        total_tokens += length
+        pm = prompt_mask_rows[i] if i < len(prompt_mask_rows) else []
+        lm = loss_mask_rows[i] if loss_mask_rows is not None and i < len(loss_mask_rows) else None
+        # Actions are positions 1..length-1 (token at position 0 has no action).
+        for pos in range(1, length):
+            is_prompt = bool(pm[pos]) if pos < len(pm) else False
+            is_loss = bool(lm[pos]) if lm is not None and pos < len(lm) else True
+            if is_prompt or not is_loss:
+                masked += 1
+            else:
+                effective += 1
+
+    mean_eff = effective / n_seqs if n_seqs > 0 else 0.0
+    return TokenCounts(
+        total_input_tokens=total_tokens,
+        masked_tokens=masked,
+        effective_loss_tokens=effective,
+        mean_effective_length=mean_eff,
+        num_sequences=n_seqs,
+    )

--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -121,13 +121,16 @@ class TrainingManager:
                 if metrics is None:
                     metrics = {}
                 metrics["auto_tune_worker_peak_mem_frac"] = float(peak) / float(total)
+            # Compute effective trainable token counts from the same masks
+            # used by the loss function (issue #227).
+            token_metrics = _compute_token_metrics(data_pack)
             return {
                 "loss": float(loss.detach().cpu()),
                 "stepped": stepped,
                 "global_step": worker._global_step,
                 "metrics": _merge_metrics(
                     metrics,
-                    None,
+                    token_metrics,
                     {"lr": current_lr},
                     {"grad_norm": grad_norm} if grad_norm is not None else None,
                     grad_zero_metrics,
@@ -200,3 +203,56 @@ class TrainingManager:
 
         ctx = get_tp_context()
         self.worker.model.finalize_router_expert_bias(ctx.group, ctx.dp_group)
+
+
+def _compute_token_metrics(data_pack: dict) -> dict[str, float] | None:
+    """Compute effective trainable token metrics from the data pack (issue #227).
+
+    Reads the same ``prompt_mask`` / ``loss_mask`` / ``packed_response_mask``
+    fields used by the loss function. Returns a metrics dict or None if
+    the required fields are not present.
+    """
+
+    from areno.engine.token_counts import compute_token_counts
+
+    try:
+        if "packed_response_mask" in data_pack:
+            resp_mask = data_pack["packed_response_mask"]
+            if isinstance(resp_mask, torch.Tensor):
+                resp_mask = resp_mask.cpu().tolist()
+            n_seqs = int(data_pack.get("packed_num_sequences", 1))
+            counts = compute_token_counts(
+                lengths=[],
+                packed_response_mask=[bool(m) for m in resp_mask],
+                num_sequences=n_seqs,
+            )
+            return counts.to_dict()
+        # Padded layout.
+        lengths_t = data_pack.get("lengths")
+        prompt_mask_t = data_pack.get("prompt_mask")
+        if lengths_t is None or prompt_mask_t is None:
+            return None
+        lengths = lengths_t.cpu().tolist() if isinstance(lengths_t, torch.Tensor) else list(lengths_t)
+        prompt_mask_rows = []
+        for row in range(len(lengths)):
+            pm = prompt_mask_t[row]
+            if isinstance(pm, torch.Tensor):
+                pm = pm.cpu().tolist()
+            prompt_mask_rows.append([bool(m) for m in pm])
+        loss_mask_rows = None
+        loss_mask_t = data_pack.get("loss_mask")
+        if loss_mask_t is not None and isinstance(loss_mask_t, torch.Tensor):
+            loss_mask_rows = []
+            for row in range(len(lengths)):
+                lm = loss_mask_t[row]
+                if isinstance(lm, torch.Tensor):
+                    lm = lm.cpu().tolist()
+                loss_mask_rows.append([bool(m) for m in lm])
+        counts = compute_token_counts(
+            lengths=lengths,
+            prompt_mask_rows=prompt_mask_rows,
+            loss_mask_rows=loss_mask_rows,
+        )
+        return counts.to_dict()
+    except (KeyError, ValueError, AttributeError, TypeError):
+        return None

--- a/docs/troubleshooting/effective-tokens.rst
+++ b/docs/troubleshooting/effective-tokens.rst
@@ -1,0 +1,48 @@
+:orphan:
+
+Effective Trainable Tokens
+==========================
+
+AReno records per-update token statistics so operators can see how many
+tokens are actually being trained on, not just how many are in the batch.
+
+Metrics
+-------
+
+The following four metrics are emitted with every training update and are
+visible in logs, TensorBoard, and the dashboard:
+
+* ``total_input_tokens`` — all valid tokens in the batch (excluding padding).
+* ``masked_tokens`` — tokens excluded from loss (prompt positions, padding,
+  or explicitly masked by ``loss_mask``).
+* ``effective_loss_tokens`` — tokens that contribute to the loss gradient.
+* ``mean_effective_length`` — average effective (response) tokens per sequence.
+
+How it works
+------------
+
+The counting uses the same ``prompt_mask`` and ``loss_mask`` consumed by the
+loss function, so the numbers are consistent with what the model actually
+trains on. Both packed (varlen) and padded (rectangular) layouts are
+supported.
+
+For agentic trajectories where prompt and response tokens are interleaved,
+the counting correctly handles mixed positions — any position marked as
+prompt in ``prompt_mask`` is counted as masked, regardless of its position
+in the sequence.
+
+Zero-token batches
+------------------
+
+If a batch contains sequences with zero valid tokens (e.g., all sequences
+were filtered out), the metrics will report zeros for all fields without
+crashing. ``mean_effective_length`` will be 0.0.
+
+Limitations
+-----------
+
+* The metrics are computed per-update (per optimizer step), not per-sample.
+* Cross-rank aggregation uses the existing ``merge_train_stats`` mechanism,
+  which averages metrics across data-parallel ranks.
+* The counting happens in the trainer's ``_train_step``, so it covers SFT,
+  DPO, and rollout-based training (GSPO/GRPO/PPO) uniformly.

--- a/docs/troubleshooting/effective-tokens.rst
+++ b/docs/troubleshooting/effective-tokens.rst
@@ -26,6 +26,29 @@ loss function, so the numbers are consistent with what the model actually
 trains on. Both packed (varlen) and padded (rectangular) layouts are
 supported.
 
+The metrics are computed in ``TrainingManager._train_step`` after packing
+and before the loss, then merged into the per-step metrics dict that flows
+through ``merge_train_stats`` for cross-rank aggregation. This means SFT,
+DPO, and rollout-based training (GSPO/GRPO/PPO) all get the metrics
+automatically — they all go through ``_train_step``.
+
+Example
+-------
+
+.. code-block:: python
+
+   from areno.engine.token_counts import compute_token_counts_from_padded
+
+   # One sequence: [P, P, P, R, R] (3 prompt, 2 response tokens)
+   # Actions at positions 1-4: pos1=P(masked), pos2=P(masked), pos3-4=R(effective)
+   counts = compute_token_counts_from_padded(
+       lengths=[5],
+       prompt_mask_rows=[[True, True, True, False, False]],
+   )
+   print(counts.to_dict())
+   # {'total_input_tokens': 5.0, 'masked_tokens': 2.0,
+   #  'effective_loss_tokens': 2.0, 'mean_effective_length': 2.0}
+
 For agentic trajectories where prompt and response tokens are interleaved,
 the counting correctly handles mixed positions — any position marked as
 prompt in ``prompt_mask`` is counted as masked, regardless of its position
@@ -34,9 +57,9 @@ in the sequence.
 Zero-token batches
 ------------------
 
-If a batch contains sequences with zero valid tokens (e.g., all sequences
-were filtered out), the metrics will report zeros for all fields without
-crashing. ``mean_effective_length`` will be 0.0.
+If a batch contains sequences with zero valid tokens, the metrics will
+report zeros for all fields without crashing. ``mean_effective_length``
+will be 0.0.
 
 Limitations
 -----------
@@ -44,5 +67,6 @@ Limitations
 * The metrics are computed per-update (per optimizer step), not per-sample.
 * Cross-rank aggregation uses the existing ``merge_train_stats`` mechanism,
   which averages metrics across data-parallel ranks.
-* The counting happens in the trainer's ``_train_step``, so it covers SFT,
-  DPO, and rollout-based training (GSPO/GRPO/PPO) uniformly.
+* Position 0 of each sequence is not an action position (no previous token
+  to predict from), so ``masked_tokens + effective_loss_tokens`` equals
+  ``total_input_tokens - num_sequences``.

--- a/tests/test_token_counts_cpu.py
+++ b/tests/test_token_counts_cpu.py
@@ -4,10 +4,11 @@ Tests cover:
 - Packed layout: response mask → counts.
 - Padded layout: lengths + prompt_mask → counts.
 - Padded layout with loss_mask: prompt_mask + loss_mask → counts.
+- total_input_tokens = masked + effective + num_sequences (padded invariant).
 - Zero-token batch (all lengths = 0).
 - Single token per sequence (length = 1, no actions).
 - Empty packed response mask.
-- Mixed prompt/response in same sequence.
+- Mixed prompt/response in same sequence (agentic).
 - Multiple sequences with varying lengths.
 - Deterministic output.
 - to_dict() structure.
@@ -18,18 +19,21 @@ from __future__ import annotations
 
 import unittest
 
-from areno.engine.token_counts import compute_token_counts
+from areno.engine.token_counts import (
+    compute_token_counts,
+    compute_token_counts_from_packed,
+    compute_token_counts_from_padded,
+)
 
 
 class TestPackedLayout(unittest.TestCase):
     """Packed layout: pass packed_response_mask and num_sequences."""
 
     def test_basic_packed(self):
-        # 3 response tokens out of 5 actions, 2 sequences.
+        # 3 effective out of 5 actions, 2 sequences.
         # total_tokens = 5 + 2 = 7, masked = 7 - 3 = 4.
-        counts = compute_token_counts(
-            lengths=[],
-            packed_response_mask=[True, False, True, False, True],
+        counts = compute_token_counts_from_packed(
+            response_mask=[True, False, True, False, True],
             num_sequences=2,
         )
         self.assertEqual(counts.effective_loss_tokens, 3)
@@ -39,9 +43,8 @@ class TestPackedLayout(unittest.TestCase):
         self.assertAlmostEqual(counts.mean_effective_length, 1.5)
 
     def test_all_effective_packed(self):
-        counts = compute_token_counts(
-            lengths=[],
-            packed_response_mask=[True, True, True],
+        counts = compute_token_counts_from_packed(
+            response_mask=[True, True, True],
             num_sequences=1,
         )
         self.assertEqual(counts.effective_loss_tokens, 3)
@@ -49,9 +52,8 @@ class TestPackedLayout(unittest.TestCase):
         self.assertEqual(counts.total_input_tokens, 4)
 
     def test_none_effective_packed(self):
-        counts = compute_token_counts(
-            lengths=[],
-            packed_response_mask=[False, False],
+        counts = compute_token_counts_from_packed(
+            response_mask=[False, False],
             num_sequences=1,
         )
         self.assertEqual(counts.effective_loss_tokens, 0)
@@ -59,22 +61,13 @@ class TestPackedLayout(unittest.TestCase):
         self.assertAlmostEqual(counts.mean_effective_length, 0.0)
 
     def test_empty_packed_mask(self):
-        counts = compute_token_counts(
-            lengths=[],
-            packed_response_mask=[],
+        counts = compute_token_counts_from_packed(
+            response_mask=[],
             num_sequences=0,
         )
         self.assertEqual(counts.effective_loss_tokens, 0)
         # num_sequences=0 defaults to 1, so total = 0 + 1 = 1.
         self.assertEqual(counts.total_input_tokens, 1)
-
-    def test_num_sequences_defaults_to_1(self):
-        counts = compute_token_counts(
-            lengths=[],
-            packed_response_mask=[True],
-            num_sequences=None,
-        )
-        self.assertEqual(counts.num_sequences, 1)
 
 
 class TestPaddedLayout(unittest.TestCase):
@@ -83,7 +76,7 @@ class TestPaddedLayout(unittest.TestCase):
     def test_basic_padded(self):
         # 1 sequence, length 5: [P, P, P, R, R]
         # Actions at positions 1-4: pos1=P(masked), pos2=P(masked), pos3=R(eff), pos4=R(eff)
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[5],
             prompt_mask_rows=[[True, True, True, False, False]],
         )
@@ -93,10 +86,21 @@ class TestPaddedLayout(unittest.TestCase):
         self.assertEqual(counts.num_sequences, 1)
         self.assertAlmostEqual(counts.mean_effective_length, 2.0)
 
+    def test_padded_invariant(self):
+        """total_input_tokens = masked + effective + num_sequences."""
+        counts = compute_token_counts_from_padded(
+            lengths=[5, 3],
+            prompt_mask_rows=[[True, True, False, False, False], [True, False, False]],
+        )
+        self.assertEqual(
+            counts.total_input_tokens,
+            counts.masked_tokens + counts.effective_loss_tokens + counts.num_sequences,
+        )
+
     def test_multiple_sequences(self):
         # seq0: length 4 [P,P,R,R] → actions pos1=P(masked), pos2-3=R(eff)
         # seq1: length 3 [P,R,R] → actions pos1=R(eff), pos2=R(eff)
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[4, 3],
             prompt_mask_rows=[
                 [True, True, False, False],
@@ -113,7 +117,7 @@ class TestPaddedLayout(unittest.TestCase):
         # pos1: prompt=True → masked
         # pos2: prompt=False, loss_mask=True → effective
         # pos3: prompt=False, loss_mask=False → masked
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[4],
             prompt_mask_rows=[[True, True, False, False]],
             loss_mask_rows=[[False, False, True, False]],
@@ -123,7 +127,7 @@ class TestPaddedLayout(unittest.TestCase):
 
     def test_single_token_sequence(self):
         # length=1 means no actions (positions 1..0 is empty).
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[1],
             prompt_mask_rows=[[True]],
         )
@@ -137,7 +141,7 @@ class TestZeroTokenBatch(unittest.TestCase):
     """Zero-token batches should not crash."""
 
     def test_all_zero_lengths(self):
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[0, 0, 0],
             prompt_mask_rows=[[], [], []],
         )
@@ -148,7 +152,7 @@ class TestZeroTokenBatch(unittest.TestCase):
 
     def test_empty_lengths(self):
         with self.assertRaises(ValueError):
-            compute_token_counts(lengths=[], prompt_mask_rows=[])
+            compute_token_counts_from_padded(lengths=[], prompt_mask_rows=[])
 
 
 class TestInvalidInputs(unittest.TestCase):
@@ -167,13 +171,9 @@ class TestDeterminism(unittest.TestCase):
     """Same inputs produce same outputs."""
 
     def test_deterministic_packed(self):
-        kwargs = dict(
-            lengths=[],
-            packed_response_mask=[True, False, True],
-            num_sequences=1,
-        )
-        c1 = compute_token_counts(**kwargs)
-        c2 = compute_token_counts(**kwargs)
+        kwargs = dict(response_mask=[True, False, True], num_sequences=1)
+        c1 = compute_token_counts_from_packed(**kwargs)
+        c2 = compute_token_counts_from_packed(**kwargs)
         self.assertEqual(c1, c2)
 
     def test_deterministic_padded(self):
@@ -181,8 +181,8 @@ class TestDeterminism(unittest.TestCase):
             lengths=[4, 3],
             prompt_mask_rows=[[True, True, False, False], [True, False, False]],
         )
-        c1 = compute_token_counts(**kwargs)
-        c2 = compute_token_counts(**kwargs)
+        c1 = compute_token_counts_from_padded(**kwargs)
+        c2 = compute_token_counts_from_padded(**kwargs)
         self.assertEqual(c1, c2)
 
 
@@ -190,7 +190,7 @@ class TestToDict(unittest.TestCase):
     """to_dict should return float metrics."""
 
     def test_to_dict_fields(self):
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[3],
             prompt_mask_rows=[[True, False, False]],
         )
@@ -201,6 +201,15 @@ class TestToDict(unittest.TestCase):
         self.assertIn("mean_effective_length", d)
         self.assertIsInstance(d["total_input_tokens"], float)
         self.assertIsInstance(d["effective_loss_tokens"], float)
+
+    def test_to_dict_values(self):
+        counts = compute_token_counts_from_packed(
+            response_mask=[True, True, False],
+            num_sequences=1,
+        )
+        d = counts.to_dict()
+        self.assertEqual(d["effective_loss_tokens"], 2.0)
+        self.assertEqual(d["total_input_tokens"], 4.0)
 
 
 class TestMixedPromptResponse(unittest.TestCase):
@@ -213,12 +222,31 @@ class TestMixedPromptResponse(unittest.TestCase):
         # pos2: prompt=False → effective
         # pos3: prompt=True → masked
         # pos4: prompt=False → effective
-        counts = compute_token_counts(
+        counts = compute_token_counts_from_padded(
             lengths=[5],
             prompt_mask_rows=[[True, False, False, True, False]],
         )
         self.assertEqual(counts.effective_loss_tokens, 3)
         self.assertEqual(counts.masked_tokens, 1)
+
+
+class TestDispatch(unittest.TestCase):
+    """compute_token_counts dispatches to packed or padded correctly."""
+
+    def test_dispatches_to_packed(self):
+        counts = compute_token_counts(
+            lengths=[],
+            packed_response_mask=[True, False],
+            num_sequences=1,
+        )
+        self.assertEqual(counts.effective_loss_tokens, 1)
+
+    def test_dispatches_to_padded(self):
+        counts = compute_token_counts(
+            lengths=[3],
+            prompt_mask_rows=[[True, False, False]],
+        )
+        self.assertEqual(counts.effective_loss_tokens, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_token_counts_cpu.py
+++ b/tests/test_token_counts_cpu.py
@@ -1,0 +1,225 @@
+"""CPU tests for effective trainable token counting (issue #227).
+
+Tests cover:
+- Packed layout: response mask → counts.
+- Padded layout: lengths + prompt_mask → counts.
+- Padded layout with loss_mask: prompt_mask + loss_mask → counts.
+- Zero-token batch (all lengths = 0).
+- Single token per sequence (length = 1, no actions).
+- Empty packed response mask.
+- Mixed prompt/response in same sequence.
+- Multiple sequences with varying lengths.
+- Deterministic output.
+- to_dict() structure.
+- Invalid inputs (missing required args).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from areno.engine.token_counts import compute_token_counts
+
+
+class TestPackedLayout(unittest.TestCase):
+    """Packed layout: pass packed_response_mask and num_sequences."""
+
+    def test_basic_packed(self):
+        # 3 response tokens out of 5 actions, 2 sequences.
+        # total_tokens = 5 + 2 = 7, masked = 7 - 3 = 4.
+        counts = compute_token_counts(
+            lengths=[],
+            packed_response_mask=[True, False, True, False, True],
+            num_sequences=2,
+        )
+        self.assertEqual(counts.effective_loss_tokens, 3)
+        self.assertEqual(counts.total_input_tokens, 7)
+        self.assertEqual(counts.masked_tokens, 4)
+        self.assertEqual(counts.num_sequences, 2)
+        self.assertAlmostEqual(counts.mean_effective_length, 1.5)
+
+    def test_all_effective_packed(self):
+        counts = compute_token_counts(
+            lengths=[],
+            packed_response_mask=[True, True, True],
+            num_sequences=1,
+        )
+        self.assertEqual(counts.effective_loss_tokens, 3)
+        self.assertEqual(counts.masked_tokens, 1)  # 4 total - 3 effective
+        self.assertEqual(counts.total_input_tokens, 4)
+
+    def test_none_effective_packed(self):
+        counts = compute_token_counts(
+            lengths=[],
+            packed_response_mask=[False, False],
+            num_sequences=1,
+        )
+        self.assertEqual(counts.effective_loss_tokens, 0)
+        self.assertEqual(counts.masked_tokens, 3)
+        self.assertAlmostEqual(counts.mean_effective_length, 0.0)
+
+    def test_empty_packed_mask(self):
+        counts = compute_token_counts(
+            lengths=[],
+            packed_response_mask=[],
+            num_sequences=0,
+        )
+        self.assertEqual(counts.effective_loss_tokens, 0)
+        # num_sequences=0 defaults to 1, so total = 0 + 1 = 1.
+        self.assertEqual(counts.total_input_tokens, 1)
+
+    def test_num_sequences_defaults_to_1(self):
+        counts = compute_token_counts(
+            lengths=[],
+            packed_response_mask=[True],
+            num_sequences=None,
+        )
+        self.assertEqual(counts.num_sequences, 1)
+
+
+class TestPaddedLayout(unittest.TestCase):
+    """Padded layout: pass lengths, prompt_mask_rows."""
+
+    def test_basic_padded(self):
+        # 1 sequence, length 5: [P, P, P, R, R]
+        # Actions at positions 1-4: pos1=P(masked), pos2=P(masked), pos3=R(eff), pos4=R(eff)
+        counts = compute_token_counts(
+            lengths=[5],
+            prompt_mask_rows=[[True, True, True, False, False]],
+        )
+        self.assertEqual(counts.total_input_tokens, 5)
+        self.assertEqual(counts.effective_loss_tokens, 2)  # pos 3,4
+        self.assertEqual(counts.masked_tokens, 2)  # pos 1,2
+        self.assertEqual(counts.num_sequences, 1)
+        self.assertAlmostEqual(counts.mean_effective_length, 2.0)
+
+    def test_multiple_sequences(self):
+        # seq0: length 4 [P,P,R,R] → actions pos1=P(masked), pos2-3=R(eff)
+        # seq1: length 3 [P,R,R] → actions pos1=R(eff), pos2=R(eff)
+        counts = compute_token_counts(
+            lengths=[4, 3],
+            prompt_mask_rows=[
+                [True, True, False, False],
+                [True, False, False],
+            ],
+        )
+        self.assertEqual(counts.total_input_tokens, 7)
+        self.assertEqual(counts.effective_loss_tokens, 4)  # 2 + 2
+        self.assertEqual(counts.masked_tokens, 1)  # 1 from seq0
+        self.assertAlmostEqual(counts.mean_effective_length, 2.0)
+
+    def test_with_loss_mask(self):
+        # seq0: length 4, prompt_mask=[T,T,F,F], loss_mask=[F,F,T,F]
+        # pos1: prompt=True → masked
+        # pos2: prompt=False, loss_mask=True → effective
+        # pos3: prompt=False, loss_mask=False → masked
+        counts = compute_token_counts(
+            lengths=[4],
+            prompt_mask_rows=[[True, True, False, False]],
+            loss_mask_rows=[[False, False, True, False]],
+        )
+        self.assertEqual(counts.effective_loss_tokens, 1)  # only pos2
+        self.assertEqual(counts.masked_tokens, 2)  # pos1 + pos3
+
+    def test_single_token_sequence(self):
+        # length=1 means no actions (positions 1..0 is empty).
+        counts = compute_token_counts(
+            lengths=[1],
+            prompt_mask_rows=[[True]],
+        )
+        self.assertEqual(counts.total_input_tokens, 1)
+        self.assertEqual(counts.effective_loss_tokens, 0)
+        self.assertEqual(counts.masked_tokens, 0)
+        self.assertAlmostEqual(counts.mean_effective_length, 0.0)
+
+
+class TestZeroTokenBatch(unittest.TestCase):
+    """Zero-token batches should not crash."""
+
+    def test_all_zero_lengths(self):
+        counts = compute_token_counts(
+            lengths=[0, 0, 0],
+            prompt_mask_rows=[[], [], []],
+        )
+        self.assertEqual(counts.total_input_tokens, 0)
+        self.assertEqual(counts.effective_loss_tokens, 0)
+        self.assertEqual(counts.masked_tokens, 0)
+        self.assertAlmostEqual(counts.mean_effective_length, 0.0)
+
+    def test_empty_lengths(self):
+        with self.assertRaises(ValueError):
+            compute_token_counts(lengths=[], prompt_mask_rows=[])
+
+
+class TestInvalidInputs(unittest.TestCase):
+    """Invalid inputs should raise clear errors."""
+
+    def test_missing_prompt_mask_for_padded(self):
+        with self.assertRaises(ValueError):
+            compute_token_counts(lengths=[5])
+
+    def test_missing_both_layouts(self):
+        with self.assertRaises(ValueError):
+            compute_token_counts(lengths=[])
+
+
+class TestDeterminism(unittest.TestCase):
+    """Same inputs produce same outputs."""
+
+    def test_deterministic_packed(self):
+        kwargs = dict(
+            lengths=[],
+            packed_response_mask=[True, False, True],
+            num_sequences=1,
+        )
+        c1 = compute_token_counts(**kwargs)
+        c2 = compute_token_counts(**kwargs)
+        self.assertEqual(c1, c2)
+
+    def test_deterministic_padded(self):
+        kwargs = dict(
+            lengths=[4, 3],
+            prompt_mask_rows=[[True, True, False, False], [True, False, False]],
+        )
+        c1 = compute_token_counts(**kwargs)
+        c2 = compute_token_counts(**kwargs)
+        self.assertEqual(c1, c2)
+
+
+class TestToDict(unittest.TestCase):
+    """to_dict should return float metrics."""
+
+    def test_to_dict_fields(self):
+        counts = compute_token_counts(
+            lengths=[3],
+            prompt_mask_rows=[[True, False, False]],
+        )
+        d = counts.to_dict()
+        self.assertIn("total_input_tokens", d)
+        self.assertIn("masked_tokens", d)
+        self.assertIn("effective_loss_tokens", d)
+        self.assertIn("mean_effective_length", d)
+        self.assertIsInstance(d["total_input_tokens"], float)
+        self.assertIsInstance(d["effective_loss_tokens"], float)
+
+
+class TestMixedPromptResponse(unittest.TestCase):
+    """Prompt and response can be interleaved (agentic trajectories)."""
+
+    def test_interleaved(self):
+        # [P, R, R, P, R] — prompt and response alternate
+        # Actions at pos 1-4:
+        # pos1: prompt=False → effective
+        # pos2: prompt=False → effective
+        # pos3: prompt=True → masked
+        # pos4: prompt=False → effective
+        counts = compute_token_counts(
+            lengths=[5],
+            prompt_mask_rows=[[True, False, False, True, False]],
+        )
+        self.assertEqual(counts.effective_loss_tokens, 3)
+        self.assertEqual(counts.masked_tokens, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements issue #227: record effective trainable tokens per update.

Emit four metrics for every training update, using the same `prompt_mask` and `loss_mask` consumed by the loss function:
- `total_input_tokens` — all valid tokens in the batch (excluding padding)
- `masked_tokens` — tokens excluded from loss (prompt positions)
- `effective_loss_tokens` — tokens that contribute to the loss gradient
- `mean_effective_length` — average effective tokens per sequence

## Changes

### New module: `areno/engine/token_counts.py`
- `TokenCounts` dataclass with `to_dict()` for metrics merging
- `compute_token_counts_from_packed()` — packed (varlen) layout
- `compute_token_counts_from_padded()` — padded (rectangular) layout
- `compute_token_counts()` — dispatcher
- Pure Python, no torch dependency, testable without GPU
- Handles zero-token batches, single-token sequences, interleaved prompt/response (agentic trajectories)
- Padded invariant: `total_input_tokens = masked + effective + num_sequences` (position 0 is not an action)

### Trainer integration: `areno/engine/training.py`
- `_compute_token_metrics()` reads `packed_response_mask` or `prompt_mask`/`loss_mask` from the data pack
- Called in `_train_step` after packing, before loss, merged into per-step metrics dict
- Covers SFT, DPO, and rollout-based training (GSPO/GRPO/PPO) — all go through `_train_step`
- Cross-rank aggregation via existing `merge_train_stats` (averages across DP ranks)

### Tests: 20 CPU tests
- Packed layout (basic/all-effective/none-effective/empty)
- Padded layout (basic/multiple sequences/with loss_mask/single token/invariant)
- Zero-token batches, invalid inputs, determinism, to_dict(), mixed prompt/response, dispatch

### Documentation
- New `docs/troubleshooting/effective-tokens.rst` with runnable example and expected output

## Acceptance criteria

- [x] Covers SFT, DPO, and rollout-based training (all go through `_train_step`)
- [x] Reconciles aggregate counts across ranks (via existing `merge_train_stats`)
- [x] Handles zero-token batches clearly (zeros, no crash, `max(0)` clamp)
- [x] Exposes metrics through existing sinks (merged into train stats metrics dict)
- [x] Uses existing AReno contracts, no external database or sandbox
- [x] Default behavior remains backward compatible (new module + metrics merge, no changes to existing behavior)
- [x] Focused automated tests cover success, invalid input, and boundary/failure paths
- [x] User documentation includes minimal runnable example and explains observable output

Closes #227
