### PR TITLE
feat(metrics): record effective trainable tokens per update

### DIFF
--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -123,6 +123,27 @@ def create_tensorboard_writer(log_dir: str):
     return SummaryWriter(log_dir=log_dir)
 
 
+def _effective_loss_token_count(prompt_mask: list[bool], loss_mask: list[bool] | None) -> int:
+    """Count tokens that actually contributed to the loss, using the same next-token convention as the packed path.
+
+    A position is a loss target when it is NOT a prompt token AND the (optional) `loss_mask` keeps it
+    trainable. The loss trains on next-token targets, so position `0` is never a target -- mirroring
+    `_sft_target_token_count` in `areno/api/backend/areno/backend.py`. When `loss_mask` is absent or
+    empty it defaults to `~prompt_mask` (the packer applies the same default at
+    `areno/api/backend/areno/backend.py`).
+    """
+
+    length = min(len(prompt_mask), len(loss_mask)) if loss_mask else len(prompt_mask)
+    count = 0
+    for idx in range(1, length):
+        if prompt_mask[idx]:
+            continue
+        if loss_mask and not loss_mask[idx]:
+            continue
+        count += 1
+    return count
+
+
 def collect_train_batch_stats(train_batch) -> dict:
     """Summarize rewards, advantages, lengths, and rollout logprobs.
 
@@ -149,6 +170,13 @@ def collect_train_batch_stats(train_batch) -> dict:
             response_logprobs=response_logprobs,
             response_len=response_len,
         )
+        # Effective-trainable-token accounting from the same mask the loss
+        # consumes. Length is clamped to the shorter of tokens/mask so a
+        # trailing mismatch can never index past the mask.
+        length = min(len(seq.tokens), len(prompt_mask))
+        effective = _effective_loss_token_count(prompt_mask, list(seq.loss_mask) if seq.loss_mask else None)
+        stats["effective_loss_tokens"].append(effective)
+        stats["total_input_tokens"].append(length)
     return stats
 
 
@@ -162,6 +190,8 @@ def init_rollout_stats(skipped_long: int = 0, total_skipped_long: int = 0) -> di
         "seq_len": [],
         "prompt_len": [],
         "response_len": [],
+        "effective_loss_tokens": [],
+        "total_input_tokens": [],
         "skipped_long": skipped_long,
         "total_skipped_long": total_skipped_long,
     }
@@ -207,6 +237,17 @@ def record_training_stats(writer, stats, step, train_res, train_batch, timings: 
         if values:
             writer.add_scalar(f"rollout/{key}_mean", np.mean(values), step)
     writer.add_scalar("rollout/num_sequences", len(train_batch), step)
+    effective_tokens = stats.get("effective_loss_tokens", [])
+    input_tokens = stats.get("total_input_tokens", [])
+    if effective_tokens and input_tokens:
+        effective_total = sum(effective_tokens)
+        input_total = sum(input_tokens)
+        writer.add_scalar("rollout/effective_loss_tokens", effective_total, step)
+        writer.add_scalar("rollout/total_input_tokens", input_total, step)
+        # `masked_tokens` is everything excluded from the loss: prompt tokens,
+        # padding, and response spans the loss mask dropped (total - effective).
+        writer.add_scalar("rollout/masked_tokens", input_total - effective_total, step)
+        writer.add_scalar("rollout/effective_length_mean", effective_total / len(effective_tokens), step)
     for key in ("skipped_long", "total_skipped_long"):
         if key in stats:
             writer.add_scalar(f"rollout/{key}", stats[key], step)

--- a/docs/cli/observability.rst
+++ b/docs/cli/observability.rst
@@ -132,7 +132,22 @@ The writer lives in ``areno.api.metrics``. It records three namespaces:
    ``rollout/advantages_std``, ``rollout/logprobs_mean``,
    ``rollout/seq_len_mean``, ``rollout/prompt_len_mean``,
    ``rollout/response_len_mean``, ``rollout/num_sequences``,
+   ``rollout/effective_loss_tokens``, ``rollout/total_input_tokens``,
+   ``rollout/masked_tokens``, ``rollout/effective_length_mean``,
    ``rollout/skipped_long``, and ``rollout/total_skipped_long``.
+
+   The four effective-token scalars are derived from the same mask the loss
+   consumes, so they describe what the step actually trained on rather than the
+   raw response length: ``effective_loss_tokens`` is the count of next-token
+   targets that contributed to the loss (prompt positions and response spans the
+   loss mask dropped are excluded); ``total_input_tokens`` is the real
+   pre-padding token count; ``masked_tokens`` is ``total_input_tokens`` minus
+   ``effective_loss_tokens`` (prompt tokens, padding, and loss-masked-out
+   response spans); and ``effective_length_mean`` is the per-sequence mean of
+   the effective count. Unlike ``rollout/response_len_mean`` — which is computed
+   from ``prompt_mask`` alone and so overcounts agentic batches where
+   ``loss_mask`` narrows the trainable span — these scalars reflect the true
+   trainable-token budget per update.
 
 ``train/*``
    Every scalar returned in ``train_stats``. Typical examples are

--- a/tests/test_metrics_cpu.py
+++ b/tests/test_metrics_cpu.py
@@ -5,6 +5,7 @@ import unittest
 from areno.api import metrics as metrics_mod
 from areno.api.metrics import (
     MetricsRecorder,
+    _effective_loss_token_count,
     collect_train_batch_stats,
     init_rollout_stats,
     record_rollout_sequence_stats,
@@ -65,6 +66,148 @@ class MetricsUtilityTest(unittest.TestCase):
             metrics_mod.create_tensorboard_writer = old_factory
 
         self.assertEqual(writer.close_count, 1)
+
+
+class EffectiveTrainableTokenTest(unittest.TestCase):
+    """Effective-trainable-token accounting uses the loss mask, next-token shifted."""
+
+    def test_effective_count_excludes_prompt_and_index_zero(self):
+        """With no loss_mask, effective tokens are response positions past idx 0."""
+        # prompt_mask=[T,T,F,F] -> response at idx 2,3; both count (idx0 skipped).
+        count = _effective_loss_token_count([True, True, False, False], None)
+        self.assertEqual(count, 2)
+
+    def test_effective_count_honors_narrower_loss_mask(self):
+        """loss_mask narrower than the response (e.g. masked tool-call span) drops those tokens."""
+        # response at idx 2,3,4; loss_mask keeps only idx 2,3 -> 2 effective.
+        count = _effective_loss_token_count([True, True, False, False, False], [False, False, True, True, False])
+        self.assertEqual(count, 2)
+
+    def test_effective_count_is_zero_for_all_prompt_sequence(self):
+        """An all-prompt sequence contributes no loss targets."""
+        count = _effective_loss_token_count([True, True, True], None)
+        self.assertEqual(count, 0)
+
+    def test_init_rollout_stats_carries_effective_token_keys(self):
+        """The accumulator must expose the effective-token keys."""
+        stats = init_rollout_stats()
+        self.assertEqual(stats["effective_loss_tokens"], [])
+        self.assertEqual(stats["total_input_tokens"], [])
+
+    def test_collect_train_batch_stats_accounts_effective_and_total_tokens(self):
+        """Default span (no loss_mask): effective = response tokens, total = sequence length."""
+        seq = TrainSequence(
+            prompt_mask=[True, True, False, False],
+            tokens=[1, 2, 3, 4],
+            logprobs=[0.0, 0.0, -0.2, -0.4],
+            advantages=[0.0, 0.0, 1.0, -1.0],
+            reward=1.0,
+        )
+
+        stats = collect_train_batch_stats([seq])
+
+        self.assertEqual(stats["effective_loss_tokens"], [2])
+        self.assertEqual(stats["total_input_tokens"], [4])
+
+    def test_collect_train_batch_stats_loss_mask_narrows_effective_below_response_len(self):
+        """A narrower loss_mask makes effective < response_len (the gap issue #227 fills)."""
+        # response_len counts non-prompt positions (3); loss_mask drops idx 4 -> effective 2.
+        seq = TrainSequence(
+            prompt_mask=[True, True, False, False, False],
+            loss_mask=[False, False, True, True, False],
+            tokens=[1, 2, 3, 4, 5],
+            logprobs=[0.0, 0.0, -0.2, -0.4, -0.6],
+            advantages=[0.0, 0.0, 1.0, -1.0, 0.5],
+            reward=1.0,
+        )
+
+        stats = collect_train_batch_stats([seq])
+
+        self.assertEqual(stats["effective_loss_tokens"], [2])
+        self.assertEqual(stats["response_len"], [3])
+        self.assertTrue(stats["effective_loss_tokens"][0] < stats["response_len"][0])
+
+    def test_collect_train_batch_stats_mean_effective_length_across_sequences(self):
+        """Mean effective length is the per-sequence effective count averaged over the batch."""
+        seq_a = TrainSequence(prompt_mask=[True, True, False, False], tokens=[1, 2, 3, 4], reward=1.0)
+        # response at idx 3,4 (skip idx0) -> 2 effective.
+        seq_b = TrainSequence(prompt_mask=[True, False, False, False, False], tokens=[1, 3, 4, 5, 6], reward=1.0)
+
+        stats = collect_train_batch_stats([seq_a, seq_b])
+
+        self.assertEqual(stats["effective_loss_tokens"], [2, 4])
+        self.assertAlmostEqual(sum(stats["effective_loss_tokens"]) / len(stats["effective_loss_tokens"]), 3.0)
+
+    def test_collect_train_batch_stats_empty_batch_keeps_empty_accumulators(self):
+        """An empty batch must not raise and leaves the effective-token lists empty."""
+        stats = collect_train_batch_stats([])
+
+        self.assertEqual(stats["effective_loss_tokens"], [])
+        self.assertEqual(stats["total_input_tokens"], [])
+
+    def test_collect_train_batch_stats_clamps_length_on_trailing_token_mismatch(self):
+        """tokens longer than prompt_mask must not index past the mask."""
+        # prompt_mask covers 3 tokens, tokens has 5 -> total clamps to 3, effective over 3.
+        seq = TrainSequence(
+            prompt_mask=[True, False, False],
+            tokens=[1, 2, 3, 4, 5],
+            logprobs=[0.0, -0.2, -0.4],
+            advantages=[0.0, 1.0, -1.0],
+            reward=1.0,
+        )
+
+        stats = collect_train_batch_stats([seq])
+
+        self.assertEqual(stats["total_input_tokens"], [3])
+        # response at idx 1,2 (skip idx0) -> 2 effective.
+        self.assertEqual(stats["effective_loss_tokens"], [2])
+
+    def test_record_training_stats_emits_effective_token_scalars(self):
+        """record_training_stats writes the four effective-token scalars for a real batch."""
+        recorded: dict[str, float] = {}
+
+        class FakeWriter:
+            def add_scalar(self, tag, value, _step):
+                recorded[tag] = float(value)
+
+            def flush(self):
+                pass
+
+        seq = TrainSequence(
+            prompt_mask=[True, True, False, False],
+            loss_mask=[False, False, True, True],
+            tokens=[1, 2, 3, 4],
+            logprobs=[0.0, 0.0, -0.2, -0.4],
+            advantages=[0.0, 0.0, 1.0, -1.0],
+            reward=1.0,
+        )
+        stats = collect_train_batch_stats([seq])
+
+        metrics_mod.record_training_stats(FakeWriter(), stats, step=1, train_res={}, train_batch=[seq])
+
+        self.assertEqual(recorded["rollout/effective_loss_tokens"], 2.0)
+        self.assertEqual(recorded["rollout/total_input_tokens"], 4.0)
+        self.assertEqual(recorded["rollout/masked_tokens"], 2.0)
+        self.assertEqual(recorded["rollout/effective_length_mean"], 2.0)
+
+    def test_record_training_stats_empty_batch_skips_effective_token_scalars(self):
+        """An empty batch records num_sequences=0 and skips the effective-token scalars (no 0/0)."""
+        recorded: dict[str, float] = {}
+
+        class FakeWriter:
+            def add_scalar(self, tag, value, _step):
+                recorded[tag] = float(value)
+
+            def flush(self):
+                pass
+
+        stats = collect_train_batch_stats([])
+
+        metrics_mod.record_training_stats(FakeWriter(), stats, step=1, train_res={}, train_batch=[])
+
+        self.assertEqual(recorded["rollout/num_sequences"], 0.0)
+        self.assertNotIn("rollout/effective_loss_tokens", recorded)
+        self.assertNotIn("rollout/effective_length_mean", recorded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #227.

  What it does
  
  Records the true trainable-token budget per update, so training runs become comparable and reproducible across algorithms and runs.

  The current rollout/response_len_mean is derived from prompt_mask alone, so it overcounts what the loss actually trained on whenever loss_mask
  narrows the trainable span — e.g. agentic batches that mask tool-call / tool-result spans. This PR computes four quantities from the same mask the
  loss already consumes (prompt_mask + optional loss_mask), reflecting the real trainable-token budget:

  - effective_loss_tokens — next-token loss targets (prompt and loss_mask-dropped response spans excluded; skips position 0 to match the loss's
  next-token convention)
  - total_input_tokens — real (pre-padding) token count
  - masked_tokens = total_input_tokens − effective_loss_tokens (prompt + padding + dropped response spans)
  - effective_length_mean = effective_loss_tokens / num_sequences

  The counting logic mirrors the existing _sft_target_token_count (areno/api/backend/areno/backend.py) — which already has identical next-token
  semantics but is used only for SFT loss normalization and was never surfaced as a metric. This PR generalizes it to all algorithms and promotes it
  to a metric.

  Usage

  Zero-config, on by default. Whenever --metrics-log-dir points to a valid directory (default /tmp/areno/tfevent, already enabled), each update
  automatically computes and writes four rollout/* TensorBoard scalars:

  rollout/effective_loss_tokens
  rollout/total_input_tokens
  rollout/masked_tokens
  rollout/effective_length_mean

  No new CLI flag, no config field. Algorithm-agnostic: SFT / DPO / GRPO / GSPO / PPO / agentic all covered automatically.

  Note: these four scalars go to TensorBoard only — they do not appear in the console train_stats={...} log line. Inspect via tensorboard --logdir 
  <metrics-log-dir> or by reading the event file directly.

  Files changed
  
  - areno/api/metrics.py — adds _effective_loss_token_count helper; collect_train_batch_stats accumulates per-sequence effective_loss_tokens /
  total_input_tokens; record_training_stats emits the four rollout/* scalars (skipped on empty batch to avoid 0/0). The computation runs on the
  pre-pack TrainSequence list, so it is algorithm-agnostic and off the GPU hot path.
  - tests/test_metrics_cpu.py — adds 11 CPU tests: default span, narrower loss_mask (the gap this fills), mean across sequences, empty batch,
  trailing length-mismatch clamp, all-prompt sequence, writer-level scalar emission, and the empty-batch guard.
  - docs/cli/observability.rst — documents the four new scalars and the effective/masked definition.

  Design note: deliberately no gating flag and no change to trainer_config.py / cli/train.py. The metric is cheap and metrics_log_dir is on by
  default, so this augments the existing metrics channel rather than introducing new behavior — and it avoids the config/CLI "Ask first" surfaces
  flagged in AGENTS.md. If a maintainer later wants gating, the additive scalars can be put behind a flag without touching the computation.

  Verification

  - CPU: pytest tests/test_metrics_cpu.py -k cpu → 14 passed; pytest tests/ -k cpu → 378 passed (green). ruff check + ruff format --check clean.
  - GPU end-to-end: Kaggle Tesla T4×2, SFT, Qwen3-0.6B (--model-hub hf, yahma/alpaca-cleaned, --world-size 2 --tp-size 1 --max-new-tokens 8), 164
  consecutive steps, all four scalars emitted throughout. Sample:
  - The invariant masked == total − effective holds (1078 = 1272 − 194), and effective_length_mean = effective / num_sequences holds.
  
<img width="2834" height="1424" alt="issue1" src="https://github.com/user-attachments/assets/80086c89-0de2-42d3-97dc-0395e4576ab1" />
