### PR TITLE
feat: validate reward-hook inputs and outputs at runtime (#222)

### DIFF
--- a/areno/api/reward_validation.py
+++ b/areno/api/reward_validation.py
@@ -92,12 +92,14 @@ def _check_signature(fn: Callable, hook_name: str) -> None:
         )
 
 
-def _validate_scalar_output(value: Any, *, hook_name: str, prompt_preview: str) -> float:
+def _validate_scalar_output(value: Any, *, hook_name: str, prompt_preview: str,
+                            sample_idx: int | str = "unknown") -> float:
     """Validate a single reward output and return it as ``float``.
 
     Raises :class:`RewardValidationError` for invalid types or non-finite
     values.
     """
+    ctx = f"sample_index: {sample_idx}; prompt: {prompt_preview}"
     # --- torch tensor / numpy scalar (duck-typed via .item()) ---------------
     if hasattr(value, "item") and callable(value.item):
         # Reject multi-dimensional tensors
@@ -105,24 +107,23 @@ def _validate_scalar_output(value: Any, *, hook_name: str, prompt_preview: str) 
         if ndim is not None and ndim > 0:
             raise RewardValidationError(
                 f"reward hook '{hook_name}' returned a {ndim}-d tensor, "
-                f"expected a scalar; prompt: {prompt_preview}"
+                f"expected a scalar; {ctx}"
             )
         try:
             value = float(value.item())
         except (TypeError, ValueError) as exc:
             raise RewardValidationError(
                 f"reward hook '{hook_name}' returned a tensor that cannot be "
-                f"converted to float; prompt: {prompt_preview}"
+                f"converted to float; {ctx}"
             ) from exc
     elif value is None:
         raise RewardValidationError(
-            f"reward hook '{hook_name}' returned None; prompt: {prompt_preview}"
+            f"reward hook '{hook_name}' returned None; {ctx}"
         )
     elif isinstance(value, list):
         raise RewardValidationError(
             f"reward hook '{hook_name}' returned a list of length {len(value)}, "
-            f"expected a scalar; reward_fn must return one float per call; "
-            f"prompt: {prompt_preview}"
+            f"expected a scalar; reward_fn must return one float per call; {ctx}"
         )
     elif isinstance(value, bool):
         # bool is a subclass of int; accept and convert
@@ -132,13 +133,12 @@ def _validate_scalar_output(value: Any, *, hook_name: str, prompt_preview: str) 
     else:
         raise RewardValidationError(
             f"reward hook '{hook_name}' returned non-numeric value of type "
-            f"{type(value).__name__}; prompt: {prompt_preview}"
+            f"{type(value).__name__}; {ctx}"
         )
 
     if not math.isfinite(value):
         raise RewardValidationError(
-            f"reward hook '{hook_name}' returned non-finite value: {value}; "
-            f"prompt: {prompt_preview}"
+            f"reward hook '{hook_name}' returned non-finite value: {value}; {ctx}"
         )
 
     return value
@@ -156,15 +156,18 @@ def _wrap(fn: Callable, *, hook_name: str) -> Callable[[RewardRecord], float]:
 
     def validated_reward_fn(record: RewardRecord) -> float:
         prompt_preview = _truncate(getattr(record, "prompt", ""))
+        metadata = getattr(record, "metadata", {}) or {}
+        sample_idx = metadata.get("sample_index", "unknown")
         try:
             result = fn(record)
         except Exception as exc:
             raise RewardValidationError(
                 f"reward hook '{hook_name}' raised {type(exc).__name__}: {exc}; "
-                f"prompt: {prompt_preview}"
+                f"sample_index: {sample_idx}; prompt: {prompt_preview}"
             ) from exc
         return _validate_scalar_output(
-            result, hook_name=hook_name, prompt_preview=prompt_preview
+            result, hook_name=hook_name, prompt_preview=prompt_preview,
+            sample_idx=sample_idx,
         )
 
     return validated_reward_fn
@@ -231,7 +234,8 @@ def validate_and_wrap_reward_fn(
             )
         else:
             _validate_scalar_output(
-                dry_result, hook_name=hook_name, prompt_preview=""
+                dry_result, hook_name=hook_name, prompt_preview="",
+                sample_idx="dry-run",
             )
 
     # 3. Return a wrapper that validates every subsequent call.

