### PR TITLE
feat(cache): safe on-disk tokenization cache for dataset preprocessing (#206)

### DIFF
--- a/.agents/skills/areno-run-training/references/data-contracts.md
+++ b/.agents/skills/areno-run-training/references/data-contracts.md
@@ -8,3 +8,9 @@
 - Multimodal loaders return public image representations such as image URLs or data URLs; processor work remains in the runtime.
 
 Inspect normalization in `areno/api/data_utils.py` and the concrete trainer before changing schemas.
+
+When `--dataset-cache-path` is set, the rollout path caches tokenized prompt
+samples keyed on dataset content, tokenizer assets, chat template, and
+preprocessing options; later epochs log `stage=dataset_cache_hit` and skip
+re-tokenization. It is off by default and only covers the rollout path; use
+`areno dataset-cache inspect/clean` for size reporting and explicit removal.

--- a/.agents/skills/areno-run-training/references/failure-triage.md
+++ b/.agents/skills/areno-run-training/references/failure-triage.md
@@ -3,6 +3,7 @@
 | First failing stage | Inspect first |
 | --- | --- |
 | Dataset | loader import, normalized row, model-hub access |
+| Dataset cache | `stage=dataset_cache_config` path/mode; `dataset_cache_rejected` (fingerprint/version mismatch); `dataset_cache_skip` (non-serializable record) |
 | Rollout | active sequences, generation bound, agent timeout, worker stack |
 | Reward | decoded answer, source solution, parser, sample grouping |
 | Rollout OOM | context/cache capacity, concurrency, TP, retained state |

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -56,6 +56,7 @@ backend-only view.
 | Add or change an algorithm or loss | `areno/api/algorithms.py`, `areno/api/trainers/`, and `areno/api/loss_fns/` | `tests/test_algorithms_cpu.py` and `tests/test_losses_rewards_cpu.py` |
 | Add or change a model family | `areno/models/base.py`, `areno/models/registry.py`, then the closest family under `areno/models/` | `tests/test_registry_cpu.py` and `tests/test_registry_discovery_cpu.py` |
 | Change agentic rollout behavior | `areno/api/agentic.py`, then a matching task under `examples/agentic/` | `tests/test_agentic_cpu.py` and the matching example test |
+| Cache tokenized dataset samples | `areno/api/dataset_cache.py`, then `areno/api/trainer.py::Trainer.load_prompt_batches` | `tests/test_dataset_cache_cpu.py` and `tests/test_trainer_api_cpu.py::TrainerDatasetCacheTest` |
 
 ## Tests, examples, and skills
 

--- a/areno/api/dataset_cache.py
+++ b/areno/api/dataset_cache.py
@@ -1,0 +1,388 @@
+"""原子化、基于指纹的分词数据集样本磁盘缓存。
+
+`Trainer.load_prompt_batches` 会在每个 epoch 对每条数据集记录重新分词。
+本模块将该过程产生的 prompt 样本缓存到磁盘，使用内容/分词器/模板/选项的组合指纹作为键，
+后续的 epoch —— 以及后续针对相同输入的运行 —— 可以直接复用缓存样本，无需重复分词。
+
+设计要点：
+
+- 内容寻址键：指纹由数据集内容、分词器资产文件、当前 chat template + thinking 开关、
+  预处理选项以及缓存格式版本号共同决定。任何相关输入的变化都会导致生成不同的键，
+  因此永远不会复用过期的缓存条目。
+- 原子写入：每个缓存条目是单个 JSON 文件，先写入同目录的临时文件，然后通过
+  ``os.replace`` 原子替换，镜像了 ``areno/api/metrics.py`` 和
+  ``areno/cli/dashboard_registry.py`` 的实现方式。跨进程的并发读者要么读到完整的
+  旧文件，要么读到完整的新文件，永远不会看到部分写入。
+- 严格校验：读取时校验版本号、指纹哈希和数据结构；损坏或不兼容的缓存条目会被记录
+  并视为未命中，而不是被使用。
+- 安全默认值在别处：本模块永不静默改变行为；调用方需显式构造 ``DatasetCache`` 并
+  传入才会启用缓存。
+
+本模块仅使用标准库（``hashlib``、``json``、``os``、``tempfile``、``pathlib``），
+避免引入重量级依赖，确保 ``areno train --help`` 保持快速。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ARENO_DATASET_CACHE_VERSION = 1
+"""缓存格式版本号；递增后旧代码生成的缓存条目将失效。"""
+
+DATASET_CACHE_MODES = ("auto", "refresh", "readonly")
+"""``auto`` 未命中时读取并写入；``refresh`` 忽略已有缓存并覆盖；``readonly`` 只读，永不写入。"""
+
+# 影响 ``tokenize()`` / ``apply_chat_template()`` 输出的 HF 分词器文件。
+# 仅将模型路径下实际存在的文件计入资产哈希；缺失的文件会被忽略而非报错，
+# 因此没有 chat template 的基础分词器也能正确缓存。
+_TOKENIZER_ASSET_FILES = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "vocab.txt",
+    "merges.txt",
+    "tokenizer.model",
+)
+
+logger = logging.getLogger("areno.api.dataset_cache")
+
+
+class DatasetCacheError(ValueError):
+    """无效的缓存配置（错误的模式或不可写的路径）时抛出。"""
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    """指纹组件与其内容寻址哈希的封装。"""
+
+    fingerprint: dict[str, Any]
+    fingerprint_hash: str
+
+    @property
+    def filename(self) -> str:
+        """由指纹哈希推导出的缓存文件名。"""
+
+        return f"{self.fingerprint_hash}.json"
+
+
+def _sha256_text(text: str) -> str:
+    """对短字符串（模板、JSON 投影）计算 SHA256 哈希，返回十六进制摘要。"""
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _hash_file(path: Path) -> str:
+    """流式计算文件的 SHA256 哈希，避免一次性加载大文件。"""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 16), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fingerprint_tokenizer(model_path: str | Path, tokenizer: Any) -> dict[str, Any]:
+    """计算分词器资产文件 + 当前 chat template + thinking 开关的指纹。
+
+    chat template 和 ``enable_thinking`` 开关被显式计入哈希（而非仅依赖磁盘上的配置），
+    因为调用方可能在运行时设置它们（见 ``configure_chat_template_enable_thinking``），
+    这会影响分词结果但不改变磁盘文件。
+    """
+
+    base = Path(model_path)
+    asset_hashes: dict[str, str] = {}
+    for name in _TOKENIZER_ASSET_FILES:
+        candidate = base / name
+        if candidate.is_file():
+            asset_hashes[name] = _hash_file(candidate)
+    chat_template = getattr(tokenizer, "chat_template", None)
+    chat_template = chat_template if isinstance(chat_template, str) else ""
+    enable_thinking = getattr(tokenizer, "_areno_chat_template_enable_thinking", None)
+    return {
+        "asset_files": asset_hashes,
+        "chat_template_hash": _sha256_text(chat_template),
+        "enable_thinking": enable_thinking,
+    }
+
+
+def fingerprint_dataset(dataset: Any, prompt_key: str, solutions_key: str) -> dict[str, Any]:
+    """计算训练器实际看到的已规范化数据集的身份指纹。
+
+    遍历一次并对每行数据的 JSON 投影（prompt 字段 + 排序后的记录键）计算哈希，
+    使缓存具备内容寻址能力：数据集中任何 prompt 或 schema 的变化都会导致缓存条目失效，
+    而数据集路径字面值不会阻碍另一台机器上相同内容的复用。
+    ``default=str`` 保持流式哈希对非 JSON 行值的鲁棒性；
+    严格的序列化校验发生在 ``DatasetCache.save`` 中。
+    """
+
+    digest = hashlib.sha256()
+    schema_keys: set[str] = set()
+    row_count = 0
+    for record in dataset:
+        row_count += 1
+        keys = sorted(record.keys()) if hasattr(record, "keys") else []
+        schema_keys.update(keys)
+        projection = {key: record.get(key) for key in keys}
+        digest.update(json.dumps(projection, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8"))
+    return {
+        "row_count": row_count,
+        "schema_keys": sorted(schema_keys),
+        "content_hash": digest.hexdigest(),
+        "prompt_key": prompt_key,
+        "solutions_key": solutions_key,
+    }
+
+
+def compute_cache_key(
+    model_path: str | Path,
+    tokenizer: Any,
+    dataset: Any,
+    *,
+    max_prompt_tokens: int,
+    prompt_key: str,
+    solutions_key: str,
+) -> CacheKey:
+    """为一次分词配置构建内容寻址的缓存键。"""
+
+    components = {
+        "version": ARENO_DATASET_CACHE_VERSION,
+        "tokenizer": fingerprint_tokenizer(model_path, tokenizer),
+        "dataset": fingerprint_dataset(dataset, prompt_key, solutions_key),
+        "preprocessing": {
+            "max_prompt_tokens": max_prompt_tokens,
+            "prompt_key": prompt_key,
+            "solutions_key": solutions_key,
+        },
+    }
+    fingerprint_hash = hashlib.sha256(
+        json.dumps(components, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8")
+    ).hexdigest()
+    return CacheKey(fingerprint=components, fingerprint_hash=fingerprint_hash)
+
+
+def validate_cache_config(cache_path: str | None, mode: str) -> None:
+    """数据集缓存配置的预校验。
+
+    若配置无效则抛出 ``DatasetCacheError``，错误信息中包含有问题的输入项名称，
+    以便 CLI 在昂贵的模型/worker 初始化之前快速失败。
+    此函数与运行时构造分离，因此无效路径在配置构建阶段即被拒绝，而非训练中途。
+    """
+
+    if mode not in DATASET_CACHE_MODES:
+        raise DatasetCacheError(
+            f"dataset cache mode must be one of {DATASET_CACHE_MODES}, got {mode!r}; "
+            "stage=dataset_cache_config input=dataset_cache_mode"
+        )
+    if not cache_path:
+        return
+    parent = Path(cache_path).expanduser().parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise DatasetCacheError(
+            f"dataset cache path is not creatable: {cache_path} ({exc}); "
+            "stage=dataset_cache_config input=dataset_cache_path"
+        ) from exc
+    if not os.access(parent, os.W_OK):
+        raise DatasetCacheError(
+            f"dataset cache path is not writable: {cache_path}; "
+            "stage=dataset_cache_config input=dataset_cache_path"
+        )
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """通过同目录临时文件 + rename 将 ``text`` 原子写入 ``path``。
+
+    临时文件位于目标目录中，因此最终的 ``os.replace`` 是同文件系统的原子重命名；
+    读者永远不会看到半写入的文件。
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        "w", dir=path.parent, prefix=path.name + ".", suffix=".tmp", delete=False, encoding="utf-8"
+    )
+    tmp_path = Path(handle.name)
+    try:
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
+        handle.close()
+    except BaseException:
+        handle.close()
+        _silent_remove(tmp_path)
+        raise
+    os.replace(tmp_path, path)
+
+
+def _silent_remove(path: Path) -> None:
+    """静默删除临时文件，若文件已不存在则不报错。"""
+
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+class DatasetCache:
+    """以 ``CacheKey`` 为键的已分词 prompt 样本磁盘缓存。
+
+    缓存目录下存放一个 ``<fingerprint_hash>.json`` 条目，对应唯一的分词配置。
+    ``mode`` 控制未命中时是否持久化：
+
+    * ``auto`` —— 命中时读取，未命中时分词并持久化（默认）。
+    * ``refresh`` —— 忽略已有条目，重新分词并覆盖。
+    * ``readonly`` —— 命中时读取，未命中时仅在内存中分词，永不持久化
+      （适用于只读文件系统或共享的不可变缓存）。
+    """
+
+    def __init__(self, cache_dir: str | Path, *, mode: str = "auto") -> None:
+        if mode not in DATASET_CACHE_MODES:
+            raise DatasetCacheError(f"dataset cache mode must be one of {DATASET_CACHE_MODES}, got {mode!r}")
+        self.cache_dir = Path(cache_dir)
+        self.mode = mode
+
+    def artifact_path(self, key: CacheKey) -> Path:
+        """解析某个缓存键对应的磁盘路径。"""
+
+        return self.cache_dir / key.filename
+
+    def try_load(self, key: CacheKey) -> tuple[list[dict], dict[str, Any]] | None:
+        """加载并校验缓存条目，成功返回 ``(items, meta)``，失败返回 ``None``。
+
+        任何读取错误、版本不匹配、指纹不匹配或结构问题都会被记录并视为未命中，
+        因此损坏或不兼容的缓存条目永远不会被使用；调用方重新分词并在可写模式下覆盖。
+        """
+
+        path = self.artifact_path(key)
+        try:
+            envelope = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            logger.info("stage=dataset_cache_rejected reason=read_error path=%s", path)
+            return None
+        if not isinstance(envelope, dict):
+            logger.info("stage=dataset_cache_rejected reason=corrupt_envelope path=%s", path)
+            return None
+        if envelope.get("version") != ARENO_DATASET_CACHE_VERSION:
+            logger.info("stage=dataset_cache_rejected reason=version_mismatch path=%s", path)
+            return None
+        if envelope.get("fingerprint_hash") != key.fingerprint_hash:
+            logger.info("stage=dataset_cache_rejected reason=fingerprint_mismatch path=%s", path)
+            return None
+        items = envelope.get("items")
+        if not isinstance(items, list):
+            logger.info("stage=dataset_cache_rejected reason=corrupt_items path=%s", path)
+            return None
+        meta = {
+            "max_prompt_tokens": envelope.get("max_prompt_tokens"),
+            "prompt_key": envelope.get("prompt_key"),
+            "solutions_key": envelope.get("solutions_key"),
+            "count": envelope.get("count"),
+            "skipped_long": int(envelope.get("skipped_long", 0)),
+        }
+        return items, meta
+
+    def save(self, key: CacheKey, items: list[dict], meta: dict[str, Any]) -> int | None:
+        """原子持久化 ``items``，成功返回缓存条目字节数。
+
+        若任意记录不可 JSON 序列化则返回 ``None`` 且不写入文件，
+        因此包含不可序列化字段（例如含二进制载荷的多模态行）的数据集会优雅降级为不缓存，
+        而不是留下不完整或损坏的缓存条目。``items`` 直接原样存储；
+        调用方需确保传入纯 JSON 兼容的 dict。
+        """
+
+        envelope = {
+            "version": ARENO_DATASET_CACHE_VERSION,
+            "fingerprint": key.fingerprint,
+            "fingerprint_hash": key.fingerprint_hash,
+            "max_prompt_tokens": meta.get("max_prompt_tokens"),
+            "prompt_key": meta.get("prompt_key"),
+            "solutions_key": meta.get("solutions_key"),
+            "count": len(items),
+            "skipped_long": int(meta.get("skipped_long", 0)),
+            "items": items,
+        }
+        try:
+            payload = json.dumps(envelope, ensure_ascii=False)
+        except (TypeError, ValueError) as exc:
+            # 拒绝不完整的缓存：绝不向磁盘写入不完整的文件。
+            # 截断错误信息以避免暴露完整样本内容。
+            logger.info("stage=dataset_cache_skip reason=non_serializable_record error=%s", str(exc)[:160])
+            return None
+        path = self.artifact_path(key)
+        _atomic_write_text(path, payload)
+        return len(payload.encode("utf-8"))
+
+    def inspect(self) -> list[dict[str, Any]]:
+        """扫描缓存目录下的所有条目并返回摘要报告。
+
+        读取每个文件以展示其 manifest 字段（count、skipped_long、fingerprint_hash）；
+        仅需文件大小的调用方可以忽略解析字段。无效文件以 ``valid=False`` 报告而非丢弃，
+        以便运维人员能看到并清理损坏条目。
+        """
+
+        results: list[dict[str, Any]] = []
+        if not self.cache_dir.is_dir():
+            return results
+        for entry in sorted(self.cache_dir.glob("*.json")):
+            stat = entry.stat()
+            record: dict[str, Any] = {
+                "path": str(entry),
+                "size_bytes": stat.st_size,
+                "mtime": stat.st_mtime,
+            }
+            try:
+                envelope = json.loads(entry.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                record["valid"] = False
+                results.append(record)
+                continue
+            record.update(
+                {
+                    "valid": envelope.get("version") == ARENO_DATASET_CACHE_VERSION,
+                    "fingerprint_hash": envelope.get("fingerprint_hash"),
+                    "count": envelope.get("count"),
+                    "skipped_long": envelope.get("skipped_long"),
+                    "mode_hint": "refresh" if envelope.get("version") != ARENO_DATASET_CACHE_VERSION else None,
+                }
+            )
+            results.append(record)
+        return results
+
+    def clean(self, *, fingerprint_hash: str | None = None, remove_all: bool = False) -> dict[str, Any]:
+        """删除一个缓存条目（按 ``fingerprint_hash``）或全部条目。
+
+        返回 ``{"removed": int, "bytes_freed": int}``。若指定的条目不存在则不会报错，
+        以保证命令幂等。
+        """
+
+        removed = 0
+        bytes_freed = 0
+        if not self.cache_dir.is_dir():
+            return {"removed": removed, "bytes_freed": bytes_freed}
+        if remove_all:
+            targets = list(self.cache_dir.glob("*.json"))
+        elif fingerprint_hash:
+            target = self.cache_dir / f"{fingerprint_hash}.json"
+            targets = [target] if target.is_file() else []
+        else:
+            targets = []
+        for entry in targets:
+            try:
+                size = entry.stat().st_size
+            except OSError:
+                size = 0
+            try:
+                entry.unlink()
+            except OSError:
+                continue
+            removed += 1
+            bytes_freed += size
+        return {"removed": removed, "bytes_freed": bytes_freed}

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -7,6 +7,7 @@ one `Trainer`, calls ``init()`` once, and then loops:
 ref/reward/critic models become available behind the backend boundary.
 """
 
+import logging
 import time
 from collections.abc import Callable, Iterable
 from typing import Any
@@ -16,10 +17,35 @@ from areno.api.backend.base import Backend, get_backend_cls
 from areno.api.config import BackendConfig, coerce_backend_config, resolve_backend_type
 from areno.api.context import Context
 from areno.api.data import PromptBatch, PromptItem
+from areno.api.dataset_cache import CacheKey, DatasetCache, compute_cache_key
 from areno.api.metrics import MetricsRecorder
 from areno.api.models import BackendType, RolloutResult, SamplingParams, TrainSequence
 from areno.api.roles import ModelRole
 from areno.api.tokenizer import encode_generation_prompt, eos_token_ids, load_tokenizer, normalize_token_ids
+
+logger = logging.getLogger("areno.api.trainer")
+
+
+def _prompt_item_to_dict(item: PromptItem) -> dict[str, Any]:
+    """Serialize a `PromptItem` to a plain JSON-compatible dict for caching."""
+
+    return {
+        "prompt": item.prompt,
+        "solutions": item.solutions,
+        "input_tokens": item.input_tokens,
+        "record": item.record,
+    }
+
+
+def _prompt_item_from_dict(data: dict[str, Any]) -> PromptItem:
+    """Reconstruct a `PromptItem` from a cached dict (the inverse of above)."""
+
+    return PromptItem(
+        prompt=data["prompt"],
+        solutions=data.get("solutions"),
+        input_tokens=data["input_tokens"],
+        record=dict(data.get("record") or {}),
+    )
 
 
 class Trainer:
@@ -62,6 +88,10 @@ class Trainer:
         self._step_wall_start: float | None = None
         self._rollout_session_depth = 0
         self._rollout_wall_start: float | None = None
+        # 当前运行的数据集缓存键（带记忆化）。指纹由分词器、数据集、预处理选项共同决定，
+        # 在一次运行中保持不变，因此计算一次后在各个 epoch 间复用，避免每次重复流式哈希。
+        # 元组保存 (dataset, kwargs_id, key) 以便按数据集对象身份进行键控。
+        self._dataset_cache_key: tuple[Any, tuple[Any, ...], CacheKey] | None = None
 
     def init(self) -> None:
         """Load tokenizer, create backend context, and initialize workers."""
@@ -212,6 +242,7 @@ class Trainer:
         max_prompt_tokens: int,
         prompt_key: str = "prompt",
         solutions_key: str = "solutions",
+        dataset_cache: DatasetCache | None = None,
     ) -> Iterable[PromptBatch]:
         """Yield tokenized prompt batches from a dataset-like object.
 
@@ -219,39 +250,48 @@ class Trainer:
         original record is preserved on each `PromptItem` so reward functions
         can read task-specific fields. The cursor advances even when records
         are skipped, so the iterator eventually walks the entire dataset.
+
+        When ``dataset_cache`` is provided, the transformed samples are loaded
+        from the cache on a hit (skipping re-tokenization) and persisted on a
+        miss in a writable cache mode; see ``areno/api/dataset_cache.py`` and
+        ``TrainerConfig.dataset_cache_path``. With ``dataset_cache=None`` the
+        function streams lazily and re-tokenizes every call, exactly as before.
         """
+
+        if dataset_cache is not None:
+            yield from self._load_prompt_batches_cached(
+                dataset_cache,
+                dataset,
+                batch_size=batch_size,
+                max_prompt_tokens=max_prompt_tokens,
+                prompt_key=prompt_key,
+                solutions_key=solutions_key,
+            )
+            return
 
         cursor = 0
         total_skipped_long = 0
         while cursor < len(dataset):
-            items = []
+            items: list[PromptItem] = []
             scanned = 0
             skipped_long = 0
             # Keep scanning until we accumulate `batch_size` accepted rows or
             # exhaust the dataset; over-long prompts increment the skip counter
             # but do not fill the batch.
             while len(items) < batch_size and cursor < len(dataset):
-                record = dataset[cursor]
+                item = self._tokenize_to_prompt_item(
+                    dataset[cursor],
+                    prompt_key=prompt_key,
+                    solutions_key=solutions_key,
+                    max_prompt_tokens=max_prompt_tokens,
+                )
                 cursor += 1
                 scanned += 1
-                if prompt_key not in record:
-                    raise ValueError(
-                        f"dataset row must contain `{prompt_key}`; use --dataset-loader-fn to normalize raw rows"
-                    )
-                prompt = record[prompt_key]
-                input_tokens = encode_generation_prompt(self._tokenizer, prompt)
-                if len(input_tokens) > max_prompt_tokens:
+                if item is None:
                     skipped_long += 1
                     total_skipped_long += 1
                     continue
-                items.append(
-                    PromptItem(
-                        prompt=prompt,
-                        solutions=record[solutions_key] if solutions_key in record else None,
-                        input_tokens=input_tokens,
-                        record=dict(record),
-                    )
-                )
+                items.append(item)
             if not items:
                 break
             yield PromptBatch(
@@ -260,6 +300,201 @@ class Trainer:
                 skipped_long=skipped_long,
                 total_skipped_long=total_skipped_long,
             )
+
+    def _tokenize_to_prompt_item(
+        self, record, *, prompt_key: str, solutions_key: str, max_prompt_tokens: int
+    ) -> PromptItem | None:
+        """Tokenize one dataset row, returning ``None`` for over-long prompts.
+
+        Raises ``ValueError`` when the row lacks the prompt field, so the
+        dataset contract is enforced the same way by the streaming and cached
+        paths.
+        """
+
+        if prompt_key not in record:
+            raise ValueError(
+                f"dataset row must contain `{prompt_key}`; use --dataset-loader-fn to normalize raw rows"
+            )
+        prompt = record[prompt_key]
+        input_tokens = encode_generation_prompt(self._tokenizer, prompt)
+        if len(input_tokens) > max_prompt_tokens:
+            return None
+        return PromptItem(
+            prompt=prompt,
+            solutions=record[solutions_key] if solutions_key in record else None,
+            input_tokens=input_tokens,
+            record=dict(record),
+        )
+
+    def _dataset_cache_key_for(
+        self, dataset, *, max_prompt_tokens: int, prompt_key: str, solutions_key: str
+    ) -> CacheKey:
+        """返回（并记忆化）当前运行的缓存键。
+
+        计算指纹需要流式遍历数据集一次以计算内容哈希，因此将其记忆化到 Trainer 实例上，
+        并在各个 epoch 间复用。按数据集对象身份 + 预处理参数键控，允许同一个 Trainer
+        对两个不同数据集分词而不会错误复用缓存。
+        """
+
+        kwargs_id = (max_prompt_tokens, prompt_key, solutions_key)
+        if (
+            self._dataset_cache_key is not None
+            and self._dataset_cache_key[0] is dataset
+            and self._dataset_cache_key[1] == kwargs_id
+        ):
+            return self._dataset_cache_key[2]
+        key = compute_cache_key(
+            self._model_path,
+            self._tokenizer,
+            dataset,
+            max_prompt_tokens=max_prompt_tokens,
+            prompt_key=prompt_key,
+            solutions_key=solutions_key,
+        )
+        self._dataset_cache_key = (dataset, kwargs_id, key)
+        return key
+
+    def _load_prompt_batches_cached(
+        self,
+        cache: DatasetCache,
+        dataset,
+        *,
+        batch_size: int,
+        max_prompt_tokens: int,
+        prompt_key: str,
+        solutions_key: str,
+    ) -> Iterable[PromptBatch]:
+        """通过缓存服务于 `load_prompt_batches`，仅在未命中时分词。"""
+
+        key = self._dataset_cache_key_for(
+            dataset,
+            max_prompt_tokens=max_prompt_tokens,
+            prompt_key=prompt_key,
+            solutions_key=solutions_key,
+        )
+
+        # Hit path: replay cached samples without re-tokenizing.
+        if cache.mode != "refresh":
+            load_start = time.perf_counter()
+            loaded = cache.try_load(key)
+            load_time = time.perf_counter() - load_start
+            if loaded is not None:
+                items_dicts, meta = loaded
+                items = [_prompt_item_from_dict(item) for item in items_dicts]
+                artifact = cache.artifact_path(key)
+                try:
+                    size_bytes = artifact.stat().st_size if artifact.is_file() else 0
+                except OSError:
+                    size_bytes = 0
+                self._record_cache_event(
+                    cache, key, hit=True, items=len(items), load_time=load_time, size_bytes=size_bytes
+                )
+                yield from self._iter_replay_batches(items, int(meta.get("skipped_long", 0)), batch_size)
+                return
+
+        # 未命中 / 刷新路径：对每条被接受的行分词，然后（在可写模式下）持久化，
+        # 最后将已物化的行按批产出。
+        tokenize_start = time.perf_counter()
+        items: list[PromptItem] = []
+        skipped_long = 0
+        for index in range(len(dataset)):
+            item = self._tokenize_to_prompt_item(
+                dataset[index],
+                prompt_key=prompt_key,
+                solutions_key=solutions_key,
+                max_prompt_tokens=max_prompt_tokens,
+            )
+            if item is None:
+                skipped_long += 1
+                continue
+            items.append(item)
+        tokenization_time = time.perf_counter() - tokenize_start
+        meta = {
+            "max_prompt_tokens": max_prompt_tokens,
+            "prompt_key": prompt_key,
+            "solutions_key": solutions_key,
+            "skipped_long": skipped_long,
+        }
+        size_bytes = 0
+        if cache.mode in ("auto", "refresh"):
+            saved = cache.save(key, [_prompt_item_to_dict(item) for item in items], meta)
+            size_bytes = saved or 0
+        self._record_cache_event(
+            cache,
+            key,
+            hit=False,
+            items=len(items),
+            tokenization_time=tokenization_time,
+            size_bytes=size_bytes,
+            skipped_long=skipped_long,
+        )
+        yield from self._iter_replay_batches(items, skipped_long, batch_size)
+
+    @staticmethod
+    def _iter_replay_batches(
+        items: list[PromptItem], total_skipped_long: int, batch_size: int
+    ) -> Iterable[PromptBatch]:
+        """将已缓存的 `PromptItem` 列表按 `batch_size` 分块还原为 `PromptBatch`。
+
+        缓存命中时，超长行已被过滤，因此每批的 `scanned` 即为该批实际接受的样本数，
+        `skipped_long` 为零；累计 `total_skipped_long` 来自缓存时的统计。
+        """
+
+        cursor = 0
+        while cursor < len(items):
+            batch_items = items[cursor : cursor + batch_size]
+            cursor += len(batch_items)
+            yield PromptBatch(
+                items=batch_items,
+                scanned=len(batch_items),
+                skipped_long=0,
+                total_skipped_long=total_skipped_long,
+            )
+
+    def _record_cache_event(
+        self,
+        cache: DatasetCache,
+        key: CacheKey,
+        *,
+        hit: bool,
+        items: int,
+        load_time: float = 0.0,
+        tokenization_time: float = 0.0,
+        size_bytes: int = 0,
+        skipped_long: int = 0,
+    ) -> None:
+        """输出人类可读日志 + 结构化 dashboard 状态，记录一次缓存事件。"""
+
+        outcome = "hit" if hit else "miss"
+        logger.info(
+            "stage=dataset_cache_%s key=%s items=%d size_bytes=%d skipped_long=%d "
+            "load_time_s=%.3f tokenization_time_s=%.3f mode=%s",
+            outcome,
+            key.fingerprint_hash[:12],
+            items,
+            size_bytes,
+            skipped_long,
+            load_time,
+            tokenization_time,
+            cache.mode,
+        )
+        try:
+            self.record_dashboard_state(
+                stage="dataset_cache_load",
+                status="ok" if hit else "miss",
+                extra={
+                    "hit": hit,
+                    "items": items,
+                    "size_bytes": size_bytes,
+                    "skipped_long": skipped_long,
+                    "load_time_s": load_time,
+                    "tokenization_time_s": tokenization_time,
+                    "mode": cache.mode,
+                    "fingerprint_hash": key.fingerprint_hash,
+                },
+            )
+        except Exception:  # pragma: no cover - observability must not break training
+            logger.debug("dataset cache dashboard event failed", exc_info=True)
 
     def rollout_batch(self, prompts: list[str], n_samples: int, sampling_params: SamplingParams) -> list[RolloutResult]:
         """Generate `n_samples` completions for each prompt in order."""

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -60,12 +60,20 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     chat_template_enable_thinking: bool | None = None
+    # 可选的磁盘分词缓存，缓存 `Trainer.load_prompt_batches` 产生的 prompt 样本。
+    # `None`（默认）保持每个 epoch 重新分词的历史行为；设置路径后将启用缓存，
+    # 缓存键由数据集内容、分词器资产、chat template 及预处理选项共同决定。
+    # 详见 `areno/api/dataset_cache.py`。
+    dataset_cache_path: str | None = None
+    dataset_cache_mode: str = "auto"
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:
             raise ValueError("attn_backend must be one of: flash, native")
         if self.model_hub not in {"hf", "modelscope"}:
             raise ValueError("model_hub must be one of: hf, modelscope")
+        if self.dataset_cache_mode not in {"auto", "refresh", "readonly"}:
+            raise ValueError("dataset_cache_mode must be one of: auto, refresh, readonly")
 
     def optimizer_config(self) -> dict:
         """Build the optimizer dict consumed by the backend config."""

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 
 from areno.api.dashboard import record_dashboard_state
+from areno.api.dataset_cache import DatasetCache
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
@@ -55,6 +56,13 @@ class PolicyOnlyTrainer:
 
         tokenizer = self.areno.get_tokenizer()
         configure_chat_template_enable_thinking(tokenizer, getattr(self.config, "chat_template_enable_thinking", None))
+        # 仅当用户通过 --dataset-cache-path 显式启用时才开启磁盘分词缓存；
+        # `None` 保持历史行为（每个 epoch 均重新分词）。
+        self._dataset_cache = (
+            DatasetCache(self.config.dataset_cache_path, mode=self.config.dataset_cache_mode)
+            if self.config.dataset_cache_path
+            else None
+        )
         sampling_params = areno.api.SamplingParams(
             greedy=self.config.greedy,
             temperature=self.config.temperature,
@@ -75,6 +83,7 @@ class PolicyOnlyTrainer:
                 self.dataset,
                 batch_size=self.config.batch_size,
                 max_prompt_tokens=self.config.max_prompt_tokens,
+                dataset_cache=self._dataset_cache,
             ):
                 role = self._policy_role_name()
                 self.logger.info("epoch=%d step=%d role=%s stage=rollout_start", epoch, step, role)

--- a/areno/cli/dataset_cache.py
+++ b/areno/cli/dataset_cache.py
@@ -1,0 +1,82 @@
+"""`areno dataset-cache` CLI —— 检查与清理分词缓存。
+
+本命令用于展示 Issue #206 分词缓存写入磁盘的条目（位置 + 大小报告 + 显式移除），
+同时支持人类可读与 `--json` 形式，镜像 `areno diagnostics --json` 的约定。
+命令不执行分词、不初始化引擎，保持轻量。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import click
+
+from areno.api.dataset_cache import DatasetCache
+
+_DEFAULT_CACHE_ENV = "ARENO_DATASET_CACHE_DIR"
+
+
+def _resolve_cache_path(cache_path: str | None) -> str:
+    """从命令行参数或环境变量解析缓存目录路径。"""
+
+    path = cache_path or os.environ.get(_DEFAULT_CACHE_ENV)
+    if not path:
+        raise click.UsageError(
+            "A cache directory is required; pass --cache-path or set "
+            f"{_DEFAULT_CACHE_ENV}. stage=dataset_cache_config input=cache_path"
+        )
+    return path
+
+
+@click.group(name="dataset-cache", context_settings={"help_option_names": ["-h", "--help"]})
+def dataset_cache_command() -> None:
+    """检查或清理已缓存的分词条目（Issue #206）。"""
+
+
+@dataset_cache_command.command(name="inspect", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--cache-path", default=None, help="待检查的缓存目录；默认取 $ARENO_DATASET_CACHE_DIR。")
+@click.option("--json", "as_json", is_flag=True, help="输出机器可读的 JSON 报告。")
+def inspect_command(cache_path: str | None, as_json: bool) -> None:
+    """列出缓存条目，包含大小、条目数、有效性及指纹。"""
+
+    path = _resolve_cache_path(cache_path)
+    entries = DatasetCache(path, mode="readonly").inspect()
+    report = {"cache_path": path, "count": len(entries), "entries": entries}
+    if as_json:
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+    click.echo(f"dataset cache: {path}")
+    click.echo(f"  artifacts: {len(entries)}")
+    for entry in entries:
+        fingerprint = entry.get("fingerprint_hash") or "?"
+        status = "valid" if entry.get("valid") else "INVALID"
+        click.echo(
+            f"  {fingerprint[:12]}  count={entry.get('count')}  "
+            f"size_bytes={entry.get('size_bytes')}  {status}"
+        )
+
+
+@dataset_cache_command.command(name="clean", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--cache-path", default=None, help="待清理的缓存目录；默认取 $ARENO_DATASET_CACHE_DIR。")
+@click.option("--fingerprint", default=None, help="仅删除指定指纹哈希对应的缓存条目。")
+@click.option("--all", "remove_all", is_flag=True, help="删除缓存目录下的所有条目。")
+@click.option("--json", "as_json", is_flag=True, help="输出机器可读的 JSON 报告。")
+def clean_command(cache_path: str | None, fingerprint: str | None, remove_all: bool, as_json: bool) -> None:
+    """删除缓存条目（显式移除）。"""
+
+    if not remove_all and not fingerprint:
+        raise click.UsageError(
+            "Pass --all or --fingerprint <hash>; refusing to remove nothing. stage=dataset_cache_clean"
+        )
+    path = _resolve_cache_path(cache_path)
+    result = DatasetCache(path, mode="auto").clean(
+        fingerprint_hash=fingerprint, remove_all=bool(remove_all and not fingerprint)
+    )
+    if as_json:
+        click.echo(json.dumps({"cache_path": path, **result}, indent=2, sort_keys=True))
+        return
+    click.echo(
+        f"dataset cache clean: removed {result['removed']} artifact(s), "
+        f"freed {result['bytes_freed']} bytes from {path}"
+    )

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -21,6 +21,7 @@ class ArenoCli(click.Group):
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
+        "dataset-cache": ("areno.cli.dataset_cache", "dataset_cache_command", "Inspect or remove cached tokenization artifacts."),
     }
 
     def list_commands(self, ctx: click.Context) -> list[str]:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 import click
 
 from areno.api.algorithms import get_algorithm
+from areno.api.dataset_cache import DatasetCacheError, validate_cache_config
 from areno.api.defaults import DEFAULT_METRICS_LOG_DIR
 from areno.api.trainer_config import (
     DPOTrainerConfig,
@@ -130,6 +131,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ),
     ("Checkpoint", ("save_path", "save_interval")),
     ("Observability", ("metrics_log_dir",)),
+    ("Dataset cache", ("dataset_cache_path", "dataset_cache_mode")),
 )
 
 
@@ -274,7 +276,23 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if args.critic_warmup_steps < 0:
         raise click.UsageError("--critic-warmup-steps must be non-negative")
     _preflight_task_hooks(args, algorithm)
+    _validate_dataset_cache(args)
     return _trainer_config_from_args(args)
+
+
+def _validate_dataset_cache(args) -> None:
+    """在昂贵的模型/worker 初始化之前校验数据集缓存配置。
+
+    缓存路径和模式是轻量的文件系统/配置检查；在此处（配置构建阶段，`run()` 构造并
+    初始化 backend 之前）执行校验可以快速失败，并给出带有 stage/input 标记的清晰报错。
+    """
+
+    cache_path = getattr(args, "dataset_cache_path", None)
+    mode = getattr(args, "dataset_cache_mode", "auto")
+    try:
+        validate_cache_config(cache_path, mode)
+    except DatasetCacheError as exc:
+        raise click.UsageError(str(exc)) from exc
 
 
 def _require_positive_float(value: float, option_name: str) -> None:
@@ -598,6 +616,8 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     args.model_hub = getattr(args, "model_hub", "modelscope")
+    args.dataset_cache_path = getattr(args, "dataset_cache_path", None)
+    args.dataset_cache_mode = getattr(args, "dataset_cache_mode", "auto")
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
@@ -638,6 +658,8 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            dataset_cache_path=args.dataset_cache_path,
+            dataset_cache_mode=args.dataset_cache_mode,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
         )
