### PR TITLE
feat(agentic): add balance-scale odd-ball puzzle example (#185)

### DIFF
--- a/examples/agentic/balance_scale/README.md
+++ b/examples/agentic/balance_scale/README.md
@@ -8,11 +8,17 @@ limited weighing budget.
 ## Files
 
 - `game.py` — Balance-scale game logic: `BalanceGame` class, `generate_game`,
-  and `format_prompt`.
+  `format_prompt`, `format_xml_prompt`, and XML parsing helpers.
 - `dataset_generator.py` — Generates reproducible JSONL puzzle records.
-- `dataset_loader.py` — Loads JSONL into Areno prompt records.
+- `dataset_loader.py` — Loads JSONL into Areno prompt records (tool-call variant).
+- `dataset_loader_no_tool.py` — Same but uses XML-tag prompts for models that
+  cannot produce OpenAI tool calls.
 - `run_agent.py` — Multi-turn agent entrypoint with `weigh` and `answer` tools.
+- `run_agent_no_tool.py` — Multi-turn agent using XML tags (`<weigh>` / `<answer>`)
+  instead of OpenAI tool calls. Suitable for smaller models.
 - `reward.py` — Rewards full-answer (1.0), identity-only (0.5), or wrong (0.0).
+- `reward_no_tool.py` — Same reward logic but extracts the answer from XML tags
+  in the completion text.
 
 ## Generate Puzzle Data
 
@@ -74,3 +80,25 @@ Parameters:
   that is surfaced to the model as a tool-response message.
 - Each puzzle has exactly one odd ball; there are no "all balls equal" puzzles.
 - The multi-turn loop is capped at 20 model calls per puzzle as a safety net.
+
+## No-Tool XML Variant
+
+For models that do not reliably produce OpenAI tool calls (e.g. smaller than
+1.7B parameters), use the XML no-tool variant. The model outputs plain text
+containing `<weigh left="0,1" right="2,3"/>` and
+`<answer ball="3" direction="heavier"/>` tags instead of structured tool calls.
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-0.6B \
+  --dataset-path /tmp/areno-balance-scale-puzzles.jsonl \
+  --dataset-loader-fn examples/agentic/balance_scale/dataset_loader_no_tool.py \
+  --reward-fn-path examples/agentic/balance_scale/reward_no_tool.py \
+  --agent-fn examples/agentic/balance_scale/run_agent_no_tool.py \
+  --algo gspo \
+  --batch-size 1 \
+  --n-samples 4 \
+  --max-new-tokens 64 \
+  --adam-8bit \
+  --drop-rollout-state
+```

--- a/examples/agentic/balance_scale/README.md
+++ b/examples/agentic/balance_scale/README.md
@@ -1,0 +1,76 @@
+# Agentic Balance-Scale Example
+
+This example trains a policy to solve an odd-ball balance-scale puzzle: given a
+set of visually identical balls where one is heavier or lighter, the agent uses
+a balance scale to identify the odd ball and its weight direction within a
+limited weighing budget.
+
+## Files
+
+- `game.py` — Balance-scale game logic: `BalanceGame` class, `generate_game`,
+  and `format_prompt`.
+- `dataset_generator.py` — Generates reproducible JSONL puzzle records.
+- `dataset_loader.py` — Loads JSONL into Areno prompt records.
+- `run_agent.py` — Multi-turn agent entrypoint with `weigh` and `answer` tools.
+- `reward.py` — Rewards full-answer (1.0), identity-only (0.5), or wrong (0.0).
+
+## Generate Puzzle Data
+
+```bash
+python examples/agentic/balance_scale/dataset_generator.py \
+  --output /tmp/areno-balance-scale-puzzles.jsonl \
+  --count 2048 \
+  --seed 2026 \
+  --num-balls 9 \
+  --max-weighings 3
+```
+
+## Train
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-1.7B \
+  --dataset-path /tmp/areno-balance-scale-puzzles.jsonl \
+  --dataset-loader-fn examples/agentic/balance_scale/dataset_loader.py \
+  --reward-fn-path examples/agentic/balance_scale/reward.py \
+  --agent-fn examples/agentic/balance_scale/run_agent.py \
+  --algo gspo \
+  --batch-size 2 \
+  --n-samples 4 \
+  --max-new-tokens 256
+```
+
+## Reward Structure
+
+| Outcome | Reward |
+|---------|--------|
+| Correct ball identity + correct direction | 1.0 |
+| Correct ball identity, wrong direction | 0.5 |
+| Wrong ball or no answer | 0.0 |
+
+## Tools
+
+### weigh
+
+Compares two disjoint equal-size groups of balls on a balance scale.
+
+Parameters:
+- `left_group`: list of ball indices (integers)
+- `right_group`: list of ball indices (integers)
+
+Returns: `left_heavy`, `right_heavy`, or `balanced`.
+
+### answer
+
+Submits the final answer.
+
+Parameters:
+- `ball_index`: the index of the odd ball (integer)
+- `direction`: `"heavier"` or `"lighter"`
+
+## Limitations
+
+- The weighing budget is enforced by the game; exceeding it raises an error
+  that is surfaced to the model as a tool-response message.
+- Each puzzle has exactly one odd ball; there are no "all balls equal" puzzles.
+- The multi-turn loop is capped at 20 model calls per puzzle as a safety net.

--- a/examples/agentic/balance_scale/dataset_generator.py
+++ b/examples/agentic/balance_scale/dataset_generator.py
@@ -1,0 +1,100 @@
+"""Generate reproducible JSONL puzzle records for the balance-scale example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = 2026
+DEFAULT_NUM_BALLS = 9
+DEFAULT_MAX_WEIGHINGS = 3
+
+
+def generate_records(
+    count: int = DEFAULT_COUNT,
+    *,
+    seed: int = DEFAULT_SEED,
+    num_balls: int = DEFAULT_NUM_BALLS,
+    max_weighings: int = DEFAULT_MAX_WEIGHINGS,
+) -> list[dict]:
+    """Generate *count* reproducible puzzle records with a seeded RNG.
+
+    Records are not required to be unique — the same (odd_ball_index,
+    odd_ball_direction) combination may appear multiple times across
+    a large dataset, which is the expected behavior for RL training.
+    """
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+    if num_balls < 3:
+        raise ValueError("num_balls must be at least 3")
+
+    rng = random.Random(seed)
+    records: list[dict] = []
+    for i in range(count):
+        odd_index = rng.randint(0, num_balls - 1)
+        direction = rng.choice(game.ODD_DIRECTIONS)
+        records.append(
+            {
+                "id": f"puzzle-{i:05d}",
+                "num_balls": num_balls,
+                "odd_ball_index": odd_index,
+                "odd_ball_direction": direction,
+                "max_weighings": max_weighings,
+            }
+        )
+    return records
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write records as JSONL."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate JSONL puzzles for the AReno balance-scale agentic example."
+    )
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of puzzles to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    parser.add_argument("--num-balls", type=int, default=DEFAULT_NUM_BALLS, help="Number of balls per puzzle.")
+    parser.add_argument(
+        "--max-weighings", type=int, default=DEFAULT_MAX_WEIGHINGS, help="Maximum weighings per puzzle."
+    )
+    args = parser.parse_args()
+
+    if args.count <= 0:
+        raise ValueError("--count must be positive")
+    if args.num_balls < 3:
+        raise ValueError("--num-balls must be at least 3")
+    if args.max_weighings < 1:
+        raise ValueError("--max-weighings must be at least 1")
+
+    records = generate_records(
+        args.count,
+        seed=args.seed,
+        num_balls=args.num_balls,
+        max_weighings=args.max_weighings,
+    )
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/balance_scale/dataset_loader.py
+++ b/examples/agentic/balance_scale/dataset_loader.py
@@ -1,0 +1,52 @@
+"""Dataset loader for the balance-scale agentic example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL puzzles and convert them to Areno prompt records."""
+
+    # AReno passes a default dataset loader we do not need for this example.
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw) for raw in records]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    """Read raw puzzle records from a JSONL file; fall back to the generator when the file is missing."""
+
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "puzzles.jsonl"
+    if not path.exists():
+        return dataset_generator.generate_records()
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict) -> dict:
+    """Convert one raw JSONL record into an Areno training record with a prompt."""
+
+    num_balls = int(raw["num_balls"])
+    max_weighings = int(raw["max_weighings"])
+    return {
+        "id": raw.get("id", f"puzzle-{raw['odd_ball_index']:05d}"),
+        "prompt": game.format_prompt(num_balls, max_weighings),
+        "num_balls": num_balls,
+        "odd_ball_index": int(raw["odd_ball_index"]),
+        "odd_ball_direction": raw["odd_ball_direction"],
+        "max_weighings": max_weighings,
+    }

--- a/examples/agentic/balance_scale/dataset_loader_no_tool.py
+++ b/examples/agentic/balance_scale/dataset_loader_no_tool.py
@@ -1,0 +1,27 @@
+"""Dataset loader for the balance-scale XML no-tool example."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dataset_loader import _format_record, _load_records  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL puzzles and format XML action prompts."""
+
+    del default_loader
+    return [_format_record_xml(raw) for raw in _load_records(dataset_path)]
+
+
+def _format_record_xml(raw: dict) -> dict:
+    """Convert one raw JSONL record into an Areno training record with an XML prompt."""
+
+    record = _format_record(raw)
+    record["prompt"] = game.format_xml_prompt(
+        int(raw["num_balls"]), int(raw["max_weighings"])
+    )
+    return record

--- a/examples/agentic/balance_scale/game.py
+++ b/examples/agentic/balance_scale/game.py
@@ -1,0 +1,164 @@
+"""Balance-scale odd-ball game logic for agentic RL.
+
+A set of visually identical balls contains exactly one odd ball that is
+either heavier or lighter than the rest.  The agent may call ``weigh`` to
+compare two disjoint equal-size groups on a balance scale, and must
+eventually call ``answer`` to identify the odd ball and its weight direction.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+
+ODD_DIRECTIONS = ("heavier", "lighter")
+WEIGH_RESULTS = ("left_heavy", "right_heavy", "balanced")
+
+
+class BalanceGame:
+    """One odd-ball balance-scale puzzle instance.
+
+    Attributes:
+        num_balls: Total number of balls (0-indexed internally).
+        odd_ball_index: Index of the odd ball.
+        odd_ball_direction: ``"heavier"`` or ``"lighter"``.
+        max_weighings: Maximum allowed weighings before the agent must answer.
+    """
+
+    __slots__ = ("num_balls", "odd_ball_index", "odd_ball_direction", "max_weighings", "_weighings_used")
+
+    def __init__(
+        self,
+        num_balls: int,
+        odd_ball_index: int,
+        odd_ball_direction: str,
+        max_weighings: int,
+    ) -> None:
+        if num_balls < 3:
+            raise ValueError("num_balls must be at least 3")
+        if not (0 <= odd_ball_index < num_balls):
+            raise ValueError(f"odd_ball_index {odd_ball_index} out of range [0, {num_balls})")
+        if odd_ball_direction not in ODD_DIRECTIONS:
+            raise ValueError(f"odd_ball_direction must be one of {ODD_DIRECTIONS}")
+        if max_weighings < 1:
+            raise ValueError("max_weighings must be at least 1")
+
+        self.num_balls = num_balls
+        self.odd_ball_index = odd_ball_index
+        self.odd_ball_direction = odd_ball_direction
+        self.max_weighings = max_weighings
+        self._weighings_used = 0
+
+    # -- public API ---------------------------------------------------------
+
+    @property
+    def weighings_used(self) -> int:
+        """Number of weighings consumed so far."""
+
+        return self._weighings_used
+
+    @property
+    def weighings_remaining(self) -> int:
+        """Remaining weighings before the agent must answer."""
+
+        return self.max_weighings - self._weighings_used
+
+    def weigh(self, left_group: Sequence[int], right_group: Sequence[int]) -> str:
+        """Compare two disjoint equal-size groups on the balance scale.
+
+        Returns one of ``"left_heavy"``, ``"right_heavy"``, ``"balanced"``.
+        Raises ``ValueError`` on invalid input or when the budget is exhausted.
+        """
+
+        left = list(left_group)
+        right = list(right_group)
+        self._validate_groups(left, right)
+        if self._weighings_used >= self.max_weighings:
+            raise ValueError(
+                f"weighing budget exhausted ({self.max_weighings} weighings used)"
+            )
+        self._weighings_used += 1
+
+        odd = self.odd_ball_index
+        heavier = self.odd_ball_direction == "heavier"
+        odd_in_left = odd in left
+        odd_in_right = odd in right
+
+        if not odd_in_left and not odd_in_right:
+            return "balanced"
+        if odd_in_left:
+            return "left_heavy" if heavier else "right_heavy"
+        return "right_heavy" if heavier else "left_heavy"
+
+    def check_answer(self, ball_index: int, direction: str) -> tuple[bool, bool]:
+        """Verify the agent's final answer.
+
+        Returns ``(identity_correct, direction_correct)``.
+        """
+
+        if not (0 <= ball_index < self.num_balls):
+            raise ValueError(f"ball_index {ball_index} out of range [0, {self.num_balls})")
+        if direction not in ODD_DIRECTIONS:
+            raise ValueError(f"direction must be one of {ODD_DIRECTIONS}")
+        identity_correct = ball_index == self.odd_ball_index
+        direction_correct = direction == self.odd_ball_direction
+        return (identity_correct, direction_correct)
+
+    # -- internal helpers ---------------------------------------------------
+
+    def _validate_groups(self, left: list[int], right: list[int]) -> None:
+        for group, label in ((left, "left"), (right, "right")):
+            for idx in group:
+                if not isinstance(idx, int) or isinstance(idx, bool):
+                    raise ValueError(f"{label}_group contains non-integer index: {idx!r}")
+                if not (0 <= idx < self.num_balls):
+                    raise ValueError(f"{label}_group index {idx} out of range [0, {self.num_balls})")
+        if len(left) != len(right):
+            raise ValueError(
+                f"groups must have equal size: left={len(left)}, right={len(right)}"
+            )
+        if not left:
+            raise ValueError("groups must not be empty")
+        overlap = set(left) & set(right)
+        if overlap:
+            raise ValueError(f"groups must be disjoint: overlap={sorted(overlap)}")
+        duplicates = {idx for idx in left if left.count(idx) > 1}
+        if duplicates:
+            raise ValueError(f"left_group has duplicate indices: {sorted(duplicates)}")
+        duplicates = {idx for idx in right if right.count(idx) > 1}
+        if duplicates:
+            raise ValueError(f"right_group has duplicate indices: {sorted(duplicates)}")
+
+
+def generate_game(
+    num_balls: int = 9,
+    *,
+    seed: int | None = None,
+    max_weighings: int = 3,
+) -> BalanceGame:
+    """Create a random puzzle with a seeded RNG."""
+
+    if num_balls < 3:
+        raise ValueError("num_balls must be at least 3")
+    rng = random.Random(seed)
+    odd_index = rng.randint(0, num_balls - 1)
+    direction = rng.choice(ODD_DIRECTIONS)
+    return BalanceGame(
+        num_balls=num_balls,
+        odd_ball_index=odd_index,
+        odd_ball_direction=direction,
+        max_weighings=max_weighings,
+    )
+
+
+def format_prompt(num_balls: int, max_weighings: int) -> str:
+    """Build the user-facing prompt for one puzzle instance."""
+
+    return (
+        f"You have {num_balls} visually identical balls numbered 0 to {num_balls - 1}. "
+        f"Exactly one ball is odd — it is either heavier or lighter than the rest. "
+        f"You have a balance scale and may use it at most {max_weighings} time(s). "
+        f"Call the weigh tool to compare two equal-size disjoint groups of balls. "
+        f"When you know the answer, call the answer tool with the odd ball index "
+        f"and whether it is heavier or lighter."
+    )

--- a/examples/agentic/balance_scale/game.py
+++ b/examples/agentic/balance_scale/game.py
@@ -9,6 +9,7 @@ eventually call ``answer`` to identify the odd ball and its weight direction.
 from __future__ import annotations
 
 import random
+import re
 from collections.abc import Sequence
 
 ODD_DIRECTIONS = ("heavier", "lighter")
@@ -152,7 +153,7 @@ def generate_game(
 
 
 def format_prompt(num_balls: int, max_weighings: int) -> str:
-    """Build the user-facing prompt for one puzzle instance."""
+    """Build the user-facing prompt for the tool-call variant."""
 
     return (
         f"You have {num_balls} visually identical balls numbered 0 to {num_balls - 1}. "
@@ -162,3 +163,77 @@ def format_prompt(num_balls: int, max_weighings: int) -> str:
         f"When you know the answer, call the answer tool with the odd ball index "
         f"and whether it is heavier or lighter."
     )
+
+
+def format_xml_prompt(num_balls: int, max_weighings: int) -> str:
+    """Build the user-facing prompt for the XML no-tool variant."""
+
+    return (
+        f"You have {num_balls} visually identical balls numbered 0 to {num_balls - 1}. "
+        f"Exactly one ball is odd — it is either heavier or lighter than the rest. "
+        f"You have a balance scale and may use it at most {max_weighings} time(s).\n\n"
+        f"To weigh, output a tag like: <weigh left=\"0,1\" right=\"2,3\"/>\n"
+        f"You will receive the result (left_heavy, right_heavy, or balanced) as the next message.\n\n"
+        f"To submit your answer, output a tag like: "
+        f"<answer ball=\"3\" direction=\"heavier\"/>\n"
+        f"Direction must be \"heavier\" or \"lighter\".\n\n"
+        f"You may reason step by step before each tag. "
+        f"Use at most {max_weighings} weigh tags, then use one answer tag."
+    )
+
+
+# ---------------------------------------------------------------------------
+# XML parsing helpers for the no-tool variant
+# ---------------------------------------------------------------------------
+
+_WEIGH_RE = re.compile(
+    r'<weigh\s+left\s*=\s*"([^"]*)"\s+right\s*=\s*"([^"]*)"\s*/?>',
+    re.IGNORECASE | re.DOTALL,
+)
+_ANSWER_RE = re.compile(
+    r'<answer\s+ball\s*=\s*"(\d+)"\s+direction\s*=\s*"(heavier|lighter)"\s*/?>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def parse_xml_weigh(text: str) -> tuple[list[int], list[int]] | None:
+    """Extract the last <weigh> tag from *text*.
+
+    Returns ``(left_group, right_group)`` or ``None`` when no tag is found.
+    """
+
+    matches = list(_WEIGH_RE.finditer(text))
+    if not matches:
+        return None
+    left_str, right_str = matches[-1].group(1), matches[-1].group(2)
+    left = _parse_int_list(left_str)
+    right = _parse_int_list(right_str)
+    if left is None or right is None:
+        return None
+    return (left, right)
+
+
+def parse_xml_answer(text: str) -> tuple[int, str] | None:
+    """Extract the last <answer> tag from *text*.
+
+    Returns ``(ball_index, direction)`` or ``None`` when no tag is found.
+    """
+
+    matches = list(_ANSWER_RE.finditer(text))
+    if not matches:
+        return None
+    ball_index = int(matches[-1].group(1))
+    direction = matches[-1].group(2).lower()
+    return (ball_index, direction)
+
+
+def _parse_int_list(text: str) -> list[int] | None:
+    """Parse a comma-separated integer list like '0,1,2'."""
+
+    parts = [p.strip() for p in text.split(",") if p.strip()]
+    if not parts:
+        return None
+    try:
+        return [int(p) for p in parts]
+    except ValueError:
+        return None

--- a/examples/agentic/balance_scale/reward.py
+++ b/examples/agentic/balance_scale/reward.py
@@ -7,7 +7,7 @@ from typing import Any
 
 FULL_ANSWER_REWARD = 1.0
 IDENTITY_ONLY_REWARD = 0.5
-WRONG_REWARD = 0.0
+WRONG_REWARD = -0.5
 
 
 def reward_fn(record: Any) -> float:
@@ -16,7 +16,7 @@ def reward_fn(record: Any) -> float:
     Returns:
         1.0 — correct ball identity and weight direction.
         0.5 — correct ball identity only.
-        0.0 — wrong answer or no answer tool call found.
+        -0.5 — wrong answer or no answer tool call found.
     """
 
     source = record.source_record

--- a/examples/agentic/balance_scale/reward.py
+++ b/examples/agentic/balance_scale/reward.py
@@ -1,0 +1,57 @@
+"""Reward function for the balance-scale agentic example."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+FULL_ANSWER_REWARD = 1.0
+IDENTITY_ONLY_REWARD = 0.5
+WRONG_REWARD = 0.0
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by extracting the answer tool call.
+
+    Returns:
+        1.0 — correct ball identity and weight direction.
+        0.5 — correct ball identity only.
+        0.0 — wrong answer or no answer tool call found.
+    """
+
+    source = record.source_record
+    correct_index = int(source["odd_ball_index"])
+    correct_direction = source["odd_ball_direction"]
+    answer_index, answer_direction = _extract_answer(record)
+    if answer_index is None:
+        return WRONG_REWARD
+    if answer_index != correct_index:
+        return WRONG_REWARD
+    if answer_direction == correct_direction:
+        return FULL_ANSWER_REWARD
+    return IDENTITY_ONLY_REWARD
+
+
+def _extract_answer(record: Any) -> tuple[int | None, str | None]:
+    """Find the last answer tool call and return (ball_index, direction)."""
+
+    for call in reversed(record.tool_calls):
+        name = call.get("name") if isinstance(call, dict) else None
+        if name != "answer":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return (None, None)
+        if not isinstance(arguments, dict):
+            return (None, None)
+        ball_index = arguments.get("ball_index")
+        direction = arguments.get("direction")
+        try:
+            ball_index = int(ball_index)
+        except (TypeError, ValueError):
+            ball_index = None
+        return (ball_index, direction)
+    return (None, None)

--- a/examples/agentic/balance_scale/reward_no_tool.py
+++ b/examples/agentic/balance_scale/reward_no_tool.py
@@ -1,0 +1,37 @@
+"""Reward function for the balance-scale XML no-tool example."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+FULL_ANSWER_REWARD = 1.0
+IDENTITY_ONLY_REWARD = 0.5
+WRONG_REWARD = 0.0
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by extracting the final <answer> XML tag.
+
+    Returns:
+        1.0 — correct ball identity and weight direction.
+        0.5 — correct ball identity only.
+        0.0 — wrong answer or no answer tag found.
+    """
+
+    source = record.source_record
+    correct_index = int(source["odd_ball_index"])
+    correct_direction = source["odd_ball_direction"]
+    parsed = game.parse_xml_answer(record.completion)
+    if parsed is None:
+        return WRONG_REWARD
+    answer_index, answer_direction = parsed
+    if answer_index != correct_index:
+        return WRONG_REWARD
+    if answer_direction == correct_direction:
+        return FULL_ANSWER_REWARD
+    return IDENTITY_ONLY_REWARD

--- a/examples/agentic/balance_scale/reward_no_tool.py
+++ b/examples/agentic/balance_scale/reward_no_tool.py
@@ -11,7 +11,7 @@ import game  # noqa: E402
 
 FULL_ANSWER_REWARD = 1.0
 IDENTITY_ONLY_REWARD = 0.5
-WRONG_REWARD = 0.0
+WRONG_REWARD = -0.5
 
 
 def reward_fn(record: Any) -> float:
@@ -20,7 +20,7 @@ def reward_fn(record: Any) -> float:
     Returns:
         1.0 — correct ball identity and weight direction.
         0.5 — correct ball identity only.
-        0.0 — wrong answer or no answer tag found.
+        -0.5 — wrong answer or no answer tag found.
     """
 
     source = record.source_record

--- a/examples/agentic/balance_scale/run_agent.py
+++ b/examples/agentic/balance_scale/run_agent.py
@@ -1,0 +1,229 @@
+"""Agent entrypoint for multi-turn balance-scale tool-call rollouts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game as game_module  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are solving a balance-scale odd-ball puzzle. "
+    "You have a set of visually identical balls, one of which is heavier or lighter. "
+    "Use the weigh tool to compare two equal-size disjoint groups of balls. "
+    "When you have identified the odd ball, call the answer tool with its index "
+    "and whether it is heavier or lighter. Choose your weighings carefully — "
+    "you have a limited budget."
+)
+
+BALANCE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "weigh",
+        "description": "Compare two disjoint equal-size groups of balls on a balance scale.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "left_group": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "Ball indices to place on the left side of the scale.",
+                },
+                "right_group": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "Ball indices to place on the right side of the scale.",
+                },
+            },
+            "required": ["left_group", "right_group"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+ANSWER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "answer",
+        "description": "Submit the final answer: which ball is odd and whether it is heavier or lighter.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ball_index": {
+                    "type": "integer",
+                    "description": "The index of the odd ball.",
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["heavier", "lighter"],
+                    "description": "Whether the odd ball is heavier or lighter.",
+                },
+            },
+            "required": ["ball_index", "direction"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+TOOLS = [BALANCE_TOOL, ANSWER_TOOL]
+MAX_TURNS = 20  # Safety cap to prevent infinite loops.
+
+# Max tokens per model call.  Weighing responses are short, but the model
+# may produce reasoning text before the tool call.
+MAX_NEW_TOKENS_PER_TURN = 256
+
+
+async def run_agent(ctx, batch):
+    """Run multi-turn balance-scale rollouts, one per puzzle.
+
+    For each puzzle the agent loops: it sends the current message history to
+    the policy model, receives a tool call (weigh or answer), executes the
+    tool locally, appends the tool result to the message history, and repeats
+    until the model calls ``answer`` or the weighing budget is exhausted.
+
+    Each model invocation produces one ``AgentTrajectoryTurn``; the full
+    multi-turn trajectory is returned as ``AgentTrajectory(turns=[...])``.
+    """
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The balance-scale agentic example requires `openai` and `httpx`. "
+            "Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info(
+        "Balance-scale agent start requests=%d max_running_prompts=%d",
+        len(items),
+        ctx.max_running_prompts,
+    )
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(
+            max_connections=max_connections, max_keepalive_connections=max_connections
+        ),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(
+        base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0
+    )
+
+    async def run_one(item):
+        """Run one puzzle instance: weigh repeatedly, then answer."""
+
+        record = item.record
+        puzzle = game_module.BalanceGame(
+            num_balls=int(record["num_balls"]),
+            odd_ball_index=int(record["odd_ball_index"]),
+            odd_ball_direction=record["odd_ball_direction"],
+            max_weighings=int(record["max_weighings"]),
+        )
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+
+        turns: list[AgentTrajectoryTurn] = []
+
+        for turn_idx in range(MAX_TURNS):
+            # On the last allowed weighing, tell the model it must answer now.
+            if puzzle.weighings_remaining <= 1 and puzzle.weighings_remaining > 0:
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": "You have 1 weighing remaining. After this weighing you must call the answer tool.",
+                    }
+                )
+
+            if puzzle.weighings_remaining <= 0:
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": "Your weighing budget is exhausted. You must call the answer tool now.",
+                    }
+                )
+
+            response = await client.chat.completions.create(
+                model="policy",
+                messages=messages,
+                tools=TOOLS,
+                stream=False,
+                max_tokens=MAX_NEW_TOKENS_PER_TURN,
+            )
+
+            turn = AgentTrajectoryTurn(
+                item=item,
+                messages=list(messages),
+                response=response,
+                tools=TOOLS,
+            )
+            turns.append(turn)
+
+            tool_calls = turn.parsed_tool_calls
+            if not tool_calls:
+                # Model returned plain text without a tool call — stop.
+                break
+
+            # Process tool calls (expect one per turn for this puzzle).
+            for tc in tool_calls:
+                fn_name = tc["function"]["name"]
+                fn_args = tc["function"]["arguments"]
+                if isinstance(fn_args, str):
+                    try:
+                        fn_args = json.loads(fn_args)
+                    except json.JSONDecodeError:
+                        fn_args = {}
+
+                if fn_name == "answer":
+                    # Game over — return all turns collected so far.
+                    return turns
+
+                if fn_name == "weigh":
+                    try:
+                        result = puzzle.weigh(
+                            fn_args.get("left_group", []),
+                            fn_args.get("right_group", []),
+                        )
+                        tool_content = result
+                    except ValueError as exc:
+                        tool_content = f"error: {exc}"
+                    # Append the assistant's tool call and the tool response.
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [tc],
+                        }
+                    )
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.get("id", "call_0"),
+                            "name": "weigh",
+                            "content": tool_content,
+                        }
+                    )
+
+        return turns
+
+    try:
+        results = await asyncio.gather(*(run_one(item) for item in items))
+        all_turns: list[AgentTrajectoryTurn] = []
+        for turn_list in results:
+            all_turns.extend(turn_list)
+        return AgentTrajectory(turns=all_turns)
+    finally:
+        await client.close()

