### PR TITLE
feat(cli): protect runs from critically low disk space (#232)

### DIFF
--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -132,7 +132,13 @@ class DPOTrainer:
                     return
                 if self._disk_monitor is not None:
                     disk_status = self._disk_monitor.check(step)
-                    if disk_status == "stop":
+                    if disk_status == "warn":
+                        record_dashboard_state(
+                            self.areno, stage="disk_space_warn", epoch=epoch, step=step,
+                            role="policy",
+                            extra={"free_gb": self._disk_monitor.last_free_bytes / 1e9},
+                        )
+                    elif disk_status == "stop":
                         self.logger.critical(
                             "epoch=%d step=%d stage=disk_full_stop free_gb=%.2f",
                             epoch, step, self._disk_monitor.last_free_bytes / 1e9,

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -41,6 +41,7 @@ class DPOTrainer:
         # leave the backend-facing loss signature as loss_fn(data_pack, logprobs).
         self.loss_fn = partial(loss_fn, beta=config.dpo_beta)
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
+        self._disk_monitor = None
         self.roles = {
             # DPO only needs a frozen reference policy; no rollout, reward, or
             # critic roles are involved.
@@ -129,6 +130,19 @@ class DPOTrainer:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
                     return
+                if self._disk_monitor is not None:
+                    disk_status = self._disk_monitor.check(step)
+                    if disk_status == "stop":
+                        self.logger.critical(
+                            "epoch=%d step=%d stage=disk_full_stop free_gb=%.2f",
+                            epoch, step, self._disk_monitor.last_free_bytes / 1e9,
+                        )
+                        record_dashboard_state(
+                            self.areno, stage="disk_full_stop", epoch=epoch, step=step,
+                            role="policy", status="stopped",
+                            extra={"free_gb": self._disk_monitor.last_free_bytes / 1e9},
+                        )
+                        return
             self.logger.info("epoch=%d stage=epoch_end", epoch)
             record_dashboard_state(self.areno, stage="epoch_end", epoch=epoch, step=step, role="policy")
 

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -158,7 +158,13 @@ class PolicyOnlyTrainer:
                     return
                 if self._disk_monitor is not None:
                     disk_status = self._disk_monitor.check(step)
-                    if disk_status == "stop":
+                    if disk_status == "warn":
+                        record_dashboard_state(
+                            self.areno, stage="disk_space_warn", epoch=epoch, step=step,
+                            role=role,
+                            extra={"free_gb": self._disk_monitor.last_free_bytes / 1e9},
+                        )
+                    elif disk_status == "stop":
                         self.logger.critical(
                             "epoch=%d step=%d stage=disk_full_stop free_gb=%.2f",
                             epoch, step, self._disk_monitor.last_free_bytes / 1e9,

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -42,6 +42,7 @@ class PolicyOnlyTrainer:
         self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         self._agent_run_fn = None
+        self._disk_monitor = None
 
     def fit(self) -> None:
         self.areno.init()
@@ -155,7 +156,19 @@ class PolicyOnlyTrainer:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role=role)
                     return
-            self.logger.info("epoch=%d stage=epoch_end", epoch)
+                if self._disk_monitor is not None:
+                    disk_status = self._disk_monitor.check(step)
+                    if disk_status == "stop":
+                        self.logger.critical(
+                            "epoch=%d step=%d stage=disk_full_stop free_gb=%.2f",
+                            epoch, step, self._disk_monitor.last_free_bytes / 1e9,
+                        )
+                        record_dashboard_state(
+                            self.areno, stage="disk_full_stop", epoch=epoch, step=step,
+                            role=role, status="stopped",
+                            extra={"free_gb": self._disk_monitor.last_free_bytes / 1e9},
+                        )
+                        return
             record_dashboard_state(self.areno, stage="epoch_end", epoch=epoch, step=step, role=self._policy_role_name())
 
     def _policy_role_name(self) -> str:

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -94,7 +94,13 @@ class SFTTrainer:
                     return
                 if self._disk_monitor is not None:
                     disk_status = self._disk_monitor.check(step)
-                    if disk_status == "stop":
+                    if disk_status == "warn":
+                        record_dashboard_state(
+                            self.areno, stage="disk_space_warn", epoch=epoch, step=step,
+                            role="policy",
+                            extra={"free_gb": self._disk_monitor.last_free_bytes / 1e9},
+                        )
+                    elif disk_status == "stop":
                         self.logger.critical(
                             "epoch=%d step=%d stage=disk_full_stop free_gb=%.2f",
                             epoch, step, self._disk_monitor.last_free_bytes / 1e9,

--- a/areno/api/trainers/sft.py
+++ b/areno/api/trainers/sft.py
@@ -43,6 +43,7 @@ class SFTTrainer:
         self.dataset = dataset
         self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
+        self._disk_monitor = None
 
     def fit(self) -> None:
         self.areno.init()
@@ -91,6 +92,19 @@ class SFTTrainer:
                     self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
                     record_dashboard_state(self.areno, stage="max_steps_reached", epoch=epoch, step=step, role="policy")
                     return
+                if self._disk_monitor is not None:
+                    disk_status = self._disk_monitor.check(step)
+                    if disk_status == "stop":
+                        self.logger.critical(
+                            "epoch=%d step=%d stage=disk_full_stop free_gb=%.2f",
+                            epoch, step, self._disk_monitor.last_free_bytes / 1e9,
+                        )
+                        record_dashboard_state(
+                            self.areno, stage="disk_full_stop", epoch=epoch, step=step,
+                            role="policy", status="stopped",
+                            extra={"free_gb": self._disk_monitor.last_free_bytes / 1e9},
+                        )
+                        return
             self.logger.info("epoch=%d stage=epoch_end", epoch)
             record_dashboard_state(self.areno, stage="epoch_end", epoch=epoch, step=step, role="policy")
 

--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -13,13 +13,22 @@ import platform
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from importlib import import_module
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any
 
 import click
+
+from areno.cli.disk_guard import (
+    DiskMonitor,
+    DiskMonitorConfig,
+    build_disk_monitor_from_config,
+    disk_budget_to_json,
+    estimate_disk_usage,
+    format_disk_budget_text,
+)
 
 _ENV_VARS = (
     "CUDA_HOME",
@@ -46,8 +55,37 @@ def env_command(as_json: bool) -> None:
 
 
 @click.command(name="check", context_settings={"help_option_names": ["-h", "--help"]})
-def check_command() -> None:
+@click.option("--disk-budget", is_flag=True, help="Estimate disk space for a training run before starting.")
+@click.option("--save-path", default=None, help="Checkpoint output directory for --disk-budget estimation.")
+@click.option("--metrics-log-dir", default=None, help="Metrics/log directory for --disk-budget estimation.")
+@click.option("--epochs", type=int, default=10, show_default=True, help="Training epochs for --disk-budget estimation.")
+@click.option("--save-interval", type=int, default=100, show_default=True, help="Checkpoint interval for --disk-budget estimation.")
+@click.option("--max-steps", type=int, default=None, help="Max training steps for --disk-budget estimation (overrides --epochs).")
+@click.option("--include-checkpoints", is_flag=True, help="Include checkpoint sizes in --disk-budget estimation.")
+@click.option("--disk-json", "disk_as_json", is_flag=True, help="Emit disk budget as machine-readable JSON.")
+def check_command(
+    disk_budget: bool,
+    save_path: str | None,
+    metrics_log_dir: str | None,
+    epochs: int,
+    save_interval: int,
+    max_steps: int | None,
+    include_checkpoints: bool,
+    disk_as_json: bool,
+) -> None:
     """Check whether this machine is ready to run AReno."""
+
+    if disk_budget:
+        _run_disk_budget_check(
+            save_path=save_path,
+            metrics_log_dir=metrics_log_dir,
+            epochs=epochs,
+            save_interval=save_interval,
+            max_steps=max_steps,
+            include_checkpoints=include_checkpoints,
+            as_json=disk_as_json,
+        )
+        return
 
     report = collect_env()
     results = run_checks(report)
@@ -482,3 +520,50 @@ def _print_env_report(report: dict[str, Any]) -> None:
     click.echo("  Environment variables:")
     for name, value in report["env"].items():
         click.echo(f"    {name}={value if value is not None else '<unset>'}")
+
+
+def _run_disk_budget_check(
+    *,
+    save_path: str | None,
+    metrics_log_dir: str | None,
+    epochs: int,
+    save_interval: int,
+    max_steps: int | None,
+    include_checkpoints: bool,
+    as_json: bool,
+) -> None:
+    """Run a standalone disk-budget preflight and print the result."""
+
+    paths: list[str] = []
+    if save_path:
+        paths.append(save_path)
+    if metrics_log_dir:
+        paths.append(metrics_log_dir)
+    if not paths:
+        paths = ["."]
+
+    total_steps = max_steps if max_steps is not None else epochs * 1000
+
+    ckpt_size = 0
+    ckpt_dir = save_path or metrics_log_dir
+    if ckpt_dir and Path(ckpt_dir).is_dir():
+        for f in Path(ckpt_dir).glob("*.safetensors"):
+            ckpt_size += f.stat().st_size
+
+    config = DiskMonitorConfig(include_checkpoints=include_checkpoints)
+    monitor = DiskMonitor(
+        config=config,
+        paths=paths,
+        total_steps=total_steps,
+        checkpoint_size_bytes=ckpt_size,
+        save_interval=save_interval,
+    )
+    budget = monitor.estimate_budget()
+
+    if as_json:
+        click.echo(disk_budget_to_json(budget))
+        return
+
+    click.echo(format_disk_budget_text(budget))
+    if not budget.sufficient:
+        raise click.exceptions.Exit(1)

--- a/areno/cli/disk_guard.py
+++ b/areno/cli/disk_guard.py
@@ -105,12 +105,16 @@ class DiskMonitor:
         filesystem; intermediate calls return ``"ok"`` without I/O.
         """
 
-        if step - self._last_check_step < self._config.check_interval_steps and step > 0:
+        if self._last_check_step >= 0 and (step - self._last_check_step) < self._config.check_interval_steps:
             return "ok"
         self._last_check_step = step
 
         free = _min_free_bytes(self._paths)
         self.last_free_bytes = free
+        logger.info(
+            "disk_space: step=%d free=%.2f GB warn_threshold=%.2f GB stop_threshold=%.2f GB",
+            step, free / 1e9, self._warn_bytes / 1e9, self._stop_bytes / 1e9,
+        )
 
         if free <= self._stop_bytes:
             return "stop"

--- a/areno/cli/disk_guard.py
+++ b/areno/cli/disk_guard.py
@@ -1,0 +1,306 @@
+"""Disk space budget estimation and runtime watermark monitoring.
+
+Provides :class:`DiskBudget` for preflight estimation and :class:`DiskMonitor`
+for runtime free-space monitoring. The monitor warns once when free space
+drops below a configurable threshold and triggers a controlled stop at a
+critical threshold, reusing the existing trainer-loop ``return`` exit path.
+
+Thresholds default to percentages of total disk capacity (warn 5%, stop 1%)
+with optional absolute-value overrides that take whichever is stricter.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+# Per-step overhead: TensorBoard scalars (~2 KB) + rollout samples JSONL (~10 KB).
+_PER_STEP_BYTES = 12 * 1024
+
+
+@dataclass(frozen=True)
+class DiskBudget:
+    """Result of preflight disk space estimation.
+
+    Attributes
+    ----------
+    paths:
+        Filesystem paths checked (save_path, metrics_log_dir, etc.).
+    free_bytes:
+        Minimum free space across all checked paths' partitions.
+    total_bytes:
+        Total capacity of the partition with the least free space.
+    estimated_usage_bytes:
+        Estimated total disk usage for the full training run.
+    sufficient:
+        True when free space exceeds estimated usage plus the stop threshold.
+    detail:
+        Human-readable summary.
+    next_step:
+        Actionable suggestion when insufficient.
+    """
+
+    paths: list[str]
+    free_bytes: int
+    total_bytes: int
+    estimated_usage_bytes: int
+    sufficient: bool
+    detail: str
+    next_step: str = ""
+
+
+@dataclass
+class DiskMonitorConfig:
+    """Configuration for runtime disk monitoring.
+
+    Thresholds are computed as ``max(percent_threshold, absolute_override)``
+    so the stricter value always wins.
+    """
+
+    warn_percent: float = 5.0
+    stop_percent: float = 1.0
+    warn_gb: float | None = None
+    stop_gb: float | None = None
+    check_interval_steps: int = 10
+    include_checkpoints: bool = False
+
+
+class DiskMonitor:
+    """Runtime disk-space watermark monitor.
+
+    Call :meth:`check` every training step; it internally throttles to
+    ``check_interval_steps`` and returns ``"ok"``, ``"warn"``, or ``"stop"``.
+    Warnings are emitted exactly once per transition into the warn band.
+    """
+
+    def __init__(
+        self,
+        config: DiskMonitorConfig,
+        paths: list[str],
+        total_steps: int,
+        *,
+        checkpoint_size_bytes: int = 0,
+        save_interval: int = 100,
+    ) -> None:
+        self._config = config
+        self._paths = [str(p) for p in paths if p]
+        self._total_steps = total_steps
+        self._checkpoint_size_bytes = checkpoint_size_bytes
+        self._save_interval = save_interval
+        self._already_warned = False
+        self._last_check_step = -1
+        self.last_free_bytes: int = 0
+        self._warn_bytes, self._stop_bytes = self._compute_thresholds()
+
+    def check(self, step: int) -> Literal["ok", "warn", "stop"]:
+        """Return the current disk status, throttled by ``check_interval_steps``.
+
+        Only every ``check_interval_steps``-th call actually probes the
+        filesystem; intermediate calls return ``"ok"`` without I/O.
+        """
+
+        if step - self._last_check_step < self._config.check_interval_steps and step > 0:
+            return "ok"
+        self._last_check_step = step
+
+        free = _min_free_bytes(self._paths)
+        self.last_free_bytes = free
+
+        if free <= self._stop_bytes:
+            return "stop"
+        if free <= self._warn_bytes:
+            if not self._already_warned:
+                self._already_warned = True
+                logger.warning(
+                    "disk_space: free=%.2f GB, warn threshold=%.2f GB",
+                    free / 1e9,
+                    self._warn_bytes / 1e9,
+                )
+            return "warn"
+        return "ok"
+
+    def estimate_budget(self) -> DiskBudget:
+        """Compute a :class:`DiskBudget` for preflight display."""
+
+        estimated = estimate_disk_usage(
+            total_steps=self._total_steps,
+            save_interval=self._save_interval,
+            checkpoint_size_bytes=self._checkpoint_size_bytes,
+            include_checkpoints=self._config.include_checkpoints,
+        )
+        free = _min_free_bytes(self._paths)
+        total = _min_total_bytes(self._paths)
+        sufficient = free > estimated + self._stop_bytes
+        if sufficient:
+            detail = (
+                f"estimated {estimated / 1e6:.1f} MB usage, "
+                f"{free / 1e9:.1f} GB free — sufficient"
+            )
+            next_step = ""
+        else:
+            detail = (
+                f"estimated {estimated / 1e6:.1f} MB usage, "
+                f"{free / 1e9:.1f} GB free — insufficient"
+            )
+            next_step = (
+                "Free up disk space, reduce --epochs/--max-steps, "
+                "or move --save-path / --metrics-log-dir to a larger partition."
+            )
+        return DiskBudget(
+            paths=self._paths,
+            free_bytes=free,
+            total_bytes=total,
+            estimated_usage_bytes=estimated,
+            sufficient=sufficient,
+            detail=detail,
+            next_step=next_step,
+        )
+
+    def _compute_thresholds(self) -> tuple[int, int]:
+        total = _min_total_bytes(self._paths)
+        warn = int(total * self._config.warn_percent / 100)
+        stop = int(total * self._config.stop_percent / 100)
+        if self._config.warn_gb is not None:
+            warn = max(warn, int(self._config.warn_gb * 1e9))
+        if self._config.stop_gb is not None:
+            stop = max(stop, int(self._config.stop_gb * 1e9))
+        return warn, stop
+
+
+def estimate_disk_usage(
+    total_steps: int,
+    save_interval: int,
+    checkpoint_size_bytes: int = 0,
+    *,
+    include_checkpoints: bool = False,
+) -> int:
+    """Estimate total disk usage for a training run.
+
+    Per-step overhead covers TensorBoard scalars (~2 KB) and rollout
+    samples JSONL (~10 KB). Checkpoint sizes are excluded by default;
+    pass ``include_checkpoints=True`` and a non-zero ``checkpoint_size_bytes``
+    to include them.
+    """
+
+    metrics_total = total_steps * _PER_STEP_BYTES
+    if not include_checkpoints or checkpoint_size_bytes <= 0 or save_interval <= 0:
+        return metrics_total
+    num_saves = max(total_steps // save_interval, 0)
+    return metrics_total + num_saves * checkpoint_size_bytes
+
+
+def build_disk_monitor_from_config(
+    trainer_config: Any,
+    *,
+    disk_monitor_config: DiskMonitorConfig | None,
+) -> DiskMonitor | None:
+    """Build a :class:`DiskMonitor` from a trainer config, or ``None`` if disabled.
+
+    This helper is called by trainers to decide whether disk monitoring
+    is active. When ``disk_monitor_config`` is ``None``, monitoring is off.
+    """
+
+    if disk_monitor_config is None:
+        return None
+
+    paths: list[str] = []
+    save_path = getattr(trainer_config, "save_path", None)
+    if save_path:
+        paths.append(str(save_path))
+    metrics_log_dir = getattr(trainer_config, "metrics_log_dir", None)
+    if metrics_log_dir:
+        paths.append(str(metrics_log_dir))
+    if not paths:
+        return None
+
+    # Estimate total steps.
+    max_steps = getattr(trainer_config, "max_steps", None)
+    epochs = getattr(trainer_config, "epochs", 1)
+    if max_steps is not None:
+        total_steps = max_steps
+    else:
+        total_steps = epochs * 1000  # Conservative fallback.
+
+    save_interval = getattr(trainer_config, "save_interval", 100)
+
+    # Checkpoint size: try reading safetensors file size if available.
+    ckpt_size = 0
+    ckpt_path = getattr(trainer_config, "ckpt", None)
+    if ckpt_path and Path(ckpt_path).is_dir():
+        for f in Path(ckpt_path).glob("*.safetensors"):
+            ckpt_size += f.stat().st_size
+        # Also check index for total size.
+        index_file = Path(ckpt_path) / "model.safetensors.index.json"
+        if index_file.exists() and ckpt_size == 0:
+            try:
+                index_data = json.loads(index_file.read_text(encoding="utf-8"))
+                ckpt_size = int(index_data.get("metadata", {}).get("total_size", 0))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return DiskMonitor(
+        config=disk_monitor_config,
+        paths=paths,
+        total_steps=total_steps,
+        checkpoint_size_bytes=ckpt_size,
+        save_interval=save_interval,
+    )
+
+
+def format_disk_budget_text(budget: DiskBudget) -> str:
+    """Render a :class:`DiskBudget` as human-readable text."""
+
+    status = "OK" if budget.sufficient else "FAIL"
+    lines = [
+        f"{status:<4} disk budget  {', '.join(budget.paths) if budget.paths else '(no paths)'}",
+        f"     {budget.detail}",
+    ]
+    if not budget.sufficient and budget.next_step:
+        lines.append(f"Next:\n  {budget.next_step}")
+    return "\n".join(lines)
+
+
+def disk_budget_to_json(budget: DiskBudget) -> str:
+    """Serialise a :class:`DiskBudget` to JSON."""
+
+    return json.dumps(asdict(budget), indent=2, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _min_free_bytes(paths: list[str]) -> int:
+    """Return the minimum free space across all paths' partitions."""
+
+    if not paths:
+        return 0
+    free_values = []
+    for p in paths:
+        try:
+            usage = shutil.disk_usage(str(p))
+            free_values.append(usage.free)
+        except OSError:
+            free_values.append(0)
+    return min(free_values) if free_values else 0
+
+
+def _min_total_bytes(paths: list[str]) -> int:
+    """Return the minimum total capacity across all paths' partitions."""
+
+    if not paths:
+        return 0
+    total_values = []
+    for p in paths:
+        try:
+            usage = shutil.disk_usage(str(p))
+            total_values.append(usage.total)
+        except OSError:
+            total_values.append(0)
+    return min(total_values) if total_values else 0

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -33,6 +33,7 @@ from areno.api.trainer_config import (
     TrainerConfig,
 )
 from areno.cli.model_refs import resolve_model_refs_for_config
+from areno.cli.disk_guard import DiskMonitor, DiskMonitorConfig, build_disk_monitor_from_config
 from areno.engine.config import (
     ModelConfig,
     flash_attention_unsupported_gpu_reason,
@@ -791,7 +792,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     )
 
 
-def run(trainer_config: TrainerConfig):
+def run(trainer_config: TrainerConfig, *, disk_monitor_config: DiskMonitorConfig | None = None):
     """Build the trainer chosen by `--algo` and run `.fit()` to completion."""
 
     # Heavy dependencies are imported lazily so `python train.py --help`
@@ -823,6 +824,10 @@ def run(trainer_config: TrainerConfig):
         load_from_disk=load_from_disk,
     )
     trainer = build_trainer(trainer_config, instance=api_trainer, dataset=dataset, reward_fn=reward_fn, loss_fn=loss_fn)
+    if disk_monitor_config is not None:
+        trainer._disk_monitor = build_disk_monitor_from_config(
+            trainer_config, disk_monitor_config=disk_monitor_config
+        )
     trainer.fit()
 
 
@@ -1190,6 +1195,11 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
 @click.option("--max-steps", type=int, default=None, help="Stop after this many trainer steps.")
+@click.option("--disk-monitor", is_flag=True, help="Monitor disk space during training and stop when critically low.")
+@click.option("--disk-warn-percent", type=float, default=5.0, show_default=True, help="Disk free-space warning threshold (percent of total).")
+@click.option("--disk-stop-percent", type=float, default=1.0, show_default=True, help="Disk free-space stop threshold (percent of total).")
+@click.option("--disk-warn-gb", type=float, default=None, help="Absolute disk warning threshold in GB (overrides percent if stricter).")
+@click.option("--disk-stop-gb", type=float, default=None, help="Absolute disk stop threshold in GB (overrides percent if stricter).")
 @click.option(
     "--tune-params",
     "tune_params",
@@ -1363,7 +1373,15 @@ def train_command(**options) -> None:
         config=_training_config_settings(trainer_config),
         metrics_dir=trainer_config.metrics_log_dir,
     )
-    run(trainer_config)
+    disk_monitor_config = None
+    if options.get("disk_monitor"):
+        disk_monitor_config = DiskMonitorConfig(
+            warn_percent=options.get("disk_warn_percent", 5.0),
+            stop_percent=options.get("disk_stop_percent", 1.0),
+            warn_gb=options.get("disk_warn_gb"),
+            stop_gb=options.get("disk_stop_gb"),
+        )
+    run(trainer_config, disk_monitor_config=disk_monitor_config)
 
 
 def main() -> None:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -828,6 +828,22 @@ def run(trainer_config: TrainerConfig, *, disk_monitor_config: DiskMonitorConfig
         trainer._disk_monitor = build_disk_monitor_from_config(
             trainer_config, disk_monitor_config=disk_monitor_config
         )
+        if trainer._disk_monitor is not None:
+            import logging as _logging
+            _logging.getLogger("areno.cli.train").info(
+                "disk_monitor enabled: paths=%s warn_gb=%.1f stop_gb=%.1f",
+                trainer._disk_monitor._paths,
+                trainer._disk_monitor._warn_bytes / 1e9,
+                trainer._disk_monitor._stop_bytes / 1e9,
+            )
+        else:
+            import logging as _logging
+            _logging.getLogger("areno.cli.train").warning(
+                "disk_monitor config was set but build_disk_monitor_from_config returned None "
+                "(save_path=%s, metrics_log_dir=%s)",
+                getattr(trainer_config, "save_path", None),
+                getattr(trainer_config, "metrics_log_dir", None),
+            )
     trainer.fit()
 
 

--- a/docs/troubleshooting/oom-timeout.rst
+++ b/docs/troubleshooting/oom-timeout.rst
@@ -19,3 +19,51 @@ tests, sleeps, browser work, and sandbox actions can dominate rollout wall
 time before the model is called again.
 
 See :doc:`/cli/observability` for timing and metric interpretation.
+
+Disk space protection
+---------------------
+
+AReno can estimate disk usage before training starts and monitor free
+space during execution to prevent silent data corruption from a full disk.
+
+Preflight estimation:
+
+.. code-block:: bash
+
+   areno check --disk-budget \
+     --save-path /tmp/areno-outputs \
+     --metrics-log-dir /tmp/areno/metrics \
+     --max-steps 1000 --save-interval 100
+
+The estimator computes per-step overhead (TensorBoard scalars ~2 KB +
+rollout samples JSONL ~10 KB per step) and multiplies by total steps.
+Checkpoint sizes are **excluded by default**; pass ``--include-checkpoints``
+to include them (the estimator reads ``*.safetensors`` file sizes from
+the checkpoint directory).
+
+Runtime monitoring:
+
+.. code-block:: bash
+
+   areno train --ckpt Qwen/Qwen3-0.6B ... --disk-monitor
+
+Thresholds default to percentages of total disk capacity:
+
+* **Warn** at 5% free (logs a one-time warning)
+* **Stop** at 1% free (triggers a controlled shutdown via the normal
+  ``max_steps_reached`` exit path)
+
+Override with absolute values if needed:
+
+.. code-block:: bash
+
+   areno train ... --disk-monitor --disk-warn-gb 20 --disk-stop-gb 5
+
+Both human-readable and JSON output are supported:
+
+.. code-block:: bash
+
+   areno check --disk-budget --save-path /tmp/outputs --disk-json
+
+The ``--disk-monitor`` flag is disabled by default; existing behavior is
+unchanged when it is not provided.

--- a/tests/test_disk_guard_cpu.py
+++ b/tests/test_disk_guard_cpu.py
@@ -1,0 +1,342 @@
+"""CPU tests for disk space budget estimation and runtime monitoring (#232).
+
+All tests use mocked ``shutil.disk_usage`` to simulate healthy, warn, and
+stop transitions — no real filesystem writes, no GPU, no torch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.cli import disk_guard
+from areno.cli import diagnostics
+from areno.cli.disk_guard import (
+    DiskBudget,
+    DiskMonitor,
+    DiskMonitorConfig,
+    build_disk_monitor_from_config,
+    disk_budget_to_json,
+    estimate_disk_usage,
+    format_disk_budget_text,
+)
+
+
+def _disk_usage_mock(total: int, free: int):
+    """Return a mock shutil.disk_usage result."""
+
+    return SimpleNamespace(total=total, free=free, used=total - free)
+
+
+class EstimateDiskUsageTest(unittest.TestCase):
+    """Tests for the estimation formula."""
+
+    def test_estimate_basic(self):
+        usage = estimate_disk_usage(total_steps=100, save_interval=100)
+        expected = 100 * 12 * 1024  # 100 steps × 12 KB/step
+        self.assertEqual(usage, expected)
+
+    def test_estimate_excludes_checkpoints_by_default(self):
+        usage = estimate_disk_usage(
+            total_steps=1000, save_interval=100, checkpoint_size_bytes=1_000_000_000
+        )
+        # Should NOT include checkpoint size.
+        expected = 1000 * 12 * 1024
+        self.assertEqual(usage, expected)
+
+    def test_estimate_includes_checkpoints_when_requested(self):
+        usage = estimate_disk_usage(
+            total_steps=1000,
+            save_interval=100,
+            checkpoint_size_bytes=1_000_000_000,
+            include_checkpoints=True,
+        )
+        # 1000 steps / 100 interval = 10 saves × 1GB
+        expected = 1000 * 12 * 1024 + 10 * 1_000_000_000
+        self.assertEqual(usage, expected)
+
+    def test_estimate_zero_steps(self):
+        usage = estimate_disk_usage(total_steps=0, save_interval=100)
+        self.assertEqual(usage, 0)
+
+    def test_estimate_zero_save_interval(self):
+        """save_interval=0 should not crash; checkpoint portion is skipped."""
+        usage = estimate_disk_usage(
+            total_steps=100, save_interval=0, checkpoint_size_bytes=1000, include_checkpoints=True
+        )
+        self.assertEqual(usage, 100 * 12 * 1024)
+
+
+class DiskMonitorThresholdTest(unittest.TestCase):
+    """Tests for threshold computation (percent + absolute override)."""
+
+    def test_thresholds_percent_default(self):
+        config = DiskMonitorConfig()
+        monitor = DiskMonitor(
+            config=config, paths=["/tmp"], total_steps=100,
+        )
+        with patch.object(disk_guard, "_min_total_bytes", return_value=100 * 1_000_000_000):
+            warn, stop = monitor._compute_thresholds()
+        # 5% of 100GB = 5GB, 1% = 1GB
+        self.assertAlmostEqual(warn, 5 * 1_000_000_000, delta=1)
+        self.assertAlmostEqual(stop, 1 * 1_000_000_000, delta=1)
+
+    def test_thresholds_absolute_override_stricter(self):
+        config = DiskMonitorConfig(warn_gb=20, stop_gb=5)
+        monitor = DiskMonitor(config=config, paths=["/tmp"], total_steps=100)
+        with patch.object(disk_guard, "_min_total_bytes", return_value=100 * 1_000_000_000):
+            warn, stop = monitor._compute_thresholds()
+        # max(5% of 100GB=5GB, 20GB) = 20GB
+        self.assertEqual(warn, int(20 * 1e9))
+        self.assertEqual(stop, int(5 * 1e9))
+
+    def test_thresholds_percent_stricter_than_absolute(self):
+        """When percent gives a larger value, it wins."""
+        config = DiskMonitorConfig(warn_gb=1, stop_gb=0.5)
+        monitor = DiskMonitor(config=config, paths=["/tmp"], total_steps=100)
+        with patch.object(disk_guard, "_min_total_bytes", return_value=1000 * 1_000_000_000):
+            warn, stop = monitor._compute_thresholds()
+        # 5% of 1000GB = 50GB > 1GB
+        self.assertEqual(warn, int(50 * 1_000_000_000))
+
+
+class DiskMonitorCheckTest(unittest.TestCase):
+    """Tests for the runtime check() method — healthy/warn/stop transitions."""
+
+    def _make_monitor(self, total_bytes=100 * 1_000_000_000):
+        config = DiskMonitorConfig(check_interval_steps=1)
+        monitor = DiskMonitor(config=config, paths=["/fake"], total_steps=100)
+        monitor._warn_bytes = int(total_bytes * 0.05)
+        monitor._stop_bytes = int(total_bytes * 0.01)
+        return monitor
+
+    def test_disk_healthy(self):
+        monitor = self._make_monitor()
+        with patch.object(disk_guard, "_min_free_bytes", return_value=80 * 1_000_000_000):
+            self.assertEqual(monitor.check(0), "ok")
+
+    def test_disk_warn_transition(self):
+        monitor = self._make_monitor()
+        with patch.object(disk_guard, "_min_free_bytes", return_value=3 * 1_000_000_000):
+            self.assertEqual(monitor.check(0), "warn")
+
+    def test_disk_stop_transition(self):
+        monitor = self._make_monitor()
+        with patch.object(disk_guard, "_min_free_bytes", return_value=500 * 1_000_000):
+            self.assertEqual(monitor.check(0), "stop")
+
+    def test_warn_emitted_only_once(self):
+        monitor = self._make_monitor()
+        with patch.object(disk_guard, "_min_free_bytes", return_value=3 * 1_000_000_000):
+            self.assertEqual(monitor.check(0), "warn")
+            self.assertTrue(monitor._already_warned)
+            # Second check at same level should still return "warn" but not re-log.
+            self.assertEqual(monitor.check(1), "warn")
+
+    def test_check_interval_throttling(self):
+        """Steps between check_interval_steps should not probe the filesystem."""
+        config = DiskMonitorConfig(check_interval_steps=10)
+        monitor = DiskMonitor(config=config, paths=["/fake"], total_steps=100)
+        monitor._warn_bytes = 5_000_000_000
+        monitor._stop_bytes = 1_000_000_000
+        call_count = 0
+        original_min_free = disk_guard._min_free_bytes
+
+        def counting_min_free(paths):
+            nonlocal call_count
+            call_count += 1
+            return original_min_free(paths)
+
+        with patch.object(disk_guard, "_min_free_bytes", side_effect=counting_min_free):
+            monitor.check(0)   # Should probe (step 0)
+            monitor.check(1)   # Should NOT probe (1 - 0 < 10)
+            monitor.check(5)   # Should NOT probe
+            monitor.check(10)  # Should probe (10 - 0 >= 10)
+        self.assertEqual(call_count, 2)
+
+    def test_zero_free_space_boundary(self):
+        monitor = self._make_monitor()
+        with patch.object(disk_guard, "_min_free_bytes", return_value=0):
+            self.assertEqual(monitor.check(0), "stop")
+
+
+class DiskBudgetEstimateTest(unittest.TestCase):
+    """Tests for the DiskMonitor.estimate_budget() method."""
+
+    def test_budget_sufficient(self):
+        config = DiskMonitorConfig()
+        monitor = DiskMonitor(config=config, paths=["/fake"], total_steps=100, save_interval=100)
+        with (
+            patch.object(disk_guard, "_min_free_bytes", return_value=100 * 1_000_000_000),
+            patch.object(disk_guard, "_min_total_bytes", return_value=200 * 1_000_000_000),
+        ):
+            budget = monitor.estimate_budget()
+        self.assertTrue(budget.sufficient)
+        self.assertEqual(budget.status if hasattr(budget, "status") else None, None)
+
+    def test_budget_insufficient(self):
+        config = DiskMonitorConfig()
+        monitor = DiskMonitor(config=config, paths=["/fake"], total_steps=100000, save_interval=1)
+        with (
+            patch.object(disk_guard, "_min_free_bytes", return_value=1 * 1_000_000),
+            patch.object(disk_guard, "_min_total_bytes", return_value=10 * 1_000_000_000),
+        ):
+            budget = monitor.estimate_budget()
+        self.assertFalse(budget.sufficient)
+        self.assertTrue(len(budget.next_step) > 0)
+
+
+class BuildDiskMonitorTest(unittest.TestCase):
+    """Tests for build_disk_monitor_from_config()."""
+
+    def test_returns_none_when_config_is_none(self):
+        config = SimpleNamespace(save_path="/tmp/out", metrics_log_dir="/tmp/metrics", max_steps=100, save_interval=10)
+        result = build_disk_monitor_from_config(config, disk_monitor_config=None)
+        self.assertIsNone(result)
+
+    def test_returns_monitor_with_valid_config(self):
+        config = SimpleNamespace(
+            save_path="/tmp/out",
+            metrics_log_dir="/tmp/metrics",
+            max_steps=100,
+            save_interval=10,
+            epochs=10,
+            ckpt=None,
+        )
+        monitor_config = DiskMonitorConfig()
+        result = build_disk_monitor_from_config(config, disk_monitor_config=monitor_config)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, DiskMonitor)
+
+    def test_returns_none_when_no_paths(self):
+        config = SimpleNamespace(
+            save_path=None, metrics_log_dir=None, max_steps=100, save_interval=10, epochs=10, ckpt=None
+        )
+        monitor_config = DiskMonitorConfig()
+        result = build_disk_monitor_from_config(config, disk_monitor_config=monitor_config)
+        self.assertIsNone(result)
+
+
+class FormattingTest(unittest.TestCase):
+    """Tests for output formatting."""
+
+    def test_format_budget_text_sufficient(self):
+        budget = DiskBudget(
+            paths=["/tmp"],
+            free_bytes=100 * 1_000_000_000,
+            total_bytes=200 * 1_000_000_000,
+            estimated_usage_bytes=1_000_000,
+            sufficient=True,
+            detail="estimated 1.0 MB usage, 100.0 GB free — sufficient",
+        )
+        text = format_disk_budget_text(budget)
+        self.assertIn("OK", text)
+        self.assertNotIn("Next", text)
+
+    def test_format_budget_text_insufficient(self):
+        budget = DiskBudget(
+            paths=["/tmp"],
+            free_bytes=1_000_000,
+            total_bytes=10 * 1_000_000_000,
+            estimated_usage_bytes=1_000_000_000,
+            sufficient=False,
+            detail="estimated 1000.0 MB usage, 0.0 GB free — insufficient",
+            next_step="Free up disk space",
+        )
+        text = format_disk_budget_text(budget)
+        self.assertIn("FAIL", text)
+        self.assertIn("Free up disk space", text)
+
+    def test_budget_to_json(self):
+        budget = DiskBudget(
+            paths=["/tmp"],
+            free_bytes=100,
+            total_bytes=200,
+            estimated_usage_bytes=10,
+            sufficient=True,
+            detail="ok",
+        )
+        json_str = disk_budget_to_json(budget)
+        parsed = json.loads(json_str)
+        self.assertTrue(parsed["sufficient"])
+        self.assertEqual(parsed["free_bytes"], 100)
+
+
+class CheckCommandDiskBudgetTest(unittest.TestCase):
+    """Integration tests for `areno check --disk-budget`."""
+
+    def test_check_disk_budget_sufficient(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = CliRunner()
+            with patch.object(disk_guard, "_min_free_bytes", return_value=100 * 1_000_000_000):
+                with patch.object(disk_guard, "_min_total_bytes", return_value=200 * 1_000_000_000):
+                    result = runner.invoke(
+                        diagnostics.check_command,
+                        ["--disk-budget", "--save-path", tmp, "--max-steps", "10"],
+                    )
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("OK", result.output)
+
+    def test_check_disk_budget_insufficient(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = CliRunner()
+            with patch.object(disk_guard, "_min_free_bytes", return_value=100):
+                with patch.object(disk_guard, "_min_total_bytes", return_value=1000):
+                    result = runner.invoke(
+                        diagnostics.check_command,
+                        ["--disk-budget", "--save-path", tmp, "--max-steps", "100000"],
+                    )
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("FAIL", result.output)
+
+    def test_check_disk_budget_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = CliRunner()
+            with patch.object(disk_guard, "_min_free_bytes", return_value=100 * 1_000_000_000):
+                with patch.object(disk_guard, "_min_total_bytes", return_value=200 * 1_000_000_000):
+                    result = runner.invoke(
+                        diagnostics.check_command,
+                        ["--disk-budget", "--save-path", tmp, "--max-steps", "10", "--disk-json"],
+                    )
+            self.assertEqual(result.exit_code, 0)
+            parsed = json.loads(result.output)
+            self.assertTrue(parsed["sufficient"])
+
+    def test_check_without_disk_budget_unchanged(self):
+        """Existing `areno check` behavior is preserved."""
+        runner = CliRunner()
+        with patch.object(diagnostics, "collect_env", return_value={
+            "platform": {"system": "Linux", "release": "6.0", "machine": "x86_64", "platform": "Linux"},
+            "torch": {"imported": False, "error": "no torch", "version": None, "cuda_build": None,
+                       "cuda_runtime": None, "cuda_runtime_error": None, "cuda_available": False,
+                       "device_count": 0, "gpus": []},
+            "cuda": {"cuda_home": None, "inferred_cuda_home": None,
+                      "nvcc": {"path": None, "version": None},
+                      "driver": {"path": None, "driver_version": None, "cuda_version": None, "error": "no smi"}},
+            "gpus": [],
+            "dependencies": {
+                "flash_attn": {"distribution": "flash-attn", "module": "flash_attn", "version": None,
+                               "imported": False, "error": "missing"},
+                "flash_linear_attention": {"distribution": "flash-linear-attention", "module": "fla",
+                                           "version": None, "imported": False, "error": "missing"},
+                "areno_accel": {"distribution": None, "module": "areno.accel._areno_accel",
+                                "version": None, "imported": False, "error": "missing"},
+            },
+            "install": {"build_ext_disabled": False},
+            "env": {},
+            "paths": {"metrics_log_dir": tmp, "hf_cache": tmp} if False else {"metrics_log_dir": "/tmp", "hf_cache": "/tmp"},
+        }):
+            with patch.object(diagnostics, "run_checks", return_value=[]):
+                result = runner.invoke(diagnostics.check_command, [])
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #232

Add disk space budget estimation and runtime watermark monitoring to prevent silent data corruption from a full disk during training.

## Files

| File | Purpose |
|------|---------|
| `areno/cli/disk_guard.py` | Core logic: `DiskBudget`, `DiskMonitorConfig`, `DiskMonitor`, `estimate_disk_usage()`, `build_disk_monitor_from_config()` |
| `areno/cli/diagnostics.py` | `check_command` gains `--disk-budget`, `--save-path`, `--metrics-log-dir`, `--epochs`, `--save-interval`, `--max-steps`, `--include-checkpoints`, `--disk-json` |
| `areno/cli/train.py` | `train_command` gains `--disk-monitor`, `--disk-warn-percent`, `--disk-stop-percent`, `--disk-warn-gb`, `--disk-stop-gb` flags |
| `areno/api/trainers/policy_only.py` | `_fit_initialized()` inserts `DiskMonitor.check()` call (PPO inherits) |
| `areno/api/trainers/sft.py` | Same insertion |
| `areno/api/trainers/dpo.py` | Same insertion |
| `tests/test_disk_guard_cpu.py` | 26 CPU tests |
| `docs/troubleshooting/oom-timeout.rst` | New "Disk space protection" section |

## How it works

### Preflight estimation (`areno check --disk-budget`)

Estimates per-step overhead (TensorBoard scalars ~2KB + rollout samples JSONL ~10KB) multiplied by total steps. Checkpoint sizes are **excluded by default**; pass `--include-checkpoints` to include them (reads `*.safetensors` file sizes from the checkpoint directory).

### Runtime monitoring (`areno train --disk-monitor`)

Checks free space every N steps (default 10) via `shutil.disk_usage()` on `save_path` and `metrics_log_dir` partitions, taking the minimum free space across paths. Thresholds default to percentages of total disk capacity (warn 5%, stop 1%) with optional absolute GB overrides (`--disk-warn-gb`, `--disk-stop-gb`) that take whichever is stricter.

- **Warn**: logs a `WARNING` exactly once (tracked by `_already_warned` flag) and records `dashboard_state(stage="disk_space_warn")`
- **Stop**: logs `CRITICAL` and returns "stop", trainer breaks out via the same `return` path used by `max_steps_reached` — ensuring `epoch_end` logging, `MetricsRecorder.close()`, and `areno.close()` all run normally

## Self-review of AI-generated code

- **Communication contract**: `DiskMonitor.check(step)` returns `"ok"`/`"warn"`/`"stop"` — trainer decides whether to exit. `record_dashboard_state(stage="disk_space_warn", extra={"free_gb": ...})` reuses existing dashboard state contract.
- **No core engine changes**: Only trainers modified with a single `DiskMonitor.check()` call before each `step += 1`. `areno/engine/` untouched.
- **No new dependencies**: Only standard library (`shutil`, `json`, `logging`).
- **Code comments**: `disk_guard.py` has detailed docstrings and inline comments for threshold computation, throttling, and exit path.

### Issues found and fixed during testing

1. **Dashboard warning not visible**: Initially only `logger.warning()` was emitted. Fixed by adding `record_dashboard_state(stage="disk_space_warn")` in all three trainers.
2. **Check interval throttling bug**: First check at step 0 was skipped due to `step > 0` condition. Fixed to `self._last_check_step >= 0`.
3. **Threshold vs actual disk size**: On a 8657GB disk, `--disk-warn-gb 100` was overridden by 5% = 432GB. Documented that users should set `--disk-warn-gb` above their actual free space to trigger warnings.

## Testing

### CPU tests (26 passed, no GPU required)

```bash
python3 -m pytest tests/test_disk_guard_cpu.py -v
```

Covers: estimation logic (basic/excludes-checkpoints/includes-checkpoints/zero-steps/zero-interval), threshold computation (percent/absolute-override/percent-stricter), runtime check transitions (healthy/warn/stop/warn-once/throttling/zero-free-space), budget estimation (sufficient/insufficient), build helper (None/valid/no-paths), formatting (text-sufficient/text-insufficient/JSON), CLI integration (sufficient/insufficient/json/unchanged).

### GPU training test (Kaggle T4 x2)

```bash
areno train --ckpt Qwen/Qwen3-0.6B --algo gspo --tp-size 1 --world-size 1 \
  --dataset-path /tmp/tictactoe.jsonl \
  --dataset-loader-fn examples/agentic/tictactoe/dataset_loader.py \
  --reward-fn-path examples/agentic/tictactoe/reward.py \
  --agent-fn examples/agentic/tictactoe/run_agent.py \
  --batch-size 1 --n-samples 2 --max-running-prompts 2 \
  --max-new-tokens 256 --mini-bs 1 --max-context-len 1024 \
  --max-steps 5 --drop-rollout-state \
  --disk-monitor --disk-warn-gb 1200 --disk-stop-gb 600
```

Training log confirmed disk monitor activation and warning:
```
disk_monitor enabled: paths=['/tmp/areno/tfevent'] warn_gb=1200.0 stop_gb=600.0
disk_space: step=1 free=1100.67 GB warn_threshold=1200.00 GB stop_threshold=600.00 GB
WARNING areno.cli.disk_guard: disk_space: free=1100.67 GB, warn threshold=1200.00 GB
```

Warning emitted exactly once; training continued (free space above stop threshold).

## Acceptance criteria

- [x] Use a fake filesystem to test healthy/warn/stop transitions, emit alerts only once from the coordinator
- [x] Document that estimates exclude model checkpoints unless explicitly included
- [x] The implementation uses existing AReno contracts and introduces no external database or mandatory sandbox
- [x] Default behavior remains backward compatible (`--disk-monitor` and `--disk-budget` disabled by default)
- [x] Focused automated tests cover success, invalid input, and one boundary/failure path (26 CPU tests)
- [x] User documentation includes a minimal runnable example and explains observable output