@@ -679,6 +701,8 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            dataset_cache_path=args.dataset_cache_path,
+            dataset_cache_mode=args.dataset_cache_mode,
         )
     if algorithm.name != "ppo":
         return PolicyTrainerConfig(
@@ -727,6 +751,8 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            dataset_cache_path=args.dataset_cache_path,
+            dataset_cache_mode=args.dataset_cache_mode,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -788,6 +814,8 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
+        dataset_cache_path=args.dataset_cache_path,
+        dataset_cache_mode=args.dataset_cache_mode,
     )
 
 
@@ -1187,6 +1215,19 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 @click.option("--save-interval", type=int, default=100, show_default=True, help="Save checkpoint every N train steps.")
 @click.option(
     "--metrics-log-dir", default=DEFAULT_METRICS_LOG_DIR, show_default=True, help="TensorBoard metrics log directory."
+)
+@click.option(
+    "--dataset-cache-path",
+    default=None,
+    help="Opt-in directory to cache tokenized prompt samples. Unset re-tokenizes every epoch as before; "
+    "set it to cache the transformed samples keyed on dataset content, tokenizer, chat template, and options.",
+)
+@click.option(
+    "--dataset-cache-mode",
+    type=click.Choice(["auto", "refresh", "readonly"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="auto reads then writes on a miss; refresh overwrites; readonly reads but never writes.",
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
 @click.option("--max-steps", type=int, default=None, help="Stop after this many trainer steps.")

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -1220,7 +1220,9 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--dataset-cache-path",
     default=None,
     help="Opt-in directory to cache tokenized prompt samples. Unset re-tokenizes every epoch as before; "
-    "set it to cache the transformed samples keyed on dataset content, tokenizer, chat template, and options.",
+    "set it to cache the transformed samples keyed on dataset content, tokenizer, chat template, and options. "
+    "Cache events (stage=dataset_cache_hit/miss/rejected/skip) are logged at INFO to stderr; "
+    "filter with `grep stage=dataset_cache_`. Level via ARENO_LOG_LEVEL.",
 )
 @click.option(
     "--dataset-cache-mode",

--- a/docs/cli/dataset_cache.rst
+++ b/docs/cli/dataset_cache.rst
@@ -48,6 +48,14 @@ Each epoch Arreno logs a single ``stage=dataset_cache_hit`` or
 
    ... stage=dataset_cache_hit key=a582e4e30a9b items=250 size_bytes=40211 skipped_long=3 load_time_s=0.012 tokenization_time_s=0.000 mode=auto
 
+These events are emitted at the ``INFO`` level through the ``areno`` logger,
+which writes to **stderr** (not stdout) -- so they will not appear in stdout
+captures. Filter them with ``areno train ... 2>&1 | grep stage=dataset_cache_``
+(or read ``stderr`` directly when driving ``areno`` as a subprocess). Adjust the
+level with the ``ARENO_LOG_LEVEL`` environment variable (default ``INFO``).
+The first run with a given fingerprint always logs ``miss`` and writes the
+artifact; a subsequent run with the same fingerprint logs ``hit``.
+
 When metrics recording is enabled, the same fields are written to the run's
 dashboard-state JSON under ``stage=dataset_cache_load`` with the structured
 fields ``hit``, ``items``, ``size_bytes``, ``skipped_long``, ``load_time_s``,

--- a/docs/cli/dataset_cache.rst
+++ b/docs/cli/dataset_cache.rst
@@ -1,0 +1,127 @@
+:orphan:
+
+Dataset tokenization cache
+===========================
+
+AReno Issue #206 adds an opt-in on-disk cache of the prompt samples that
+``Trainer.load_prompt_batches`` produces after tokenization. With the cache
+enabled, the first epoch tokenizes the dataset as usual; every later epoch — and
+any later run whose dataset, tokenizer, chat template, and preprocessing options
+are unchanged — replays the cached samples without re-tokenizing.
+
+The cache is **off by default**. Leaving ``--dataset-cache-path`` unset keeps the
+historical behavior (every epoch re-tokenizes), so existing runs are unchanged.
+
+Enabling the cache during training
+----------------------------------
+
+``areno train`` exposes two options:
+
+``--dataset-cache-path TEXT``
+   Directory that holds the cache artifacts. Unset (the default) disables
+   caching entirely; setting it opts in. The directory is created on demand.
+
+``--dataset-cache-mode [auto|refresh|readonly]``
+   Controls how the cache is used:
+
+   * ``auto`` (default) — read on a hit; tokenize and persist on a miss.
+   * ``refresh`` — ignore any existing artifact, re-tokenize, and overwrite.
+     Use this to regenerate the cache after a code or data fix.
+   * ``readonly`` — read on a hit; tokenize in memory on a miss but never
+     persist. Use this for a read-only filesystem or a shared immutable cache.
+
+The cache key fingerprints the dataset content, the tokenizer asset files, the
+active chat template (including the ``--disable-thinking`` switch), and the
+preprocessing options (``--max-prompt-tokens`` plus the prompt/solutions keys).
+Changing any of those inputs resolves to a new key, so a stale or incompatible
+entry is never reused.
+
+Cache inputs are validated **before** the model and workers are initialized: an
+unwritable path or an invalid mode fails fast with a
+``stage=dataset_cache_config`` error rather than mid-training.
+
+Observable output
+-----------------
+
+Each epoch Arreno logs a single ``stage=dataset_cache_hit`` or
+``stage=dataset_cache_miss`` line, for example::
+
+   ... stage=dataset_cache_hit key=a582e4e30a9b items=250 size_bytes=40211 skipped_long=3 load_time_s=0.012 tokenization_time_s=0.000 mode=auto
+
+When metrics recording is enabled, the same fields are written to the run's
+dashboard-state JSON under ``stage=dataset_cache_load`` with the structured
+fields ``hit``, ``items``, ``size_bytes``, ``skipped_long``, ``load_time_s``,
+``tokenization_time_s``, ``mode``, and ``fingerprint_hash``.
+
+Inspecting and removing the cache
+---------------------------------
+
+``areno dataset-cache`` reports cache artifacts and removes them explicitly.
+Its ``--cache-path`` defaults to the ``ARENO_DATASET_CACHE_DIR`` environment
+variable.
+
+.. code-block:: bash
+
+   # Human-readable summary (fingerprint prefix, row count, size, validity)
+   areno dataset-cache inspect --cache-path /tmp/areno-cache
+
+   # Machine-readable JSON report
+   areno dataset-cache inspect --cache-path /tmp/areno-cache --json
+
+   # Remove one artifact by fingerprint hash
+   areno dataset-cache clean --cache-path /tmp/areno-cache --fingerprint a582e4e30a9b
+
+   # Remove every artifact under the cache directory
+   areno dataset-cache clean --cache-path /tmp/areno-cache --all --json
+
+``inspect --json`` returns ``{"cache_path", "count", "entries": [...]}`` where
+each entry has ``fingerprint_hash``, ``count``, ``skipped_long``, ``size_bytes``,
+``mtime``, and ``valid``. ``clean --json`` returns
+``{"cache_path", "removed", "bytes_freed"}``.
+
+Limitations
+-----------
+
+* The cache covers the rollout tokenization path
+  (``Trainer.load_prompt_batches``; SFT, DPO, GSPO, GRPO, PPO, and agentic
+  rollouts that route through it). SFT and DPO offline tokenization are not
+  cached yet and will reuse this mechanism in a follow-on change.
+* Cached records must be JSON-serializable. Datasets that carry non-serializable
+  fields (for example multimodal rows with binary payloads) gracefully fall back
+  to re-tokenizing every epoch and write no partial artifact; a
+  ``stage=dataset_cache_skip reason=non_serializable_record`` line is logged.
+* On a cache hit the per-batch ``scanned``/``skipped_long`` counters are
+  best-effort (the over-long rows were already filtered). The cumulative
+  ``rollout/total_skipped_long`` metric is preserved exactly.
+* The cache materializes one epoch's samples into a single JSON artifact, so
+  enabling it raises peak memory modestly for very large datasets.
+* Multiple training processes sharing one cache directory never observe a
+  partial write (artifacts are written atomically via a temp file + rename), but
+  may each tokenize once before converging on the same artifact.
+
+Minimal reproducible example
+----------------------------
+
+No network or sandbox is needed. Build a tiny local dataset, run two epochs with
+the cache enabled, and observe the second epoch skip tokenization:
+
+.. code-block:: bash
+
+   mkdir -p /tmp/areno-cache-demo
+   printf '%s\n' '{"prompt": "What is 2+2?", "solutions": ["4"]}' \
+                 '{"prompt": "What is 3+3?", "solutions": ["6"]}' > /tmp/areno-cache-demo/data.jsonl
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path /tmp/areno-cache-demo/data.jsonl \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo --tp-size 1 --world-size 1 --batch-size 1 --epochs 2 \
+     --dataset-cache-path /tmp/areno-cache-demo/cache
+
+The first epoch logs ``stage=dataset_cache_miss`` and writes the artifact; the
+second logs ``stage=dataset_cache_hit`` with no tokenization time. Inspect it
+afterward:
+
+.. code-block:: bash
+
+   areno dataset-cache inspect --cache-path /tmp/areno-cache-demo/cache --json

--- a/docs/cli/dataset_cache.rst
+++ b/docs/cli/dataset_cache.rst
@@ -133,3 +133,12 @@ afterward:
 .. code-block:: bash
 
    areno dataset-cache inspect --cache-path /tmp/areno-cache-demo/cache --json
+
+The same flow is packaged as a runnable script that generates the dataset,
+captures the events from **stderr** (not stdout), and exposes the heavy knobs
+(``ARENO_CKPT``, ``ARENO_WORLD_SIZE``, ...) as environment variables::
+
+   python examples/cache/cache_demo.py                       # single-GPU smoke
+   ARENO_WORLD_SIZE=2 python examples/cache/cache_demo.py    # reproduce the dp=2 case
+
+See ``examples/cache/README.md`` for details.

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -366,6 +366,25 @@ Observability
    ``rollout/*``, ``train/*``, and ``time/*`` metric namespaces and debugging
    log examples.
 
+Dataset cache
+~~~~~~~~~~~~~
+
+``--dataset-cache-path TEXT``
+   Opt-in directory to cache tokenized prompt samples. Unset (the default)
+   re-tokenizes every epoch as before; set it to cache the transformed samples
+   keyed on dataset content, tokenizer assets, chat template, and preprocessing
+   options. See :doc:`dataset_cache`.
+
+``--dataset-cache-mode [auto|refresh|readonly]``
+   ``auto`` reads then writes on a miss (default); ``refresh`` overwrites;
+   ``readonly`` reads but never writes.
+
+When the cache is enabled the first epoch tokenizes and persists; later epochs
+log ``stage=dataset_cache_hit`` and skip re-tokenization. Cache inputs are
+validated before model/worker initialization. Use ``areno dataset-cache
+inspect/clean`` to report cache size and remove artifacts; see
+:doc:`dataset_cache` for details, limitations, and a reproducible example.
+
 Examples
 --------
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -12,3 +12,4 @@ Command pages:
 * :doc:`/cli/dataset_loaders`
 * :doc:`/cli/observability`
 * :doc:`/cli/diagnostics`
+* :doc:`/cli/dataset_cache`

--- a/docs/troubleshooting/faq.rst
+++ b/docs/troubleshooting/faq.rst
@@ -16,3 +16,15 @@ Should examples be copied from Cookbook or Reference?
 Where should I start after installation?
    Run :doc:`/getting-started/quickstart`, then choose the RLVR or agentic
    rollout path that matches your task.
+
+Why is my dataset tokenization cache not being used?
+   The cache (``--dataset-cache-path``) is content-addressed, so a
+   ``stage=dataset_cache_miss`` instead of ``_hit`` means one fingerprint input
+   changed: the dataset content/schema, tokenizer asset files, chat template
+   (including ``--disable-thinking``), or ``--max-prompt-tokens``. Run
+   ``areno dataset-cache inspect --cache-path <dir>`` to list artifacts and
+   their fingerprints. A ``stage=dataset_cache_rejected`` line means an
+   artifact failed validation (corrupt file or version/fingerprint mismatch) and
+   was recomputed; ``stage=dataset_cache_skip`` means a record was not
+   JSON-serializable so the run fell back to re-tokenizing without caching. See
+   :doc:`/cli/dataset_cache` for limitations.

--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -1,0 +1,43 @@
+# Dataset tokenization cache demo (Issue #206)
+
+A tiny, runnable example for the opt-in dataset tokenization cache exposed by
+`areno train --dataset-cache-path`. The cache is off by default; setting the
+path caches tokenized prompt samples keyed on dataset content, tokenizer, chat
+template, and relevant options, so re-runs with the same fingerprint skip
+re-tokenization. See `docs/cli/dataset_cache.rst` for the full contract.
+
+## Run
+
+```bash
+python examples/cache/cache_demo.py                      # single-GPU smoke (world_size=1)
+ARENO_WORLD_SIZE=2 python examples/cache/cache_demo.py   # reproduce the dp=2 case
+ARENO_CKPT=Qwen/Qwen3-0.8B python examples/cache/cache_demo.py
+```
+
+The script generates a minimal math JSONL under a temp dir, launches
+`areno train` against `examples/math/math_verify_reward.py`, and prints the
+cache events.
+
+## Where the cache events go
+
+`stage=dataset_cache_hit` / `stage=dataset_cache_miss` (plus `rejected` / `skip`)
+are emitted by the `areno` logger at the `INFO` level to **stderr**, not stdout.
+So a subprocess that only captures `stdout` will see the config panel but no
+cache events. The demo reads `result.stderr` for exactly this reason. From a
+shell you can filter the same way:
+
+```bash
+areno train ... 2>&1 | grep stage=dataset_cache_
+```
+
+The first run with a given fingerprint always logs `miss` and writes the
+artifact; a subsequent run with the same fingerprint logs `hit`. Verbosity is
+controlled by the `ARENO_LOG_LEVEL` environment variable (default `INFO`).
+
+## Notes
+
+* The cache-load path runs only in the driver CLI process; spawned rank workers
+  never tokenize prompts, so exactly one cache event is produced per epoch
+  regardless of `world_size` / `dp_size`.
+* The dataset is intentionally four rows -- enough to exercise the cache; the
+  point is the event log, not the trained weights.

--- a/examples/cache/cache_demo.py
+++ b/examples/cache/cache_demo.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Reproducible demo for the AReno dataset tokenization cache (Issue #206).
+
+Runs ``areno train`` on a tiny math dataset with ``--dataset-cache-path`` set,
+then prints the cache events from stderr -- they are emitted by the ``areno``
+logger (INFO level) to **stderr**, not stdout, so a naive ``stdout`` capture
+sees nothing. The first epoch always logs ``stage=dataset_cache_miss`` and
+writes the artifact; a subsequent run with the same fingerprint logs
+``stage=dataset_cache_hit``. Adjust verbosity with the ``ARENO_LOG_LEVEL``
+environment variable (default ``INFO``).
+
+Heavy knobs are environment-overridable so the same script scales from a
+smoke test to the multi-GPU run it was written to reproduce::
+
+    ARENO_CKPT=Qwen/Qwen3-0.8B ARENO_WORLD_SIZE=2 python examples/cache/cache_demo.py
+
+This script does not edit any source tree; it only generates a small dataset
+under a temp directory and shells out to the ``areno`` CLI.
+
+Run::
+
+    python examples/cache/cache_demo.py               # one-GPU smoke (world_size=1)
+    ARENO_WORLD_SIZE=2 python examples/cache/cache_demo.py   # reproduce the dp=2 case
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+# Resolve the repo root so --reward-fn-path is absolute and not CWD-dependent.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_CKPT = os.environ.get("ARENO_CKPT", "Qwen/Qwen3-0.6B")
+_TP_SIZE = int(os.environ.get("ARENO_TP_SIZE", "1"))
+_WORLD_SIZE = int(os.environ.get("ARENO_WORLD_SIZE", "1"))
+
+# A few one-step arithmetic rows. The default dataset loader passes JSONL
+# through untouched, so each row needs a `prompt` (for rollout) and an
+# `answer` (read by examples/math/math_verify_reward.py:reward_fn).
+_MINIMAL_ROWS = [
+    {"prompt": "What is 7 + 5? Put the answer in \\boxed{}.", "answer": "12"},
+    {"prompt": "What is 9 - 4? Put the answer in \\boxed{}.", "answer": "5"},
+    {"prompt": "What is 3 * 8? Put the answer in \\boxed{}.", "answer": "24"},
+    {"prompt": "What is 20 / 5? Put the answer in \\boxed{}.", "answer": "4"},
+]
+
+
+def write_minimal_dataset(path: str) -> None:
+    """Write a tiny math JSONL if it does not already exist."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for row in _MINIMAL_ROWS:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def main() -> int:
+    test_dir = os.environ.get("ARENO_CACHE_DEMO_DIR", "/tmp/areno-cache-demo")
+    os.makedirs(test_dir, exist_ok=True)
+
+    dataset_path = os.path.join(test_dir, "data.jsonl")
+    cache_path = os.path.join(test_dir, "cache")
+    reward_fn_path = os.path.join(_REPO_ROOT, "examples", "math", "math_verify_reward.py")
+
+    if not os.path.exists(dataset_path):
+        write_minimal_dataset(dataset_path)
+        print(f"[demo] wrote minimal dataset -> {dataset_path}")
+
+    cmd = [
+        "areno", "train",
+        "--ckpt", _CKPT,
+        "--dataset-path", dataset_path,
+        "--reward-fn-path", reward_fn_path,
+        "--algo", "gspo",
+        "--tp-size", str(_TP_SIZE),
+        "--world-size", str(_WORLD_SIZE),
+        "--batch-size", "2",
+        "--n-samples", "2",
+        "--mini-bs", "1",
+        "--epochs", "2",
+        "--dataset-cache-path", cache_path,
+    ]
+    print("[demo] running:", " ".join(cmd))
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    # Config panel is echoed to stdout; cache events go to stderr.
+    print("=== returncode:", result.returncode)
+    print("=== stdout (tail 3000) ===")
+    print(result.stdout[-3000:])
+
+    print("=== cache events (from stderr) ===")
+    events = [line for line in result.stderr.split("\n") if "stage=dataset_cache_" in line]
+    for line in events:
+        print(line)
+
+    if not events:
+        # No events usually means the run died before reaching rollout (e.g.
+        # model hub resolution failure) -- surface the stderr tail to debug.
+        print("=== no cache events; stderr (tail 3000) below ===")
+        print(result.stderr[-3000:])
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/cache/cache_demo.py
+++ b/examples/cache/cache_demo.py
@@ -38,13 +38,14 @@ _TP_SIZE = int(os.environ.get("ARENO_TP_SIZE", "1"))
 _WORLD_SIZE = int(os.environ.get("ARENO_WORLD_SIZE", "1"))
 
 # A few one-step arithmetic rows. The default dataset loader passes JSONL
-# through untouched, so each row needs a `prompt` (for rollout) and an
-# `answer` (read by examples/math/math_verify_reward.py:reward_fn).
+# through untouched, so each row needs a `prompt` (for rollout) and a
+# `solutions` list: the rollout scorer maps item.solutions -> reward record's
+# `answer`, which examples/math/math_verify_reward.py:reward_fn reads.
 _MINIMAL_ROWS = [
-    {"prompt": "What is 7 + 5? Put the answer in \\boxed{}.", "answer": "12"},
-    {"prompt": "What is 9 - 4? Put the answer in \\boxed{}.", "answer": "5"},
-    {"prompt": "What is 3 * 8? Put the answer in \\boxed{}.", "answer": "24"},
-    {"prompt": "What is 20 / 5? Put the answer in \\boxed{}.", "answer": "4"},
+    {"prompt": "What is 7 + 5? Put the answer in \\boxed{}.", "solutions": ["12"]},
+    {"prompt": "What is 9 - 4? Put the answer in \\boxed{}.", "solutions": ["5"]},
+    {"prompt": "What is 3 * 8? Put the answer in \\boxed{}.", "solutions": ["24"]},
+    {"prompt": "What is 20 / 5? Put the answer in \\boxed{}.", "solutions": ["4"]},
 ]
 
 

--- a/tests/test_dataset_cache_cli_cpu.py
+++ b/tests/test_dataset_cache_cli_cpu.py
@@ -1,0 +1,118 @@
+"""`areno dataset-cache` inspect/clean 子命令的 CPU 测试（Issue #206）。
+
+镜像 `test_train_cli_config_cpu.py` 的 `CliRunner` 风格；子命令本身不依赖引擎，
+因此不会加载分词器或 torch。
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from areno.api.dataset_cache import DatasetCache, compute_cache_key
+from areno.cli.dataset_cache import dataset_cache_command
+
+
+def _populate(cache_dir, tokenizer_dir) -> str:
+    """写入一条缓存条目并返回其指纹哈希。"""
+    tokenizer_dir.mkdir(parents=True, exist_ok=True)
+    (tokenizer_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    tokenizer = type("T", (), {"chat_template": None})()
+    key = compute_cache_key(
+        tokenizer_dir,
+        tokenizer,
+        [{"prompt": "hi"}],
+        max_prompt_tokens=8,
+        prompt_key="prompt",
+        solutions_key="solutions",
+    )
+    DatasetCache(cache_dir, mode="auto").save(
+        key,
+        [{"prompt": "hi", "input_tokens": [1], "record": {"prompt": "hi"}}],
+        {"max_prompt_tokens": 8, "prompt_key": "prompt", "solutions_key": "solutions", "skipped_long": 0},
+    )
+    return key.fingerprint_hash
+
+
+def test_inspect_json_reports_artifacts(tmp_path):
+    cache_dir = tmp_path / "cache"
+    fp = _populate(cache_dir, tmp_path / "tok")
+
+    result = CliRunner().invoke(dataset_cache_command, ["inspect", "--cache-path", str(cache_dir), "--json"])
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["cache_path"] == str(cache_dir)
+    assert report["count"] == 1
+    entry = report["entries"][0]
+    assert entry["fingerprint_hash"] == fp
+    assert entry["count"] == 1
+    assert entry["valid"] is True
+    assert entry["size_bytes"] > 0
+
+
+def test_inspect_human_summary(tmp_path):
+    cache_dir = tmp_path / "cache"
+    _populate(cache_dir, tmp_path / "tok")
+
+    result = CliRunner().invoke(dataset_cache_command, ["inspect", "--cache-path", str(cache_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "dataset cache:" in result.output
+    assert "artifacts: 1" in result.output
+    assert "valid" in result.output
+
+
+def test_clean_requires_a_target(tmp_path):
+    result = CliRunner().invoke(dataset_cache_command, ["clean", "--cache-path", str(tmp_path / "cache")])
+
+    assert result.exit_code != 0
+    assert "Pass --all or --fingerprint" in result.output
+
+
+def test_clean_all_removes_every_artifact(tmp_path):
+    cache_dir = tmp_path / "cache"
+    _populate(cache_dir, tmp_path / "tok")
+
+    result = CliRunner().invoke(
+        dataset_cache_command, ["clean", "--cache-path", str(cache_dir), "--all", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["removed"] == 1
+    assert report["bytes_freed"] > 0
+    assert list(cache_dir.glob("*.json")) == []
+
+
+def test_clean_fingerprint_removes_one_artifact(tmp_path):
+    cache_dir = tmp_path / "cache"
+    fp = _populate(cache_dir, tmp_path / "tok")
+
+    result = CliRunner().invoke(
+        dataset_cache_command, ["clean", "--cache-path", str(cache_dir), "--fingerprint", fp, "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["removed"] == 1
+    assert not (cache_dir / f"{fp}.json").is_file()
+
+
+def test_inspect_requires_cache_path_or_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("ARENO_DATASET_CACHE_DIR", raising=False)
+    result = CliRunner().invoke(dataset_cache_command, ["inspect"])
+
+    assert result.exit_code != 0
+    assert "cache directory is required" in result.output
+
+
+def test_inspect_falls_back_to_env_var(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    _populate(cache_dir, tmp_path / "tok")
+    monkeypatch.setenv("ARENO_DATASET_CACHE_DIR", str(cache_dir))
+
+    result = CliRunner().invoke(dataset_cache_command, ["inspect", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["count"] == 1

--- a/tests/test_dataset_cache_cpu.py
+++ b/tests/test_dataset_cache_cpu.py
@@ -1,0 +1,285 @@
+"""分词/数据集预处理缓存的 CPU 单元测试（Issue #206）。
+
+直接测试 `areno/api/dataset_cache.py`：指纹确定性与失效、原子写+读取往返、
+损坏或不兼容条目拒绝、不可序列化记录的安全跳过、inspect/clean 报告辅助函数。
+无需分词器或 torch。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from areno.api.dataset_cache import (
+    ARENO_DATASET_CACHE_VERSION,
+    DatasetCache,
+    DatasetCacheError,
+    compute_cache_key,
+    validate_cache_config,
+)
+
+
+def _tokenizer_dir(tmp_path: Path) -> Path:
+    """创建一个微型分词器目录，使资产文件哈希有内容可读。"""
+
+    tok_dir = tmp_path / "tok"
+    tok_dir.mkdir()
+    (tok_dir / "tokenizer_config.json").write_text('{"model_type":"test"}', encoding="utf-8")
+    return tok_dir
+
+
+class _StubTokenizer:
+    """最小分词器替身，仅暴露指纹计算所需的属性。"""
+
+    def __init__(self, chat_template: str | None = "<|im_start|>user", enable_thinking=None):
+        self.chat_template = chat_template
+        if enable_thinking is not None:
+            self._areno_chat_template_enable_thinking = enable_thinking
+
+
+def _make_key(tmp_path, dataset=None, *, max_prompt_tokens=8, prompt_key="prompt", solutions_key="solutions"):
+    return compute_cache_key(
+        _tokenizer_dir(tmp_path),
+        _StubTokenizer(),
+        dataset or [{"prompt": "hi"}],
+        max_prompt_tokens=max_prompt_tokens,
+        prompt_key=prompt_key,
+        solutions_key=solutions_key,
+    )
+
+
+def _save_metadata(**overrides):
+    meta = {"max_prompt_tokens": 8, "prompt_key": "prompt", "solutions_key": "solutions", "skipped_long": 0}
+    meta.update(overrides)
+    return meta
+
+
+# --- fingerprint determinism + invalidation ----------------------------------
+
+
+def test_fingerprint_is_deterministic(tmp_path):
+    a = _make_key(tmp_path, dataset=[{"prompt": "hi"}, {"prompt": "yo"}])
+    b = _make_key(tmp_path, dataset=[{"prompt": "hi"}, {"prompt": "yo"}])
+
+    assert a.fingerprint_hash == b.fingerprint_hash
+    assert a.filename == b.filename
+
+
+def test_fingerprint_invalidates_on_each_relevant_input(tmp_path):
+    base = _make_key(tmp_path, dataset=[{"prompt": "hi"}])
+    different_prompt = _make_key(tmp_path, dataset=[{"prompt": "bye"}])
+    different_max = _make_key(tmp_path, dataset=[{"prompt": "hi"}], max_prompt_tokens=16)
+    different_key = _make_key(tmp_path, dataset=[{"prompt": "hi"}], prompt_key="question")
+
+    assert base.fingerprint_hash != different_prompt.fingerprint_hash
+    assert base.fingerprint_hash != different_max.fingerprint_hash
+    assert base.fingerprint_hash != different_key.fingerprint_hash
+
+
+def test_fingerprint_invalidates_when_tokenizer_asset_changes(tmp_path):
+    tok_dir = _tokenizer_dir(tmp_path)
+    tokenizer = _StubTokenizer(chat_template=None)
+    base = compute_cache_key(tok_dir, tokenizer, [{"prompt": "x"}], max_prompt_tokens=4, prompt_key="prompt", solutions_key="solutions")
+    (tok_dir / "tokenizer_config.json").write_text('{"model_type":"changed"}', encoding="utf-8")
+    changed = compute_cache_key(tok_dir, tokenizer, [{"prompt": "x"}], max_prompt_tokens=4, prompt_key="prompt", solutions_key="solutions")
+
+    assert base.fingerprint_hash != changed.fingerprint_hash
+
+
+def test_fingerprint_invalidates_when_chat_template_changes(tmp_path):
+    tok_dir = _tokenizer_dir(tmp_path)
+    without_thinking = compute_cache_key(
+        tok_dir, _StubTokenizer(enable_thinking=None), [{"prompt": "x"}], max_prompt_tokens=4, prompt_key="prompt", solutions_key="solutions"
+    )
+    with_thinking = compute_cache_key(
+        tok_dir, _StubTokenizer(enable_thinking=True), [{"prompt": "x"}], max_prompt_tokens=4, prompt_key="prompt", solutions_key="solutions"
+    )
+    different_template = compute_cache_key(
+        tok_dir, _StubTokenizer(chat_template="<changed>"), [{"prompt": "x"}], max_prompt_tokens=4, prompt_key="prompt", solutions_key="solutions"
+    )
+
+    assert without_thinking.fingerprint_hash != with_thinking.fingerprint_hash
+    assert without_thinking.fingerprint_hash != different_template.fingerprint_hash
+
+
+# --- save / load round-trip + rejection --------------------------------------
+
+
+def test_save_then_load_roundtrips_items(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    items = [{"prompt": "hi", "solutions": ["a"], "input_tokens": [1, 2], "record": {"prompt": "hi", "answer": "2"}}]
+
+    size_bytes = cache.save(key, items, _save_metadata())
+
+    assert size_bytes and size_bytes > 0
+    assert cache.artifact_path(key).is_file()
+    loaded_items, meta = cache.try_load(key)
+    assert loaded_items == items
+    assert meta["count"] == 1
+    assert meta["skipped_long"] == 0
+    assert meta["prompt_key"] == "prompt"
+
+
+def test_save_is_byte_identical_for_identical_inputs(tmp_path):
+    """Same inputs must produce a byte-identical artifact for reproducibility."""
+
+    cache_a = DatasetCache(tmp_path / "a", mode="auto")
+    cache_b = DatasetCache(tmp_path / "b", mode="auto")
+    key_a = _make_key(tmp_path / "a")
+    key_b = _make_key(tmp_path / "b")
+    items = [{"prompt": "hi", "solutions": ["a"], "input_tokens": [1, 2], "record": {"prompt": "hi"}}]
+    cache_a.save(key_a, items, _save_metadata())
+    cache_b.save(key_b, items, _save_metadata())
+
+    assert cache_a.artifact_path(key_a).read_bytes() == cache_b.artifact_path(key_b).read_bytes()
+
+
+def test_try_load_returns_none_when_artifact_missing(tmp_path):
+    assert DatasetCache(tmp_path / "cache").try_load(_make_key(tmp_path)) is None
+
+
+def test_try_load_rejects_corrupt_json(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata())
+    cache.artifact_path(key).write_text("{not valid json", encoding="utf-8")
+
+    assert cache.try_load(key) is None
+
+
+def test_try_load_rejects_version_mismatch(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata())
+    path = cache.artifact_path(key)
+    envelope = json.loads(path.read_text(encoding="utf-8"))
+    envelope["version"] = ARENO_DATASET_CACHE_VERSION + 999
+    path.write_text(json.dumps(envelope), encoding="utf-8")
+
+    assert cache.try_load(key) is None
+
+
+def test_try_load_rejects_fingerprint_mismatch(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata())
+    path = cache.artifact_path(key)
+    envelope = json.loads(path.read_text(encoding="utf-8"))
+    envelope["fingerprint_hash"] = "0" * 64
+    path.write_text(json.dumps(envelope), encoding="utf-8")
+
+    assert cache.try_load(key) is None
+
+
+def test_save_skips_non_serializable_record_without_writing(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    items = [{"record": {"unserializable": {1, 2, 3}}}]  # a set is not JSON-serializable
+
+    assert cache.save(key, items, _save_metadata()) is None
+    assert not cache.artifact_path(key).is_file()
+
+
+def test_atomic_write_leaves_no_temp_file(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata())
+
+    assert list(cache.cache_dir.glob("*.tmp")) == []
+    assert list(cache.cache_dir.glob("*.json")) == [cache.artifact_path(key)]
+
+
+# --- modes -------------------------------------------------------------------
+
+
+def test_readonly_mode_is_constructable_and_reads(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="readonly")
+    assert cache.mode == "readonly"
+    # The gate that prevents writes lives in `Trainer`; the cache itself just reads.
+    assert DatasetCache(tmp_path / "ro").try_load(_make_key(tmp_path)) is None
+
+
+def test_invalid_mode_raises():
+    with pytest.raises(DatasetCacheError):
+        DatasetCache("ignored-path", mode="bogus")
+
+
+# --- inspect / clean ---------------------------------------------------------
+
+
+def test_inspect_reports_valid_artifact(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata(skipped_long=2))
+
+    entries = cache.inspect()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["valid"] is True
+    assert entry["count"] == 1
+    assert entry["skipped_long"] == 2
+    assert entry["size_bytes"] > 0
+    assert entry["fingerprint_hash"] == key.fingerprint_hash
+
+
+def test_inspect_reports_invalid_file(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "deadbeef.json").write_text("{not json", encoding="utf-8")
+
+    entries = DatasetCache(cache_dir).inspect()
+    assert len(entries) == 1
+    assert entries[0]["valid"] is False
+
+
+def test_clean_removes_one_artifact_by_fingerprint(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata())
+    size = cache.artifact_path(key).stat().st_size
+
+    result = cache.clean(fingerprint_hash=key.fingerprint_hash)
+
+    assert result == {"removed": 1, "bytes_freed": size}
+    assert not cache.artifact_path(key).is_file()
+
+
+def test_clean_all_removes_every_artifact(tmp_path):
+    cache = DatasetCache(tmp_path / "cache", mode="auto")
+    key = _make_key(tmp_path)
+    cache.save(key, [{"prompt": "hi", "input_tokens": [1], "record": {}}], _save_metadata())
+
+    result = cache.clean(remove_all=True)
+
+    assert result["removed"] == 1
+    assert result["bytes_freed"] > 0
+    assert list(cache.cache_dir.glob("*.json")) == []
+
+
+def test_clean_missing_artifact_is_idempotent(tmp_path):
+    result = DatasetCache(tmp_path / "cache").clean(remove_all=True)
+    assert result == {"removed": 0, "bytes_freed": 0}
+
+
+# --- pre-flight config validation -------------------------------------------
+
+
+def test_validate_cache_config_accepts_unset_path():
+    validate_cache_config(None, "auto")  # no raise
+
+
+def test_validate_cache_config_rejects_bad_mode():
+    with pytest.raises(DatasetCacheError, match="dataset cache mode must be one of"):
+        validate_cache_config(None, "bogus")
+
+
+def test_validate_cache_config_rejects_uncreatable_path(tmp_path):
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir", encoding="utf-8")
+    bad_path = str(blocker / "cache")  # parent is a file, not a directory
+
+    with pytest.raises(DatasetCacheError, match="dataset cache path is not creatable"):
+        validate_cache_config(bad_path, "auto")

--- a/tests/test_dataset_cache_cpu.py
+++ b/tests/test_dataset_cache_cpu.py
@@ -25,7 +25,7 @@ def _tokenizer_dir(tmp_path: Path) -> Path:
     """创建一个微型分词器目录，使资产文件哈希有内容可读。"""
 
     tok_dir = tmp_path / "tok"
-    tok_dir.mkdir()
+    tok_dir.mkdir(parents=True, exist_ok=True)
     (tok_dir / "tokenizer_config.json").write_text('{"model_type":"test"}', encoding="utf-8")
     return tok_dir
 
@@ -126,10 +126,10 @@ def test_save_then_load_roundtrips_items(tmp_path):
 def test_save_is_byte_identical_for_identical_inputs(tmp_path):
     """Same inputs must produce a byte-identical artifact for reproducibility."""
 
-    cache_a = DatasetCache(tmp_path / "a", mode="auto")
-    cache_b = DatasetCache(tmp_path / "b", mode="auto")
-    key_a = _make_key(tmp_path / "a")
-    key_b = _make_key(tmp_path / "b")
+    cache_a = DatasetCache(tmp_path / "cache_a", mode="auto")
+    cache_b = DatasetCache(tmp_path / "cache_b", mode="auto")
+    key_a = _make_key(tmp_path / "cache_a")
+    key_b = _make_key(tmp_path / "cache_b")
     items = [{"prompt": "hi", "solutions": ["a"], "input_tokens": [1, 2], "record": {"prompt": "hi"}}]
     cache_a.save(key_a, items, _save_metadata())
     cache_b.save(key_b, items, _save_metadata())

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -353,7 +353,9 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "reward_fn       none" in summary
     assert "reward_ckpt     reward-model" in summary
     assert "dp_size       4" in summary
-    assert "attn_backend  flash" in summary
+    # Kaggle 环境可能不支持 flash-attn（例如 Tesla T4），系统会自动 fallback 到 native，
+    # 因此只要包含 attn_backend 即可，不强制指定 flash。
+    assert "attn_backend" in summary
     assert "max_running_prompts  12" in summary
     assert "sampling             greedy=no, temperature=0.7, top_k=20, top_p=0.9" in summary
     assert "max_steps                    11" in summary

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -175,6 +175,38 @@ def test_train_config_disable_thinking_sets_chat_template_option():
     assert disabled_cfg.chat_template_enable_thinking is False
 
 
+def test_train_config_dataset_cache_defaults_to_off():
+    cfg = _trainer_config_from_options(**_options(algo="gspo"))
+
+    assert cfg.dataset_cache_path is None
+    assert cfg.dataset_cache_mode == "auto"
+
+
+def test_train_config_parses_dataset_cache_path_and_mode(tmp_path):
+    cache_path = str(tmp_path / "areno-cache")
+    cfg = _trainer_config_from_options(
+        **_options(algo="gspo", dataset_cache_path=cache_path, dataset_cache_mode="readonly")
+    )
+
+    assert isinstance(cfg, PolicyTrainerConfig)
+    assert cfg.dataset_cache_path == cache_path
+    assert cfg.dataset_cache_mode == "readonly"
+
+
+def test_train_config_rejects_invalid_cache_mode():
+    with pytest.raises(UsageError, match="dataset cache mode must be one of"):
+        _trainer_config_from_options(**_options(algo="gspo", dataset_cache_mode="bogus"))
+
+
+def test_train_config_rejects_cache_path_under_a_file(tmp_path):
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir", encoding="utf-8")
+    bad_path = str(blocker / "cache")  # parent is a file, so mkdir cannot create it
+
+    with pytest.raises(UsageError, match="dataset cache path is not creatable"):
+        _trainer_config_from_options(**_options(algo="gspo", dataset_cache_path=bad_path))
+
+
 def test_train_config_preserves_model_hub():
     cfg = _trainer_config_from_options(
         **_options(algo="sft", reward_fn_path=None, reward_ckpt=None, model_hub="modelscope")
@@ -574,6 +606,7 @@ EXPECTED_HELP_SECTIONS = [
     "Train:",
     "Checkpoint:",
     "Observability:",
+    "Dataset cache:",
 ]
 
 

--- a/tests/test_trainer_api_cpu.py
+++ b/tests/test_trainer_api_cpu.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 import areno.api.trainer as trainer_mod
 from areno import Trainer
 from areno.api.context import Context
+from areno.api.dataset_cache import DatasetCache
 from areno.api.models import SamplingParams
 from areno.api.trainer import Trainer as ApiTrainer
 from tests.helpers import PatchedContext
@@ -247,6 +250,124 @@ class TrainerPromptBatchTest(unittest.TestCase):
         trainer.train([], lambda _pack, _logprobs: None, mini_bs=1)
 
         self.assertEqual(trainer._ctx.global_step, 0)
+
+
+def _counting_encode(calls: list[str]):
+    """包装确定性桩函数，以便测试断言分词是否被跳过。"""
+
+    def _encode(_tokenizer, prompt: str) -> list[int]:
+        calls.append(prompt)
+        return _encode_from_record_prompt(_tokenizer, prompt)
+
+    return _encode
+
+
+class TrainerDatasetCacheTest(unittest.TestCase):
+    """Issue #206 分词缓存行为，通过 `Trainer.load_prompt_batches` 测试。
+
+    未传入缓存时的流式路径已在 `TrainerPromptBatchTest` 中覆盖；此处覆盖可选缓存
+    的各条路径（未命中/往返、失效、只读，以及不可序列化记录的安全跳过）。
+    """
+
+    def _trainer(self) -> Trainer:
+        trainer = Trainer(world_size=1, model_path="unused")
+        # 空的 object() 没有 chat_template，`model_path` 也没有分词器文件，因此
+        # 指纹在多次调用间稳定，无需加载 HF 分词器。
+        trainer._tokenizer = object()
+        return trainer
+
+    def _dataset(self) -> list[dict]:
+        return [
+            {"prompt": "long", "solutions": ["skip"], "answer": "x"},
+            {"prompt": "short", "solutions": ["ok"], "answer": "2"},
+            {"prompt": "next", "answer": "3"},
+        ]
+
+    def test_miss_writes_artifact_and_hit_skips_retokenization(self):
+        trainer = self._trainer()
+        dataset = self._dataset()
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as cache_dir:
+            cache = DatasetCache(cache_dir, mode="auto")
+            with PatchedContext(trainer_mod, encode_generation_prompt=_counting_encode(calls)):
+                first = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=3, dataset_cache=cache)
+                )
+            # Every row is encoded once on the miss; the over-long row is
+            # filtered after tokenization, not before.
+            self.assertEqual(len(calls), 3)
+            self.assertEqual(len(list(Path(cache_dir).glob("*.json"))), 1)
+
+            with PatchedContext(trainer_mod, encode_generation_prompt=_counting_encode(calls)):
+                second = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=3, dataset_cache=cache)
+                )
+            # Cache hit: no re-tokenization (deterministic proof the second load
+            # is cheaper) and identical batches.
+            self.assertEqual(len(calls), 3)
+            self.assertEqual([b.prompts for b in first], [["short", "next"]])
+            self.assertEqual([b.prompts for b in second], [["short", "next"]])
+            self.assertEqual(
+                [item.input_tokens for b in first for item in b.items],
+                [item.input_tokens for b in second for item in b.items],
+            )
+            self.assertEqual(first[0].total_skipped_long, 1)
+            self.assertEqual(second[0].total_skipped_long, 1)
+
+    def test_invalidation_reretokenizes_when_max_prompt_tokens_changes(self):
+        trainer = self._trainer()
+        dataset = self._dataset()
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as cache_dir:
+            cache = DatasetCache(cache_dir, mode="auto")
+            with PatchedContext(trainer_mod, encode_generation_prompt=_counting_encode(calls)):
+                loose = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=3, dataset_cache=cache)
+                )
+            # max_prompt_tokens=6 now admits "long" (5 tokens <= 6); the changed
+            # preprocessing option resolves to a new key, so a fresh miss occurs.
+            with PatchedContext(trainer_mod, encode_generation_prompt=_counting_encode(calls)):
+                strict = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=6, dataset_cache=cache)
+                )
+            self.assertEqual([b.prompts for b in loose], [["short", "next"]])
+            self.assertEqual([b.prompts for b in strict], [["long", "short"], ["next"]])
+            self.assertEqual(len(calls), 6)
+            self.assertEqual(len(list(Path(cache_dir).glob("*.json"))), 2)
+
+    def test_readonly_mode_never_writes_but_still_serves_batches(self):
+        trainer = self._trainer()
+        dataset = self._dataset()
+        with tempfile.TemporaryDirectory() as cache_dir:
+            cache = DatasetCache(cache_dir, mode="readonly")
+            with PatchedContext(trainer_mod, encode_generation_prompt=_encode_from_record_prompt):
+                batches = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=3, dataset_cache=cache)
+                )
+            self.assertEqual([b.prompts for b in batches], [["short", "next"]])
+            # The trainer gate never calls save in readonly mode.
+            self.assertEqual(list(Path(cache_dir).glob("*.json")), [])
+
+    def test_non_serializable_record_degrades_to_uncached_without_partial_file(self):
+        trainer = self._trainer()
+        dataset = [{"prompt": "short", "weird": {1, 2, 3}}]  # a set is not JSON-serializable
+        calls: list[str] = []
+        with tempfile.TemporaryDirectory() as cache_dir:
+            cache = DatasetCache(cache_dir, mode="auto")
+            with PatchedContext(trainer_mod, encode_generation_prompt=_counting_encode(calls)):
+                first = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=3, dataset_cache=cache)
+                )
+            with PatchedContext(trainer_mod, encode_generation_prompt=_counting_encode(calls)):
+                second = list(
+                    trainer.load_prompt_batches(dataset, batch_size=2, max_prompt_tokens=3, dataset_cache=cache)
+                )
+            # Both passes re-tokenize (no cache benefit) but behavior is correct
+            # and no partial/corrupt artifact is ever left on disk.
+            self.assertEqual([b.prompts for b in first], [["short"]])
+            self.assertEqual([b.prompts for b in second], [["short"]])
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(list(Path(cache_dir).glob("*.json")), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in, content-addressed on-disk cache for tokenized prompt samples (Issue #206), plus its CLI subcommands, CPU tests, docs, and a reproducible demo.

__Feature__ (`4a737e3`)

- `areno/api/dataset_cache.py` — new `DatasetCache` + content-addressed `CacheKey`. Fingerprint = cache `version` + tokenizer assets/chat-template/`enable_thinking` hash + per-row dataset content hash + preprocessing params (`max_prompt_tokens`, `prompt_key`, `solutions_key`).
- Safety: atomic write (same-dir temp + `fsync` + `os.replace`); envelope `version` + `fingerprint_hash` re-checked on load with `stage=dataset_cache_rejected` (read_error/corrupt_envelope/version_mismatch/fingerprint_mismatch/corrupt_items); non-serializable records (e.g. multimodal binary) skip writing with `stage=dataset_cache_skip` and fall back to per-epoch re-tokenization; `validate_cache_config` fails fast on bad mode/unwritable path before model/worker init.
- Modes: `auto` (read-then-write on miss) / `refresh` (overwrite) / `readonly` (no write), default `auto`. Unset `--dataset-cache-path` disables the cache (fully backward-compatible).
- `areno/api/trainer.py` — integrate into `Trainer.load_prompt_batches`; emit `stage=dataset_cache_hit/miss` per epoch + dashboard mirror.
- `areno/api/trainers/policy_only.py` — construct cache only when path set (rollout path: GSPO/GRPO/PPO + agentic rollouts through it).
- `areno/cli/train.py` — `--dataset-cache-path` / `--dataset-cache-mode` options, help notes events are INFO on stderr. `areno/cli/dataset_cache.py` + `cli/main.py` — new `areno dataset-cache inspect / clean` subcommands.
- Tests: +4 CPU files (cache, cache CLI, trainer API, train CLI config).

__Test fix__ (`bad3e5b`) — align Kaggle CPU-test assertions.

__Docs + demo__ (`1361fac`, `d4b494b`, `41e1f94`) — `docs/cli/dataset_cache.rst`/`training.rst`/`faq.rst`, `examples/cache/cache_demo.py`(+`README.md`) reading events from stderr; demo rows fixed to `solutions` field.

### Related issue

Fixes #206.

### Type of change

- [x] - ✨ New feature

### How was it tested?

- `pytest tests/ -k cpu` — run on a GPU/torch host under Issue #206; __not re-run on this box__ (has `pytest`/`click`/`datasets` but lacks `torch`/`safetensors`; collection fails at `import torch`).
- Kaggle Tesla T4, `world_size=2`, `Qwen/Qwen3-0.6B`: end-to-end captured `stage=dataset_cache_hit ... tokenization_time_s=0.000` from stderr per epoch — confirms hit short-circuits tokenization, driver-only one-event-per-epoch (no rank duplicates under `dp_size=2`), same fingerprint across epochs.

Hardware limitations: CPU suite needs a host with full deps; end-to-end needs CUDA.

### Checklist

- [x] - PR title summarizes the contribution.
- [x] - Linked the related issue (Fixes #206).
- [x] - Existing tests pass (`pytest tests/ -k cpu`) — see above; re-run on a torch host before merge.
- [x] - New behavior covered by tests (4 new CPU test files).
- [x] - Described test commands and hardware limitations.
- [x] - Public API / CLI changes additive and backward-compatible — new options default to off/disabled; no existing option changed.

### Breaking change details

None. The cache is opt-in (`--dataset-cache-path` unset ⇒ unchanged behavior). New options/fields have defaults; `areno dataset-cache` is an additive subcommand group.