--- a/areno/api/reward_validation.py
+++ b/areno/api/reward_validation.py
@@ -214,7 +214,10 @@ def validate_and_wrap_reward_fn(
     #    a successful dry-run is a hard error.
     if os.environ.get("ARENO_REWARD_VALIDATION_DRY_RUN", "1") != "0":
         mock_record = make_reward_record(
-            prompt="", completion="", source_record={}
+            prompt="What is 2+2?",
+            completion="4",
+            source_record={"answer": "4", "question": "What is 2+2?"},
+            answer=["4"],
         )
         try:
             dry_result = fn(mock_record)

--- a/areno/api/reward_validation.py
+++ b/areno/api/reward_validation.py
@@ -1,0 +1,235 @@
+"""Runtime validation for user-supplied reward hooks.
+
+All validation logic is concentrated here to keep :mod:`areno.api.rewards`
+focused on reward data structures and loading.  The single public entry
+point is :func:`validate_and_wrap_reward_fn`, called by
+:func:`areno.api.rewards.load_reward_fn` to wrap every loaded reward
+function with input/output checks.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+import os
+import warnings
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from areno.api.rewards import RewardRecord, make_reward_record
+
+__all__ = ["RewardValidationError", "validate_and_wrap_reward_fn"]
+
+
+class RewardValidationError(ValueError):
+    """Raised when a reward hook produces an invalid output."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PARAM_ANNOTATIONS = {"RewardRecord", "Any", "Any | None", "Optional[Any]"}
+
+_VALID_RETURN_ANNOTATIONS = {"float", "int", "Any", "float | None", "Optional[float]"}
+
+
+def _annotation_name(annotation: Any) -> str | None:
+    """Return a human-readable name for a type annotation object.
+
+    Returns ``None`` when the parameter / return value has no annotation.
+    """
+    if annotation is inspect.Parameter.empty:
+        return None
+    if annotation is None:
+        return "None"
+    name = getattr(annotation, "__name__", None)
+    if name is not None:
+        return name
+    # typing constructs fall back to str(annotation)
+    return str(annotation)
+
+
+def _check_signature(fn: Callable, hook_name: str) -> None:
+    """Inspect *fn*'s signature and warn on suspicious annotations.
+
+    Raises ``TypeError`` only when the function does not accept exactly
+    one positional argument.  Annotation mismatches produce warnings so
+    that existing hooks without annotations remain compatible.
+    """
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    if len(params) != 1:
+        raise TypeError(
+            f"reward hook '{hook_name}' must accept exactly 1 positional argument, "
+            f"got {len(params)}"
+        )
+    param = params[0]
+    if param.kind not in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD):
+        raise TypeError(
+            f"reward hook '{hook_name}' first parameter must be positional, "
+            f"got {param.kind.name}"
+        )
+
+    param_ann = _annotation_name(param.annotation)
+    if param_ann is not None and param_ann not in _VALID_PARAM_ANNOTATIONS:
+        warnings.warn(
+            f"reward hook '{hook_name}' parameter is annotated as '{param_ann}', "
+            f"expected 'RewardRecord' or 'Any'; the hook will still be called "
+            f"with a RewardRecord instance",
+            UserWarning,
+            stacklevel=3,
+        )
+
+    return_ann = _annotation_name(sig.return_annotation)
+    if return_ann is not None and return_ann not in _VALID_RETURN_ANNOTATIONS:
+        warnings.warn(
+            f"reward hook '{hook_name}' return type is annotated as '{return_ann}', "
+            f"expected 'float' or 'int'; the return value will be validated at runtime",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
+def _validate_scalar_output(value: Any, *, hook_name: str, prompt_preview: str) -> float:
+    """Validate a single reward output and return it as ``float``.
+
+    Raises :class:`RewardValidationError` for invalid types or non-finite
+    values.
+    """
+    # --- torch tensor / numpy scalar (duck-typed via .item()) ---------------
+    if hasattr(value, "item") and callable(value.item):
+        # Reject multi-dimensional tensors
+        ndim = getattr(value, "ndim", None)
+        if ndim is not None and ndim > 0:
+            raise RewardValidationError(
+                f"reward hook '{hook_name}' returned a {ndim}-d tensor, "
+                f"expected a scalar; prompt: {prompt_preview}"
+            )
+        try:
+            value = float(value.item())
+        except (TypeError, ValueError) as exc:
+            raise RewardValidationError(
+                f"reward hook '{hook_name}' returned a tensor that cannot be "
+                f"converted to float; prompt: {prompt_preview}"
+            ) from exc
+    elif value is None:
+        raise RewardValidationError(
+            f"reward hook '{hook_name}' returned None; prompt: {prompt_preview}"
+        )
+    elif isinstance(value, list):
+        raise RewardValidationError(
+            f"reward hook '{hook_name}' returned a list of length {len(value)}, "
+            f"expected a scalar; reward_fn must return one float per call; "
+            f"prompt: {prompt_preview}"
+        )
+    elif isinstance(value, bool):
+        # bool is a subclass of int; accept and convert
+        value = float(value)
+    elif isinstance(value, (int, float)):
+        value = float(value)
+    else:
+        raise RewardValidationError(
+            f"reward hook '{hook_name}' returned non-numeric value of type "
+            f"{type(value).__name__}; prompt: {prompt_preview}"
+        )
+
+    if not math.isfinite(value):
+        raise RewardValidationError(
+            f"reward hook '{hook_name}' returned non-finite value: {value}; "
+            f"prompt: {prompt_preview}"
+        )
+
+    return value
+
+
+def _truncate(text: str, limit: int = 100) -> str:
+    """Truncate *text* to *limit* characters for error messages."""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+def _wrap(fn: Callable, *, hook_name: str) -> Callable[[RewardRecord], float]:
+    """Return a validated wrapper around *fn*."""
+
+    def validated_reward_fn(record: RewardRecord) -> float:
+        prompt_preview = _truncate(getattr(record, "prompt", ""))
+        try:
+            result = fn(record)
+        except Exception as exc:
+            raise RewardValidationError(
+                f"reward hook '{hook_name}' raised {type(exc).__name__}: {exc}; "
+                f"prompt: {prompt_preview}"
+            ) from exc
+        return _validate_scalar_output(
+            result, hook_name=hook_name, prompt_preview=prompt_preview
+        )
+
+    return validated_reward_fn
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def validate_and_wrap_reward_fn(
+    fn: Callable,
+    module_path: Path,
+) -> Callable[[RewardRecord], float]:
+    """Validate *fn*'s signature, optionally dry-run, then return a wrapper.
+
+    This is the single entry point called by
+    :func:`areno.api.rewards.load_reward_fn`.
+
+    Parameters
+    ----------
+    fn
+        The raw ``reward_fn`` callable extracted from the user's module.
+    module_path
+        Resolved path to the user's reward file, used for the hook name
+        and error messages.
+
+    Returns
+    -------
+    A new callable with the same ``RewardRecord -> float`` contract but
+    with runtime output validation applied on every call.
+    """
+    hook_name = module_path.stem
+
+    # Validation is opt-in (default off) to preserve existing behavior.
+    # Set ARENO_REWARD_VALIDATION=1 to enable signature check, dry-run,
+    # and per-call output validation.
+    if os.environ.get("ARENO_REWARD_VALIDATION", "0") != "1":
+        return fn
+
+    # 1. Signature check (warnings only, never fatal).
+    _check_signature(fn, hook_name)
+
+    # 2. Dry-run with a minimal RewardRecord (can be disabled).
+    #    Many valid reward hooks require specific field values (e.g. record.answer)
+    #    and will naturally raise on a minimal mock.  We treat dry-run *call*
+    #    failures as warnings, not errors — only an invalid return value from
+    #    a successful dry-run is a hard error.
+    if os.environ.get("ARENO_REWARD_VALIDATION_DRY_RUN", "1") != "0":
+        mock_record = make_reward_record(
+            prompt="", completion="", source_record={}
+        )
+        try:
+            dry_result = fn(mock_record)
+        except Exception as exc:
+            warnings.warn(
+                f"reward hook '{hook_name}' dry-run raised {type(exc).__name__}: "
+                f"{exc}; this may be expected if the hook requires specific field "
+                f"values (e.g. record.answer); the hook will still be loaded",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:
+            _validate_scalar_output(
+                dry_result, hook_name=hook_name, prompt_preview=""
+            )
+
+    # 3. Return a wrapper that validates every subsequent call.
+    return _wrap(fn, hook_name=hook_name)

--- a/areno/api/rewards.py
+++ b/areno/api/rewards.py
@@ -83,7 +83,8 @@ def load_reward_fn(path: str) -> Callable[[RewardRecord], float]:
         raise ValueError(f"{module_path} must define callable reward_fn(record)") from exc
     if not callable(reward_fn):
         raise ValueError(f"{module_path} must define callable reward_fn(record)")
-    return reward_fn
+    from areno.api.reward_validation import validate_and_wrap_reward_fn
+    return validate_and_wrap_reward_fn(reward_fn, module_path)
 
 
 def make_reward_record(

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -15,8 +15,10 @@ import ast
 import importlib.util
 import json
 import logging
+import os
 import shutil
 import textwrap
+import warnings
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
@@ -541,6 +543,9 @@ def _preflight_task_hooks(args, algorithm) -> None:
             expected="reward_fn(record)",
             positional_args=1,
         )
+        _check_reward_fn_return_annotation(
+            Path(args.reward_fn_path).expanduser().resolve(),
+        )
     if args.agent_fn is not None:
         _validate_python_callable(
             Path(args.agent_fn).expanduser().resolve(),
@@ -590,6 +595,29 @@ def _function_accepts_positional_args(function: ast.FunctionDef | ast.AsyncFunct
     if args.vararg is not None:
         return required_count <= count
     return required_count <= count <= positional_count
+
+
+def _check_reward_fn_return_annotation(path: Path) -> None:
+    """Warn if the reward_fn return annotation is not float/int/Any."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return
+    function = _find_top_level_function(tree, "reward_fn")
+    if function is None or function.returns is None:
+        return
+    ann = function.returns
+    name = (
+        ann.id if isinstance(ann, ast.Name) else
+        getattr(ann, "attr", None) or ast.dump(ann)
+    )
+    if name not in {"float", "int", "Any"}:
+        warnings.warn(
+            f"--reward-fn-path {path} return type is annotated as '{name}', "
+            f"expected 'float' or 'int'; the return value will be validated at runtime",
+            UserWarning,
+            stacklevel=2,
+        )
 
 
 def _trainer_config_from_args(args) -> TrainerConfig:
@@ -1179,6 +1207,12 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option("--reward-fn-path", default=None, help="Python file defining reward_fn(record).")
 @click.option(
+    "--validate-reward",
+    is_flag=True,
+    default=False,
+    help="Validate reward hook inputs and outputs at runtime (signature check, dry-run, output type/finite validation).",
+)
+@click.option(
     "--ref-ckpt", default=None, help="Optional PPO/DPO reference model checkpoint path or remote model repo ID."
 )
 @click.option("--reward-ckpt", default=None, help="Optional PPO reward model checkpoint path or remote model repo ID.")
@@ -1363,6 +1397,9 @@ def train_command(**options) -> None:
         config=_training_config_settings(trainer_config),
         metrics_dir=trainer_config.metrics_log_dir,
     )
+    if options.get("validate_reward"):
+        os.environ["ARENO_REWARD_VALIDATION"] = "1"
+
     run(trainer_config)
 
 

--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -17,4 +17,15 @@ control.
 ``MAX_JOBS``
    Set this to control parallel compilation jobs during editable installs.
 
+``ARENO_REWARD_VALIDATION``
+   Set to ``1`` to enable runtime validation of reward hook inputs and
+   outputs (signature check, dry-run, per-call output type and finiteness
+   validation).  Equivalent to the ``--validate-reward`` CLI flag.  Off by
+   default.
+
+``ARENO_REWARD_VALIDATION_DRY_RUN``
+   Set to ``0`` to skip the reward hook dry-run step while keeping per-call
+   output validation active.  Only effective when
+   ``ARENO_REWARD_VALIDATION=1``.
+
 For environment inspection, use :doc:`/cli/diagnostics`.

--- a/docs/reference/reward-function-api.rst
+++ b/docs/reference/reward-function-api.rst
@@ -48,9 +48,21 @@ When enabled, AReno checks the reward function before and during training:
 3. **Output validation** (per call): rejects non-numeric return values
    (``None``, ``str``, ``list``, ``dict``), non-finite values (``NaN``,
    ``Inf``), and multi-dimensional tensors.  Each failure message includes
-   the hook name and a truncated prompt preview (100 chars).
+   the hook name, sample index (from ``record.metadata["sample_index"]``),
+   and a truncated prompt preview (100 chars).
 
 Validation is **off by default** and does not change existing behavior.
+
+Limitations:
+
+- The reward function contract is one ``RewardRecord`` in, one ``float``
+  out.  Batch-mode reward functions (returning a list of floats) are not
+  supported; a list return value is rejected with the list length.
+- ``sample_index`` is read from ``record.metadata["sample_index"]``, which
+  is populated by AReno's trainer.  When unavailable (e.g. dry-run or
+  direct SDK calls without metadata), the index is reported as ``unknown``.
+- Serializability of the return value is not checked explicitly, but the
+  validated output is always a plain ``float``, which is serializable.
 
 Environment variables:
 

--- a/docs/reference/reward-function-api.rst
+++ b/docs/reference/reward-function-api.rst
@@ -25,3 +25,37 @@ Return value:
 
 Keep this API stable for task code. If the reward needs extra metadata, add it
 through the dataset loader record rather than through global state.
+
+Runtime validation
+------------------
+
+Enable reward hook validation with the ``--validate-reward`` CLI flag:
+
+.. code-block:: bash
+
+   areno train --ckpt Qwen/Qwen3-0.6B --dataset-path gsm8k:main \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo --tp-size 4 --validate-reward
+
+When enabled, AReno checks the reward function before and during training:
+
+1. **Signature check** (at load time): warns if the parameter or return
+   type annotation does not match ``RewardRecord`` / ``float``.
+2. **Dry-run** (at load time): calls the function once with a minimal
+   ``RewardRecord`` to catch runtime errors early.  Failures produce a
+   warning, not a hard error, because many valid hooks require specific
+   field values (e.g. ``record.answer``).
+3. **Output validation** (per call): rejects non-numeric return values
+   (``None``, ``str``, ``list``, ``dict``), non-finite values (``NaN``,
+   ``Inf``), and multi-dimensional tensors.  Each failure message includes
+   the hook name and a truncated prompt preview (100 chars).
+
+Validation is **off by default** and does not change existing behavior.
+
+Environment variables:
+
+``ARENO_REWARD_VALIDATION``
+   Set to ``1`` to enable validation (equivalent to ``--validate-reward``).
+
+``ARENO_REWARD_VALIDATION_DRY_RUN``
+   Set to ``0`` to skip the dry-run step while keeping output validation active.

--- a/examples/reward_validation_demo.py
+++ b/examples/reward_validation_demo.py
@@ -1,0 +1,82 @@
+"""Minimal example demonstrating reward hook validation (issue #222).
+
+This file can be run standalone without GPU or external databases:
+
+    python examples/reward_validation_demo.py
+
+It demonstrates the successful path (valid reward function) and one
+invalid input (reward function returning NaN).
+
+Enable validation with::
+
+    ARENO_REWARD_VALIDATION=1 python examples/reward_validation_demo.py
+"""
+
+from __future__ import annotations
+
+from areno.api.reward_validation import (
+    RewardValidationError,
+    validate_and_wrap_reward_fn,
+)
+from areno.api.rewards import RewardRecord, make_reward_record
+
+
+def _test_valid_reward():
+    """A correct reward function should pass validation and return float."""
+
+    def good_reward(record: RewardRecord) -> float:
+        return 1.0 if "4" in record.completion else 0.0
+
+    record = make_reward_record(
+        prompt="What is 2+2?",
+        completion="The answer is 4",
+        source_record={},
+        answer=["4"],
+    )
+    wrapped = validate_and_wrap_reward_fn(good_reward, __import__("pathlib").Path("good_reward"))
+    result = wrapped(record)
+    assert isinstance(result, float), f"expected float, got {type(result)}"
+    assert result == 1.0, f"expected 1.0, got {result}"
+    print("[PASS] valid reward function returned", result)
+
+
+def _test_invalid_reward_nan():
+    """A reward function returning NaN should raise RewardValidationError."""
+
+    def nan_reward(record: RewardRecord) -> float:
+        return float("nan")
+
+    try:
+        validate_and_wrap_reward_fn(nan_reward, __import__("pathlib").Path("nan_reward"))
+        raise AssertionError("expected RewardValidationError for NaN")
+    except RewardValidationError as exc:
+        assert "non-finite" in str(exc), f"unexpected message: {exc}"
+        assert "sample_index: dry-run" in str(exc), f"missing sample_index in: {exc}"
+        print("[PASS] NaN reward rejected:", exc)
+
+
+def _test_invalid_reward_string():
+    """A reward function returning a string should raise RewardValidationError."""
+
+    def str_reward(record: RewardRecord) -> float:
+        return "good"
+
+    try:
+        validate_and_wrap_reward_fn(str_reward, __import__("pathlib").Path("str_reward"))
+        raise AssertionError("expected RewardValidationError for string")
+    except RewardValidationError as exc:
+        assert "non-numeric" in str(exc), f"unexpected message: {exc}"
+        assert "str" in str(exc), f"missing type name in: {exc}"
+        print("[PASS] string reward rejected:", exc)
+
+
+if __name__ == "__main__":
+    import os
+
+    os.environ["ARENO_REWARD_VALIDATION"] = "1"
+
+    _test_valid_reward()
+    _test_invalid_reward_nan()
+    _test_invalid_reward_string()
+
+    print("\nAll demo cases passed.")

--- a/tests/test_reward_validation_cpu.py
+++ b/tests/test_reward_validation_cpu.py
@@ -15,7 +15,6 @@ from areno.api.reward_validation import (
 )
 from areno.api.rewards import RewardRecord, load_reward_fn, make_reward_record
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -320,7 +319,7 @@ class LoadRewardFnIntegrationTest(unittest.TestCase):
             try:
                 with warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter("always")
-                    fn = load_reward_fn(str(path))
+                    load_reward_fn(str(path))
             finally:
                 if old is None:
                     os.environ.pop("ARENO_REWARD_VALIDATION", None)
@@ -426,7 +425,6 @@ class CLIIntegrationTest(unittest.TestCase):
 
     def test_validate_reward_flag_sets_env_var(self):
         """train_command should set ARENO_REWARD_VALIDATION=1 when --validate-reward is passed."""
-        import areno.cli.train as train_cli
 
         # Build a minimal options dict that includes validate_reward=True.
         # We only test the env-var side effect, not the full training run.

--- a/tests/test_reward_validation_cpu.py
+++ b/tests/test_reward_validation_cpu.py
@@ -244,12 +244,15 @@ class FinitenessTest(unittest.TestCase):
         return wrapped(record)
 
     def test_runtime_exception_wrapped_with_context(self):
-        """A function that raises at call time should include hook name and prompt."""
+        """A function that raises at call time should include hook name, prompt, and sample index."""
         def fn(record):
             raise KeyError("missing field")
         wrapped = _wrap_inline(fn)
-        record = make_reward_record(prompt="What is 2+2?", completion="4", source_record={})
-        with self.assertRaisesRegex(RewardValidationError, "raised KeyError.*missing field.*What is 2\\+2"):
+        record = make_reward_record(
+            prompt="What is 2+2?", completion="4", source_record={},
+            metadata={"prompt_index": 1, "sample_index": 5},
+        )
+        with self.assertRaisesRegex(RewardValidationError, "raised KeyError.*sample_index: 5.*What is 2\\+2"):
             wrapped(record)
 
     def test_output_rejects_inf(self):

--- a/tests/test_reward_validation_cpu.py
+++ b/tests/test_reward_validation_cpu.py
@@ -1,0 +1,493 @@
+"""CPU tests for reward hook runtime validation (issue #222)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from types import SimpleNamespace
+
+from areno.api.reward_validation import (
+    RewardValidationError,
+    validate_and_wrap_reward_fn,
+)
+from areno.api.rewards import RewardRecord, load_reward_fn, make_reward_record
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_reward_file(tmpdir: str, name: str, body: str) -> Path:
+    """Write *body* to a temp Python file and return its path."""
+    path = Path(tmpdir, name)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _wrap_inline(fn, hook_name: str = "test_hook"):
+    """Wrap *fn* without going through load_reward_fn.
+
+    Tests use this helper, which forces validation on so that the
+    wrapping logic is exercised regardless of the ambient environment.
+    """
+    old = os.environ.get("ARENO_REWARD_VALIDATION")
+    os.environ["ARENO_REWARD_VALIDATION"] = "1"
+    try:
+        fake_path = Path(f"/tmp/{hook_name}.py")
+        return validate_and_wrap_reward_fn(fn, fake_path)
+    finally:
+        if old is None:
+            os.environ.pop("ARENO_REWARD_VALIDATION", None)
+        else:
+            os.environ["ARENO_REWARD_VALIDATION"] = old
+
+
+# ---------------------------------------------------------------------------
+# Signature check tests
+# ---------------------------------------------------------------------------
+
+class SignatureCheckTest(unittest.TestCase):
+    """Tests for the AST / inspect signature validation."""
+
+    def test_valid_signature_no_annotation(self):
+        """A function without annotations should not warn."""
+        def fn(record):
+            return 1.0
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            wrapped = _wrap_inline(fn)
+            self.assertEqual(wrapped(make_reward_record(prompt="x", completion="y", source_record={})), 1.0)
+
+    def test_valid_signature_with_any_annotation(self):
+        """A function annotated with ``Any`` should not warn."""
+        from typing import Any
+
+        def fn(record: Any) -> float:
+            return 0.5
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            wrapped = _wrap_inline(fn)
+            self.assertEqual(wrapped(make_reward_record(prompt="x", completion="y", source_record={})), 0.5)
+
+    def test_valid_signature_with_reward_record_annotation(self):
+        """A function annotated with ``RewardRecord`` should not warn."""
+        def fn(record: RewardRecord) -> float:
+            return 1.0
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            wrapped = _wrap_inline(fn)
+            self.assertEqual(wrapped(make_reward_record(prompt="x", completion="y", source_record={})), 1.0)
+
+    def test_warning_on_wrong_param_annotation(self):
+        """A parameter annotated as ``str`` should emit a warning."""
+        def fn(record: str) -> float:
+            return 1.0
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _wrap_inline(fn)
+        self.assertTrue(any("annotated as 'str'" in str(w.message) for w in caught))
+
+    def test_warning_on_wrong_return_annotation(self):
+        """A return annotation of ``str`` should emit a warning."""
+        def fn(record) -> str:
+            return 1.0
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _wrap_inline(fn)
+        self.assertTrue(any("return type is annotated as 'str'" in str(w.message) for w in caught))
+
+    def test_error_on_zero_args(self):
+        """A function with no parameters should raise TypeError."""
+        def fn():
+            return 1.0
+        with self.assertRaisesRegex(TypeError, "must accept exactly 1 positional argument"):
+            _wrap_inline(fn)
+
+    def test_error_on_too_many_args(self):
+        """A function with two parameters should raise TypeError."""
+        def fn(a, b):
+            return 1.0
+        with self.assertRaisesRegex(TypeError, "must accept exactly 1 positional argument"):
+            _wrap_inline(fn)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run tests
+# ---------------------------------------------------------------------------
+
+class DryRunTest(unittest.TestCase):
+    """Tests for the pre-training dry-run invocation."""
+
+    def test_dry_run_passes_with_valid_fn(self):
+        """A valid function should pass the dry-run."""
+        def fn(record):
+            return float(len(record.completion))
+        wrapped = _wrap_inline(fn)
+        self.assertEqual(wrapped(make_reward_record(prompt="x", completion="abc", source_record={})), 3.0)
+
+    def test_dry_run_warns_on_key_error(self):
+        """A function that raises KeyError on mock input should warn, not fail."""
+        def fn(record):
+            _ = record.source_record["missing"]
+            return 1.0
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            wrapped = _wrap_inline(fn)
+        self.assertTrue(any("dry-run raised KeyError" in str(w.message) for w in caught))
+        # Function should still be loaded and callable with real data
+        record = make_reward_record(prompt="x", completion="y", source_record={"missing": 1})
+        self.assertEqual(wrapped(record), 1.0)
+
+    def test_dry_run_warns_on_attribute_error(self):
+        """A function that accesses a non-existent attribute should warn, not fail."""
+        def fn(record):
+            _ = record.nonexistent_field
+            return 1.0
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _wrap_inline(fn)
+        self.assertTrue(any("dry-run raised AttributeError" in str(w.message) for w in caught))
+
+    def test_dry_run_can_be_disabled(self):
+        """ARENO_REWARD_VALIDATION_DRY_RUN=0 should skip the dry-run."""
+        def fn(record):
+            raise RuntimeError("should not be called in dry-run")
+        old = os.environ.get("ARENO_REWARD_VALIDATION_DRY_RUN")
+        try:
+            os.environ["ARENO_REWARD_VALIDATION_DRY_RUN"] = "0"
+            wrapped = _wrap_inline(fn)
+            # The wrapper should still be returned; dry-run was skipped.
+            # Calling the wrapped function should raise RewardValidationError
+            # (wrapping the user's RuntimeError with hook name and prompt).
+            with self.assertRaisesRegex(RewardValidationError, "raised RuntimeError"):
+                wrapped(make_reward_record(prompt="x", completion="y", source_record={}))
+        finally:
+            if old is None:
+                os.environ.pop("ARENO_REWARD_VALIDATION_DRY_RUN", None)
+            else:
+                os.environ["ARENO_REWARD_VALIDATION_DRY_RUN"] = old
+
+
+# ---------------------------------------------------------------------------
+# Output type validation tests
+# ---------------------------------------------------------------------------
+
+class OutputTypeTest(unittest.TestCase):
+    """Tests for return-value type checking."""
+
+    def _call_fn(self, fn) -> float:
+        """Wrap *fn* and call it with a minimal RewardRecord."""
+        wrapped = _wrap_inline(fn)
+        record = make_reward_record(prompt="test", completion="test", source_record={})
+        return wrapped(record)
+
+    def test_output_accepts_int(self):
+        """int return values should be converted to float."""
+        self.assertEqual(self._call_fn(lambda r: 1), 1.0)
+        self.assertIsInstance(self._call_fn(lambda r: 1), float)
+
+    def test_output_accepts_float(self):
+        """float return values should pass through."""
+        self.assertEqual(self._call_fn(lambda r: 1.5), 1.5)
+
+    def test_output_accepts_bool(self):
+        """bool return values should be converted to float."""
+        self.assertEqual(self._call_fn(lambda r: True), 1.0)
+        self.assertEqual(self._call_fn(lambda r: False), 0.0)
+
+    def test_output_accepts_numpy_float32(self):
+        """numpy scalar types should be accepted."""
+        import numpy as np
+        self.assertAlmostEqual(self._call_fn(lambda r: np.float32(0.5)), 0.5, places=5)
+
+    def test_output_accepts_torch_scalar(self):
+        """0-d torch tensors should be accepted and converted to float."""
+        import torch
+        result = self._call_fn(lambda r: torch.tensor(0.5))
+        self.assertIsInstance(result, float)
+        self.assertAlmostEqual(result, 0.5, places=5)
+
+    def test_output_rejects_string(self):
+        """String return values should raise RewardValidationError."""
+        with self.assertRaisesRegex(RewardValidationError, "non-numeric value of type str"):
+            self._call_fn(lambda r: "good")
+
+    def test_output_rejects_none(self):
+        """None return values should raise RewardValidationError."""
+        with self.assertRaisesRegex(RewardValidationError, "returned None"):
+            self._call_fn(lambda r: None)
+
+    def test_output_rejects_list(self):
+        """List return values should raise RewardValidationError with length info."""
+        with self.assertRaisesRegex(RewardValidationError, "returned a list of length 2.*expected a scalar"):
+            self._call_fn(lambda r: [1.0, 2.0])
+
+    def test_output_rejects_dict(self):
+        """Dict return values should raise RewardValidationError."""
+        with self.assertRaisesRegex(RewardValidationError, "non-numeric value of type dict"):
+            self._call_fn(lambda r: {})
+
+
+# ---------------------------------------------------------------------------
+# Finiteness validation tests
+# ---------------------------------------------------------------------------
+
+class FinitenessTest(unittest.TestCase):
+    """Tests for NaN / Inf rejection."""
+
+    def _call_fn(self, fn) -> float:
+        wrapped = _wrap_inline(fn)
+        record = make_reward_record(prompt="test", completion="test", source_record={})
+        return wrapped(record)
+
+    def test_runtime_exception_wrapped_with_context(self):
+        """A function that raises at call time should include hook name and prompt."""
+        def fn(record):
+            raise KeyError("missing field")
+        wrapped = _wrap_inline(fn)
+        record = make_reward_record(prompt="What is 2+2?", completion="4", source_record={})
+        with self.assertRaisesRegex(RewardValidationError, "raised KeyError.*missing field.*What is 2\\+2"):
+            wrapped(record)
+
+    def test_output_rejects_inf(self):
+        """float('inf') should be rejected."""
+        with self.assertRaisesRegex(RewardValidationError, "non-finite value"):
+            self._call_fn(lambda r: float("inf"))
+
+    def test_output_rejects_nan(self):
+        """float('nan') should be rejected."""
+        with self.assertRaisesRegex(RewardValidationError, "non-finite value"):
+            self._call_fn(lambda r: float("nan"))
+
+    def test_output_rejects_nan_in_numpy(self):
+        """numpy NaN should be rejected."""
+        import numpy as np
+        with self.assertRaisesRegex(RewardValidationError, "non-finite value"):
+            self._call_fn(lambda r: np.float64("nan"))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration via load_reward_fn
+# ---------------------------------------------------------------------------
+
+class LoadRewardFnIntegrationTest(unittest.TestCase):
+    """Integration tests through the public load_reward_fn API."""
+
+    def _load_with_validation(self, path: str):
+        """Load a reward fn with ARENO_REWARD_VALIDATION=1 enabled."""
+        old = os.environ.get("ARENO_REWARD_VALIDATION")
+        os.environ["ARENO_REWARD_VALIDATION"] = "1"
+        try:
+            return load_reward_fn(path)
+        finally:
+            if old is None:
+                os.environ.pop("ARENO_REWARD_VALIDATION", None)
+            else:
+                os.environ["ARENO_REWARD_VALIDATION"] = old
+
+    def test_load_reward_fn_wraps_output(self):
+        """With validation on, load_reward_fn should return a wrapped function that outputs float."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(tmp, "int_reward.py", "def reward_fn(record):\n    return 1\n")
+            fn = self._load_with_validation(str(path))
+            record = make_reward_record(prompt="x", completion="y", source_record={})
+            result = fn(record)
+            self.assertEqual(result, 1.0)
+            self.assertIsInstance(result, float)
+
+    def test_load_reward_fn_rejects_bad_output(self):
+        """With validation on, load_reward_fn should reject non-numeric outputs at dry-run time."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(tmp, "str_reward.py", "def reward_fn(record):\n    return 'bad'\n")
+            with self.assertRaisesRegex(RewardValidationError, "non-numeric value of type str"):
+                self._load_with_validation(str(path))
+
+    def test_load_reward_fn_dry_run_warns_on_error(self):
+        """With validation on, load_reward_fn should warn (not crash) if dry-run raises."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(
+                tmp, "crash_reward.py",
+                "def reward_fn(record):\n    raise KeyError('boom')\n",
+            )
+            old = os.environ.get("ARENO_REWARD_VALIDATION")
+            os.environ["ARENO_REWARD_VALIDATION"] = "1"
+            try:
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    fn = load_reward_fn(str(path))
+            finally:
+                if old is None:
+                    os.environ.pop("ARENO_REWARD_VALIDATION", None)
+                else:
+                    os.environ["ARENO_REWARD_VALIDATION"] = old
+            self.assertTrue(any("dry-run raised KeyError" in str(w.message) for w in caught))
+
+    def test_validation_off_by_default(self):
+        """Without ARENO_REWARD_VALIDATION, load_reward_fn should return the raw function."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(tmp, "raw_reward.py", "def reward_fn(record):\n    return 'bad'\n")
+            # Ensure env var is not set
+            old = os.environ.pop("ARENO_REWARD_VALIDATION", None)
+            try:
+                fn = load_reward_fn(str(path))
+                record = make_reward_record(prompt="x", completion="y", source_record={})
+                # Raw function returns 'bad' string — no validation applied
+                self.assertEqual(fn(record), "bad")
+            finally:
+                if old is not None:
+                    os.environ["ARENO_REWARD_VALIDATION"] = old
+
+
+# ---------------------------------------------------------------------------
+# Existing example regression test
+# ---------------------------------------------------------------------------
+
+class ExampleRegressionTest(unittest.TestCase):
+    """Ensure existing example reward files pass validation."""
+
+    def test_math_verify_reward_example(self):
+        """examples/math/math_verify_reward.py should pass validation."""
+        from examples.math.math_verify_reward import reward_fn as raw_fn
+
+        # The math verify reward accesses record.answer and calls math_verify.
+        # The dry-run with an empty RewardRecord raises KeyError (record.answer
+        # is None), which should produce a warning, not a hard failure.
+        record = make_reward_record(
+            prompt="What is 2+2?",
+            completion="4",
+            source_record={},
+            answer=["4"],
+        )
+        old = os.environ.get("ARENO_REWARD_VALIDATION")
+        os.environ["ARENO_REWARD_VALIDATION"] = "1"
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                wrapped = validate_and_wrap_reward_fn(raw_fn, Path("math_verify_reward"))
+        finally:
+            if old is None:
+                os.environ.pop("ARENO_REWARD_VALIDATION", None)
+            else:
+                os.environ["ARENO_REWARD_VALIDATION"] = old
+        # Dry-run should have warned about KeyError
+        self.assertTrue(any("dry-run raised KeyError" in str(w.message) for w in caught))
+        # But the function should still be callable with a real record
+        result = wrapped(record)
+        self.assertIn(result, {0.0, 1.0})
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: existing test from test_tokenizer_api_cpu
+# ---------------------------------------------------------------------------
+
+class BackwardCompatTest(unittest.TestCase):
+    """Ensure load_reward_fn still works with SimpleNamespace inputs."""
+
+    def test_load_reward_fn_with_simple_namespace(self):
+        """load_reward_fn should still accept SimpleNamespace-like inputs (default off)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(
+                tmp, "len_reward.py",
+                "def reward_fn(record):\n    return len(record.completion)\n",
+            )
+            # Ensure validation is off (default)
+            old = os.environ.pop("ARENO_REWARD_VALIDATION", None)
+            try:
+                fn = load_reward_fn(str(path))
+                # SimpleNamespace has .completion but not .prompt
+                # Without validation, the raw function returns int
+                result = fn(SimpleNamespace(completion="abc"))
+                self.assertEqual(result, 3)
+            finally:
+                if old is not None:
+                    os.environ["ARENO_REWARD_VALIDATION"] = old
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: --validate-reward → env → load_reward_fn chain
+# ---------------------------------------------------------------------------
+
+class CLIIntegrationTest(unittest.TestCase):
+    """Verify the --validate-reward flag propagates through to load_reward_fn."""
+
+    def setUp(self):
+        # Ensure no stale env from other tests
+        self._old_env = os.environ.pop("ARENO_REWARD_VALIDATION", None)
+
+    def tearDown(self):
+        if self._old_env is not None:
+            os.environ["ARENO_REWARD_VALIDATION"] = self._old_env
+
+    def test_validate_reward_flag_sets_env_var(self):
+        """train_command should set ARENO_REWARD_VALIDATION=1 when --validate-reward is passed."""
+        import areno.cli.train as train_cli
+
+        # Build a minimal options dict that includes validate_reward=True.
+        # We only test the env-var side effect, not the full training run.
+        # train_command calls run() which needs GPU; we intercept by checking
+        # the env var is set before run() would be called.
+        # Since train_command is a Click command, we test via the options dict.
+        options = {"validate_reward": True}
+
+        # Simulate the relevant line from train_command:
+        #   if options.get("validate_reward"):
+        #       os.environ["ARENO_REWARD_VALIDATION"] = "1"
+        old = os.environ.get("ARENO_REWARD_VALIDATION")
+        try:
+            if options.get("validate_reward"):
+                os.environ["ARENO_REWARD_VALIDATION"] = "1"
+            self.assertEqual(os.environ.get("ARENO_REWARD_VALIDATION"), "1")
+        finally:
+            if old is None:
+                os.environ.pop("ARENO_REWARD_VALIDATION", None)
+            else:
+                os.environ["ARENO_REWARD_VALIDATION"] = old
+
+    def test_validate_reward_flag_absent_does_not_set_env(self):
+        """Without --validate-reward, ARENO_REWARD_VALIDATION should remain unset."""
+        self.assertIsNone(os.environ.get("ARENO_REWARD_VALIDATION"))
+
+        # load_reward_fn with env unset should return the raw function
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(
+                tmp, "raw_reward.py",
+                "def reward_fn(record):\n    return 'not_a_number'\n",
+            )
+            fn = load_reward_fn(str(path))
+            # Raw function returns string — no validation applied
+            self.assertEqual(fn(make_reward_record(prompt="x", completion="y", source_record={})), "not_a_number")
+
+    def test_full_chain_validate_reward_to_rejection(self):
+        """Full chain: env var set → load_reward_fn wraps → bad output rejected at load time."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(
+                tmp, "nan_reward.py",
+                "def reward_fn(record):\n    return float('nan')\n",
+            )
+            # Simulate --validate-reward setting the env var
+            os.environ["ARENO_REWARD_VALIDATION"] = "1"
+            # NaN is caught by dry-run validation at load time
+            with self.assertRaisesRegex(RewardValidationError, "non-finite value"):
+                load_reward_fn(str(path))
+
+    def test_full_chain_no_flag_no_rejection(self):
+        """Full chain: no env var → load_reward_fn returns raw fn → bad output passes through."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_reward_file(
+                tmp, "nan_reward.py",
+                "def reward_fn(record):\n    return float('nan')\n",
+            )
+            # Ensure env is NOT set
+            os.environ.pop("ARENO_REWARD_VALIDATION", None)
+            fn = load_reward_fn(str(path))
+            record = make_reward_record(prompt="test prompt", completion="test", source_record={})
+            # Without validation, NaN passes through as-is
+            import math
+            self.assertTrue(math.isnan(fn(record)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reward_validation_cpu.py
+++ b/tests/test_reward_validation_cpu.py
@@ -353,8 +353,8 @@ class ExampleRegressionTest(unittest.TestCase):
         from examples.math.math_verify_reward import reward_fn as raw_fn
 
         # The math verify reward accesses record.answer and calls math_verify.
-        # The dry-run with an empty RewardRecord raises KeyError (record.answer
-        # is None), which should produce a warning, not a hard failure.
+        # With a well-formed mock record (answer=["4"], completion="4"),
+        # dry-run should succeed without warnings.
         record = make_reward_record(
             prompt="What is 2+2?",
             completion="4",
@@ -372,9 +372,9 @@ class ExampleRegressionTest(unittest.TestCase):
                 os.environ.pop("ARENO_REWARD_VALIDATION", None)
             else:
                 os.environ["ARENO_REWARD_VALIDATION"] = old
-        # Dry-run should have warned about KeyError
-        self.assertTrue(any("dry-run raised KeyError" in str(w.message) for w in caught))
-        # But the function should still be callable with a real record
+        # Dry-run should succeed — no warnings expected
+        self.assertEqual(len(caught), 0)
+        # Function should return a valid score
         result = wrapped(record)
         self.assertIn(result, {0.0, 1.0})
 


### PR DESCRIPTION
## What does this PR do?

Wraps user-supplied reward hooks with runtime validation. The current `float(self.reward_fn(record))` cast misses most errors — `float("1.0")` accepts strings, `float('nan')` poisons advantage computation silently, and `float([1.0])` throws a generic TypeError with no sample identification. This catches them before model initialization.

Three layers, all applied at the single entry point `load_reward_fn` — trainer code untouched:

1. **Signature check** (load time): verifies parameter count, warns on mismatched annotations
2. **Dry-run** (load time): calls the function once with a mock RewardRecord with realistic field values; call failures warn (valid hooks may need specific fields), invalid returns raise
3. **Output validation** (per call): type checking (int/float/bool/numpy/torch scalar ok; None/str/list/dict rejected), finiteness (NaN/Inf rejected), internal exceptions wrapped with hook name, sample index, and truncated prompt

Off by default. Enable with `--validate-reward` or `ARENO_REWARD_VALIDATION=1`.

## Related issue

Closes #222

## Type of change

- [x] ✨ New feature

## How was it tested?

**CPU unit tests** — 34 cases, all passing:

```bash
python -m pytest tests/test_reward_validation_cpu.py -v
# 34 passed in 0.12s
```

**Minimal example (no GPU needed):**

```bash
PYTHONPATH=. python examples/reward_validation_demo.py
# [PASS] valid reward function returned 1.0
# [PASS] NaN reward rejected: ... sample_index: dry-run ...
# [PASS] string reward rejected: ... sample_index: dry-run ...
```

**GPU — bad reward function rejected at load time:**

```bash
areno train --ckpt Qwen/Qwen3.5-0.8B --dataset-path AI-MO/NuminaMath-CoT \
  --dataset-loader-fn examples/math/dataset_loader.py \
  --reward-fn-path /tmp/bad_nan.py --algo gspo --world-size 2 --tp-size 2 \
  --batch-size 2 --n-samples 2 --max-running-prompts 4 --max-new-tokens 1024 \
  --mini-bs 4 --drop-rollout-state --validate-reward
```

Expected (rejected before model initialization):

```
RewardValidationError: reward hook 'bad_nan' returned non-finite value: nan
```

## Files changed

| File | Change | Description |
|------|--------|-------------|
| `areno/api/reward_validation.py` | +247 (new) | Validation logic: signature, dry-run, output wrapper with sample index |
| `areno/api/rewards.py` | +2 | Wrap `load_reward_fn` return value |
| `areno/cli/train.py` | +37 | `--validate-reward` flag + return annotation check |
| `tests/test_reward_validation_cpu.py` | +500 (new) | 34 CPU tests |
| `examples/reward_validation_demo.py` | +85 (new) | Standalone demo: valid path + two invalid inputs |
| `docs/reference/reward-function-api.rst` | +48 | User documentation + limitations |
| `docs/reference/environment-variables.rst` | +11 | Env var docs |

## Usage

```bash
# Enable validation
areno train ... --validate-reward

# Via env var
ARENO_REWARD_VALIDATION=1 areno train ...

# Default (off)
areno train ...
```

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description.
- [x] Existing tests pass.
- [x] New behavior is covered by tests.
- [x] Described the test commands run.
- [x] Public API / CLI changes are additive and backward-compatible.