### PR TITLE
feat(agentic): add 6x6 Othello adversarial RL example

### DIFF
--- a/examples/agentic/othello/README.md
+++ b/examples/agentic/othello/README.md
@@ -1,0 +1,143 @@
+# Agentic 6x6 Othello Example
+
+This example trains a policy to choose one 6x6 Othello move for the side to
+move from a rendered board. The environment is deterministic, self-contained,
+and reusable: legal-move enumeration with 8-direction line flipping, placement,
+forced-pass handling, two-consecutive-pass terminal detection, and terminal
+scoring.
+
+The example **adds no code to `areno/`** and registers nothing. AReno discovers
+it purely by file paths passed to the existing `areno train` flags.
+
+## Files
+
+- `game.py` — pure 6x6 Othello rules (board validation, `legal_moves`,
+  `apply_move`, `flips_for`, `score_board`, terminal detection, move parsing,
+  and the `score_move` reward kernel). No AReno imports.
+- `dataset_generator.py` — generates reproducible, *reachable* opening
+  positions by playing only legal moves from the standard opening.
+- `dataset_loader.py` — `load_training_dataset(...) -> list[dict]`, converting
+  JSONL boards into Areno prompt records.
+- `run_agent.py` — `async def run_agent(ctx, batch) -> AgentTrajectory` issuing
+  one OpenAI-compatible tool-call request per board (the `choose_move` tool
+  takes `row` and `col`, each bounded to `0..5`).
+- `reward.py` — `def reward_fn(record) -> float`, parsing the `choose_move`
+  tool call and scoring it with `game.score_move`.
+- `opponent.py` — seeded random opponent + self-play evaluation harness. Runs
+  fully offline (no LLM, no network, no database).
+
+## Input contract
+
+- Board: a 6x6 list of rows of `B`, `W`, `.`.
+- `choose_move` tool: `{"row": int, "col": int}` with `0 <= row,col <= 5`,
+  `required=["row","col"]`, `additionalProperties=False`.
+- XML no-tool action (optional): `<move>r,c</move>`.
+
+## Defaults and reward convention
+
+`score_move(board, move, player)` uses a **tiered** reward so a GSPO group with
+mixed outcomes always has a non-zero gradient:
+
+- No `choose_move` tool call, or its arguments could not be parsed → `-1.0`
+  (worst tier; the model produced no actionable call). The reward function
+  never raises.
+- A `choose_move` call with an **out-of-range** coordinate → `-0.5`. Illegal,
+  but the model did emit a call with integers, so it beats doing nothing.
+- A `choose_move` call with an **in-range but illegal** cell (occupied, or no
+  flanked line) → `-0.3`. Better than out-of-range: a real cell was targeted.
+- A **legal, non-terminal** move → `+0.4`.
+- A legal move that **ends the game** leaving `player` ahead → `+1.0`.
+
+The illegal tiers are deliberately separated from the no-call tier (`-1.0`).
+With a flat `-1.0` for every illegal action and every absent call, the
+group-relative advantage for "called the tool with a bad cell" equals that of
+"called no tool", so the gradient that suppresses a bad cell also suppresses
+tool calling itself — driving `tool_calls` to zero and freezing reward at
+`-1.0` with no gradient to recover (a cold-start collapse observed on a 0.6B
+policy). The tiers make "keep calling the tool" strictly better than "stop",
+so the policy is structurally pulled toward continued tool use. Defaults
+(count=128, seed=2026, max-plies=8) produce Black-to-move, non-terminal,
+reachable openings.
+
+## Generate Opening Boards
+
+```bash
+python examples/agentic/othello/dataset_generator.py \
+  --output /tmp/areno-othello-boards.jsonl \
+  --count 2048 \
+  --seed 2026 \
+  --max-plies 8
+```
+
+Invalid inputs (`--count <= 0`, `--seed < 0`, `--max-plies < 0`) raise a clear
+`ValueError` before any boards are generated.
+
+## Run with Tool Calls (training)
+
+```bash
+areno train \
+  --ckpt Qwen/Qwen3-1.7B \
+  --dataset-path /tmp/areno-othello-boards.jsonl \
+  --dataset-loader-fn examples/agentic/othello/dataset_loader.py \
+  --reward-fn-path examples/agentic/othello/reward.py \
+  --agent-fn examples/agentic/othello/run_agent.py \
+  --algo gspo \
+  --batch-size 2 \
+  --n-samples 4 \
+  --max-new-tokens 64 \
+  --max-context-len 1024
+```
+
+If `--dataset-path` is missing or points at a directory without `boards.jsonl`,
+the loader falls back to generating boards inline with the default seed.
+
+## Offline Self-Play Evaluation (no LLM / no network)
+
+The acceptance harness plays the policy against a seeded random opponent and
+reports **win rate** and **invalid-move rate** over reproducible matches:
+
+```bash
+python examples/agentic/othello/opponent.py \
+  --n-games 20 \
+  --seed 2026 \
+  --policy greedy \
+  --policy-side B \
+  --max-steps 80
+```
+
+Example output (deterministic for a given seed):
+
+```
+6x6 Othello self-play evaluation
+  games          : 20
+  policy side    : B
+  win rate       : 0.800
+  draw rate      : 0.100
+  invalid rate   : 0.000
+```
+
+Structured JSON (full per-match breakdown) is also printed (or written with
+`--output`). The policy choices are `random` (the demo) and `greedy`
+(most-discs-flipped). Both use the same seeded RNG as the random opponent, so
+every match is fully reproducible.
+
+## Observable outputs
+
+- During `areno train`: `rollout/rewards_mean|std|max|min`,
+  `rollout/accuracy` (proxy win rate), `rollout/response_len_mean`, and the
+  other auto metrics Areno records, plus the standard run-config and rollout
+  artifacts under `metrics_log_dir`.
+- Offline evaluation: a human-readable summary plus a structured JSON report
+  with `win_rate`, `draw_rate`, `invalid_move_rate`, and per-match
+  `{winner, black, white, steps, passes, invalid, terminal}`.
+
+## Limitations
+
+- 6x6 only; the board size is fixed and validated.
+- The reward is terminal-led but uses tiered shaping (legal `+0.4`, in-range
+  illegal `-0.3`, out-of-range `-0.5`, no-call `-1.0`) to break the cold-start
+  zero-gradient lock; it is not a dense per-flip or disc-count reward.
+- The offline harness ships `random`/`greedy` policies; wiring an LLM policy is
+  done by providing a `policy_fn(board, player, rng) -> (row,col)|None` that
+  calls your served model.
+- No external database, sandbox, or heavyweight dependency is required or added.