--- a/examples/agentic/balance_scale/run_agent_no_tool.py
+++ b/examples/agentic/balance_scale/run_agent_no_tool.py
@@ -1,0 +1,162 @@
+"""Agent entrypoint for multi-turn balance-scale XML rollouts.
+
+This variant does not use OpenAI tool calls.  Instead, the model outputs plain
+text containing XML tags such as ``<weigh left="0,1" right="2,3"/>`` and
+``<answer ball="3" direction="heavier"/>``.  The agent loop parses these tags,
+executes the weighing locally, and appends the result as a user message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game as game_module  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are solving a balance-scale odd-ball puzzle. "
+    "You have a set of visually identical balls, one of which is heavier or lighter. "
+    "Output a weigh tag to compare two equal-size disjoint groups of balls. "
+    "Output an answer tag when you have identified the odd ball. "
+    "Choose your weighings carefully — you have a limited budget."
+)
+
+MAX_TURNS = 20
+MAX_NEW_TOKENS_PER_TURN = 256
+
+
+async def run_agent(ctx, batch):
+    """Run multi-turn balance-scale XML rollouts, one per puzzle."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The balance-scale agentic example requires `openai` and `httpx`. "
+            "Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info(
+        "Balance-scale XML agent start requests=%d max_running_prompts=%d",
+        len(items),
+        ctx.max_running_prompts,
+    )
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(
+            max_connections=max_connections, max_keepalive_connections=max_connections
+        ),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(
+        base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0
+    )
+
+    async def run_one(item):
+        """Run one puzzle instance using XML tags instead of tool calls."""
+
+        record = item.record
+        puzzle = game_module.BalanceGame(
+            num_balls=int(record["num_balls"]),
+            odd_ball_index=int(record["odd_ball_index"]),
+            odd_ball_direction=record["odd_ball_direction"],
+            max_weighings=int(record["max_weighings"]),
+        )
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+
+        turns: list[AgentTrajectoryTurn] = []
+
+        for turn_idx in range(MAX_TURNS):
+            # Nudge the model when the budget is running low.
+            if puzzle.weighings_remaining <= 1 and puzzle.weighings_remaining > 0:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "You have 1 weighing remaining. Use it wisely, then answer.",
+                    }
+                )
+
+            if puzzle.weighings_remaining <= 0:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "Your weighing budget is exhausted. You must output an answer tag now.",
+                    }
+                )
+
+            response = await client.chat.completions.create(
+                model="policy",
+                messages=messages,
+                stream=False,
+                max_tokens=MAX_NEW_TOKENS_PER_TURN,
+            )
+
+            turn = AgentTrajectoryTurn(
+                item=item,
+                messages=list(messages),
+                response=response,
+            )
+            turns.append(turn)
+
+            # Extract the model's text from the response.
+            text = _response_text(response)
+
+            # Check for an answer tag first — if found, we are done.
+            answer = game_module.parse_xml_answer(text)
+            if answer is not None:
+                return turns
+
+            # Check for a weigh tag.
+            weigh = game_module.parse_xml_weigh(text)
+            if weigh is None:
+                # No actionable tag — stop to avoid infinite loops.
+                break
+
+            left_group, right_group = weigh
+            try:
+                result = puzzle.weigh(left_group, right_group)
+            except ValueError as exc:
+                result = f"error: {exc}"
+
+            # Feed the weighing result back to the model as a user message.
+            messages.append({"role": "assistant", "content": text})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"Result: {result}",
+                }
+            )
+
+        return turns
+
+    try:
+        results = await asyncio.gather(*(run_one(item) for item in items))
+        all_turns: list[AgentTrajectoryTurn] = []
+        for turn_list in results:
+            all_turns.extend(turn_list)
+        return AgentTrajectory(turns=all_turns)
+    finally:
+        await client.close()
+
+
+def _response_text(response) -> str:
+    """Extract the assistant text from an OpenAI-compatible response."""
+
+    try:
+        return response.choices[0].message.content or ""
+    except (AttributeError, IndexError, TypeError):
+        return ""

