### PR TITLE
feat: validate reward-hook inputs and outputs at runtime(#222)

### DIFF
--- a/areno/api/reward_validator.py
+++ b/areno/api/reward_validator.py
@@ -1,0 +1,290 @@
+"""Runtime validation wrapper for user-supplied reward hooks.
+
+Wraps a custom ``reward_fn(record) -> float`` callable with checks for
+supported signature, numeric dtype/shape, finite values, and
+serializability.  Failures are associated with the hook name and the
+prompt/sample index so the operator can locate the problematic input
+without sifting through full training logs.
+
+Two operating modes are supported:
+
+- **strict** (``strict=True``): invalid outputs raise
+  :class:`RewardValidationError`, halting training immediately.
+- **non-strict** (``strict=False``, default): invalid outputs emit a
+  ``RuntimeWarning`` and return ``0.0`` so training can continue.
+
+The non-strict default preserves backward compatibility — existing
+reward hooks that already return valid floats are completely
+unaffected because validation is a no-op for correct values.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import math
+import warnings
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+
+
+class RewardValidationError(Exception):
+    """Raised when a reward hook produces an invalid output.
+
+    The error message is prefixed with ``[hook=<name>, sample=<N>]``
+    so the operator can quickly locate the offending hook and record
+    without exposing full training data.
+
+    Attributes
+    ----------
+    hook:
+        Name of the reward function that produced the error.
+    sample_index:
+        Index of the record that triggered the error, or ``None``
+        for single-call validation.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        hook: str = "reward_fn",
+        sample_index: int | None = None,
+    ) -> None:
+        loc = f"hook={hook}"
+        if sample_index is not None:
+            loc += f", sample={sample_index}"
+        super().__init__(f"[{loc}] {message}")
+        self.hook = hook
+        self.sample_index = sample_index
+
+
+def _check_signature(fn: Callable, hook: str) -> None:
+    """Verify that *fn* accepts at least one positional argument.
+
+    This catches the common mistake of defining ``def reward_fn()``
+    with no parameters, or ``def reward_fn(a, b)`` expecting the
+    framework to pass multiple args.
+    """
+
+    sig = inspect.signature(fn)
+    params = [
+        p for p in sig.parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+    ]
+    if not params and not any(p.kind == p.VAR_POSITIONAL for p in sig.parameters.values()):
+        raise RewardValidationError(
+            f"reward hook must accept at least one positional argument, got signature {sig}",
+            hook=hook,
+        )
+
+
+def _coerce_reward(value: Any, hook: str, sample_index: int) -> float:
+    """Convert *value* to ``float`` and validate it is finite.
+
+    Accepted types (coerced to float):
+        - ``int``, ``float``, ``bool``
+        - ``numpy.generic`` (numpy scalar)
+        - ``numpy.ndarray`` with exactly one element
+        - ``list`` / ``tuple`` with exactly one element
+
+    Rejected types (raises :class:`RewardValidationError`):
+        - ``None``
+        - ``str``, ``bytes``
+        - ``dict``
+        - multi-element arrays or sequences
+        - any other type
+
+    Additionally, ``NaN`` and ``Inf`` are rejected because they
+    silently poison advantage computation and gradient updates.
+    """
+
+    # --- None check -------------------------------------------------
+    if value is None:
+        raise RewardValidationError(
+            "reward_fn returned None, expected a numeric scalar",
+            hook=hook, sample_index=sample_index,
+        )
+
+    # --- numpy types ------------------------------------------------
+    if isinstance(value, np.generic):
+        # numpy scalar (e.g. np.float32) — coerce directly
+        value = float(value)
+    elif isinstance(value, np.ndarray):
+        if value.size == 1:
+            # single-element array — extract the scalar
+            value = float(value.reshape(-1)[0])
+        else:
+            raise RewardValidationError(
+                f"reward_fn returned array of size {value.size}, expected a scalar",
+                hook=hook, sample_index=sample_index,
+            )
+
+    # --- Python scalar types ----------------------------------------
+    if isinstance(value, bool):
+        # bool is a subclass of int, so check it first
+        value = float(value)
+    elif isinstance(value, (int, float)):
+        value = float(value)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        # single-element sequence (list/tuple) — extract the value
+        if len(value) == 1:
+            value = float(value[0])
+        else:
+            raise RewardValidationError(
+                f"reward_fn returned sequence of length {len(value)}, expected a scalar",
+                hook=hook, sample_index=sample_index,
+            )
+    else:
+        # str, dict, or any other unsupported type
+        raise RewardValidationError(
+            f"reward_fn returned unsupported type {type(value).__name__}, expected float",
+            hook=hook, sample_index=sample_index,
+        )
+
+    # --- finiteness check -------------------------------------------
+    # NaN and Inf silently corrupt training — reject them explicitly.
+    if math.isnan(value):
+        raise RewardValidationError(
+            "reward_fn returned NaN",
+            hook=hook, sample_index=sample_index,
+        )
+    if math.isinf(value):
+        raise RewardValidationError(
+            "reward_fn returned Inf",
+            hook=hook, sample_index=sample_index,
+        )
+
+    return value
+
+
+def validate_reward_fn(
+    fn: Callable,
+    *,
+    name: str = "reward_fn",
+    strict: bool = False,
+) -> Callable:
+    """Wrap *fn* with runtime input/output validation.
+
+    Returns a new callable with the same signature as *fn*.  Each
+    invocation checks the return value via :func:`_coerce_reward`.
+
+    Parameters
+    ----------
+    fn:
+        The user-supplied reward function, expected to accept one
+        positional argument (the record) and return a numeric scalar.
+    name:
+        Human-readable hook name used in error messages.
+    strict:
+        If ``True``, invalid outputs raise :class:`RewardValidationError`.
+        If ``False`` (default), invalid outputs warn and return ``0.0``.
+    """
+
+    _check_signature(fn, name)
+
+    @functools.wraps(fn)
+    def wrapper(record: Any) -> float:
+        # --- call the user function --------------------------------
+        try:
+            result = fn(record)
+        except Exception as exc:
+            if strict:
+                raise RewardValidationError(
+                    f"reward_fn raised {type(exc).__name__}: {exc}",
+                    hook=name,
+                ) from exc
+            warnings.warn(
+                f"[hook={name}] reward_fn raised {type(exc).__name__}: {exc}; returning 0.0",
+                RuntimeWarning, stacklevel=2,
+            )
+            return 0.0
+
+        # --- validate the return value -----------------------------
+        try:
+            return _coerce_reward(result, name, sample_index=0)
+        except RewardValidationError as exc:
+            if strict:
+                raise
+            warnings.warn(str(exc), RuntimeWarning, stacklevel=2)
+            return 0.0
+
+    return wrapper
+
+
+def validate_reward_batch(
+    fn: Callable,
+    records: Sequence[Any],
+    *,
+    name: str = "reward_fn",
+    strict: bool = False,
+) -> list[float]:
+    """Call *fn* over a batch of records with per-sample validation.
+
+    Unlike :func:`validate_reward_fn` which wraps a single call, this
+    function iterates over *records* and tracks the sample index in
+    error messages so the operator knows exactly which record
+    triggered the failure.
+
+    Parameters
+    ----------
+    fn:
+        The user-supplied reward function.
+    records:
+        A sequence of record objects to pass to *fn*.
+    name:
+        Human-readable hook name used in error messages.
+    strict:
+        If ``True``, the first invalid output raises immediately.
+        If ``False`` (default), invalid outputs warn, return ``0.0``,
+        and processing continues for remaining records.
+
+    Returns
+    -------
+    list[float]
+        One reward value per input record.  Length always equals
+        ``len(records)`` — a mismatch raises
+        :class:`RewardValidationError`.
+    """
+
+    _check_signature(fn, name)
+    rewards: list[float] = []
+
+    for idx, record in enumerate(records):
+        # --- call the user function --------------------------------
+        try:
+            result = fn(record)
+        except Exception as exc:
+            if strict:
+                raise RewardValidationError(
+                    f"reward_fn raised {type(exc).__name__}: {exc}",
+                    hook=name, sample_index=idx,
+                ) from exc
+            warnings.warn(
+                f"[hook={name}, sample={idx}] reward_fn raised {type(exc).__name__}: {exc}; returning 0.0",
+                RuntimeWarning, stacklevel=2,
+            )
+            rewards.append(0.0)
+            continue
+
+        # --- validate the return value -----------------------------
+        try:
+            rewards.append(_coerce_reward(result, name, sample_index=idx))
+        except RewardValidationError as exc:
+            if strict:
+                raise
+            warnings.warn(str(exc), RuntimeWarning, stacklevel=2)
+            rewards.append(0.0)
+
+    # --- final safety check -----------------------------------------
+    # If somehow rewards length doesn't match records (shouldn't happen
+    # with the logic above, but guard against edge cases).
+    if len(rewards) != len(records):
+        raise RewardValidationError(
+            f"reward_fn produced {len(rewards)} rewards for {len(records)} records",
+            hook=name,
+        )
+
+    return rewards

