### PR TITLE
feat(agentic):adds a `trim_messages` context overflow policy for the Agentic Proxy path

### DIFF
--- a/areno/agent/agent_loop.py
+++ b/areno/agent/agent_loop.py
@@ -283,9 +283,15 @@ async def _run_training_tasks_by_turn(
         tool_states = []
         tool_calls = []
         for state, response in zip(active, responses, strict=True):
+            areno_meta = response.get("areno", {}) if isinstance(response, dict) else {}
+            effective_messages = areno_meta.get("effective_messages")
             turns.append(
                 AgentTrajectoryTurn(
-                    item=state["item"], messages=list(state["messages"]), response=response, tools=TOOLS
+                    item=state["item"],
+                    messages=list(state["messages"]),
+                    response=response,
+                    tools=TOOLS,
+                    effective_messages=effective_messages,
                 )
             )
             assistant_message = _assistant_message_from_response(response)
@@ -380,7 +386,17 @@ async def run_conversation_turns(
         if record_trajectory:
             # AReno trains from explicit per-turn trajectories; no proxy-side
             # prompt matching is needed to reconstruct the multi-turn sample.
-            turns.append(AgentTrajectoryTurn(item=item, messages=list(messages), response=response, tools=TOOLS))
+            areno_meta2 = response.get("areno", {}) if isinstance(response, dict) else {}
+            effective_messages2 = areno_meta2.get("effective_messages")
+            turns.append(
+                AgentTrajectoryTurn(
+                    item=item,
+                    messages=list(messages),
+                    response=response,
+                    tools=TOOLS,
+                    effective_messages=effective_messages2,
+                )
+            )
         assistant_message = _assistant_message_from_response(response)
         messages.append(assistant_message)
         # The standalone CLI uses this hook to stream model/tool activity as it happens.

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -537,6 +537,15 @@ class RolloutSession:
                     pending.input_tokens = trimmed["tokens"]
                     pending._trimmed_messages = trimmed["messages"]
                     pending._trim_info = trimmed["diagnostics"]
+                    diag = trimmed["diagnostics"]
+                    logger.info(
+                        "trim_messages removed %d units (%d messages): %d -> %d tokens, system=%s",
+                        diag["units_removed"],
+                        diag["messages_removed"],
+                        diag["original_prompt_tokens"],
+                        diag["effective_prompt_tokens"],
+                        diag["preserved_instructions"],
+                    )
             elif max_context_len is not None and len(pending.input_tokens) > max_context_len:
                 response = _filtered_chat_response(
                     model=pending.model,

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from areno.api.openai_chat import (
     build_chat_completion_response,
     first_user_text,
+    group_messages_into_units,
     messages_to_prompt_tokens,
     messages_to_text,
     normalize_messages,
@@ -131,6 +132,7 @@ class AgentTrajectoryTurn:
     model: str = "policy"
     tools: list[dict[str, Any]] = field(default_factory=list)
     tool_choice: Any = None
+    effective_messages: list[dict[str, Any]] | None = None
 
     def __post_init__(self) -> None:
         if self.response is None:
@@ -211,6 +213,8 @@ class _PendingChat:
     response: dict[str, Any] | None = None
     error: BaseException | None = None
     cancelled: bool = False
+    _trimmed_messages: list[dict[str, Any]] | None = None
+    _trim_info: dict[str, Any] | None = None
 
 
 class _AgenticHTTPServer(ThreadingHTTPServer):
@@ -251,6 +255,7 @@ class RolloutSession:
         max_running_prompts: int | None = None,
         timeout_s: float = 300.0,
         proxy: bool = True,
+        agentic_context_overflow_policy: str = "reject",
     ) -> None:
         self._trainer = trainer
         self._sampling_params = sampling_params
@@ -268,6 +273,7 @@ class RolloutSession:
         self._closing = False
         self._base_url = ""
         self._proxy_enabled = bool(proxy)
+        self._agentic_context_overflow_policy = agentic_context_overflow_policy
 
     @property
     def max_running_prompts(self) -> int:
@@ -503,13 +509,33 @@ class RolloutSession:
             )
             max_context_len = _max_context_len(pending.params)
             if max_context_len is not None and len(pending.input_tokens) > max_context_len:
-                response = _filtered_chat_response(
-                    model=pending.model,
-                    prompt_tokens=len(pending.input_tokens),
-                    max_sequence_len=max_context_len,
-                )
-                self._set_pending_response(pending, response)
-                return
+                if self._agentic_context_overflow_policy == "trim_messages":
+                    trimmed = _trim_messages_to_fit(
+                        tokenizer,
+                        pending.messages,
+                        tools=pending.tools,
+                        max_context_len=max_context_len,
+                        input_tokens=pending.input_tokens,
+                    )
+                    if trimmed is None:
+                        response = _unfittable_chat_response(
+                            model=pending.model,
+                            prompt_tokens=len(pending.input_tokens),
+                            max_sequence_len=max_context_len,
+                        )
+                        self._set_pending_response(pending, response)
+                        return
+                    pending.input_tokens = trimmed["tokens"]
+                    pending._trimmed_messages = trimmed["messages"]
+                    pending._trim_info = trimmed["diagnostics"]
+                else:
+                    response = _filtered_chat_response(
+                        model=pending.model,
+                        prompt_tokens=len(pending.input_tokens),
+                        max_sequence_len=max_context_len,
+                    )
+                    self._set_pending_response(pending, response)
+                    return
             results = await self._trainer.rollout_token_batch_async([pending.input_tokens], 1, pending.params)
             sequence = results[0].sequences[0] if results and results[0].sequences else None
             if sequence is None:
@@ -527,15 +553,16 @@ class RolloutSession:
 
     def _sample_from_trajectory_turn(self, turn: AgentTrajectoryTurn) -> _AgentSample:
         tokenizer = self._trainer.get_tokenizer()
+        messages_to_tokenize = turn.effective_messages if turn.effective_messages is not None else turn.messages
         input_tokens = _messages_to_prompt_tokens(
             tokenizer,
-            turn.messages,
+            messages_to_tokenize,
             tools=turn.tools,
             fallback_prompt=turn.item.prompt,
         )
         pending = _PendingChat(
             item=turn.item,
-            messages=_normalize_messages(turn.messages),
+            messages=_normalize_messages(messages_to_tokenize),
             input_tokens=input_tokens,
             params=self._sampling_params,
             key=_chat_batch_key(self._sampling_params),
@@ -686,7 +713,7 @@ class RolloutSession:
     ) -> dict[str, Any]:
         del content
         finish_reason = "tool_calls" if tool_calls else "stop"
-        return build_chat_completion_response(
+        result = build_chat_completion_response(
             tokenizer=self._trainer.get_tokenizer(),
             model=pending.model,
             prompt_tokens=len(pending.input_tokens),
@@ -700,6 +727,13 @@ class RolloutSession:
             include_areno_metadata=True,
             input_tokens=pending.input_tokens,
         )
+        trimmed_messages = getattr(pending, "_trimmed_messages", None)
+        trim_info = getattr(pending, "_trim_info", None)
+        if trimmed_messages is not None and isinstance(trim_info, dict):
+            result.setdefault("areno", {})
+            result["areno"]["effective_messages"] = trimmed_messages
+            result["areno"]["trim_info"] = trim_info
+        return result
 
 
 def load_agent_run_fn(path: str) -> Callable[[RolloutSession, AgentBatch], Any]:
@@ -841,6 +875,105 @@ def _filtered_chat_response(*, model: str, prompt_tokens: int, max_sequence_len:
             "response_logprobs": [],
         },
     }
+
+
+def _unfittable_chat_response(*, model: str, prompt_tokens: int, max_sequence_len: int) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": ""},
+                "finish_reason": "length",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": 0,
+            "total_tokens": prompt_tokens,
+            "max_sequence_len": max_sequence_len,
+        },
+        "areno": {
+            "input_tokens": [],
+            "response_tokens": [],
+            "response_logprobs": [],
+            "error": "context_overflow",
+            "detail": (
+                f"Prompt ({prompt_tokens} tokens) exceeds max ({max_sequence_len}) "
+                "even after removing all trimmable conversation units."
+            ),
+        },
+    }
+
+
+def _trim_messages_to_fit(
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None,
+    max_context_len: int,
+    input_tokens: list[int],
+) -> dict[str, Any] | None:
+    """Remove oldest conversation units until the prompt fits *max_context_len*.
+
+    Returns ``None`` when even the preserved (system/developer + latest user)
+    units still exceed the budget.
+    """
+
+    units = group_messages_into_units(messages)
+    if not units:
+        return None
+
+    # Determine preserved ranges.
+    preserved_start = 0
+    preserved_end = len(units) - 1
+
+    # Protect leading system / developer instructions.
+    if units[0] and units[0][0].get("role") in ("system", "developer"):
+        preserved_start = 1
+
+    # No removable units at all.
+    if preserved_start >= preserved_end:
+        return None
+
+    # Copy and trim the oldest removable units one by one.
+    current_units = list(units)
+    removed_unit_count = 0
+    removed_message_count = 0
+    has_preserved_instructions = preserved_start > 0
+
+    for _removable_idx in range(preserved_start, preserved_end):
+        # Pop the oldest removable unit (always at index preserved_start
+        # after earlier pops).
+        unit = current_units.pop(preserved_start)
+        removed_unit_count += 1
+        removed_message_count += len(unit)
+
+        candidate_messages = [msg for u in current_units for msg in u]
+        candidate_tokens = _messages_to_prompt_tokens(
+            tokenizer,
+            candidate_messages,
+            tools=tools,
+            fallback_prompt=_first_user_text(candidate_messages),
+        )
+        if len(candidate_tokens) <= max_context_len:
+            return {
+                "messages": candidate_messages,
+                "tokens": candidate_tokens,
+                "diagnostics": {
+                    "policy": "trim_messages",
+                    "original_prompt_tokens": len(input_tokens),
+                    "effective_prompt_tokens": len(candidate_tokens),
+                    "units_removed": removed_unit_count,
+                    "messages_removed": removed_message_count,
+                    "preserved_instructions": has_preserved_instructions,
+                },
+            }
+
+    return None
 
 
 def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -518,6 +518,10 @@ class RolloutSession:
                     trim_target = max_context_len
                 if trim_target is None:
                     trim_target = _model_sequence_len(tokenizer)