--- a/examples/agentic/balance_scale/run_agent_no_tool.py
+++ b/examples/agentic/balance_scale/run_agent_no_tool.py
@@ -123,8 +123,20 @@ async def run_agent(ctx, batch):
             # Check for a weigh tag.
             weigh = game_module.parse_xml_weigh(text)
             if weigh is None:
-                # No actionable tag — stop to avoid infinite loops.
-                break
+                # No actionable tag — nudge the model and try again.
+                messages.append({"role": "assistant", "content": text})
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "Your response did not contain a <weigh> or <answer> tag. "
+                            "Please output one now. "
+                            "To weigh: <weigh left=\"0,1\" right=\"2,3\"/>. "
+                            "To answer: <answer ball=\"3\" direction=\"heavier\"/>."
+                        ),
+                    }
+                )
+                continue
 
             left_group, right_group = weigh
             try:

--- a/examples/agentic/balance_scale/web_ui.py
+++ b/examples/agentic/balance_scale/web_ui.py
@@ -1,0 +1,520 @@
+"""Interactive web UI for the balance-scale agentic example.
+
+Run a policy server first, then start this UI:
+
+    areno serve --model-path /path/to/model --tp-size 1 --world-size 1 --port 8000
+    python examples/agentic/balance_scale/web_ui.py \\
+        --base-url http://127.0.0.1:8000/v1 --api-key token --model policy
+
+Open http://127.0.0.1:8768 in a browser.  Set the number of balls, the odd-ball
+index, and its direction (heavier/lighter).  Click "Run" to watch the model
+solve the puzzle step by step.
+
+The UI uses the XML no-tool variant: the model outputs <weigh> and <answer>
+tags, and the UI parses them, executes the weighing locally, and feeds the
+result back to the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game as game_module  # noqa: E402
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8768
+MAX_TURNS = 20
+MAX_NEW_TOKENS = 256
+
+SYSTEM_PROMPT = (
+    "You are solving a balance-scale odd-ball puzzle. "
+    "You have a set of visually identical balls, one of which is heavier or lighter. "
+    "Output a weigh tag to compare two equal-size disjoint groups of balls. "
+    "Output an answer tag when you have identified the odd ball. "
+    "Choose your weighings carefully — you have a limited budget."
+)
+
+
+class BalanceServer(ThreadingHTTPServer):
+    """Stateful HTTP server for one balance-scale puzzle session."""
+
+    def __init__(self, server_address, request_handler, *, args):
+        super().__init__(server_address, request_handler)
+        self.args = args
+        self.reset(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+
+    def reset(self, *, num_balls: int, odd_ball_index: int, odd_ball_direction: str, max_weighings: int) -> None:
+        self.puzzle = game_module.BalanceGame(
+            num_balls=num_balls,
+            odd_ball_index=odd_ball_index,
+            odd_ball_direction=odd_ball_direction,
+            max_weighings=max_weighings,
+        )
+        self.turns: list[dict[str, Any]] = []
+        self.finished = False
+        self.model_answer: tuple[int, str] | None = None
+        self.error: str | None = None
+
+
+class BalanceHandler(BaseHTTPRequestHandler):
+    server: BalanceServer
+
+    def do_GET(self) -> None:
+        route = _route_path(self.path)
+        if route == "index":
+            self._send_html(INDEX_HTML)
+        elif route == "state":
+            self._send_json(_payload(self.server))
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def do_POST(self) -> None:
+        route = _route_path(self.path)
+        if route == "setup":
+            body = self._read_json()
+            self._handle_setup(body)
+        elif route == "run":
+            self._send_json(_handle_run(self.server))
+        elif route == "random":
+            body = self._read_json()
+            self._handle_random(body)
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("balance-web: " + fmt % args + "\n")
+
+    def _read_json(self) -> Any:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def _send_html(self, html: str) -> None:
+        encoded = html.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _send_json(self, payload: Any, status: HTTPStatus = HTTPStatus.OK) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _handle_setup(self, body: Any) -> None:
+        if not isinstance(body, dict):
+            self._send_json({"error": "invalid body"}, HTTPStatus.BAD_REQUEST)
+            return
+        try:
+            num_balls = int(body.get("num_balls", 9))
+            odd_ball_index = int(body.get("odd_ball_index", 0))
+            odd_ball_direction = body.get("odd_ball_direction", "heavier")
+            max_weighings = int(body.get("max_weighings", 3))
+            self.server.reset(
+                num_balls=num_balls,
+                odd_ball_index=odd_ball_index,
+                odd_ball_direction=odd_ball_direction,
+                max_weighings=max_weighings,
+            )
+            self._send_json(_payload(self.server))
+        except (ValueError, TypeError) as exc:
+            self._send_json({"error": str(exc)}, HTTPStatus.BAD_REQUEST)
+
+    def _handle_random(self, body: Any) -> None:
+        if not isinstance(body, dict):
+            body = {}
+        num_balls = int(body.get("num_balls", 9))
+        max_weighings = int(body.get("max_weighings", 3))
+        import random
+        rng = random.Random()
+        odd_index = rng.randint(0, num_balls - 1)
+        direction = rng.choice(["heavier", "lighter"])
+        self.server.reset(
+            num_balls=num_balls,
+            odd_ball_index=odd_index,
+            odd_ball_direction=direction,
+            max_weighings=max_weighings,
+        )
+        self._send_json(_payload(self.server))
+
+
+def _route_path(raw_path: str) -> str:
+    path = urlparse(raw_path).path.rstrip("/") or "/"
+    if path.endswith("/api/state"):
+        return "state"
+    if path.endswith("/api/setup"):
+        return "setup"
+    if path.endswith("/api/run"):
+        return "run"
+    if path.endswith("/api/random"):
+        return "random"
+    if "/api/" in path:
+        return "missing"
+    if path == "/" or not path.rsplit("/", 1)[-1].count("."):
+        return "index"
+    return "missing"
+
+
+def _payload(server: BalanceServer) -> dict[str, Any]:
+    puzzle = server.puzzle
+    result: dict[str, Any] = {
+        "num_balls": puzzle.num_balls,
+        "odd_ball_index": puzzle.odd_ball_index,
+        "odd_ball_direction": puzzle.odd_ball_direction,
+        "max_weighings": puzzle.max_weighings,
+        "weighings_used": puzzle.weighings_used,
+        "weighings_remaining": puzzle.weighings_remaining,
+        "turns": server.turns,
+        "finished": server.finished,
+        "error": server.error,
+    }
+    if server.model_answer is not None:
+        ball, direction = server.model_answer
+        identity_correct, direction_correct = puzzle.check_answer(ball, direction)
+        result["model_answer"] = {"ball_index": ball, "direction": direction}
+        result["identity_correct"] = identity_correct
+        result["direction_correct"] = direction_correct
+        if identity_correct and direction_correct:
+            result["verdict"] = "Fully correct! Ball index and direction both match."
+        elif identity_correct:
+            result["verdict"] = "Identity only: correct ball, wrong direction."
+        else:
+            result["verdict"] = "Wrong answer."
+    return result
+
+
+def _handle_run(server: BalanceServer) -> dict[str, Any]:
+    """Run the full multi-turn agent loop synchronously and return the final state."""
+
+    if server.finished:
+        return _payload(server)
+
+    args = server.args
+    try:
+        from openai import OpenAI
+    except ImportError:
+        server.error = "openai package not installed. Run: pip install openai"
+        return _payload(server)
+
+    client = OpenAI(base_url=args.base_url, api_key=args.api_key, max_retries=0)
+    puzzle = server.puzzle
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": game_module.format_xml_prompt(puzzle.num_balls, puzzle.max_weighings)},
+    ]
+
+    for turn_idx in range(MAX_TURNS):
+        if puzzle.weighings_remaining <= 1 and puzzle.weighings_remaining > 0:
+            messages.append({
+                "role": "user",
+                "content": "You have 1 weighing remaining. Use it wisely, then answer.",
+            })
+        if puzzle.weighings_remaining <= 0:
+            messages.append({
+                "role": "user",
+                "content": "Your weighing budget is exhausted. You must output an answer tag now.",
+            })
+
+        try:
+            response = client.chat.completions.create(
+                model=args.model,
+                messages=messages,
+                stream=False,
+                max_tokens=MAX_NEW_TOKENS,
+            )
+        except Exception as exc:
+            server.error = f"Model request failed: {exc}"
+            server.finished = True
+            return _payload(server)
+
+        text = ""
+        try:
+            text = response.choices[0].message.content or ""
+        except (AttributeError, IndexError, TypeError):
+            pass
+
+        # Check for answer tag.
+        answer = game_module.parse_xml_answer(text)
+        if answer is not None:
+            ball, direction = answer
+            server.model_answer = (ball, direction)
+            server.turns.append({"turn": turn_idx + 1, "action": "answer", "text": text, "ball": ball, "direction": direction})
+            server.finished = True
+            return _payload(server)
+
+        # Check for weigh tag.
+        weigh = game_module.parse_xml_weigh(text)
+        if weigh is None:
+            messages.append({"role": "assistant", "content": text})
+            messages.append({
+                "role": "user",
+                "content": (
+                    'Your response did not contain a <weigh> or <answer> tag. '
+                    'Please output one now. '
+                    'To weigh: <weigh left="0,1" right="2,3"/>. '
+                    'To answer: <answer ball="3" direction="heavier"/>.'
+                ),
+            })
+            server.turns.append({"turn": turn_idx + 1, "action": "nudge", "text": text})
+            continue
+
+        left_group, right_group = weigh
+        try:
+            result = puzzle.weigh(left_group, right_group)
+        except ValueError as exc:
+            result = f"error: {exc}"
+
+        server.turns.append({
+            "turn": turn_idx + 1,
+            "action": "weigh",
+            "left": left_group,
+            "right": right_group,
+            "result": result,
+            "text": text,
+        })
+        messages.append({"role": "assistant", "content": text})
+        messages.append({"role": "user", "content": f"Result: {result}"})
+
+    server.finished = True
+    server.error = "Max turns reached without an answer."
+    return _payload(server)
+
+
+# ---------------------------------------------------------------------------
+# HTML page
+# ---------------------------------------------------------------------------
+
+INDEX_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Balance Scale Agent</title>
+<style>
+* { box-sizing: border-box; }
+body { font-family: system-ui, sans-serif; max-width: 800px; margin: 20px auto; padding: 16px; background: #f5f5f5; }
+h1 { color: #333; }
+.card { background: white; border-radius: 8px; padding: 20px; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+label { display: inline-block; width: 140px; font-weight: 600; margin-bottom: 8px; }
+input, select { padding: 6px 10px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
+button { padding: 8px 20px; border: none; border-radius: 4px; background: #4a90d9; color: white; font-size: 14px; cursor: pointer; margin-right: 8px; }
+button:hover { background: #357abd; }
+button:disabled { background: #ccc; cursor: not-allowed; }
+button.secondary { background: #6c757d; }
+button.secondary:hover { background: #5a6268; }
+table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #e0e0e0; }
+th { background: #f0f0f0; font-weight: 600; }
+.turn-entry { padding: 8px 0; border-bottom: 1px solid #eee; }
+.turn-entry .turn-num { font-weight: 700; color: #4a90d9; }
+.turn-entry .turn-action { font-weight: 600; color: #333; }
+.turn-entry .turn-result { color: #e74c3c; font-weight: 600; }
+.verdict-correct { color: #27ae60; font-weight: 700; }
+.verdict-wrong { color: #e74c3c; font-weight: 700; }
+.verdict-partial { color: #f39c12; font-weight: 700; }
+.error { color: #e74c3c; font-weight: 600; }
+.controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: end; }
+.field { display: flex; flex-direction: column; gap: 4px; }
+.field label { width: auto; }
+#run-btn { background: #27ae60; }
+#run-btn:hover { background: #229954; }
+</style>
+</head>
+<body>
+<h1>Balance Scale Agent</h1>
+<p>Set puzzle parameters, run the model, and watch it solve the odd-ball puzzle step by step.</p>
+
+<div class="card">
+  <h3>Puzzle Setup</h3>
+  <div class="controls">
+    <div class="field">
+      <label>Number of balls</label>
+      <input type="number" id="num-balls" value="9" min="3" max="20">
+    </div>
+    <div class="field">
+      <label>Odd ball index (0-based)</label>
+      <input type="number" id="odd-index" value="0" min="0" max="19">
+    </div>
+    <div class="field">
+      <label>Odd ball direction</label>
+      <select id="odd-direction">
+        <option value="heavier">heavier</option>
+        <option value="lighter">lighter</option>
+      </select>
+    </div>
+    <div class="field">
+      <label>Max weighings</label>
+      <input type="number" id="max-weighings" value="3" min="1" max="10">
+    </div>
+    <button id="setup-btn">Apply Setup</button>
+    <button id="random-btn" class="secondary">Random</button>
+    <button id="run-btn">Run Model</button>
+  </div>
+</div>
+
+<div class="card" id="result-card" style="display:none">
+  <h3>Result</h3>
+  <table>
+    <tr><th>Item</th><th>Value</th></tr>
+    <tr><td>Number of balls</td><td id="r-num-balls"></td></tr>
+    <tr><td>Odd ball</td><td id="r-odd-ball"></td></tr>
+    <tr><td>True direction</td><td id="r-true-dir"></td></tr>
+    <tr><td>Model answer</td><td id="r-model-answer"></td></tr>
+    <tr><td>Verdict</td><td id="r-verdict"></td></tr>
+    <tr><td>Weighings used</td><td id="r-weighings"></td></tr>
+  </table>
+</div>
+
+<div class="card" id="error-card" style="display:none">
+  <p class="error" id="error-text"></p>
+</div>
+
+<div class="card">
+  <h3>Weighing Process</h3>
+  <div id="turns"></div>
+</div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+
+async function postJSON(url, body) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body || {}),
+  });
+  return resp.json();
+}
+
+async function getState() {
+  const resp = await fetch('/api/state');
+  return resp.json();
+}
+
+function applySetup() {
+  const body = {
+    num_balls: parseInt($('num-balls').value),
+    odd_ball_index: parseInt($('odd-index').value),
+    odd_ball_direction: $('odd-direction').value,
+    max_weighings: parseInt($('max-weighings').value),
+  };
+  postJSON('/api/setup', body).then(render);
+}
+
+function randomPuzzle() {
+  const body = {
+    num_balls: parseInt($('num-balls').value),
+    max_weighings: parseInt($('max-weighings').value),
+  };
+  postJSON('/api/random', body).then(render);
+}
+
+function runModel() {
+  $('run-btn').disabled = true;
+  $('run-btn').textContent = 'Running...';
+  postJSON('/api/run', {}).then((data) => {
+    render(data);
+    $('run-btn').disabled = false;
+    $('run-btn').textContent = 'Run Model';
+  }).catch(() => {
+    $('run-btn').disabled = false;
+    $('run-btn').textContent = 'Run Model';
+  });
+}
+
+function render(data) {
+  if (data.error) {
+    $('error-card').style.display = '';
+    $('error-text').textContent = data.error;
+  } else {
+    $('error-card').style.display = 'none';
+  }
+
+  if (data.model_answer) {
+    $('result-card').style.display = '';
+    $('r-num-balls').textContent = data.num_balls;
+    $('r-odd-ball').textContent = '#' + data.odd_ball_index;
+    $('r-true-dir').textContent = data.odd_ball_direction;
+    $('r-model-answer').textContent = 'Ball ' + data.model_answer.ball_index + ' (' + data.model_answer.direction + ')';
+    $('r-weighings').textContent = data.weighings_used + ' / ' + data.max_weighings;
+    const v = $('r-verdict');
+    v.textContent = data.verdict || '';
+    v.className = '';
+    if (data.identity_correct && data.direction_correct) v.className = 'verdict-correct';
+    else if (data.identity_correct) v.className = 'verdict-partial';
+    else v.className = 'verdict-wrong';
+  } else {
+    $('result-card').style.display = 'none';
+  }
+
+  const turnsDiv = $('turns');
+  turnsDiv.innerHTML = '';
+  if (!data.turns || data.turns.length === 0) {
+    turnsDiv.innerHTML = '<p style="color:#999">No turns yet. Click "Run Model" to start.</p>';
+    return;
+  }
+  for (const t of data.turns) {
+    const div = document.createElement('div');
+    div.className = 'turn-entry';
+    let html = '<span class="turn-num">--- Turn ' + t.turn + ' ---</span><br>';
+    if (t.action === 'weigh') {
+      html += '<span class="turn-action">weigh(left=[' + t.left + '], right=[' + t.right + '])</span><br>';
+      html += '<span class="turn-result">&rarr; ' + t.result + '</span>';
+    } else if (t.action === 'answer') {
+      html += '<span class="turn-action">answer(ball=' + t.ball + ', direction=' + t.direction + ')</span>';
+    } else {
+      html += '<span class="turn-action">(no valid tag, retrying)</span><br><span style="color:#999;font-size:12px">' + (t.text || '').substring(0, 100) + '...</span>';
+    }
+    div.innerHTML = html;
+    turnsDiv.appendChild(div);
+  }
+}
+
+$('setup-btn').addEventListener('click', applySetup);
+$('random-btn').addEventListener('click', randomPuzzle);
+$('run-btn').addEventListener('click', runModel);
+
+getState().then(render);
+</script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Web UI for the balance-scale agentic example.")
+    parser.add_argument("--host", default=DEFAULT_HOST, help=f"Bind host (default: {DEFAULT_HOST})")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"Bind port (default: {DEFAULT_PORT})")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000/v1", help="OpenAI-compatible base URL")
+    parser.add_argument("--api-key", default="token", help="API key for the model server")
+    parser.add_argument("--model", default="policy", help="Model name for chat completions")
+    args = parser.parse_args()
+
+    server = BalanceServer((args.host, args.port), BalanceHandler, args=args)
+    print(f"Balance Scale Web UI: http://{args.host}:{args.port}")
+    print(f"Model endpoint: {args.base_url}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_balance_scale_cpu.py
+++ b/tests/test_balance_scale_cpu.py
@@ -1,0 +1,346 @@
+"""CPU-only tests for the balance-scale agentic example.
+
+No GPU, network, or model weights required.  These tests validate the game
+logic, dataset generation, dataset loading, and reward function.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+# Load example modules from their directory.
+example_dir = Path(__file__).resolve().parent.parent / "examples" / "agentic" / "balance_scale"
+sys.path.insert(0, str(example_dir))
+
+game = importlib.import_module("game")
+dataset_generator = importlib.import_module("dataset_generator")
+dataset_loader = importlib.import_module("dataset_loader")
+reward = importlib.import_module("reward")
+
+
+def _make_record(
+    *,
+    odd_ball_index: int = 3,
+    odd_ball_direction: str = "heavier",
+    tool_calls: list[dict] | None = None,
+    num_balls: int = 9,
+    max_weighings: int = 3,
+) -> SimpleNamespace:
+    """Build a minimal RewardRecord-like object for reward_fn tests."""
+
+    return SimpleNamespace(
+        source_record={
+            "id": "test-001",
+            "prompt": "test prompt",
+            "num_balls": num_balls,
+            "odd_ball_index": odd_ball_index,
+            "odd_ball_direction": odd_ball_direction,
+            "max_weighings": max_weighings,
+        },
+        tool_calls=tool_calls or [],
+    )
+
+
+class GameLogicTest(unittest.TestCase):
+    """Tests for BalanceGame and generate_game."""
+
+    def test_heavier_ball_on_left(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=2, odd_ball_direction="heavier", max_weighings=3)
+        self.assertEqual(g.weigh([2], [0]), "left_heavy")
+
+    def test_lighter_ball_on_left(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=2, odd_ball_direction="lighter", max_weighings=3)
+        self.assertEqual(g.weigh([2], [0]), "right_heavy")
+
+    def test_heavier_ball_on_right(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=5, odd_ball_direction="heavier", max_weighings=3)
+        self.assertEqual(g.weigh([0], [5]), "right_heavy")
+
+    def test_odd_ball_not_in_groups(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=4, odd_ball_direction="heavier", max_weighings=3)
+        self.assertEqual(g.weigh([0, 1], [2, 3]), "balanced")
+
+    def test_multi_ball_groups_balanced(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=8, odd_ball_direction="heavier", max_weighings=3)
+        self.assertEqual(g.weigh([0, 1, 2], [3, 4, 5]), "balanced")
+
+    def test_multi_ball_groups_heavier(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=1, odd_ball_direction="heavier", max_weighings=3)
+        self.assertEqual(g.weigh([0, 1, 2], [3, 4, 5]), "left_heavy")
+
+    def test_unequal_group_size_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "equal size"):
+            g.weigh([0, 1], [2])
+
+    def test_overlapping_groups_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "disjoint"):
+            g.weigh([0, 1], [1, 2])
+
+    def test_index_out_of_range_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "out of range"):
+            g.weigh([0, 9], [1, 2])
+
+    def test_empty_groups_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "not be empty"):
+            g.weigh([], [])
+
+    def test_duplicate_index_in_group_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            g.weigh([0, 0], [1, 2])
+
+    def test_weighing_budget_exhausted_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=1)
+        g.weigh([0], [1])
+        with self.assertRaisesRegex(ValueError, "budget exhausted"):
+            g.weigh([2], [3])
+
+    def test_weighings_remaining_decrements(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+        self.assertEqual(g.weighings_remaining, 3)
+        g.weigh([0], [1])
+        self.assertEqual(g.weighings_remaining, 2)
+        self.assertEqual(g.weighings_used, 1)
+
+    def test_check_answer_full_correct(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=3, odd_ball_direction="heavier", max_weighings=3)
+        identity, direction = g.check_answer(3, "heavier")
+        self.assertTrue(identity)
+        self.assertTrue(direction)
+
+    def test_check_answer_identity_only(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=3, odd_ball_direction="heavier", max_weighings=3)
+        identity, direction = g.check_answer(3, "lighter")
+        self.assertTrue(identity)
+        self.assertFalse(direction)
+
+    def test_check_answer_both_wrong(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=3, odd_ball_direction="heavier", max_weighings=3)
+        identity, direction = g.check_answer(5, "lighter")
+        self.assertFalse(identity)
+        self.assertFalse(direction)
+
+    def test_check_answer_invalid_index_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=3, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "out of range"):
+            g.check_answer(99, "heavier")
+
+    def test_check_answer_invalid_direction_raises(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=3, odd_ball_direction="heavier", max_weighings=3)
+        with self.assertRaisesRegex(ValueError, "direction"):
+            g.check_answer(3, "same")
+
+    def test_invalid_num_balls_raises(self):
+        with self.assertRaisesRegex(ValueError, "at least 3"):
+            game.BalanceGame(num_balls=2, odd_ball_index=0, odd_ball_direction="heavier", max_weighings=3)
+
+    def test_invalid_odd_index_raises(self):
+        with self.assertRaisesRegex(ValueError, "out of range"):
+            game.BalanceGame(num_balls=5, odd_ball_index=10, odd_ball_direction="heavier", max_weighings=3)
+
+    def test_generate_game_reproducible(self):
+        g1 = game.generate_game(num_balls=9, seed=42, max_weighings=3)
+        g2 = game.generate_game(num_balls=9, seed=42, max_weighings=3)
+        self.assertEqual(g1.odd_ball_index, g2.odd_ball_index)
+        self.assertEqual(g1.odd_ball_direction, g2.odd_ball_direction)
+
+    def test_generate_game_different_seeds_differ(self):
+        g1 = game.generate_game(num_balls=9, seed=1, max_weighings=3)
+        g2 = game.generate_game(num_balls=9, seed=999, max_weighings=3)
+        # Extremely unlikely to be identical with 9 balls × 2 directions.
+        self.assertTrue(
+            g1.odd_ball_index != g2.odd_ball_index or g1.odd_ball_direction != g2.odd_ball_direction
+        )
+
+    def test_format_prompt_contains_ball_count(self):
+        text = game.format_prompt(12, 4)
+        self.assertIn("12", text)
+        self.assertIn("0 to 11", text)
+        self.assertIn("4", text)
+
+    def test_lighter_ball_on_right(self):
+        g = game.BalanceGame(num_balls=9, odd_ball_index=7, odd_ball_direction="lighter", max_weighings=3)
+        self.assertEqual(g.weigh([0], [7]), "left_heavy")
+
+
+class DatasetGeneratorTest(unittest.TestCase):
+    """Tests for dataset_generator."""
+
+    def test_generates_correct_count(self):
+        records = dataset_generator.generate_records(50, seed=2026, num_balls=9, max_weighings=3)
+        self.assertEqual(len(records), 50)
+
+    def test_records_have_valid_fields(self):
+        records = dataset_generator.generate_records(18, seed=2026, num_balls=9, max_weighings=3)
+        keys = {(r["odd_ball_index"], r["odd_ball_direction"]) for r in records}
+        # With 9 balls × 2 directions = 18 possible combinations, 18 records
+        # should cover all of them with high probability.
+        self.assertGreaterEqual(len(keys), 10)
+
+    def test_seeded_reproducibility(self):
+        r1 = dataset_generator.generate_records(10, seed=123, num_balls=9, max_weighings=3)
+        r2 = dataset_generator.generate_records(10, seed=123, num_balls=9, max_weighings=3)
+        self.assertEqual(r1, r2)
+
+    def test_different_seeds_differ(self):
+        r1 = dataset_generator.generate_records(10, seed=1, num_balls=9, max_weighings=3)
+        r2 = dataset_generator.generate_records(10, seed=2, num_balls=9, max_weighings=3)
+        self.assertNotEqual(r1, r2)
+
+    def test_record_fields(self):
+        records = dataset_generator.generate_records(5, seed=2026, num_balls=9, max_weighings=2)
+        for r in records:
+            self.assertIn("id", r)
+            self.assertIn("num_balls", r)
+            self.assertIn("odd_ball_index", r)
+            self.assertIn("odd_ball_direction", r)
+            self.assertIn("max_weighings", r)
+            self.assertEqual(r["num_balls"], 9)
+            self.assertEqual(r["max_weighings"], 2)
+
+    def test_zero_count_raises(self):
+        with self.assertRaises(ValueError):
+            dataset_generator.generate_records(0)
+
+    def test_too_few_balls_raises(self):
+        with self.assertRaises(ValueError):
+            dataset_generator.generate_records(5, seed=2026, num_balls=2, max_weighings=3)
+
+
+class DatasetLoaderTest(unittest.TestCase):
+    """Tests for dataset_loader."""
+
+    def test_loads_jsonl_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "puzzles.jsonl"
+            records = dataset_generator.generate_records(10, seed=2026, num_balls=9, max_weighings=3)
+            with path.open("w", encoding="utf-8") as f:
+                for r in records:
+                    f.write(json.dumps(r) + "\n")
+            loaded = dataset_loader.load_training_dataset(str(path))
+            self.assertEqual(len(loaded), 10)
+            for record in loaded:
+                self.assertIn("prompt", record)
+                self.assertIn("num_balls", record)
+                self.assertIn("odd_ball_index", record)
+                self.assertIn("odd_ball_direction", record)
+                self.assertIn("max_weighings", record)
+
+    def test_fallback_to_generator_when_file_missing(self):
+        loaded = dataset_loader.load_training_dataset("/nonexistent/path/to/puzzles.jsonl")
+        self.assertTrue(len(loaded) > 0)
+        self.assertIn("prompt", loaded[0])
+
+
+class RewardTest(unittest.TestCase):
+    """Tests for reward_fn."""
+
+    def test_full_correct_answer(self):
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "answer", "arguments": json.dumps({"ball_index": 3, "direction": "heavier"})}
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 1.0)
+
+    def test_identity_only_wrong_direction(self):
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "answer", "arguments": json.dumps({"ball_index": 3, "direction": "lighter"})}
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 0.5)
+
+    def test_wrong_ball(self):
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "answer", "arguments": json.dumps({"ball_index": 5, "direction": "heavier"})}
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 0.0)
+
+    def test_no_answer_tool_call(self):
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "weigh", "arguments": json.dumps({"left_group": [0], "right_group": [1]})},
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 0.0)
+
+    def test_no_tool_calls_at_all(self):
+        record = _make_record(odd_ball_index=3, odd_ball_direction="heavier", tool_calls=[])
+        self.assertEqual(reward.reward_fn(record), 0.0)
+
+    def test_uses_last_answer_call(self):
+        """When multiple answer calls exist, the last one is used."""
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "answer", "arguments": json.dumps({"ball_index": 5, "direction": "heavier"})},
+                {"name": "answer", "arguments": json.dumps({"ball_index": 3, "direction": "heavier"})},
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 1.0)
+
+    def test_answer_with_dict_arguments(self):
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "answer", "arguments": {"ball_index": 3, "direction": "heavier"}},
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 1.0)
+
+    def test_malformed_arguments(self):
+        record = _make_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            tool_calls=[
+                {"name": "answer", "arguments": "not json"},
+            ],
+        )
+        self.assertEqual(reward.reward_fn(record), 0.0)
+
+
+class ImportBoundaryTest(unittest.TestCase):
+    """Verify example modules import without AReno engine dependencies."""
+
+    def test_game_module_imports_cleanly(self):
+        # game.py should only use stdlib.
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "game_check", example_dir / "game.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self.assertTrue(hasattr(module, "BalanceGame"))
+
+    def test_reward_constants(self):
+        self.assertEqual(reward.FULL_ANSWER_REWARD, 1.0)
+        self.assertEqual(reward.IDENTITY_ONLY_REWARD, 0.5)
+        self.assertEqual(reward.WRONG_REWARD, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_balance_scale_cpu.py
+++ b/tests/test_balance_scale_cpu.py
@@ -273,7 +273,7 @@ class RewardTest(unittest.TestCase):
                 {"name": "answer", "arguments": json.dumps({"ball_index": 5, "direction": "heavier"})}
             ],
         )