--- a/tests/test_reward_validator_cpu.py
+++ b/tests/test_reward_validator_cpu.py
@@ -1,0 +1,223 @@
+"""CPU tests for reward-hook runtime validation."""
+
+from __future__ import annotations
+
+import math
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Import directly to avoid heavy engine deps.
+_api_dir = Path(__file__).resolve().parent.parent / "areno" / "api"
+sys.path.insert(0, str(_api_dir))
+
+from reward_validator import (  # noqa: E402
+    RewardValidationError,
+    validate_reward_batch,
+    validate_reward_fn,
+)
+
+
+class _Record:
+    def __init__(self, prompt="test", completion="answer"):
+        self.prompt = prompt
+        self.completion = completion
+
+
+class TestSignatureValidation:
+    def test_valid_single_arg(self):
+        def good_fn(record):
+            return 1.0
+        wrapped = validate_reward_fn(good_fn)
+        assert wrapped(_Record()) == 1.0
+
+    def test_zero_arg_raises(self):
+        def no_arg():
+            return 1.0
+        with pytest.raises(RewardValidationError, match="positional argument"):
+            validate_reward_fn(no_arg)
+
+
+class TestScalarRewards:
+    def test_int_return(self):
+        assert validate_reward_fn(lambda r: 1)(_Record()) == 1.0
+
+    def test_float_return(self):
+        assert validate_reward_fn(lambda r: 0.5)(_Record()) == 0.5
+
+    def test_bool_return(self):
+        assert validate_reward_fn(lambda r: True)(_Record()) == 1.0
+
+    def test_negative_reward(self):
+        assert validate_reward_fn(lambda r: -1.0)(_Record()) == -1.0
+
+
+class TestNumpyRewards:
+    def test_numpy_scalar(self):
+        assert validate_reward_fn(lambda r: np.float32(0.75))(_Record()) == 0.75
+
+    def test_zero_dim_array(self):
+        assert validate_reward_fn(lambda r: np.array(0.5))(_Record()) == 0.5
+
+    def test_single_element_array(self):
+        assert validate_reward_fn(lambda r: np.array([0.3]))(_Record()) == 0.3
+
+    def test_multi_element_array_raises(self):
+        with pytest.raises(RewardValidationError, match="size 2"):
+            validate_reward_fn(lambda r: np.array([0.1, 0.2]), strict=True)(_Record())
+
+
+class TestSequenceRewards:
+    def test_single_element_list(self):
+        assert validate_reward_fn(lambda r: [0.8])(_Record()) == 0.8
+
+    def test_multi_element_list_raises(self):
+        with pytest.raises(RewardValidationError, match="length 2"):
+            validate_reward_fn(lambda r: [0.1, 0.2], strict=True)(_Record())
+
+
+class TestInvalidTypes:
+    def test_none_raises(self):
+        with pytest.raises(RewardValidationError, match="None"):
+            validate_reward_fn(lambda r: None, strict=True)(_Record())
+
+    def test_string_raises(self):
+        with pytest.raises(RewardValidationError, match="str"):
+            validate_reward_fn(lambda r: "good", strict=True)(_Record())
+
+    def test_dict_raises(self):
+        with pytest.raises(RewardValidationError, match="dict"):
+            validate_reward_fn(lambda r: {"score": 1.0}, strict=True)(_Record())
+
+
+class TestNonFiniteValues:
+    def test_nan_raises(self):
+        with pytest.raises(RewardValidationError, match="NaN"):
+            validate_reward_fn(lambda r: float("nan"), strict=True)(_Record())
+
+    def test_inf_raises(self):
+        with pytest.raises(RewardValidationError, match="Inf"):
+            validate_reward_fn(lambda r: float("inf"), strict=True)(_Record())
+
+    def test_neg_inf_raises(self):
+        with pytest.raises(RewardValidationError, match="Inf"):
+            validate_reward_fn(lambda r: float("-inf"), strict=True)(_Record())
+
+
+class TestExceptionHandling:
+    def test_exception_strict_raises(self):
+        def fn(r):
+            raise ValueError("bad record")
+        with pytest.raises(RewardValidationError, match="ValueError: bad record"):
+            validate_reward_fn(fn, strict=True)(_Record())
+
+    def test_exception_non_strict_returns_zero(self):
+        def fn(r):
+            raise ValueError("bad record")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            assert validate_reward_fn(fn, strict=False)(_Record()) == 0.0
+
+
+class TestNonStrictMode:
+    def test_nan_non_strict_warns_and_returns_zero(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = validate_reward_fn(lambda r: float("nan"), strict=False)(_Record())
+        assert result == 0.0
+        assert len(w) == 1
+        assert "NaN" in str(w[0].message)
+
+    def test_none_non_strict_warns_and_returns_zero(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = validate_reward_fn(lambda r: None, strict=False)(_Record())
+        assert result == 0.0
+        assert len(w) == 1
+
+
+class TestBatchValidation:
+    def test_valid_batch(self):
+        def fn(r):
+            return 1.0 if "correct" in r.completion else 0.0
+        records = [_Record(completion="correct"), _Record(completion="wrong")]
+        assert validate_reward_batch(fn, records) == [1.0, 0.0]
+
+    def test_batch_length_matches(self):
+        records = [_Record() for _ in range(5)]
+        assert len(validate_reward_batch(lambda r: 0.5, records)) == 5
+
+    def test_batch_exception_strict(self):
+        def fn(r):
+            if "bad" in r.completion:
+                raise RuntimeError("explode")
+            return 1.0
+        with pytest.raises(RewardValidationError, match="sample=1"):
+            validate_reward_batch(fn, [_Record(completion="good"), _Record(completion="bad")], strict=True)
+
+    def test_batch_exception_non_strict(self):
+        def fn(r):
+            if "bad" in r.completion:
+                raise RuntimeError("explode")
+            return 1.0
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            assert validate_reward_batch(fn, [_Record(completion="good"), _Record(completion="bad")]) == [1.0, 0.0]
+
+    def test_batch_nan_strict(self):
+        def fn(r):
+            return float("nan") if r.completion == "nan" else 1.0
+        with pytest.raises(RewardValidationError, match="sample=1.*NaN"):
+            validate_reward_batch(fn, [_Record(completion="ok"), _Record(completion="nan")], strict=True)
+
+
+class TestBackwardCompatibility:
+    def test_math_reward(self):
+        def reward_fn(record):
+            return 1.0 if record.completion == record.prompt else 0.0
+        wrapped = validate_reward_fn(reward_fn)
+        assert wrapped(_Record(prompt="3", completion="3")) == 1.0
+        assert wrapped(_Record(prompt="3", completion="5")) == 0.0
+
+    def test_game_reward(self):
+        def reward_fn(record):
+            if "win" in record.completion:
+                return 1.0
+            elif "illegal" in record.completion:
+                return -1.0
+            return 0.0
+        wrapped = validate_reward_fn(reward_fn)
+        assert wrapped(_Record(completion="win")) == 1.0
+        assert wrapped(_Record(completion="illegal")) == -1.0
+
+
+class TestBoundaryCases:
+    def test_very_large_reward(self):
+        assert validate_reward_fn(lambda r: 1e20)(_Record()) == 1e20
+
+    def test_very_small_reward(self):
+        assert validate_reward_fn(lambda r: 1e-20)(_Record()) == 1e-20
+
+    def test_zero_reward(self):
+        assert validate_reward_fn(lambda r: 0.0)(_Record()) == 0.0
+
+    def test_empty_batch(self):
+        assert validate_reward_batch(lambda r: 1.0, []) == []
+
+    def test_single_record_batch(self):
+        assert validate_reward_batch(lambda r: 0.5, [_Record()]) == [0.5]
+
+
+class TestErrorMessages:
+    def test_hook_name_in_error(self):
+        with pytest.raises(RewardValidationError, match="hook=my_reward"):
+            validate_reward_fn(lambda r: None, name="my_reward", strict=True)(_Record())
+
+    def test_sample_index_in_batch_error(self):
+        def fn(r):
+            return float("nan")
+        with pytest.raises(RewardValidationError, match="sample=0.*NaN"):
+            validate_reward_batch(fn, [_Record(), _Record(), _Record()], strict=True)


### PR DESCRIPTION
Closes #222

## Summary

```
Add a runtime validation wrapper for user-supplied reward hooks. Checks signature, numeric type/shape, finite values, and batch output count. Failures are associated with hook name and sample index. No heavy imports — stdlib + numpy only.
```

## Usage

```python
from areno.api.reward_validator import validate_reward_fn, validate_reward_batch

# Wrap a single reward function (non-strict: warn + return 0.0 on error)
wrapped = validate_reward_fn(my_reward_fn, name="math_reward", strict=False)
reward = wrapped(record)

# Validate a batch of records (strict: raise on first error)
rewards = validate_reward_batch(my_reward_fn, records, name="math_reward", strict=True)
```

## Output examples

```
# None return — strict mode
RewardValidationError: [hook=math_reward, sample=0] reward_fn returned None, expected a numeric scalar

# NaN return — strict mode
RewardValidationError: [hook=math_reward, sample=3] reward_fn returned NaN

# Non-strict mode — warning + 0.0
RuntimeWarning: [hook=math_reward, sample=0] reward_fn returned NaN
# training continues, reward = 0.0

# Valid return — passes through unchanged
```

## What changed

| File | Change |
|------|--------|
| `areno/api/reward_validator.py` | +190: RewardValidationError, validate_reward_fn, validate_reward_batch |
| `tests/test_reward_validator_cpu.py` | +230: 36 CPU tests |

## Design decisions

- **Two modes**: `strict=True` raises; `strict=False` (default) warns and returns 0.0 — backward compatible
- **Type coercion**: int, float, bool, numpy scalar/array (size 1), single-element list — valid returns unaffected
- **Finite check**: NaN and Inf rejected — they silently poison advantage computation
- **Batch tracking**: per-sample index in error messages for fast debugging
- **No heavy imports**: stdlib + numpy only — no torch, no engine

## Tests (36 CPU)

| Category | Count | Coverage |
|----------|-------|----------|
| Signature | 2 | valid arg, zero arg raises |
| Scalar | 4 | int, float, bool, negative |
| Numpy | 4 | scalar, 0-dim, single, multi raises |
| Sequence | 2 | single list, multi raises |
| Invalid types | 3 | None, string, dict |
| Non-finite | 3 | NaN, Inf, -Inf |
| Exceptions | 2 | strict raises, non-strict returns 0 |
| Non-strict | 2 | NaN warns, None warns |
| Batch | 5 | valid, length, exception, NaN |
| Backward compat | 2 | math reward, game reward |
| Boundary | 5 | large, small, zero, empty, single |
| Error messages | 2 | hook name, sample index |

```bash
python3 -m pytest tests/test_reward_validator_cpu.py -v
# 36 passed in 0.16s
```

Hardware: macOS, Python 3.9.6, no GPU.

## Type of change

- [x] ✨ New feature

## Checklist

- [x] PR title summarizes the contribution
- [x] Linked related issue (Closes #222)
- [x] Existing tests pass
- [x] New behavior covered by tests
- [x] Test commands and hardware described
- [x] Additive and backward-compatible