--- a/examples/agentic/othello/dataset_generator.py
+++ b/examples/agentic/othello/dataset_generator.py
@@ -1,0 +1,114 @@
+"""Generate 6x6 Othello openings for the agentic example.
+
+Produces deterministic, *reachable* opening positions by playing only legal
+moves from the standard opening. Never emits arbitrary/invalid boards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = 2026
+DEFAULT_MAX_PLIES = 8
+
+
+def generate_records(
+    count: int = DEFAULT_COUNT,
+    *,
+    seed: int = DEFAULT_SEED,
+    max_plies: int = DEFAULT_MAX_PLIES,
+) -> list[dict]:
+    """Generate reproducible reachable opening positions where Black is to move.
+
+    Each board is built by playing a random *legal* move sequence from the
+    standard opening, alternating players, for a small random number of plies.
+    The resulting board is kept only if the game is non-terminal and it is
+    Black's turn; otherwise more attempts are tried.
+    """
+
+    if count <= 0:
+        raise ValueError("--count must be positive")
+    if seed < 0:
+        raise ValueError("--seed must be non-negative")
+    if max_plies < 0:
+        raise ValueError("--max-plies must be non-negative")
+
+    rng = random.Random(seed)
+    records: list[dict] = []
+    seen: set[tuple[tuple[str, ...], ...]] = set()
+    attempts = 0
+    while len(records) < count:
+        attempts += 1
+        if attempts > count * 200:
+            raise RuntimeError("could not generate enough unique Othello openings")
+        board = _random_opening(rng, max_plies)
+        if game.is_terminal(board):
+            continue
+        if game.next_player(board) != "B":
+            continue
+        key = tuple(tuple(row) for row in board)
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append({"id": f"generated-{len(records):05d}", "board": board})
+    return records
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write generated records as JSONL."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def _random_opening(rng: random.Random, max_plies: int) -> game.Board:
+    """Play a random legal-move prefix of an Othello game from the opening."""
+
+    board = game.new_board()
+    player = "B"
+    plies = rng.randint(0, max_plies)
+    for _ in range(plies):
+        moves = game.legal_moves(board, player)
+        if not moves:
+            # Forced pass: the other side keeps the turn.
+            player = game.opponent(player)
+            moves = game.legal_moves(board, player)
+            if not moves:
+                break
+        move = rng.choice(moves)
+        board = game.apply_move(board, move[0], move[1], player)
+        player = game.opponent(player)
+    return board
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate JSONL boards for the Areno 6x6 Othello agentic example."
+    )
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of boards to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed.")
+    parser.add_argument("--max-plies", type=int, default=DEFAULT_MAX_PLIES, help="Max opening plies.")
+    args = parser.parse_args()
+
+    records = generate_records(args.count, seed=args.seed, max_plies=args.max_plies)
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/othello/dataset_loader.py
+++ b/examples/agentic/othello/dataset_loader.py
@@ -1,0 +1,48 @@
+"""Dataset loader for the 6x6 Othello tool-call example."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader=None, **_: object) -> list[dict]:
+    """Load JSONL boards and convert them to Areno prompt records."""
+
+    del default_loader
+    records = _load_records(dataset_path)
+    return [_format_record(raw, idx) for idx, raw in enumerate(records, start=1)]
+
+
+def _load_records(dataset_path: str) -> list[dict]:
+    path = Path(dataset_path).expanduser()
+    if path.is_dir():
+        path = path / "boards.jsonl"
+    if not path.exists():
+        return dataset_generator.generate_records()
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_record(raw: dict, index: int) -> dict:
+    board = game.normalize_board(raw["board"])
+    player = raw.get("player", game.next_player(board) or "B")
+    if player not in game.PLAYERS:
+        raise ValueError(f"record player must be B or W, got {player!r}")
+    return {
+        "id": raw.get("id", f"board-{index:05d}"),
+        "prompt": game.format_prompt(board, player),
+        "board": board,
+        "player": player,
+        "valid_moves": game.legal_moves(board, player),
+    }