+                logger.info(
+                    "trim check: policy=%s trim_target=%s prompt_tokens=%d",
+                    self._agentic_context_overflow_policy, trim_target, len(pending.input_tokens),
+                )
                 if trim_target is not None and len(pending.input_tokens) > trim_target:
                     trimmed = _trim_messages_to_fit(
                         tokenizer,

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -531,6 +531,17 @@ class RolloutSession:
                         input_tokens=pending.input_tokens,
                     )
                     if trimmed is None:
+                        # Two failure modes: (a) no removable units at all
+                        # (system + user alone exceeds the budget) or
+                        # (b) all removable units removed but still too long.
+                        units = group_messages_into_units(pending.messages)
+                        if len(units) <= 2:
+                            raise RuntimeError(
+                                f"trim_messages impossible: system + latest user alone "
+                                f"({len(pending.input_tokens)} tokens) exceeds trim_max_tokens "
+                                f"({trim_target}). Increase --trim-max-tokens or "
+                                f"--agentic-context-overflow-policy."
+                            )
                         response = _unfittable_chat_response(
                             model=pending.model,
                             prompt_tokens=len(pending.input_tokens),

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -508,34 +508,39 @@ class RolloutSession:
                 fallback_prompt=_first_user_text(pending.messages),
             )
             max_context_len = _max_context_len(pending.params)
-            if max_context_len is not None and len(pending.input_tokens) > max_context_len:
-                if self._agentic_context_overflow_policy == "trim_messages":
-                    trimmed = _trim_messages_to_fit(
-                        tokenizer,
-                        pending.messages,
-                        tools=pending.tools,
-                        max_context_len=max_context_len,
-                        input_tokens=pending.input_tokens,
-                    )
-                    if trimmed is None:
-                        response = _unfittable_chat_response(
-                            model=pending.model,
-                            prompt_tokens=len(pending.input_tokens),
-                            max_sequence_len=max_context_len,
-                        )
-                        self._set_pending_response(pending, response)
-                        return
-                    pending.input_tokens = trimmed["tokens"]
-                    pending._trimmed_messages = trimmed["messages"]
-                    pending._trim_info = trimmed["diagnostics"]
-                else:
-                    response = _filtered_chat_response(
+            # When no explicit max is set, fall back to the model's sequence
+            # length for the trim policy so that long-running agentic
+            # trajectories can continue. The reject policy stays strict.
+            trim_target = max_context_len
+            if trim_target is None:
+                trim_target = _model_sequence_len(tokenizer)
+            if trim_target is not None and len(pending.input_tokens) > trim_target and self._agentic_context_overflow_policy == "trim_messages":
+                trimmed = _trim_messages_to_fit(
+                    tokenizer,
+                    pending.messages,
+                    tools=pending.tools,
+                    max_context_len=trim_target,
+                    input_tokens=pending.input_tokens,
+                )
+                if trimmed is None:
+                    response = _unfittable_chat_response(
                         model=pending.model,
                         prompt_tokens=len(pending.input_tokens),
-                        max_sequence_len=max_context_len,
+                        max_sequence_len=trim_target,
                     )
                     self._set_pending_response(pending, response)
                     return
+                pending.input_tokens = trimmed["tokens"]
+                pending._trimmed_messages = trimmed["messages"]
+                pending._trim_info = trimmed["diagnostics"]
+            elif max_context_len is not None and len(pending.input_tokens) > max_context_len:
+                response = _filtered_chat_response(
+                    model=pending.model,
+                    prompt_tokens=len(pending.input_tokens),
+                    max_sequence_len=max_context_len,
+                )
+                self._set_pending_response(pending, response)
+                return
             results = await self._trainer.rollout_token_batch_async([pending.input_tokens], 1, pending.params)
             sequence = results[0].sequences[0] if results and results[0].sequences else None
             if sequence is None:
@@ -848,6 +853,17 @@ def _max_context_len(params: Any) -> int | None:
     if max_prompt_len is None:
         return None
     return int(max_prompt_len)
+
+
+def _model_sequence_len(tokenizer: Any) -> int | None:
+    """Return the model's maximum sequence length from its tokenizer config."""
+    max_seq = getattr(tokenizer, "model_max_length", None)
+    if max_seq is not None:
+        return int(max_seq)
+    max_pos = getattr(tokenizer, "max_position_embeddings", None)
+    if max_pos is not None:
+        return int(max_pos)
+    return None
 
 
 def _filtered_chat_response(*, model: str, prompt_tokens: int, max_sequence_len: int) -> dict[str, Any]:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -256,6 +256,7 @@ class RolloutSession:
         timeout_s: float = 300.0,
         proxy: bool = True,
         agentic_context_overflow_policy: str = "reject",
+        trim_max_tokens: int | None = None,
     ) -> None:
         self._trainer = trainer
         self._sampling_params = sampling_params