-        self.assertEqual(reward.reward_fn(record), 0.0)
+        self.assertEqual(reward.reward_fn(record), -0.5)
 
     def test_no_answer_tool_call(self):
         record = _make_record(
@@ -283,11 +283,11 @@ class RewardTest(unittest.TestCase):
                 {"name": "weigh", "arguments": json.dumps({"left_group": [0], "right_group": [1]})},
             ],
         )
-        self.assertEqual(reward.reward_fn(record), 0.0)
+        self.assertEqual(reward.reward_fn(record), -0.5)
 
     def test_no_tool_calls_at_all(self):
         record = _make_record(odd_ball_index=3, odd_ball_direction="heavier", tool_calls=[])
-        self.assertEqual(reward.reward_fn(record), 0.0)
+        self.assertEqual(reward.reward_fn(record), -0.5)
 
     def test_uses_last_answer_call(self):
         """When multiple answer calls exist, the last one is used."""
@@ -319,7 +319,7 @@ class RewardTest(unittest.TestCase):
                 {"name": "answer", "arguments": "not json"},
             ],
         )
-        self.assertEqual(reward.reward_fn(record), 0.0)
+        self.assertEqual(reward.reward_fn(record), -0.5)
 
 
 class ImportBoundaryTest(unittest.TestCase):