--- a/examples/agentic/othello/game.py
+++ b/examples/agentic/othello/game.py
@@ -1,0 +1,380 @@
+"""Small 6x6 Othello helpers for agentic examples.
+
+Pure-Python rules: legal-move enumeration, placement with 8-direction line
+flipping, forced-pass handling, two-consecutive-pass terminal detection, and
+terminal scoring. No AReno imports, no registration.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+SIZE = 6
+Board = list[list[str]]
+PLAYERS = ("B", "W")
+EMPTY = "."
+
+# All eight line directions (dr, dc).
+DIRECTIONS = [
+    (-1, -1), (-1, 0), (-1, 1),
+    (0, -1), (0, 1),
+    (1, -1), (1, 0), (1, 1),
+]
+
+_XML_MOVE_RE = re.compile(r"<move>\s*(\d{1,2})\s*,\s*(\d{1,2})\s*</move>", re.IGNORECASE | re.DOTALL)
+_THINK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
+_CHAT_SPECIAL_RE = re.compile(r"<\|[^>]+?\|>|</?s>", re.IGNORECASE)
+
+
+def new_board() -> Board:
+    """Return the standard 6x6 Othello opening position (4 center discs)."""
+
+    board = [[EMPTY for _ in range(SIZE)] for _ in range(SIZE)]
+    mid = SIZE // 2
+    board[mid - 1][mid - 1] = "W"
+    board[mid - 1][mid] = "B"
+    board[mid][mid - 1] = "B"
+    board[mid][mid] = "W"
+    return board
+
+
+def normalize_board(board: Iterable[Iterable[str]]) -> Board:
+    """Return a validated 6x6 Othello board."""
+
+    rows = [[str(cell).upper() if str(cell) != EMPTY else EMPTY for cell in row] for row in board]
+    if len(rows) != SIZE or any(len(row) != SIZE for row in rows):
+        raise ValueError(f"Othello board must be {SIZE}x{SIZE}")
+    allowed = {"B", "W", EMPTY}
+    for r, row in enumerate(rows):
+        for c, cell in enumerate(row):
+            if cell not in allowed:
+                raise ValueError(f"Othello cells must be B, W, or .; got {cell!r} at ({r},{c})")
+    return rows
+
+
+def opponent(player: str) -> str:
+    """Return the other player."""
+
+    player = player.upper()
+    if player == "B":
+        return "W"
+    if player == "W":
+        return "B"
+    raise ValueError(f"player must be B or W, got {player!r}")
+
+
+def count_disks(board: Board) -> dict[str, int]:
+    """Return {"B": n, "W": m, ".": empty} counts."""
+
+    board = normalize_board(board)
+    counts = {"B": 0, "W": 0, EMPTY: 0}
+    for row in board:
+        for cell in row:
+            counts[cell] += 1
+    return counts
+
+
+def _in_bounds(row: int, col: int) -> bool:
+    return 0 <= row < SIZE and 0 <= col < SIZE
+
+
+def flips_for(board: Board, row: int, col: int, player: str) -> list[tuple[int, int]]:
+    """Return the opponent disks that would flip if ``player`` plays (row, col).
+
+    Empty (and the move is illegal) if the cell is non-empty, out of bounds, or
+    no direction sandwiches opponent discs.
+    """
+
+    board = normalize_board(board)
+    player = player.upper()
+    if player not in PLAYERS:
+        raise ValueError(f"player must be B or W, got {player!r}")
+    if not _in_bounds(row, col):
+        return []
+    if board[row][col] != EMPTY:
+        return []
+    other = opponent(player)
+    flipped: list[tuple[int, int]] = []
+    for dr, dc in DIRECTIONS:
+        line: list[tuple[int, int]] = []
+        r, c = row + dr, col + dc
+        while _in_bounds(r, c) and board[r][c] == other:
+            line.append((r, c))
+            r += dr
+            c += dc
+        # A flip closes the bracket only if the far end is the mover's own disc.
+        if line and _in_bounds(r, c) and board[r][c] == player:
+            flipped.extend(line)
+    return flipped
+
+
+def legal_moves(board: Board, player: str) -> list[tuple[int, int]]:
+    """Return all legal (row, col) moves for ``player``. Empty list forces a pass."""
+
+    board = normalize_board(board)
+    player = player.upper()
+    moves = [
+        (r, c)
+        for r in range(SIZE)
+        for c in range(SIZE)
+        if board[r][c] == EMPTY and flips_for(board, r, c, player)
+    ]
+    return moves
+
+
+def has_legal_move(board: Board, player: str) -> bool:
+    """Cheap check for whether ``player`` has any legal move."""
+
+    return bool(legal_moves(board, player))
+
+
+def apply_move(board: Board, row: int, col: int, player: str) -> Board:
+    """Apply a legal move, flipping all captured discs. Returns a new board."""
+
+    board = normalize_board(board)
+    player = player.upper()
+    if player not in PLAYERS:
+        raise ValueError(f"player must be B or W, got {player!r}")
+    if not _in_bounds(row, col):
+        raise ValueError(f"Othello move out of bounds: ({row},{col})")
+    if (row, col) not in legal_moves(board, player):
+        raise ValueError(f"illegal Othello move: ({row},{col}) for {player}")
+    flipped = flips_for(board, row, col, player)
+    next_board = [list(row_values) for row_values in board]
+    next_board[row][col] = player
+    for r, c in flipped:
+        next_board[r][c] = player
+    return next_board
+
+
+def is_terminal(board: Board) -> bool:
+    """Terminal when neither player has a legal move (two consecutive passes)."""
+
+    board = normalize_board(board)
+    return not has_legal_move(board, "B") and not has_legal_move(board, "W")
+
+
+def score_board(board: Board) -> dict[str, Any]:
+    """Return terminal counts and winner (count-majority, draw on tie)."""
+
+    counts = count_disks(board)
+    black = counts["B"]
+    white = counts["W"]
+    if black > white:
+        winner = "B"
+    elif white > black:
+        winner = "W"
+    else:
+        winner = "draw"
+    return {"black": black, "white": white, "winner": winner}
+
+
+def next_player(board: Board) -> str | None:
+    """Infer the side to move from disc counts (Black moves first).
+
+    Returns ``None`` when the counts are not consistent with a reachable game
+    (e.g. equal counts) - the caller is then expected to track turns explicitly.
+    """
+
+    counts = count_disks(board)
+    black = counts["B"]
+    white = counts["W"]
+    total = black + white
+    if total % 2 == 0:
+        # After an even number of discs it is Black's turn in a normal game.
+        return "B" if black == white else None
+    # Odd disc count (after a pass imbalance) generally means White to move.
+    return "W" if white == black - 1 else None
+
+
+def strip_think_tags(text: str) -> str:
+    """Remove reasoning spans before parsing the policy action."""
+
+    return _THINK_RE.sub(" ", text)
+
+
+def strip_chat_special_tokens(text: str) -> str:
+    """Remove chat-template sentinels that may trail generated text."""
+
+    return _CHAT_SPECIAL_RE.sub(" ", text)
+
+
+def parse_move(text: str) -> tuple[int, int] | None:
+    """Extract the final XML ``<move>r,c</move>`` from a model response.
+
+    Returns ``None`` on any malformed input (never raises).
+    """
+
+    text = strip_chat_special_tokens(strip_think_tags(text)).strip()
+    matches = list(_XML_MOVE_RE.finditer(text))
+    if not matches:
+        return None
+    row = int(matches[-1].group(1))
+    col = int(matches[-1].group(2))
+    if not _in_bounds(row, col):
+        return None
+    return row, col
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_tool_move(tool_calls: list[dict]) -> tuple[int, int] | None:
+    """Extract the (row, col) from ``choose_move`` tool calls.
+
+    Accepts ``arguments`` as a dict or JSON string with ``row``/``col``. Returns
+    ``None`` on any malformed or missing tool call (never raises).
+    """
+
+    parsed = parse_tool_move_raw(tool_calls)
+    if parsed is None:
+        return None
+    row, col = parsed
+    if not _in_bounds(row, col):
+        return None
+    return row, col
+
+
+def parse_tool_move_raw(tool_calls: list[dict]) -> tuple[int, int] | None:
+    """Like :func:`parse_tool_move` but keeps out-of-bounds coordinates.
+
+    Returns the raw ``(row, col)`` for the first ``choose_move`` call whose
+    ``arguments`` parse to two integers, even when the coordinates are out of
+    range. Used by the reward function to distinguish "the model emitted a
+    ``choose_move`` tool call with a bad coordinate" from "the model emitted no
+    ``choose_move`` call at all" — the two cases need different reward tiers so
+    that penalizing an illegal move does not also suppress tool-calling behavior
+    and lock the policy into producing no tool calls (a cold-start collapse).
+    Returns ``None`` when no ``choose_move`` call is present, its arguments are
+    not a dict/JSON, or the coordinates are not integers. Never raises.
+    """
+
+    import json
+
+    for call in tool_calls or []:
+        name = call.get("name") if isinstance(call, dict) else None
+        if name != "choose_move":
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(arguments, dict):
+            return None
+        row = _coerce_int(arguments.get("row"))
+        col = _coerce_int(arguments.get("col"))
+        if row is None or col is None:
+            return None
+        return row, col
+    return None
+
+
+def board_to_text(board: Board) -> str:
+    """Render the board; empty cells show their ``(row,col)`` label."""
+
+    board = normalize_board(board)
+    rows = []
+    for r, row in enumerate(board):
+        cells = [f"({r},{c})" if cell == EMPTY else cell for c, cell in enumerate(row)]
+        rows.append(" ".join(f"{cell:>5}" for cell in cells))
+    return "\n".join(rows)
+
+
+def format_prompt(board: Board, player: str) -> str:
+    """Build the one-step prompt for the tool-call agent."""
+
+    player = player.upper()
+    moves = legal_moves(board, player)
+    moves_text = ", ".join(f"({r},{c})" for r, c in moves) if moves else "pass (no legal move)"
+    side = "Black (B)" if player == "B" else "White (W)"
+    return (
+        f"You are playing 6x6 Othello as {side}. Choose the best legal next move.\n\n"
+        "Rules:\n"
+        "- B and W are already-placed discs.\n"
+        "- Labels like (row,col) on empty cells are coordinate references, not discs.\n"
+        "- A legal move must flank one or more opponent discs in a straight line "
+        "(horizontal, vertical, or diagonal) between the new disc and another of yours.\n"
+        "- Legal moves flip the flanked opponent discs to your color.\n"
+        "- Choose exactly one legal move by calling the choose_move tool with row and col.\n"
+        "- Avoid passing (a pass only happens when you have no legal move).\n\n"
+        f"Legal moves for you: {moves_text}\n\n"
+        f"Board:\n{board_to_text(board)}\n\nMove:"
+    )
+
+
+def format_xml_prompt(board: Board, player: str) -> str:
+    """Build the one-step prompt for the XML no-tool agent."""
+
+    player = player.upper()
+    moves = legal_moves(board, player)
+    moves_text = ", ".join(f"({r},{c})" for r, c in moves) if moves else "pass (no legal move)"
+    side = "Black (B)" if player == "B" else "White (W)"
+    return (
+        f"You are playing 6x6 Othello as {side}. Choose the best legal next move.\n\n"
+        "Rules:\n"
+        "- B and W are already-placed discs.\n"
+        "- Labels like (row,col) on empty cells are coordinate references, not discs.\n"
+        "- A legal move must flank opponent discs in a straight line between the new "
+        "disc and another of yours; the flanked discs flip to your color.\n"
+        "- Choose only one of the legal moves shown on the board.\n"
+        "- Answer with exactly one XML tag such as <move>2,3</move>.\n\n"
+        f"Legal moves for you: {moves_text}\n\n"
+        f"Board:\n{board_to_text(board)}\n\nMove:"
+    )
+
+
+def score_move(board: Board, move: tuple[int, int] | None, player: str) -> float:
+    """Score one move using a *tiered* reward kernel.
+
+    The tiers are deliberately distinct so that, in a GSPO group, samples with
+    different outcomes get different advantages and thus a non-zero gradient.
+    Critically, the tiers separate *what the model did*:
+
+    - ``None`` (no ``choose_move`` tool call was emitted, or its arguments
+      could not be parsed) -> ``-1.0``. This is the worst tier: the model did
+      not even produce an actionable tool call.
+    - The coordinates were emitted but out of range -> ``-0.5``. Still an
+      illegal action, but the model at least produced a ``choose_move`` call
+      with integers, so it is better than emitting nothing.
+    - The coordinates are in range but the cell is not a legal Othello move
+      (occupied, or no flanked line) -> ``-0.3``. Better than out-of-range:
+      the model targeted a real cell.
+    - A legal, non-terminal move -> ``+0.4``. The model took a real, legal,
+      in-play action.
+    - A legal move that ends the game leaving ``player`` ahead -> ``+1.0``.
+
+    Separating the illegal tiers from the ``None`` tier is what prevents the
+    cold-start collapse seen with a flat ``-1.0`` penalty: when every illegal
+    action and every absent tool call share the same reward, the group-relative
+    advantage for "called the tool with a bad cell" equals that of "called no
+    tool", so the gradient that suppresses bad cells also suppresses tool
+    calling itself, driving ``tool_calls`` to zero and freezing reward at
+    ``-1.0`` with no gradient to recover. The reward function never raises.
+    """
+
+    player = player.upper()
+    if move is None:
+        return -1.0
+    row, col = move
+    if player not in PLAYERS:
+        return -1.0
+    if not _in_bounds(row, col):
+        return -0.5
+    board = normalize_board(board)
+    if board[row][col] != EMPTY or not flips_for(board, row, col, player):
+        return -0.3
+    next_board = apply_move(board, row, col, player)
+    if not is_terminal(next_board):
+        return 0.4
+    result = score_board(next_board)
+    if result["winner"] == player:
+        return 1.0
+    return 0.0

--- a/examples/agentic/othello/opponent.py
+++ b/examples/agentic/othello/opponent.py
@@ -1,0 +1,183 @@
+"""Seeded random opponent and self-play evaluation harness for 6x6 Othello.
+
+Pure Python / CPU: no LLM, no network, no database. Provides the acceptance
+harness (seeded random opponent, win rate + invalid-move rate) plus a CLI demo
+that runs out of the box.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+PolicyFn = "callable[[list[list[str]], str, random.Random], tuple[int, int] | None]"
+
+
+def random_opponent_pick(board: game.Board, player: str, rng: random.Random) -> tuple[int, int] | None:
+    """Return a uniform random legal move, or ``None`` to pass when forced."""
+
+    moves = game.legal_moves(board, player)
+    return rng.choice(moves) if moves else None
+
+
+def greedy_opponent_pick(board: game.Board, player: str, rng: random.Random) -> tuple[int, int] | None:
+    """Return a legal move flipping the most discs (ties broken by seed)."""
+
+    moves = game.legal_moves(board, player)
+    if not moves:
+        return None
+    scored = [(len(game.flips_for(board, r, c, player)), r, c) for r, c in moves]
+    best = max(score[0] for score in scored)
+    choices = [(r, c) for _, r, c in scored if _ == best]
+    return rng.choice(choices)
+
+
+def play_match(
+    policy_fn: PolicyFn,
+    *,
+    policy_side: str = "B",
+    seed: int = 2026,
+    max_steps: int = 100,
+) -> dict:
+    """Play one game: ``policy_fn`` vs a seeded random opponent.
+
+    ``policy_fn(board, player, rng)`` returns ``(row, col) | None`` (None = no
+    move / pass). Both sides draw from the same seeded RNG so the match is fully
+    reproducible. Returns a structured result dict.
+    """
+
+    if max_steps <= 0:
+        raise ValueError("--max-steps must be positive")
+    if seed < 0:
+        raise ValueError("--seed must be non-negative")
+
+    rng = random.Random(seed)
+    board = game.new_board()
+    player = "B"
+    passes = 0
+    invalid = 0
+    steps = 0
+
+    while steps < max_steps and not game.is_terminal(board):
+        steps += 1
+        is_policy = player == policy_side
+        if is_policy:
+            move = policy_fn(board, player, rng)
+        else:
+            move = random_opponent_pick(board, player, rng)
+        if move is None:
+            # No move chosen -> treat as a pass (only legal when no moves exist).
+            if game.has_legal_move(board, player):
+                invalid += 1 if is_policy else 0
+            passes += 1
+            player = game.opponent(player)
+            continue
+        if move not in game.legal_moves(board, player):
+            invalid += 1 if is_policy else 0
+            player = game.opponent(player)
+            continue
+        board = game.apply_move(board, move[0], move[1], player)
+        player = game.opponent(player)
+        # If the next player has no legal move, they pass automatically.
+        if not game.has_legal_move(board, player):
+            passes += 1
+            player = game.opponent(player)
+
+    result = game.score_board(board)
+    return {
+        "winner": result["winner"],
+        "black": result["black"],
+        "white": result["white"],
+        "steps": steps,
+        "passes": passes,
+        "invalid": invalid,
+        "policy_side": policy_side,
+        "terminal": game.is_terminal(board),
+    }
+
+
+def evaluate(
+    policy_fn: PolicyFn,
+    n_games: int = 20,
+    *,
+    seed: int = 2026,
+    max_steps: int = 100,
+    policy_side: str = "B",
+) -> dict:
+    """Aggregate win rate and invalid-move rate over ``n_games`` seeded matches."""
+
+    if n_games <= 0:
+        raise ValueError("--n-games must be positive")
+
+    wins = 0
+    draws = 0
+    invalid_total = 0
+    games: list[dict] = []
+    for i in range(n_games):
+        game_seed = seed + i
+        match = play_match(policy_fn, policy_side=policy_side, seed=game_seed, max_steps=max_steps)
+        games.append(match)
+        if match["winner"] == policy_side:
+            wins += 1
+        elif match["winner"] == "draw":
+            draws += 1
+        invalid_total += match["invalid"]
+
+    summary = {
+        "n_games": n_games,
+        "win_rate": wins / n_games,
+        "draw_rate": draws / n_games,
+        "invalid_move_rate": invalid_total / n_games,
+        "policy_side": policy_side,
+    }
+    return {"summary": summary, "games": games}
+
+
+def _print_summary(report: dict) -> None:
+    summary = report["summary"]
+    print("6x6 Othello self-play evaluation")
+    print(f"  games          : {summary['n_games']}")
+    print(f"  policy side    : {summary['policy_side']}")
+    print(f"  win rate       : {summary['win_rate']:.3f}")
+    print(f"  draw rate      : {summary['draw_rate']:.3f}")
+    print(f"  invalid rate   : {summary['invalid_move_rate']:.3f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run a CPU-only 6x6 Othello self-play evaluation against a seeded random opponent."
+    )
+    parser.add_argument("--n-games", type=int, default=20, help="Number of matches to play.")
+    parser.add_argument("--seed", type=int, default=2026, help="Base random seed.")
+    parser.add_argument("--max-steps", type=int, default=100, help="Max steps per match.")
+    parser.add_argument(
+        "--policy", choices=["random", "greedy"], default="random", help="Policy (the random opponent is always random)."
+    )
+    parser.add_argument("--policy-side", choices=["B", "W"], default="B", help="Side the policy plays.")
+    parser.add_argument("--output", "-o", default="-", help="Write JSON report to this path, or '-' for stdout.")
+    args = parser.parse_args()
+
+    if args.policy == "greedy":
+        def policy_fn(board, player, rng):  # noqa: ANN001
+            return greedy_opponent_pick(board, player, rng)
+    else:
+        def policy_fn(board, player, rng):  # noqa: ANN001
+            return random_opponent_pick(board, player, rng)
+
+    report = evaluate(policy_fn, args.n_games, seed=args.seed, max_steps=args.max_steps, policy_side=args.policy_side)
+    _print_summary(report)
+    payload = json.dumps(report, indent=2, default=str)
+    if args.output == "-":
+        print(payload)
+    else:
+        Path(args.output).expanduser().write_text(payload + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/othello/reward.py
+++ b/examples/agentic/othello/reward.py
@@ -1,0 +1,25 @@
+"""Reward function for the 6x6 Othello tool-call example."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def reward_fn(record: Any) -> float:
+    """Score one completion by extracting the choose_move tool call.
+
+    Uses :func:`game.parse_tool_move_raw` (keeps out-of-range coordinates) so
+    that :func:`game.score_move` can apply its tiered rewards: a tool call with
+    a bad coordinate is a different (less negative) tier than no tool call at
+    all, which prevents the policy from collapsing to "never call the tool".
+    """
+
+    source = record.source_record
+    board = game.normalize_board(source["board"])
+    player = source.get("player", "B")
+    return game.score_move(board, game.parse_tool_move_raw(record.tool_calls), player)

--- a/examples/agentic/othello/run_agent.py
+++ b/examples/agentic/othello/run_agent.py
@@ -1,0 +1,93 @@
+"""Agent entrypoint for one-step 6x6 Othello tool-call rollouts."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are a careful 6x6 Othello player. You are given the current board and "
+    "your color. Choose exactly one legal move by calling the choose_move tool "
+    "with a row and col in [0, 5]. Labels like (row,col) on empty cells are "
+    "coordinate references, not discs. Prefer moves that flip more discs and "
+    "keep stable corners; avoid passing unless you have no legal move."
+)
+
+CHOOSE_MOVE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "choose_move",
+        "description": "Choose the next 6x6 Othello move (row, col) for the player.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "row": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 5,
+                    "description": "The row index to place the disc in (0-5).",
+                },
+                "col": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 5,
+                    "description": "The column index to place the disc in (0-5).",
+                },
+            },
+            "required": ["row", "col"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+async def run_agent(ctx, batch):
+    """Run one tool-call model request for each board."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The Othello agentic example requires `openai` and `httpx`. Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info("Othello agent start requests=%d max_running_prompts=%d", len(items), ctx.max_running_prompts)
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+
+    async def run_one(item):
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": item.prompt},
+        ]
+        tool_choice = {"type": "function", "function": {"name": "choose_move"}}
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=messages,
+            tools=[CHOOSE_MOVE_TOOL],
+            tool_choice=tool_choice,
+            stream=False,
+        )
+        return AgentTrajectoryTurn(
+            item=item,
+            messages=messages,
+            response=response,
+            tools=[CHOOSE_MOVE_TOOL],
+            tool_choice=tool_choice,
+        )
+
+    try:
+        return AgentTrajectory(turns=list(await asyncio.gather(*(run_one(item) for item in items))))
+    finally:
+        await client.close()

--- a/tests/test_agentic_othello_example_cpu.py
+++ b/tests/test_agentic_othello_example_cpu.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import inspect
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "othello"
+
+
+@contextmanager
+def _stubbed_agentic():
+    """Load ``run_agent`` without the torch-backed ``areno.api.agentic``.
+
+    ``run_agent.py`` imports ``AgentTrajectory`` / ``AgentTrajectoryTurn`` at
+    module top, which pulls in the full areno stack (and torch). In CPU tests we
+    stub those names plus ``openai`` / ``httpx`` so the module loads without the
+    heavy backend. Restores prior ``sys.modules`` entries on exit.
+    """
+
+    import sys as _sys
+
+    saved = {key: _sys.modules.get(key) for key in ("areno.api.agentic", "openai", "httpx")}
+    _sys.modules["areno.api.agentic"] = SimpleNamespace(
+        AgentTrajectory=lambda turns: SimpleNamespace(turns=turns),
+        AgentTrajectoryTurn=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is not None:
+                _sys.modules[key] = value
+            else:
+                _sys.modules.pop(key, None)
+
+
+def _load_module(name: str):
+    """Load an Othello example module by file path with an isolated ``game`` import.
+
+    Saves/restores ``sys.modules['game']`` so the per-example ``game`` module
+    does not leak across tests (mirrors the shopping/codebreaker test pattern).
+    """
+
+    path = EXAMPLE_DIR / f"{name}.py"
+    previous_game = sys.modules.pop("game", None)
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(f"agentic_othello_{name}_for_tests", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+
+
+# --------------------------------------------------------------------------- #
+# Environment rules
+# --------------------------------------------------------------------------- #
+
+
+def test_new_board_is_standard_opening():
+    game = _load_module("game")
+
+    board = game.new_board()
+
+    assert len(board) == 6 and all(len(row) == 6 for row in board)
+    counts = game.count_disks(board)
+    assert counts["B"] == 2 and counts["W"] == 2 and counts["."] == 32
+    mid = 3
+    assert board[mid - 1][mid - 1] == "W"
+    assert board[mid - 1][mid] == "B"
+    assert board[mid][mid - 1] == "B"
+    assert board[mid][mid] == "W"
+
+
+def test_opening_legal_moves_are_symmetric_four():
+    game = _load_module("game")
+
+    moves = game.legal_moves(game.new_board(), "B")
+
+    assert moves == [(1, 2), (2, 1), (3, 4), (4, 3)]
+
+
+def _blank_board(game, fill_with="."):
+    """A 6x6 board filled with the given cell, then renormalized."""
+
+    return game.normalize_board([[fill_with for _ in range(6)] for _ in range(6)])
+
+
+def _directioned_board(game, mover, opp, target, direction):
+    """Build a board where ``mover`` playing ``target`` flips exactly one disc
+    sitting one step along ``direction`` from ``target``, bracketed by another
+    mover disc two steps along ``direction``.
+
+    ``direction`` is one of the 8 ``(dr, dc)`` unit vectors. Returns the board.
+    """
+
+    board = [[game.EMPTY for _ in range(6)] for _ in range(6)]
+    tr, tc = target
+    dr, dc = direction
+    mid = (tr + dr, tc + dc)
+    far = (tr + 2 * dr, tc + 2 * dc)
+    board[mid[0]][mid[1]] = opp
+    board[far[0]][far[1]] = mover
+    return game.normalize_board(board)
+
+
+def test_flips_for_each_of_eight_directions():
+    game = _load_module("game")
+
+    target = (2, 2)
+    expected_flips = []
+    for direction in game.DIRECTIONS:
+        dr, dc = direction
+        board = _directioned_board(game, "B", "W", target, direction)
+        flipped = game.flips_for(board, target[0], target[1], "B")
+        mid = (target[0] + dr, target[1] + dc)
+        assert flipped == [mid], f"direction {direction} expected flip at {mid}, got {flipped}"
+        applied = game.apply_move(board, target[0], target[1], "B")
+        assert applied[mid[0]][mid[1]] == "B"
+        expected_flips.append(mid)
+    assert len(expected_flips) == 8
+
+
+def test_flips_for_non_empty_or_unbracketed_returns_empty():
+    game = _load_module("game")
+
+    board = game.new_board()
+    # (2,2) currently W -> non-empty, no flips.
+    assert game.flips_for(board, 2, 2, "B") == []
+    # Out of bounds.
+    assert game.flips_for(board, -1, 0, "B") == []
+    # An empty corner with no bracket (a lone opponent disc unbracketed by a mover
+    # disc) flips nothing.
+    blank = game.normalize_board([["." if (r, c) != (1, 1) else "W" for c in range(6)] for r in range(6)])
+    assert game.flips_for(blank, 0, 0, "B") == []
+
+
+def test_legal_moves_and_apply_move_from_opening():
+    game = _load_module("game")
+
+    board = game.new_board()
+    assert (1, 2) in game.legal_moves(board, "B")
+    next_board = game.apply_move(board, 1, 2, "B")
+    # The played cell and the flipped W disc are both B now.
+    assert next_board[1][2] == "B"
+    assert next_board[2][2] == "B"
+    counts = game.count_disks(next_board)
+    assert counts["B"] == 4 and counts["W"] == 1
+
+
+def test_apply_move_rejects_illegal_cells():
+    game = _load_module("game")
+
+    board = game.new_board()
+    for bad in [(0, 0), (2, 2), (-1, 0), (6, 0)]:
+        try:
+            game.apply_move(board, bad[0], bad[1], "B")
+            raise AssertionError(f"expected ValueError for illegal move {bad}")
+        except ValueError:
+            pass
+
+
+def test_force_pass_when_player_has_no_legal_move():
+    game = _load_module("game")
+
+    # Evolve a reachable position where Black has no legal move but White does.
+    # We search a small prefix of random-but-seeded legal play for such a board.
+    import random
+
+    rng = random.Random(123)
+    found_board = None
+    for _ in range(2000):
+        board = game.new_board()
+        player = "B"
+        for _step in range(rng.randint(6, 30)):
+            moves = game.legal_moves(board, player)
+            if not moves:
+                player = game.opponent(player)
+                moves = game.legal_moves(board, player)
+                if not moves:
+                    break
+            move = rng.choice(moves)
+            board = game.apply_move(board, move[0], move[1], player)
+            player = game.opponent(player)
+            if (
+                game.legal_moves(board, "B") == []
+                and game.has_legal_move(board, "W")
+                and not game.is_terminal(board)
+            ):
+                found_board = board
+                break
+        if found_board is not None:
+            break
+    assert found_board is not None, "could not evolve a forced-pass position in the seed budget"
+    assert game.legal_moves(found_board, "B") == []
+    assert game.has_legal_move(found_board, "W")
+    assert not game.is_terminal(found_board)
+
+
+def test_two_consecutive_passes_is_terminal():
+    game = _load_module("game")
+
+    # A full board (no empty cell) means neither side can move -> terminal by
+    # the two-consecutive-pass rule.
+    full = game.normalize_board(
+        [["B" if (r + c) % 2 == 0 else "W" for c in range(6)] for r in range(6)]
+    )
+    assert not game.has_legal_move(full, "B")
+    assert not game.has_legal_move(full, "W")
+    assert game.is_terminal(full)
+
+
+def test_terminal_scoring_black_white_draw():
+    game = _load_module("game")
+
+    full = game.normalize_board(
+        [["B" if (r + c) % 2 == 0 else "W" for c in range(6)] for r in range(6)]
+    )
+    result = game.score_board(full)
+    assert result["black"] == 18 and result["white"] == 18 and result["winner"] == "draw"
+
+    black_wins = game.normalize_board([["B" for _ in range(6)] for _ in range(6)])
+    result = game.score_board(black_wins)
+    assert result["winner"] == "B" and result["black"] == 36
+
+
+def test_score_move_reward_kernel_is_tiered():
+    game = _load_module("game")
+
+    board = game.new_board()
+    # Non-terminal legal move -> +0.4 (legal-action shaping credit).
+    assert game.score_move(board, (1, 2), "B") == 0.4
+    # No move / unparseable tool call -> -1.0 (worst tier: no actionable call).
+    assert game.score_move(board, None, "B") == -1.0
+    # Out-of-bounds coordinate -> -0.5 (bad coordinate, but still emitted a call).
+    assert game.score_move(board, (-1, 2), "B") == -0.5
+    assert game.score_move(board, (6, 0), "B") == -0.5
+    # In-range but illegal cell (occupied or no flank) -> -0.3 (targeted a real
+    # cell, better than out-of-range).
+    assert game.score_move(board, (0, 0), "B") == -0.3  # empty corner, no flank
+    assert game.score_move(board, (2, 2), "B") == -0.3  # occupied cell
+    # Every illegal tier must differ from both the no-call tier (-1.0) and each
+    # other, so GSPO group-relative advantage is non-zero when outcomes differ.
+    tiers = {-1.0, -0.5, -0.3, 0.4}
+    assert len(tiers) == 4
+
+    # A move that fills the last empty cell and ends the game with the mover
+    # ahead -> 1.0.
+    near_full = game.normalize_board(
+        [["B" if not (r == 0 and c == 0) else "." for c in range(6)] for r in range(6)]
+    )
+    # Find a mover+target whose sole legal move on a board that becomes terminal
+    # leaves them ahead. Construct: place W so B at (0,0) flips it and wins.
+    # Simpler: directly assert on a hand-built terminal-winning board state.
+    board_w = game.normalize_board(
+        [
+            [".", "W", "B", "B", "B", "B"],
+            ["B", "B", "B", "B", "B", "B"],
+            ["B", "B", "B", "B", "B", "B"],
+            ["B", "B", "B", "B", "B", "B"],
+            ["B", "B", "B", "B", "B", "B"],
+            ["B", "B", "B", "B", "B", "B"],
+        ]
+    )
+    # Black playing (0,0) brackets the W at (0,1) against the B at (0,2).
+    assert (0, 0) in game.legal_moves(board_w, "B")
+    after = game.apply_move(board_w, 0, 0, "B")
+    assert game.is_terminal(after)
+    assert game.score_board(after)["winner"] == "B"
+    assert game.score_move(board_w, (0, 0), "B") == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Parsing and reward
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_move_and_parse_tool_move_handle_malformed():
+    game = _load_module("game")
+
+    assert game.parse_move("play <move>2,3</move> now") == (2, 3)
+    # Last tag wins.
+    assert game.parse_move("x <move>5,5</move> y <move>0,1</move>") == (0, 1)
+    # Out-of-range coordinates -> None.
+    assert game.parse_move("<move>9,9</move>") is None
+    # No move tag -> None (never raises).
+    assert game.parse_move("I have no idea") is None
+
+    assert game.parse_tool_move([{"name": "choose_move", "arguments": {"row": 1, "col": 2}}]) == (1, 2)
+    # JSON-string arguments.
+    assert game.parse_tool_move(
+        [{"name": "choose_move", "arguments": json.dumps({"row": 4, "col": 0})}]
+    ) == (4, 0)
+    # Wrong tool, missing fields, out of range, malformed JSON -> None.
+    assert game.parse_tool_move([{"name": "other", "arguments": {"row": 1, "col": 2}}]) is None
+    assert game.parse_tool_move([{"name": "choose_move", "arguments": {"row": 1}}]) is None
+    assert game.parse_tool_move([{"name": "choose_move", "arguments": {"row": 9, "col": 9}}]) is None
+    assert game.parse_tool_move([{"name": "choose_move", "arguments": "{bad json"}]) is None
+    assert game.parse_tool_move([]) is None
+    assert game.parse_tool_move(None) is None
+
+
+def test_reward_fn_scores_tool_move_only():
+    game = _load_module("game")
+    reward = _load_module("reward")
+    board = game.new_board()
+    record = SimpleNamespace(
+        source_record={"board": board, "player": "B"},
+        completion="<move>1,2</move>",
+        tool_calls=[{"name": "choose_move", "arguments": {"row": 0, "col": 0}}],
+    )
+    # (0,0) is in range but illegal (no flank) -> -0.3.
+    assert reward.reward_fn(record) == -0.3
+
+    # Out-of-range coordinate via the tool call -> -0.5 (still emitted a call).
+    record.tool_calls = [{"name": "choose_move", "arguments": {"row": 9, "col": 9}}]
+    assert reward.reward_fn(record) == -0.5
+
+    record.tool_calls = [{"name": "choose_move", "arguments": {"row": 1, "col": 2}}]
+    # (1,2) is a legal non-terminal opening move -> +0.4.
+    assert (1, 2) in game.legal_moves(board, "B")
+    assert reward.reward_fn(record) == 0.4
+
+    # Malformed / missing tool call -> no parseable coordinates -> -1.0.
+    record.tool_calls = [{"name": "choose_move", "arguments": {"row": 1}}]
+    assert reward.reward_fn(record) == -1.0
+    record.tool_calls = []
+    assert reward.reward_fn(record) == -1.0
+
+
+# --------------------------------------------------------------------------- #
+# Dataset generator / loader
+# --------------------------------------------------------------------------- #
+
+
+def test_generator_is_reproducible_and_produces_reachable_openings():
+    generator = _load_module("dataset_generator")
+    game = _load_module("game")
+
+    rows = generator.generate_records(16, seed=7)
+
+    assert rows == generator.generate_records(16, seed=7)
+    assert len(rows) == 16
+    for record in rows:
+        board = game.normalize_board(record["board"])
+        assert game.next_player(board) == "B"
+        assert not game.is_terminal(board)
+        assert game.legal_moves(board, "B")
+
+
+def test_generator_rejects_invalid_args():
+    generator = _load_module("dataset_generator")
+
+    for bad in [dict(count=0, seed=1), dict(count=5, seed=-1), dict(count=5, seed=1, max_plies=-1)]:
+        try:
+            generator.generate_records(**bad)
+            raise AssertionError(f"expected ValueError for {bad}")
+        except ValueError:
+            pass
+
+
+def test_loader_formats_records_from_jsonl(tmp_path):
+    loader = _load_module("dataset_loader")
+    generator = _load_module("dataset_generator")
+    game = _load_module("game")
+
+    rows = generator.generate_records(8, seed=3)
+    path = tmp_path / "boards.jsonl"
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+    records = loader.load_training_dataset(str(path))
+
+    assert len(records) == len(rows) == 8
+    for raw, record in zip(rows, records):
+        board = game.normalize_board(record["board"])
+        assert record["id"] == raw["id"]
+        assert record["player"] == "B"
+        assert record["valid_moves"] == game.legal_moves(board, "B")
+        assert record["prompt"].startswith("You are playing 6x6 Othello")
+        assert record["prompt"].endswith("Move:")
+
+
+def test_loader_falls_back_to_generator_when_missing(tmp_path):
+    loader = _load_module("dataset_loader")
+
+    records = loader.load_training_dataset(str(tmp_path / "does-not-exist.jsonl"))
+
+    assert records
+    assert all("prompt" in record and "board" in record for record in records)
+
+
+# --------------------------------------------------------------------------- #
+# Agent fn contract + seeded-opponent harness
+# --------------------------------------------------------------------------- #
+
+
+def test_run_agent_signature_accepts_two_positional_args():
+    with _stubbed_agentic():
+        run_agent = _load_module("run_agent")
+
+    sig = inspect.signature(run_agent.run_agent)
+    positionals = [
+        p
+        for p in sig.parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ]
+    assert len(positionals) == 2
+
+
+def test_choose_move_tool_schema_is_closed_and_bounded():
+    with _stubbed_agentic():
+        run_agent = _load_module("run_agent")
+
+    tool = run_agent.CHOOSE_MOVE_TOOL["function"]
+    params = tool["parameters"]
+    assert tool["name"] == "choose_move"
+    assert params["additionalProperties"] is False
+    assert params["required"] == ["row", "col"]
+    assert params["properties"]["row"]["minimum"] == 0
+    assert params["properties"]["row"]["maximum"] == 5
+    assert params["properties"]["col"]["minimum"] == 0
+    assert params["properties"]["col"]["maximum"] == 5
+
+
+def test_run_agent_builds_trajectories_with_fake_client():
+    import sys as _sys
+
+    saved_agentic = _sys.modules.get("areno.api.agentic")
+    saved_openai = _sys.modules.get("openai")
+    saved_httpx = _sys.modules.get("httpx")
+    try:
+        _sys.modules["areno.api.agentic"] = SimpleNamespace(
+            AgentTrajectory=lambda turns: SimpleNamespace(turns=turns),
+            AgentTrajectoryTurn=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+
+        class FakeCompletions:
+            def __init__(self):
+                self.requests = []
+
+            async def create(self, **kwargs):
+                self.requests.append(kwargs)
+                message = SimpleNamespace(
+                    content=None,
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call-0",
+                            type="function",
+                            function=SimpleNamespace(
+                                name="choose_move", arguments=json.dumps({"row": 1, "col": 2})
+                            ),
+                        )
+                    ],
+                )
+                return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+        class FakeChat:
+            def __init__(self):
+                self.completions = FakeCompletions()
+
+        class FakeOpenAI:
+            def __init__(self, **kwargs):
+                self.chat = FakeChat()
+
+            async def close(self):
+                pass
+
+        class FakeLimits:
+            def __init__(self, **kwargs):
+                pass
+
+        class FakeTimeout:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        class FakeAsyncClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        _sys.modules["openai"] = SimpleNamespace(AsyncOpenAI=FakeOpenAI)
+        _sys.modules["httpx"] = SimpleNamespace(
+            AsyncClient=FakeAsyncClient, Limits=FakeLimits, Timeout=FakeTimeout
+        )
+
+        run_agent = _load_module("run_agent")
+
+        class FakeCtx:
+            max_running_prompts = 8
+            api_key = "k"
+
+            def get_base_url(self):
+                return "http://localhost:8000/v1"
+
+        class FakeBatch:
+            def __init__(self, prompts):
+                self._items = [SimpleNamespace(prompt=p, record={"board": None}) for p in prompts]
+
+            def iter_samples(self):
+                return iter(self._items)
+
+        trajectory = asyncio.run(run_agent.run_agent(FakeCtx(), FakeBatch(["p0", "p1"])))
+
+        turns = trajectory.turns
+        assert len(turns) == 2
+        assert turns[0].item.prompt == "p0"
+        assert turns[1].item.prompt == "p1"
+        # Both turns forced the choose_move tool choice.
+        assert all(turn.tool_choice == {"type": "function", "function": {"name": "choose_move"}} for turn in turns)
+    finally:
+        for name, saved in (("areno.api.agentic", saved_agentic), ("openai", saved_openai), ("httpx", saved_httpx)):
+            if saved is not None:
+                _sys.modules[name] = saved
+            else:
+                _sys.modules.pop(name, None)
+
+
+def test_evaluate_reports_win_rate_and_invalid_move_rate():
+    opponent = _load_module("opponent")
+    game = _load_module("game")
+
+    def random_policy(board, player, rng):
+        return opponent.random_opponent_pick(board, player, rng)
+
+    report = opponent.evaluate(random_policy, n_games=20, seed=2026, max_steps=60)
+
+    summary = report["summary"]
+    assert summary["n_games"] == 20
+    assert 0.0 <= summary["win_rate"] <= 1.0
+    assert 0.0 <= summary["invalid_move_rate"] <= 1.0
+    assert summary["policy_side"] == "B"
+    assert len(report["games"]) == 20
+    for match in report["games"]:
+        assert "winner" in match
+        assert match["winner"] in ("B", "W", "draw")
+        assert {"black", "white", "steps", "passes", "invalid"}.issubset(match.keys())
+
+
+def test_play_match_rejects_invalid_args():
+    opponent = _load_module("opponent")
+
+    def stub(board, player, rng):
+        return None
+
+    for bad in [dict(max_steps=0), dict(max_steps=5, seed=-1)]:
+        try:
+            opponent.play_match(stub, **bad)
+            raise AssertionError(f"expected ValueError for {bad}")
+        except ValueError:
+            pass
+
+
+def test_help_listed_examples_module_smoke():
+    # A backward-compat sanity check: the example directory exposes the three
+    # required entry symbols. ``run_agent`` imports ``areno.api.agentic`` at
+    # module top, so load it under the same stub used by the integration test.
+    for name, symbol in (("dataset_loader", "load_training_dataset"), ("reward", "reward_fn")):
+        module = _load_module(name)
+        assert callable(getattr(module, symbol, None)), f"{name}.py missing {symbol}"
+    with _stubbed_agentic():
+        run_agent = _load_module("run_agent")
+        assert callable(getattr(run_agent, "run_agent", None))


### PR DESCRIPTION
## Summary

Resolves #190.

Adds a **self-contained 6×6 Othello agentic-RL example** under `examples/agentic/othello/`, following the same file-callback contract pattern AReno already uses for `tictactoe` / `codebreaker` / `shopping`. **Zero edits to any `areno/` source, no new dependency, no external DB / sandbox, default behavior unchanged** when the example is not invoked.

## What's in this PR

  | File | Role | Lines |
  |---|---|---|
  | `examples/agentic/othello/game.py` | Pure-rules engine + **tiered reward kernel** + move parsing | 380 |
  | `examples/agentic/othello/opponent.py` | Seeded random-opponent self-play harness (offline eval) | 183 |
  | `examples/agentic/othello/dataset_generator.py` | Deterministic *reachable* opening generator | 114 |
  | `examples/agentic/othello/dataset_loader.py` | `load_training_dataset(...)` JSONL loader | 48 |
  | `examples/agentic/othello/run_agent.py` | `async run_agent(ctx, batch)` tool-call agent | 93 |
  | `examples/agentic/othello/reward.py` | `reward_fn(record)` | 25 |
  | `examples/agentic/othello/README.md` | User docs + runnable example | 143 |
  | `tests/test_agentic_othello_example_cpu.py` | 22 CPU tests | 578 |

### Environment rules (`game.py`)

  - Standard 6×6 opening (`new_board()`): center 4 discs, 32 empty.
  - `legal_moves(board, player)` — enumerates cells whose `flips_for()` is non-empty; empty list ⇒ forced pass.
  - `flips_for(board, row, col, player)` — scans **all 8 directions**; a bracket closes only if the far end is the mover's own disc (the Othello sandwich rule).
  - `apply_move(board, row, col, player)` — places + flips all 8-direction captured discs; `ValueError` on illegal.
  - `is_terminal(board)` — terminal when **neither** player has a legal move (covers the two-consecutive-pass end condition and a full board).
  - `score_board(board)` — count-majority winner, draw on tie.
  - Move parsing: `parse_move(text)` (XML `<move>r,c</move>`) and `parse_tool_move(raw | filtered)` (extract `choose_move({row,col})`), each `None` on any malformed input — **the reward function never raises.**

### Reward: tiered kernel (`score_move`) — the key design choice

A **flat** reward (−1.0 for every illegal/unparseable, 0.0 legal, 1.0 win) collapses the policy to *never calling the tool* during GSPO cold start. Mechanics:

> When every bad action maps to the same −1.0, the GSPO group-relative advantage of *"called `choose_move` with a bad cell"* equals that of *"called no tool at all"*. The gradient that suppresses a bad cell **also suppresses tool-calling**, driving `tool_calls → 0`. Once there, the group reward is identical (all −1.0) ⇒ advantage = 0 ⇒ **zero gradient** ⇒ the policy is permanently stuck, with **no signal to recover**.

Tiering separates *what the agent did*, so identical group rewards rarely occur — keeping advantages non-zero:

  | Agent action | Reward | Rationale |
  |---|---|---|
  | No `choose_move` call, or unparseable args | **−1.0** | Worst tier — produced no actionable call |
  | `choose_move` with **out-of-bounds** coordinate | **−0.5** | Illegal but did emit a call with integers |
  | **In-bounds but illegal** cell (occupied / no flank) | **−0.3** | Targeted a real cell, better than OOB |
  | **Legal, non-terminal** move | **+0.4** | Real legal move |
  | Legal move that **ends the game**, agent ahead | **+1.0** | Win |

`reward.py` uses `parse_tool_move_raw` (keeps OOB coordinates instead of filtering them to `None`) so `score_move` can apply the −0.5 tier — **this is the structural lockout prevention**.

### Seeded-opponent evaluation (`opponent.py`)

Pure Python / CPU, no LLM, no network, no DB. Ships `random` and `greedy` (most-discs-flipped) policies:
- `play_match(policy_fn, *, policy_side, seed, max_steps)` — full self-play with forced-pass handling and double-pass termination.
- `evaluate(policy_fn, n_games, seed, ...)` — aggregates **win rate** and **invalid-move rate** over `n_games` deterministic matches; human-readable summary + structured JSON.
- `main()` CLI so it runs out-of-the-box: `python examples/agentic/othello/opponent.py --n-games 20 --seed 2026 --policy greedy`.

### Deterministic reachable openings (`dataset_generator.py`)

Generates boards by **playing only legal moves** from `new_board()` for a random small number of plies (default `max_plies=8`), alternating B/W. Rejects duplicates / terminal / wrong-side-to-move boards; uses a seeded `random.Random(seed)`. Up-front validation: `--count > 0`, `--seed >= 0`, `--max-plies >= 0` raise clear `ValueError`s before any work.

## Mapping to issue #190 acceptance criteria

  | Criterion | Where |
  |---|---|
  | All flip directions, forced pass, two consecutive passes, terminal scoring, illegal cells | `game.py` +     `test_flips_for_each_of_eight_directions`, `test_force_pass_when_player_has_no_legal_move`, `test_two_consecutive_passes_is_terminal`, `test_terminal_scoring_*`, `test_apply_move_rejects_illegal_cells` |
  | Seed-random-opponent win rate + invalid-move rate | `opponent.py` + `test_evaluate_reports_win_rate_and_invalid_move_rate` |
  | Existing AReno contracts, no external DB / sandbox | only file-callbacks (`--agent-fn` / `--reward-fn-path` /
`--dataset-loader-fn`); no new deps |
  | Default behavior unchanged | new files only; no `areno/` edits |
  | Focused CPU tests: success / invalid / boundary | 22 tests, `_cpu.py` suffix (CI `-k cpu` filter) |
  | Runnable example + observable output | `README.md` + `opponent.py` harness |

## Verification

### CPU tests
  ```
pytest tests/test_agentic_othello_example_cpu.py  # 22 passed
  ```

### Offline evaluation (no GPU/LLM)
  ```
python examples/agentic/othello/dataset_generator.py --output /tmp/boards.jsonl --count 32 --seed 2026
python examples/agentic/othello/opponent.py --n-games 20 --seed 2026 --policy greedy
# → win_rate 0.75, invalid_rate 0.00 (greedy vs seeded random)
  ```
### End-to-end agentic RL on Kaggle T4 — tiered vs flat (controlled comparison)

Same model (Qwen3-0.6B + short SFT warmup), same `areno train` config, only the reward differs:

**Tiered (this PR) — stable, no collapse:**
```bash
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True areno train \
  --algo gspo --tp-size 1 --world-size 1 \
  --batch-size 1 --n-samples 8 \
  --max-new-tokens 64 --max-context-len 1280 --max-running-prompts 8 --mini-bs 1 \
  --adam-8bit --disable-thinking --lr 1e-7 --grad-clip-norm 0.5 --temperature 1.2 --top-p 0.95
  ```
Observed over 10 steps: `tool_calls` stays ≥ 1 every step, `rollout/advantages_std > 0` every step (no zero-gradient
  lockout), `rollout/accuracy` 0.25–0.75 (no self-destruction).

**Flat reward (control) — collapses, replicating the failure mode:**
Same config, flat `score_move` (`−1.0` illegal / `0.0` legal / `1.0` win). Observed:
- `tool_calls → 0` by step 3
- `rollout/advantages_std → 0` by step 5
- `rollout/accuracy` stuck at `0.0` thereafter (frozen, zero gradient, no recovery signal)

Both runs on the same 16 generated boards + warmup checkpoint. The tiered reward is the **only** independent variable, so the survival vs collapse is attributable to it.

## Risk / rollback

All changes are **additive**: new files only under `examples/agentic/othello/` (plus one new test file). **No `areno/`
core edits, no CLI/config/dataclass changes, no new dependency.** Reverting is a clean `git revert` with **no side effects** on existing examples, the trainer, the rollout engine, the dashboard, or default behavior. Nothing runs unless a user explicitly points `--agent-fn` / `--reward-fn-path` / `--dataset-loader-fn` at these files.

## Test-file size note

`tests/test_agentic_othello_example_cpu.py` is 578 lines / 22 tests (~26 lines/test). This is driven by **breadth of coverage**, not copy-paste boilerplate: 8-direction flip enumeration, the five reward tiers, determinism, an integration-style stubbed async episode, and `run_agent` schema/signature checks. For reference the sibling `codebreaker` example is 201 lines / 9 tests — this file is ~3× the tests at ~3× the lines. If a reviewer prefers, the rules-reward block and the integration block can be split into two files (`..._rules_cpu.py` +`..._integration_cpu.py`); I'll do that if requested.

## Implementation notes / limitations

- 6×6 only; board size fixed and validated.
- Reward is terminal-led with tiered shaping; **not** a dense per-flip / disc-count reward — kept the contract simple and comparable.
- `--disable-thinking` recommended for Qwen3 (shortens prompt rendering, avoids the context-length filtering that can drop all trajectories when Qwen3 emits a long reasoning span).
- `opponent.py` ships `random` / `greedy`; an LLM policy is wired by providing a `policy_fn(board, player, rng) ->(row, col) | None`.