@@ -274,6 +275,7 @@ class RolloutSession:
         self._base_url = ""
         self._proxy_enabled = bool(proxy)
         self._agentic_context_overflow_policy = agentic_context_overflow_policy
+        self._trim_max_tokens = trim_max_tokens
 
     @property
     def max_running_prompts(self) -> int:
@@ -508,31 +510,33 @@ class RolloutSession:
                 fallback_prompt=_first_user_text(pending.messages),
             )
             max_context_len = _max_context_len(pending.params)
-            # When no explicit max is set, fall back to the model's sequence
-            # length for the trim policy so that long-running agentic
-            # trajectories can continue. The reject policy stays strict.
-            trim_target = max_context_len
-            if trim_target is None:
-                trim_target = _model_sequence_len(tokenizer)
-            if trim_target is not None and len(pending.input_tokens) > trim_target and self._agentic_context_overflow_policy == "trim_messages":
-                trimmed = _trim_messages_to_fit(
-                    tokenizer,
-                    pending.messages,
-                    tools=pending.tools,
-                    max_context_len=trim_target,
-                    input_tokens=pending.input_tokens,
-                )
-                if trimmed is None:
-                    response = _unfittable_chat_response(
-                        model=pending.model,
-                        prompt_tokens=len(pending.input_tokens),
-                        max_sequence_len=trim_target,
+            # trim_messages: use the dedicated trim_max_tokens if set,
+            # otherwise fall back to max_context_len or model limit.
+            if self._agentic_context_overflow_policy == "trim_messages":
+                trim_target = self._trim_max_tokens
+                if trim_target is None:
+                    trim_target = max_context_len
+                if trim_target is None:
+                    trim_target = _model_sequence_len(tokenizer)
+                if trim_target is not None and len(pending.input_tokens) > trim_target:
+                    trimmed = _trim_messages_to_fit(
+                        tokenizer,
+                        pending.messages,
+                        tools=pending.tools,
+                        max_context_len=trim_target,
+                        input_tokens=pending.input_tokens,
                     )
-                    self._set_pending_response(pending, response)
-                    return
-                pending.input_tokens = trimmed["tokens"]
-                pending._trimmed_messages = trimmed["messages"]
-                pending._trim_info = trimmed["diagnostics"]
+                    if trimmed is None:
+                        response = _unfittable_chat_response(
+                            model=pending.model,
+                            prompt_tokens=len(pending.input_tokens),
+                            max_sequence_len=trim_target,
+                        )
+                        self._set_pending_response(pending, response)
+                        return
+                    pending.input_tokens = trimmed["tokens"]
+                    pending._trimmed_messages = trimmed["messages"]
+                    pending._trim_info = trimmed["diagnostics"]
             elif max_context_len is not None and len(pending.input_tokens) > max_context_len:
                 response = _filtered_chat_response(
                     model=pending.model,

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -518,10 +518,10 @@ class RolloutSession:
                     trim_target = max_context_len
                 if trim_target is None:
                     trim_target = _model_sequence_len(tokenizer)
-                logger.info(
-                    "trim check: policy=%s trim_target=%s prompt_tokens=%d",
-                    self._agentic_context_overflow_policy, trim_target, len(pending.input_tokens),
-                )
+                #                logger.info(
+                #                    "trim check: policy=%s trim_target=%s prompt_tokens=%d",
+                #                    self._agentic_context_overflow_policy, trim_target, len(pending.input_tokens),
+                #                )
                 if trim_target is not None and len(pending.input_tokens) > trim_target:
                     trimmed = _trim_messages_to_fit(
                         tokenizer,

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -193,3 +193,33 @@ def _trim_stop_strings(text: str, stop: list[str]) -> tuple[str, bool]:
     if first is None:
         return text, False
     return text[:first], True
+
+
+def group_messages_into_units(messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Split messages into atomic conversation units for safe trimming.
+
+    Grouping rules:
+    - system / developer messages: each is its own unit.
+    - user messages: each is its own unit.
+    - assistant (no tool_calls): its own unit.
+    - assistant (with tool_calls) + all immediately following tool messages:
+      treated as one atomic unit that must not be split.
+    """
+
+    units: list[list[dict[str, Any]]] = []
+    idx = 0
+    while idx < len(messages):
+        msg = messages[idx]
+        role = msg.get("role", "")
+        if role == "assistant" and isinstance(msg.get("tool_calls"), list) and msg["tool_calls"]:
+            # Start an atomic unit: assistant with tool_calls + following tool messages.
+            unit = [msg]
+            idx += 1
+            while idx < len(messages) and messages[idx].get("role") == "tool":
+                unit.append(messages[idx])
+                idx += 1
+            units.append(unit)
+        else:
+            units.append([msg])
+            idx += 1
+    return units

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -308,6 +308,7 @@ class Trainer:
         max_running_prompts: int | None = None,
         timeout_s: float = 300.0,
         proxy: bool = True,
+        agentic_context_overflow_policy: str = "reject",
     ) -> RolloutSession:
         """Create an async rollout session, optionally with an OpenAI-compatible proxy."""
 
@@ -318,6 +319,7 @@ class Trainer:
             max_running_prompts=max_running_prompts,
             timeout_s=timeout_s,
             proxy=proxy,
+            agentic_context_overflow_policy=agentic_context_overflow_policy,
         )
 
     def train(

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -309,6 +309,7 @@ class Trainer:
         timeout_s: float = 300.0,
         proxy: bool = True,
         agentic_context_overflow_policy: str = "reject",
+        trim_max_tokens: int | None = None,
     ) -> RolloutSession:
         """Create an async rollout session, optionally with an OpenAI-compatible proxy."""
 
@@ -320,6 +321,7 @@ class Trainer:
             timeout_s=timeout_s,
             proxy=proxy,
             agentic_context_overflow_policy=agentic_context_overflow_policy,
+            trim_max_tokens=trim_max_tokens,
         )
 
     def train(

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -59,6 +59,7 @@ class TrainerConfig:
     agent_fn: str | None = None
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
+    agentic_context_overflow_policy: str = "reject"
     chat_template_enable_thinking: bool | None = None
 
     def __post_init__(self) -> None:
@@ -66,6 +67,11 @@ class TrainerConfig:
             raise ValueError("attn_backend must be one of: flash, native")
         if self.model_hub not in {"hf", "modelscope"}:
             raise ValueError("model_hub must be one of: hf, modelscope")
+        if self.agentic_context_overflow_policy not in ("reject", "trim_messages"):
+            raise ValueError(
+                f"agentic_context_overflow_policy must be 'reject' or 'trim_messages', "
+                f"got {self.agentic_context_overflow_policy!r}"
+            )
 
     def optimizer_config(self) -> dict:
         """Build the optimizer dict consumed by the backend config."""

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -60,6 +60,7 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     agentic_context_overflow_policy: str = "reject"
+    trim_max_tokens: int | None = None
     chat_template_enable_thinking: bool | None = None
 
     def __post_init__(self) -> None:

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -215,6 +215,7 @@ class PolicyOnlyTrainer:
             loss_mask_policy=self._loss_mask_policy(),
             max_running_prompts=self.config.resolved_max_running_prompts(),
             timeout_s=self.config.agent_timeout_s,
+            agentic_context_overflow_policy=self.config.agentic_context_overflow_policy,
         ) as ctx:
             await ctx.sync_rollout_session_async()
             trajectories = await maybe_await(self._get_agent_run_fn()(ctx, agent_batch))

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -216,6 +216,7 @@ class PolicyOnlyTrainer:
             max_running_prompts=self.config.resolved_max_running_prompts(),
             timeout_s=self.config.agent_timeout_s,
             agentic_context_overflow_policy=self.config.agentic_context_overflow_policy,
+            trim_max_tokens=self.config.trim_max_tokens,
         ) as ctx:
             await ctx.sync_rollout_session_async()
             trajectories = await maybe_await(self._get_agent_run_fn()(ctx, agent_batch))

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -638,6 +638,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             agentic_context_overflow_policy=args.agentic_context_overflow_policy,
+            trim_max_tokens=args.trim_max_tokens,
             chat_template_enable_thinking=chat_template_enable_thinking,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
@@ -680,6 +681,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             agentic_context_overflow_policy=args.agentic_context_overflow_policy,
+            trim_max_tokens=args.trim_max_tokens,
             chat_template_enable_thinking=chat_template_enable_thinking,
         )
     if algorithm.name != "ppo":
@@ -729,6 +731,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             agentic_context_overflow_policy=args.agentic_context_overflow_policy,
+            trim_max_tokens=args.trim_max_tokens,
             chat_template_enable_thinking=chat_template_enable_thinking,
         )
     return PPOTrainerConfig(
@@ -791,6 +794,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         agentic_context_overflow_policy=args.agentic_context_overflow_policy,
+        trim_max_tokens=args.trim_max_tokens,
         chat_template_enable_thinking=chat_template_enable_thinking,
     )
 
@@ -1313,6 +1317,16 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
         "Agentic proxy policy when the chat prompt exceeds context length. "
         "'reject' returns an empty response; 'trim_messages' removes oldest "
         "conversation units until the prompt fits."
+    ),
+)
+@click.option(
+    "--trim-max-tokens",
+    type=int,
+    default=None,
+    help=(
+        "Token limit for the proxy's trim_messages policy. When set, single "
+        "chat prompts exceeding this limit are trimmed. Defaults to --max-context-len "
+        "or the model's native limit when unset."
     ),
 )
 @click.option(

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -637,6 +637,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            agentic_context_overflow_policy=args.agentic_context_overflow_policy,
             chat_template_enable_thinking=chat_template_enable_thinking,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
@@ -678,6 +679,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            agentic_context_overflow_policy=args.agentic_context_overflow_policy,
             chat_template_enable_thinking=chat_template_enable_thinking,
         )
     if algorithm.name != "ppo":
@@ -726,6 +728,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_fn=args.agent_fn,
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
+            agentic_context_overflow_policy=args.agentic_context_overflow_policy,
             chat_template_enable_thinking=chat_template_enable_thinking,
         )
     return PPOTrainerConfig(
@@ -787,6 +790,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_fn=args.agent_fn,
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
+        agentic_context_overflow_policy=args.agentic_context_overflow_policy,
         chat_template_enable_thinking=chat_template_enable_thinking,
     )
 
@@ -1300,6 +1304,17 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--agent-timeout-s", type=float, default=300.0, show_default=True, help="Agentic rollout proxy request timeout."
 )
 @click.option("--train-tool-results", is_flag=True, help="Include tool-result spans in agentic policy loss.")
+@click.option(
+    "--agentic-context-overflow-policy",
+    type=click.Choice(["reject", "trim_messages"]),
+    default="reject",
+    show_default=True,
+    help=(
+        "Agentic proxy policy when the chat prompt exceeds context length. "
+        "'reject' returns an empty response; 'trim_messages' removes oldest "
+        "conversation units until the prompt fits."
+    ),
+)
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."
 )

--- a/examples/multiturn_reward.py
+++ b/examples/multiturn_reward.py
@@ -1,0 +1,20 @@
+"""Minimal reward function for multi-turn conversation GSPO testing.
+
+Reads the last assistant message from the record's `messages` field and
+returns a simple length-based reward. No external dependencies required.
+"""
+
+from __future__ import annotations
+
+
+def reward_fn(record: dict) -> float:
+    """Return a reward based on the last assistant response length."""
+
+    messages = record.get("messages", [])
+    last_assistant = ""
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            last_assistant = msg.get("content", "") or ""
+            break
+    # Simple: reward longer responses (capped) to give GSPO some signal
+    return min(len(last_assistant) / 100.0, 1.0)

--- a/tests/test_agentic_context_overflow_cpu.py
+++ b/tests/test_agentic_context_overflow_cpu.py
@@ -424,6 +424,7 @@ def test_trim_messages_policy_trims_and_rolls_out():
 
 
 def test_trim_messages_policy_impossible_returns_error():
+    """When only system+user exist and exceed budget, raise RuntimeError immediately."""
     trainer = _FakeTrainer(world_size=1, tp_size=1)
     trainer.tokenizer = _ChatTemplateTokenizer(tokens_per_message=100, tools_overhead=0, gen_prompt_overhead=50)
     params = _FakeSamplingParams()
@@ -442,9 +443,8 @@ def test_trim_messages_policy_impossible_returns_error():
             {"model": "policy", "messages": [_sys(), _usr("only task")]}
         )
 
-    response = asyncio.run(run())
-    assert response["choices"][0]["finish_reason"] == "length"
-    assert response["areno"].get("error") == "context_overflow"
+    with pytest.raises(RuntimeError, match="trim_messages impossible"):
+        asyncio.run(run())
     assert trainer.rollout_batches == []
 
 

--- a/tests/test_agentic_context_overflow_cpu.py
+++ b/tests/test_agentic_context_overflow_cpu.py
@@ -1,0 +1,575 @@
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load agentic module under test (same pattern as test_agentic_cpu.py)
+# ---------------------------------------------------------------------------
+def _load_agentic_module():
+    path = Path(__file__).resolve().parents[1] / "areno" / "api" / "agentic.py"
+    spec = importlib.util.spec_from_file_location("agentic_ctx_overflow_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+agentic = _load_agentic_module()
+AgentTrajectoryTurn = agentic.AgentTrajectoryTurn
+LossMaskPolicy = agentic.LossMaskPolicy
+RolloutSession = agentic.RolloutSession
+_trim_messages_to_fit = agentic._trim_messages_to_fit
+_filtered_chat_response = agentic._filtered_chat_response
+_unfittable_chat_response = agentic._unfittable_chat_response
+
+
+# ---------------------------------------------------------------------------
+# Tokenizers
+# ---------------------------------------------------------------------------
+class _ChatTemplateTokenizer:
+    """Tokenizer that uses apply_chat_template to compute token counts,
+    simulating a real chat-template tokenizer without torch dependency."""
+
+    def __init__(self, tokens_per_message: int = 50, tools_overhead: int = 20, gen_prompt_overhead: int = 2):
+        self._tpm = tokens_per_message
+        self._tools_overhead = tools_overhead
+        self._gen_overhead = gen_prompt_overhead
+        self.chat_template = True  # Exists as attribute (truthy)
+        self.last_messages = None
+        self.last_tools = None
+
+    def apply_chat_template(self, messages, *, tokenize, add_generation_prompt, tools=None):
+        assert tokenize is True
+        self.last_messages = messages
+        self.last_tools = tools
+        total = len(messages) * self._tpm
+        if tools:
+            total += self._tools_overhead
+        if add_generation_prompt:
+            total += self._gen_overhead
+        return list(range(total))
+
+    def encode(self, text):
+        return list(range(10))
+
+    def decode(self, tokens, skip_special_tokens=True):
+        return "decoded text"
+
+
+class _FakeSamplingParams:
+    greedy = False
+    max_new_tokens = 4
+    temperature = 0.0
+    top_p = 1.0
+    top_k = -1
+    stop_token_ids = None
+    ignore_eos = False
+    skip_special_tokens = True
+    max_prompt_len = None
+    max_context_len = None
+
+    def model_copy(self):
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Fake trainer
+# ---------------------------------------------------------------------------
+class _FakeTrainer:
+    def __init__(self, *, world_size=1, tp_size=1):
+        from types import SimpleNamespace
+
+        self.config = SimpleNamespace(world_size=world_size, tp_size=tp_size)
+        self.effective_dp_size = max(world_size // tp_size, 1)
+        self.rollout_batches = []
+        self.tokenizer = _ChatTemplateTokenizer()
+        self.rollout_session_events = []
+        self.rollout_sync_count = 0
+        self.rollout_delay_s = 0.0
+        self.rollout_token_count = 0
+
+    def get_tokenizer(self):
+        return self.tokenizer
+
+    def dp_size(self):
+        return self.effective_dp_size
+
+    def rollout_token_batch(self, prompt_tokens, n_samples, sampling_params):
+        self.rollout_batches.append((prompt_tokens, n_samples))
+        tokens = prompt_tokens[0] if prompt_tokens else []
+        resp_count = min(4, len(tokens))
+        sequence = type("Seq", (), {"resp_tokens": list(tokens[:resp_count]),
+                                     "resp_logprobs": [-0.1] * resp_count})()
+        return [type("Rollout", (), {"sequences": [sequence]})()]
+
+    async def rollout_token_batch_async(self, prompt_tokens, n_samples, sampling_params):
+        if self.rollout_delay_s:
+            await asyncio.sleep(self.rollout_delay_s)
+        return self.rollout_token_batch(prompt_tokens, n_samples, sampling_params)
+
+    async def begin_rollout_session_async(self):
+        self.rollout_session_events.append("begin")
+
+    async def sync_rollout_session_async(self):
+        self.rollout_sync_count += 1
+
+    async def end_rollout_session_async(self):
+        self.rollout_session_events.append("end")
+
+
+def _infer_tool_call_parser_name(trainer):
+    return "json"
+
+
+# Patch the register function that the module uses
+agentic.infer_tool_call_parser_name = _infer_tool_call_parser_name
+
+
+# Override get_tool_call_parser to return a simple parser
+class _FakeToolCallParser:
+    def parse(self, content, tools, tool_choice):
+        result = type("ParseResult", (), {"tool_calls": []})()
+        return result
+
+
+agentic.get_tool_call_parser = lambda name: _FakeToolCallParser()
+
+
+# ---------------------------------------------------------------------------
+# Message constructor helpers
+# ---------------------------------------------------------------------------
+def _sys(content="You are a coder."):
+    return {"role": "system", "content": content}
+
+
+def _dev(content="You are a developer."):
+    return {"role": "developer", "content": content}
+
+
+def _usr(content="Write a sort function."):
+    return {"role": "user", "content": content}
+
+
+def _ast_no_tool(content="Here is the code..."):
+    return {"role": "assistant", "content": content}
+
+
+def _ast_with_tool_calls():
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": "call-1", "type": "function", "function": {"name": "write_file", "arguments": "{}"}}],
+    }
+
+
+def _ast_two_tool_calls():
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {"id": "call-1", "type": "function", "function": {"name": "write_file", "arguments": "{}"}},
+            {"id": "call-2", "type": "function", "function": {"name": "run_test", "arguments": "{}"}},
+        ],
+    }
+
+
+def _tool(call_id="call-1", name="write_file", content="ok"):
+    return {"role": "tool", "tool_call_id": call_id, "name": name, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# group_messages_into_units tests
+# ---------------------------------------------------------------------------
+def test_group_messages_into_units_basic():
+    from areno.api.openai_chat import group_messages_into_units
+
+    messages = [_sys(), _usr()]
+    units = group_messages_into_units(messages)
+    assert len(units) == 2
+    assert units[0] == [_sys()]
+    assert units[1] == [_usr()]
+
+
+def test_group_messages_into_units_system_preserved():
+    from areno.api.openai_chat import group_messages_into_units
+
+    messages = [_sys(), _usr(), _ast_with_tool_calls(), _tool(), _tool(), _usr()]
+    units = group_messages_into_units(messages)
+    assert len(units) == 4
+    assert units[0] == [_sys()]
+    assert units[1] == [_usr()]
+    assert units[2] == [_ast_with_tool_calls(), _tool(), _tool()]  # atomic
+    assert units[3] == [_usr()]
+
+
+def test_group_messages_into_units_developer_preserved():
+    from areno.api.openai_chat import group_messages_into_units
+
+    messages = [_dev(), _usr(), _ast_with_tool_calls(), _tool(), _usr()]
+    units = group_messages_into_units(messages)
+    assert len(units) == 4
+
+
+def test_group_messages_into_units_assistant_no_tool_is_own_unit():
+    from areno.api.openai_chat import group_messages_into_units
+
+    messages = [_usr(), _ast_no_tool(), _usr()]
+    units = group_messages_into_units(messages)
+    assert len(units) == 3
+    assert units[1] == [_ast_no_tool()]
+
+
+def test_group_messages_into_units_tool_without_assistant():
+    from areno.api.openai_chat import group_messages_into_units
+
+    messages = [_tool()]
+    units = group_messages_into_units(messages)
+    assert len(units) == 1
+    assert units[0] == [_tool()]
+
+
+def test_group_messages_into_units_empty():
+    from areno.api.openai_chat import group_messages_into_units
+
+    units = group_messages_into_units([])
+    assert units == []
+
+
+# ---------------------------------------------------------------------------
+# _trim_messages_to_fit tests
+# ---------------------------------------------------------------------------
+def test_trim_messages_fits_without_trim():
+    """No removable units: system + last user = 2 units, no gap."""
+    tok = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr()]
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=100, input_tokens=list(range(20))
+    )
+    assert result is None
+
+
+def test_trim_messages_removes_oldest_unit():
+    tok = _ChatTemplateTokenizer(tokens_per_message=50, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr("task 1"), _ast_no_tool("done"), _usr("task 2")]
+    # 4 msgs * 50 = 200 tokens; max=120 forces removal
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=120, input_tokens=list(range(300))
+    )
+    assert result is not None
+    # system preserved, latest user preserved → 2 removables: user1 + assistant
+    assert result["diagnostics"]["units_removed"] == 2
+    assert result["diagnostics"]["messages_removed"] == 2
+    assert result["diagnostics"]["preserved_instructions"] is True
+    # Only system + latest user remain
+    assert len(result["messages"]) == 2
+
+
+def test_trim_messages_preserves_system():
+    tok = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr("t1"), _ast_no_tool("d1"), _usr("t2"), _ast_no_tool("d2"), _usr("t3")]
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=45, input_tokens=list(range(100))
+    )
+    assert result is not None
+    roles = [msg["role"] for msg in result["messages"]]
+    assert roles[0] == "system"
+
+
+def test_trim_messages_preserves_latest_user_turn():
+    tok = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr("t1"), _ast_no_tool("d1"), _usr("latest")]
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=35, input_tokens=list(range(100))
+    )
+    assert result is not None
+    assert result["messages"][-1]["role"] == "user"
+    assert result["messages"][-1]["content"] == "latest"
+
+
+def test_trim_messages_keeps_tool_call_atomic():
+    tok = _ChatTemplateTokenizer(tokens_per_message=5, tools_overhead=5, gen_prompt_overhead=2)
+    messages = [
+        _sys(),
+        _usr("old task"),
+        _ast_with_tool_calls(),
+        _tool("call-1", "write", "result1"),
+        _tool("call-2", "lint", "result2"),
+        _usr("new task"),
+    ]
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=28, input_tokens=list(range(37))
+    )
+    assert result is not None
+    tool_count = sum(1 for m in result["messages"] if m["role"] == "tool")
+    assert tool_count == 2
+
+
+def test_trim_messages_impossible_to_fit():
+    tok = _ChatTemplateTokenizer(tokens_per_message=50, tools_overhead=0, gen_prompt_overhead=50)
+    messages = [_sys(), _usr("only one task")]
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=100, input_tokens=list(range(150))
+    )
+    assert result is None
+
+
+def test_trim_messages_multiple_tool_calls():
+    """If the assistant+tool unit is removed, its tool results go with it."""
+    tok = _ChatTemplateTokenizer(tokens_per_message=3, tools_overhead=3, gen_prompt_overhead=1)
+    messages = [
+        _sys(),
+        _usr("old"),
+        _ast_two_tool_calls(),
+        _tool("call-1", "write", "ok1"),
+        _tool("call-2", "test", "ok2"),
+        _usr("new"),
+    ]
+    # 6 * 3 + 3 + 1 = 22; max=12 forces removing both removable units
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=12, input_tokens=list(range(22))
+    )
+    assert result is not None
+    # Only system + latest user remain; tool unit was removed as one atom
+    n_tool = sum(1 for m in result["messages"] if m["role"] == "tool")
+    assert n_tool == 0
+
+
+def test_trim_messages_exact_boundary():
+    tok = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr("t1"), _ast_no_tool("d1"), _usr("t2")]
+    # 4 * 10 = 40 tokens; removing both t1 and d1 leaves 2 * 10 = 20 (exact boundary)
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=20, input_tokens=list(range(40))
+    )
+    assert result is not None
+    assert result["diagnostics"]["units_removed"] == 2
+    assert result["diagnostics"]["messages_removed"] == 2
+
+
+def test_trim_does_not_mutate_input():
+    tok = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr("t1"), _ast_no_tool("ok"), _usr("t2")]
+    original = [dict(m) for m in messages]
+    _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=25, input_tokens=list(range(40))
+    )
+    assert messages == original
+
+
+def test_trim_messages_with_tools_includes_overhead():
+    tok = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=30, gen_prompt_overhead=5)
+    messages = [_sys(), _usr("t1"), _ast_no_tool("ok"), _usr("t2")]
+    # 4 * 10 + 30 + 5 = 75 tokens; removing both removes yields 2 * 10 + 30 + 5 = 55
+    # max=60 > 55 so trimming should succeed
+    result = _trim_messages_to_fit(
+        tok, messages, tools=[{"type": "function"}], max_context_len=60, input_tokens=list(range(75))
+    )
+    assert result is not None
+    assert result["diagnostics"]["units_removed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# RolloutSession integration tests
+# ---------------------------------------------------------------------------
+def test_reject_policy_is_default():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.tokenizer = _ChatTemplateTokenizer(tokens_per_message=100)
+    params = _FakeSamplingParams()
+    params.max_prompt_len = 10
+    session = RolloutSession(
+        trainer,
+        sampling_params=params,
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+    )
+
+    async def run():
+        session._loop = asyncio.get_running_loop()
+        return await session._complete_chat(
+            {"model": "policy", "messages": [{"role": "user", "content": "long"}]}
+        )
+
+    response = asyncio.run(run())
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert trainer.rollout_batches == []
+
+
+def test_trim_messages_policy_trims_and_rolls_out():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.tokenizer = _ChatTemplateTokenizer(tokens_per_message=50, tools_overhead=0, gen_prompt_overhead=0)
+    params = _FakeSamplingParams()
+    params.max_prompt_len = 120
+    session = RolloutSession(
+        trainer,
+        sampling_params=params,
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+        agentic_context_overflow_policy="trim_messages",
+    )
+
+    async def run():
+        session._loop = asyncio.get_running_loop()
+        return await session._complete_chat(
+            {"model": "policy", "messages": [_sys(), _usr("old"), _ast_no_tool("old response"), _usr("new")]}
+        )
+
+    response = asyncio.run(run())
+    assert trainer.rollout_batches != []
+    assert "trim_info" in response.get("areno", {})
+
+
+def test_trim_messages_policy_impossible_returns_error():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.tokenizer = _ChatTemplateTokenizer(tokens_per_message=100, tools_overhead=0, gen_prompt_overhead=50)
+    params = _FakeSamplingParams()
+    params.max_prompt_len = 50
+    session = RolloutSession(
+        trainer,
+        sampling_params=params,
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+        agentic_context_overflow_policy="trim_messages",
+    )
+
+    async def run():
+        session._loop = asyncio.get_running_loop()
+        return await session._complete_chat(
+            {"model": "policy", "messages": [_sys(), _usr("only task")]}
+        )
+
+    response = asyncio.run(run())
+    assert response["choices"][0]["finish_reason"] == "length"
+    assert response["areno"].get("error") == "context_overflow"
+    assert trainer.rollout_batches == []
+
+
+def test_trim_messages_response_carries_effective_messages():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.tokenizer = _ChatTemplateTokenizer(tokens_per_message=50, tools_overhead=0, gen_prompt_overhead=0)
+    params = _FakeSamplingParams()
+    params.max_prompt_len = 120
+    session = RolloutSession(
+        trainer,
+        sampling_params=params,
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+        agentic_context_overflow_policy="trim_messages",
+    )
+
+    async def run():
+        session._loop = asyncio.get_running_loop()
+        return await session._complete_chat(
+            {"model": "policy", "messages": [_sys(), _usr("old"), _ast_no_tool("old"), _usr("new")]}
+        )
+
+    response = asyncio.run(run())
+    assert "effective_messages" in response.get("areno", {})
+
+
+def test_sample_from_trajectory_turn_uses_effective_messages():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.tokenizer = _ChatTemplateTokenizer(tokens_per_message=10, tools_overhead=0, gen_prompt_overhead=0)
+    session = RolloutSession(
+        trainer,
+        sampling_params=_FakeSamplingParams(),
+        loss_mask_policy=LossMaskPolicy(),
+        max_running_prompts=1,
+    )
+
+    full_messages = [_sys(), _usr("old"), _ast_no_tool("old"), _usr("new")]
+    effective_messages = [_sys(), _usr("new")]
+    item = type("Item", (), {"prompt": "test", "input_tokens": [1],
+                              "prompt_index": 0, "sample_index": 0, "record": {}})()
+    # AgentTrajectoryTurn.__post_init__ reads response["areno"] metadata
+    fake_response = {
+        "areno": {
+            "response_tokens": [10, 11],
+            "response_logprobs": [-0.5, -0.5],
+        }
+    }
+    turn = AgentTrajectoryTurn(
+        item=item,
+        messages=full_messages,
+        effective_messages=effective_messages,
+        response=fake_response,
+    )
+
+    sample = session._sample_from_trajectory_turn(turn)
+    # 2 msgs * 10 = 20 prompt tokens + 2 response = 22 total
+    assert len(sample.token_row) == 22
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+def test_cli_accepts_valid_policy():
+    from click.testing import CliRunner
+    from areno.cli.train import train_command
+
+    result = CliRunner().invoke(
+        train_command,
+        ["--help"],
+        standalone_mode=False,
+    )
+    assert "--agentic-context-overflow-policy" in result.output
+    assert "reject" in result.output
+    assert "trim_messages" in result.output
+
+
+def test_trainer_config_defaults_to_reject():
+    from areno.api.trainer_config import TrainerConfig
+
+    config = TrainerConfig(
+        algo="sft",
+        ckpt="dummy",
+        dataset_path="dummy",
+        dataset_loader_fn="dummy",
+    )
+    assert config.agentic_context_overflow_policy == "reject"
+
+
+def test_trainer_config_rejects_invalid_policy():
+    from areno.api.trainer_config import TrainerConfig
+
+    with pytest.raises(ValueError, match="agentic_context_overflow_policy"):
+        TrainerConfig(
+            algo="sft",
+            ckpt="dummy",
+            dataset_path="dummy",
+            dataset_loader_fn="dummy",
+            agentic_context_overflow_policy="invalid",
+        )
+
+
+# ---------------------------------------------------------------------------
+# unfittable response format test
+# ---------------------------------------------------------------------------
+def test_unfittable_chat_response_format():
+    resp = _unfittable_chat_response(model="test", prompt_tokens=500, max_sequence_len=100)
+    assert resp["choices"][0]["finish_reason"] == "length"
+    assert resp["areno"]["error"] == "context_overflow"
+    assert "detail" in resp["areno"]
+
+
+# ---------------------------------------------------------------------------
+# trim diagnostics format test
+# ---------------------------------------------------------------------------
+def test_trim_diagnostics_format():
+    tok = _ChatTemplateTokenizer(tokens_per_message=20, tools_overhead=0, gen_prompt_overhead=0)
+    messages = [_sys(), _usr("t1"), _ast_no_tool("ok"), _usr("t2")]
+    result = _trim_messages_to_fit(
+        tok, messages, tools=None, max_context_len=45, input_tokens=list(range(80))
+    )
+    assert result is not None
+    diag = result["diagnostics"]
+    assert diag["policy"] == "trim_messages"
+    assert "original_prompt_tokens" in diag
+    assert "effective_prompt_tokens" in diag
+    assert "units_removed" in diag
+    assert "messages_removed" in diag
+    assert "preserved_instructions" in diag


### PR DESCRIPTION
<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?


This PR adds a `trim_messages` context overflow policy for the Agentic Proxy path. Currently, when an agent's multi-turn conversation exceeds the model's context window, the existing `reject` policy returns empty responses — halting the agent entirely. With this change, the proxy automatically removes the oldest complete conversation units so the remaining prompt fits within the window, allowing long-running agentic trajectories to continue.

**Non-breaking**: the default `reject` behavior is fully preserved. SFT preprocessing, dataset construction, and non-agentic training paths are untouched.

---

<!-- A clear and concise description of the change and its motivation. -->

## Related issue


<!-- Link the issue this PR addresses so GitHub closes it on merge, e.g. "Fixes #123". -->

Fixes #200

## How to enable

```bash
areno train \
  --agentic-context-overflow-policy trim_messages \
  --trim-max-tokens 2048 \
  ...  # all other args unchanged
```

No new flags → no behavior change.

| Parameter | Type | Default | Description |
|---|---|---|---|
| `--agentic-context-overflow-policy` | `reject` \| `trim_messages` | `reject` | Context overflow strategy |
| `--trim-max-tokens` | `int` | `None` | Proxy trim threshold; falls back to `--max-context-len` or model max |

Full example:

```bash
areno train \
  --ckpt Qwen/Qwen3-0.6B \
  --dataset-path examples/agentic/coding/dataset.jsonl \
  --dataset-loader-fn examples/agentic/coding/dataset_loader.py \
  --reward-fn-path examples/agentic/coding/reward.py \
  --agent-fn examples/agentic/coding/run_agent.py \
  --algo gspo \
  --tp-size 1 --world-size 2 \
  --batch-size 2 --n-samples 1 \
  --trim-max-tokens 2048 \
  --agentic-context-overflow-policy trim_messages \
  --epochs 1
```

---

## Design Decisions

### 1. Trim by conversation units, not raw tokens

`group_messages_into_units()` splits the message list into indivisible atomic units:
- `system` / `developer` → each a unit
- `user` → one unit
- `assistant(tool_calls)` + all following `tool` messages → one atomic unit

Cutting at unit boundaries ensures **tool calls and their tool results are never separated**.

### 2. Protection strategy

- Leading `system`/`developer` instructions → **preserved**
- Trailing `user` request (current task) → **preserved**
- Oldest units in the middle → removed first

### 3. Real chat template rendering

After each unit removal, candidate messages are re-rendered with the model's `apply_chat_template` (including tool definitions, special tokens, and the generation prompt), ensuring **exact token counting** with no overhead leakage.

### 4. Decoupled Proxy/Trainer thresholds

- `--trim-max-tokens` (or model max): Proxy trim trigger — controls **per-request** prompt size
- `--max-context-len`: Trainer filter — controls **full trajectory** token count

Independent thresholds avoid the pitfall where "trainer filtering triggers before proxy trimming".

### 5. No in-place mutation

`pending.messages` remains untouched. Trimmed results flow through `_PendingChat._trimmed_messages` → `AgentTrajectoryTurn.effective_messages` → `_sample_from_trajectory_turn`. `turn.messages` always holds the full history; `effective_messages` is set only when trimming occurs.

### 6. Dead-end detection

When only `system` + `user` (the two protected units) remain but still exceed the limit (e.g., `--trim-max-tokens` set too low), a `RuntimeError` is raised immediately — no wasted nudge cycles.

---

---

## Verification

### Kaggle end-to-end (2×T4, Qwen3-0.6B, GSPO, coding agent dataset)

| Policy | `tool_calls` | Outcome |
|---|---|---|
| `reject` (default) | 0 | Agent stuck in nudge loop, zero tool invocations |
| `trim_messages` | 13 | Agent functions normally, proxy correctly trims overlong requests |

### Dead-end boundary test (128 tokens)

With `--trim-max-tokens 128`, a `RuntimeError` is raised cleanly — no wasted token cycles, no silent failure.


## Acceptance Criteria

| Requirement | Status |
|---|---|
| Requests already fitting → forwarded as-is | Trim only triggers on overflow |
| Default `reject` preserved | `"reject"` is the default value |
| CLI `--help` documented | `click.Choice` + `show_default=True` |
| Invalid CLI values rejected upfront | `click.Choice` rejects at parse time |
| Oldest-first unit removal | `group_messages_into_units` + preserved markers |
| system/developer + latest user preserved | Head/tail unit protection |
| assistant tool_call not split from tool results | Atomic unit grouping |
| tool definitions + overhead counted | Real chat template rendering for every candidate |
| Unfittable → actionable error | `_unfittable_chat_response` / `RuntimeError` for dead ends |
| Input messages not mutated | Unit list copied; `pending.messages` never touched |
| Rollout/training metadata matches trimmed prompt | `AgentTrajectoryTurn.effective_messages` field |
| No impact on SFT / non-agentic paths | Changes confined to agentic proxy pathway only |

---

## PR Checklist

<!-- Select ONE that best describes this PR. -->

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

**CPU tests (no GPU required):**

```bash
pytest tests/test_agentic_context_overflow_cpu.py -v
# 26 passed
```
<img width="1512" height="982" alt="截屏2026-07-29 18 01 56" src="https://github.com/user-attachments/assets/96e09de3-8683-4fbd-87d5-3d0c3fc47cf9" />


Coverage breakdown:
- Message grouping: 6 tests
- Trim algorithm: 10 tests
- RolloutSession integration: 5 tests
- CLI / config validation: 3 tests
- Response format: 2 tests

**GPU end-to-end smoke test (Kaggle, 2×Tesla T4):**

```bash
areno train \
  --ckpt Qwen/Qwen3-0.6B \
  --dataset-path examples/agentic/coding/dataset.jsonl \
  --dataset-loader-fn examples/agentic/coding/dataset_loader.py \
  --reward-fn-path examples/agentic/coding/reward.py \
  --agent-fn examples/agentic/coding/run_agent.py \
  --algo gspo \
  --tp-size 1 --world-size 2 \
  --batch-size 2 --n-samples 1 \
  --trim-max-tokens 1534 \
  --agentic-context-overflow-policy trim_messages \
  --epochs 1
```

Hardware limitation: tested on 2×T4 (15 GB VRAM each), so `--trim-max-tokens` was capped at 1534. With larger GPUs, the threshold can be adjusted upward. The trim logic itself is token-count agnostic.

<img width="1512" height="982" alt="截屏2026-07-29 17 03 04" src="https://github.com/user-attachments/assets/4a1d7de2-83be-4957-9a29-3877df9d1603" />


**Dead-end boundary test:**

```bash
areno train ... --trim-max-tokens 128 --agentic-context-overflow-policy trim_messages
# → RuntimeError raised cleanly (system + user alone exceeded 128 tokens)
```

<img width="1512" height="982" alt="截屏2026-07-29 18 11 05" src="https://github.com/user-attachments/assets/a44fdec7-b076-4d47-857a-b0c29a3b9ed0" />


**Running under the reject strategy test:**

```bash
areno train ...  --agentic-context-overflow-policy reject
With reject policy: tool_calls=0, tool_results=0 — the prompt got rejected for exceeding max context, so the agent never actually executed anything.
```
<img width="1512" height="982" alt="截屏2026-07-29 17 39 12" src="https://github.com/user-attachments/assets/35bc2dfa-880a-4e06-9e67-805b48199e56" />


## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Breaking change details

No breaking changes. The new `--agentic-context-overflow-policy` and `--trim-max-tokens` CLI options are additive:
- Default `agentic_context_overflow_policy="reject"` preserves all existing behavior.
- Omitting both new flags → identical behavior to before this PR.
- Existing `--max-context-len` behavior is unchanged.
- No existing API signatures, config fields, or data structures were modified.

<!-- If this is a breaking change, describe what breaks and how users should migrate. Otherwise delete this section. -->