@@ -339,7 +339,7 @@ class ImportBoundaryTest(unittest.TestCase):
     def test_reward_constants(self):
         self.assertEqual(reward.FULL_ANSWER_REWARD, 1.0)
         self.assertEqual(reward.IDENTITY_ONLY_REWARD, 0.5)
-        self.assertEqual(reward.WRONG_REWARD, 0.0)
+        self.assertEqual(reward.WRONG_REWARD, -0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -483,7 +483,7 @@ class NoToolRewardTest(unittest.TestCase):
             odd_ball_direction="heavier",
             completion='<answer ball="5" direction="heavier"/>',
         )
-        self.assertEqual(reward_no_tool.reward_fn(record), 0.0)
+        self.assertEqual(reward_no_tool.reward_fn(record), -0.5)
 
     def test_no_answer_tag(self):
         record = _make_no_tool_record(
@@ -491,7 +491,7 @@ class NoToolRewardTest(unittest.TestCase):
             odd_ball_direction="heavier",
             completion="I think the odd ball is 3 but I forgot to use the tag.",
         )
-        self.assertEqual(reward_no_tool.reward_fn(record), 0.0)
+        self.assertEqual(reward_no_tool.reward_fn(record), -0.5)
 
     def test_answer_with_reasoning(self):
         record = _make_no_tool_record(

--- a/tests/test_balance_scale_cpu.py
+++ b/tests/test_balance_scale_cpu.py
@@ -342,5 +342,197 @@ class ImportBoundaryTest(unittest.TestCase):
         self.assertEqual(reward.WRONG_REWARD, 0.0)
 
 
+# ---------------------------------------------------------------------------
+# XML no-tool variant tests
+# ---------------------------------------------------------------------------
+
+reward_no_tool = importlib.import_module("reward_no_tool")
+dataset_loader_no_tool = importlib.import_module("dataset_loader_no_tool")
+
+
+def _make_no_tool_record(
+    *,
+    odd_ball_index: int = 3,
+    odd_ball_direction: str = "heavier",
+    completion: str = "",
+    num_balls: int = 9,
+    max_weighings: int = 3,
+) -> SimpleNamespace:
+    """Build a minimal record for the no-tool reward_fn tests."""
+
+    return SimpleNamespace(
+        source_record={
+            "id": "test-001",
+            "prompt": "test prompt",
+            "num_balls": num_balls,
+            "odd_ball_index": odd_ball_index,
+            "odd_ball_direction": odd_ball_direction,
+            "max_weighings": max_weighings,
+        },
+        completion=completion,
+    )
+
+
+class XmlParseTest(unittest.TestCase):
+    """Tests for parse_xml_weigh and parse_xml_answer in game.py."""
+
+    def test_parse_weigh_basic(self):
+        result = game.parse_xml_weigh('<weigh left="0,1" right="2,3"/>')
+        self.assertEqual(result, ([0, 1], [2, 3]))
+
+    def test_parse_weigh_single_ball(self):
+        result = game.parse_xml_weigh('<weigh left="0" right="1"/>')
+        self.assertEqual(result, ([0], [1]))
+
+    def test_parse_weigh_with_spaces(self):
+        result = game.parse_xml_weigh('<weigh left=" 0 , 1 " right=" 2 , 3 "/>')
+        self.assertEqual(result, ([0, 1], [2, 3]))
+
+    def test_parse_weigh_case_insensitive(self):
+        result = game.parse_xml_weigh('<WEIGH LEFT="0,1" RIGHT="2,3"/>')
+        self.assertEqual(result, ([0, 1], [2, 3]))
+
+    def test_parse_weigh_non_self_closing(self):
+        result = game.parse_xml_weigh('<weigh left="0,1" right="2,3"></weigh>')
+        self.assertEqual(result, ([0, 1], [2, 3]))
+
+    def test_parse_weigh_takes_last_match(self):
+        text = '<weigh left="0" right="1"/>\n<weigh left="2" right="3"/>'
+        result = game.parse_xml_weigh(text)
+        self.assertEqual(result, ([2], [3]))
+
+    def test_parse_weigh_no_match(self):
+        self.assertIsNone(game.parse_xml_weigh("no weigh tag here"))
+
+    def test_parse_weigh_invalid_ints(self):
+        self.assertIsNone(game.parse_xml_weigh('<weigh left="a,b" right="2,3"/>'))
+
+    def test_parse_answer_basic(self):
+        result = game.parse_xml_answer('<answer ball="3" direction="heavier"/>')
+        self.assertEqual(result, (3, "heavier"))
+
+    def test_parse_answer_case_insensitive_direction(self):
+        result = game.parse_xml_answer('<answer ball="3" direction="HEAVIER"/>')
+        self.assertEqual(result, (3, "heavier"))
+
+    def test_parse_answer_non_self_closing(self):
+        result = game.parse_xml_answer('<answer ball="5" direction="lighter"></answer>')
+        self.assertEqual(result, (5, "lighter"))
+
+    def test_parse_answer_takes_last_match(self):
+        text = '<answer ball="1" direction="heavier"/>\n<answer ball="3" direction="lighter"/>'
+        result = game.parse_xml_answer(text)
+        self.assertEqual(result, (3, "lighter"))
+
+    def test_parse_answer_with_reasoning_text(self):
+        text = "Let me think...\nThe odd ball is 3, it feels heavier.\n<answer ball=\"3\" direction=\"heavier\"/>"
+        result = game.parse_xml_answer(text)
+        self.assertEqual(result, (3, "heavier"))
+
+    def test_parse_answer_no_match(self):
+        self.assertIsNone(game.parse_xml_answer("no answer tag"))
+
+    def test_parse_answer_invalid_direction(self):
+        self.assertIsNone(game.parse_xml_answer('<answer ball="3" direction="same"/>'))
+
+
+class FormatXmlPromptTest(unittest.TestCase):
+    """Tests for format_xml_prompt."""
+
+    def test_contains_ball_count(self):
+        text = game.format_xml_prompt(12, 4)
+        self.assertIn("12", text)
+        self.assertIn("0 to 11", text)
+        self.assertIn("4", text)
+
+    def test_contains_weigh_example(self):
+        text = game.format_xml_prompt(9, 3)
+        self.assertIn("<weigh", text)
+        self.assertIn("left=", text)
+        self.assertIn("right=", text)
+
+    def test_contains_answer_example(self):
+        text = game.format_xml_prompt(9, 3)
+        self.assertIn("<answer", text)
+        self.assertIn("ball=", text)
+        self.assertIn("direction=", text)
+
+
+class NoToolRewardTest(unittest.TestCase):
+    """Tests for reward_no_tool.reward_fn."""
+
+    def test_full_correct(self):
+        record = _make_no_tool_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            completion='<answer ball="3" direction="heavier"/>',
+        )
+        self.assertEqual(reward_no_tool.reward_fn(record), 1.0)
+
+    def test_identity_only(self):
+        record = _make_no_tool_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            completion='<answer ball="3" direction="lighter"/>',
+        )
+        self.assertEqual(reward_no_tool.reward_fn(record), 0.5)
+
+    def test_wrong_ball(self):
+        record = _make_no_tool_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            completion='<answer ball="5" direction="heavier"/>',
+        )
+        self.assertEqual(reward_no_tool.reward_fn(record), 0.0)
+
+    def test_no_answer_tag(self):
+        record = _make_no_tool_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            completion="I think the odd ball is 3 but I forgot to use the tag.",
+        )
+        self.assertEqual(reward_no_tool.reward_fn(record), 0.0)
+
+    def test_answer_with_reasoning(self):
+        record = _make_no_tool_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            completion=(
+                "After weighing, ball 3 is heavier.\n"
+                '<answer ball="3" direction="heavier"/>'
+            ),
+        )
+        self.assertEqual(reward_no_tool.reward_fn(record), 1.0)
+
+    def test_takes_last_answer(self):
+        record = _make_no_tool_record(
+            odd_ball_index=3,
+            odd_ball_direction="heavier",
+            completion=(
+                '<answer ball="5" direction="heavier"/>\n'
+                '<answer ball="3" direction="heavier"/>'
+            ),
+        )
+        self.assertEqual(reward_no_tool.reward_fn(record), 1.0)
+
+
+class NoToolDatasetLoaderTest(unittest.TestCase):
+    """Tests for dataset_loader_no_tool."""
+
+    def test_loads_jsonl_with_xml_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "puzzles.jsonl"
+            records = dataset_generator.generate_records(5, seed=2026, num_balls=9, max_weighings=3)
+            with path.open("w", encoding="utf-8") as f:
+                for r in records:
+                    f.write(json.dumps(r) + "\n")
+            loaded = dataset_loader_no_tool.load_training_dataset(str(path))
+            self.assertEqual(len(loaded), 5)
+            for record in loaded:
+                self.assertIn("prompt", record)
+                self.assertIn("<weigh", record["prompt"])
+                self.assertIn("<answer", record["prompt"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds a new agentic RL example under examples/agentic/balance_scale/ where a policy model solves an odd-ball balance-scale puzzle: given N visually identical balls with one heavier or lighter odd ball, the agent uses a weigh tool to compare two disjoint equal-size groups, then calls an answer tool to identify the odd ball and its weight direction — all within a limited weighing budget.

The agent runs multi-turn: each model call produces one AgentTrajectoryTurn, the tool result is fed back to the model, and the loop continues until the model answers or the budget is exhausted. The reward function gives tiered scores: 1.0 for correct ball + direction, 0.5 for correct ball only, 0.0 otherwise.

Both a tool-call variant run_agent.py) and an XML no-tool variant run_agent_no_tool.py) are provided. The no-tool variant uses <weigh> and <answer> XML tags for smaller models that cannot reliably produce OpenAI tool calls.

No AReno core code was modified. All files are new, following the same structure and conventions as the existing examples/agentic/tictactoe/ example.

## Files

- game.py — BalanceGame class with weigh() / check_answer() / weighing budget, generate_game() with seeded RNG, format_prompt() / format_xml_prompt(), XML parsing helpers

- dataset_generator.py — Reproducible JSONL puzzle generation with seeded RNG --num-balls 9 --max-weighings 3 defaults)

- dataset_loader.py — Load JSONL puzzles or fall back to on-the-fly generation

- dataset_loader_no_tool.py — Same but with XML-tag prompts

- reward.py — Tiered reward: 1.0 full answer, 0.5 identity only, 0.0 wrong

- reward_no_tool.py — Same reward logic, extracts answer from XML tags

- run_agent.py — Multi-turn OpenAI-compatible agent with weigh and answer tools

- run_agent_no_tool.py — Multi-turn agent using XML tags instead of tool calls

- README.md — Documentation with both variant commands

- tests/test_balance_scale_cpu.py — CPU-only tests

## Metrics

The reward function naturally distinguishes:

- Full-answer accuracy: reward = 1.0 (correct ball + correct direction)

- Identity-only accuracy: reward = 0.5 (correct ball, wrong direction)

- Mean weighings: tracked via BalanceGame.weighings_used per puzzle

## Related issue

Closes #185

## Type of change

- [x] New feature

## How was it tested?

```

pytest tests/test_balance_scale_cpu.py -v

```

43 tests passed, CPU-only, no GPU required. Tests cover:

- Game logic: weighing results (heavier/lighter/balanced), invalid inputs (unequal groups, overlap, out-of-range, empty, duplicates), budget exhaustion, answer verification, seeded reproducibility

- Dataset generation: count, reproducibility, field validation, invalid params

- Dataset loading: JSONL file parsing, fallback to generator on missing file

- Reward: full answer (1.0), identity-only (0.5), wrong ball (0.0), no answer call, multiple answer calls (last wins), dict arguments, malformed arguments

- Import boundary: game.py uses only stdlib

Training was validated on Kaggle Tesla T4 (2x) with Qwen3-0.6B using the no-tool XML variant. The training loop ran successfully with reward rising from 0.0 to 0.25 in early steps. Long-term training stability is limited by T4's 16GB VRAM (no native BF16 support) and the 0.6B model's capacity for multi-turn reasoning.

## Checklist

- [x] The PR title summarizes the contribution.

- [x] Linked the related issue in the description (Closes #185).

- [x] Existing tests pass pytest tests/ -k cpu).

- [x] New behavior is covered by tests.

- [x] Described the test commands run and any hardware limitations.

- [x] Public API / CLI changes are additive and backward-compatible (no core code modified).

