### PR TITLE
feat(cli): add areno timing-summary for per-phase RL timing

### DIFF
--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -21,6 +21,11 @@ class ArenoCli(click.Group):
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
+        "timing-summary": (
+            "areno.cli.timing_summary",
+            "timing_summary_command",
+            "Summarize time spent in each RL training phase for a run.",
+        ),
     }
 
     def list_commands(self, ctx: click.Context) -> list[str]:

--- a/areno/cli/timing_summary.py
+++ b/areno/cli/timing_summary.py
@@ -1,0 +1,80 @@
+"""``areno timing-summary`` — summarize time spent in each RL training phase.
+
+This command reads a run's local metrics artifacts (TensorBoard event files
+written by ``areno.api.metrics`` under ``--metrics-log-dir``) and aggregates
+per-phase timing into two views: the latest update and the whole run. It is a
+read-only, side-effect-free snapshot — it writes nothing, kills nothing, and
+never initializes models or workers.
+
+Background: the training loop already records per-step wall times for each
+phase (rollout / reward / train / etc.) as TensorBoard scalars. This command
+simply reads them back and reconciles the totals, so users can operate,
+compare, and reproduce runs without one-off scripts. See issue #256.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from areno.dashboard.timeperf import (
+    format_json,
+    format_table,
+    summarize,
+)
+
+
+def _validate_run_dir(run_dir: Path) -> None:
+    """Validate the run directory *before* any expensive event reading.
+
+    Mirrors the issue's requirement that inputs be validated prior to heavy
+    work and that failures name the offending stage/input. Raises
+    ``click.exceptions.Exit`` with a stderr message on any failure.
+    """
+    if not run_dir.exists():
+        raise click.exceptions.Exit(_fail(f"run directory does not exist: {run_dir}"))
+    if not run_dir.is_dir():
+        raise click.exceptions.Exit(_fail(f"run path is not a directory: {run_dir}"))
+    # A valid AReno metrics dir has either TensorBoard event files or a
+    # dashboard_state.<pid>.json snapshot. Reject empty/foreign directories
+    # up front with a clear message rather than silently emitting an empty run.
+    has_events = any(p.name.startswith("events.out.tfevents.") for p in run_dir.rglob("events.out.tfevents.*"))
+    has_state = any(run_dir.glob("dashboard_state.*.json"))
+    if not has_events and not has_state:
+        raise click.exceptions.Exit(
+            _fail(f"no AReno metrics found under {run_dir} (expected events.out.tfevents.* or dashboard_state.*.json)")
+        )
+
+
+def _fail(message: str) -> int:
+    """Print ``message`` to stderr and return exit code 1."""
+    click.echo(f"areno timing-summary: {message}", err=True)
+    return 1
+
+
+@click.command(
+    name="timing-summary",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.argument("run_dir", type=click.Path(exists=False))
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON summary instead of a table.")
+def timing_summary_command(run_dir: str, as_json: bool) -> None:
+    """Summarize time spent in each RL training phase for a run."""
+
+    run_path = Path(run_dir).expanduser()
+    _validate_run_dir(run_path)
+
+    try:
+        summary = summarize(run_path)
+    except RuntimeError as exc:
+        # Raised by load_step_segments when the 'tensorboard' reader package is
+        # missing. Surface it clearly rather than crashing with a traceback.
+        raise click.exceptions.Exit(_fail(str(exc)))
+    except Exception as exc:  # pragma: no cover - defensive, unexpected IO/parse
+        raise click.exceptions.Exit(_fail(f"failed to read run metrics: {exc}"))
+
+    if as_json:
+        click.echo(format_json(summary))
+    else:
+        click.echo(format_table(summary))

--- a/areno/cli/timing_summary.py
+++ b/areno/cli/timing_summary.py
@@ -56,8 +56,21 @@ def _fail(message: str) -> int:
 @click.command(
     name="timing-summary",
     context_settings={"help_option_names": ["-h", "--help"]},
+    help=(
+        "Aggregate wall time spent in each RL training phase (generation, reward, "
+        "training, sync, waiting) for a run's metrics directory. Reports the latest "
+        "update and the whole run, reconciles totals against raw step events, and "
+        "prints a phase table by default or JSON with --json. Read-only; can be run "
+        "while the run is still in progress.\n\n"
+        "RUN_DIR is the metrics directory written by --metrics-log-dir and must "
+        "contain events.out.tfevents.* or dashboard_state.<pid>.json."
+    ),
 )
-@click.argument("run_dir", type=click.Path(exists=False))
+@click.argument(
+    "run_dir",
+    type=click.Path(exists=False),
+    metavar="RUN_DIR",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON summary instead of a table.")
 def timing_summary_command(run_dir: str, as_json: bool) -> None:
     """Summarize time spent in each RL training phase for a run."""

--- a/areno/dashboard/timeperf.py
+++ b/areno/dashboard/timeperf.py
@@ -235,8 +235,16 @@ def load_step_segments(
     rollup_seen: dict[int, dict[str, float]] = {}
     phase_seen: dict[int, dict[str, float]] = {}
     divergences: list[str] = []
+    # Track which (step, tag) pairs we've already accepted, so a re-run that
+    # rewrites step 0 into a second event file does not double-count it.
+    # ``tensorboard_event_sources`` returns files in ascending mtime order, so
+    # we iterate newest-first: the first time we see a (step, tag) we keep that
+    # value (from the most recent run) and skip older duplicates. See review
+    # finding: real GSPO run restarted 3x and step 0 was summed 3x.
+    processed: set[tuple[int, str]] = set()
 
-    for accumulator_path in tensorboard_event_sources(run_dir, pid):
+    sources = tensorboard_event_sources(run_dir, pid)
+    for accumulator_path in reversed(sources):
         try:
             accumulator = EventAccumulator(str(accumulator_path), size_guidance={"scalars": 10000})
             accumulator.Reload()
@@ -253,6 +261,10 @@ def load_step_segments(
                 if math.isnan(value):
                     continue
                 step = int(event.step)
+                key = (step, tag)
+                if key in processed:
+                    continue
+                processed.add(key)
                 bucket = by_step.setdefault(step, {})
                 msg = _accumulate_event(bucket, step, tag, value, rollup_seen, phase_seen)
                 if msg:

--- a/areno/dashboard/timeperf.py
+++ b/areno/dashboard/timeperf.py
@@ -360,9 +360,11 @@ def summarize(run_dir: Path, pid: int | None = None) -> dict[str, Any]:
         }
         latest_update = {
             "step": last,
-            "segments": {
-                name: (val if val and val > 0 else None) for name, val in latest_phases.items()
-            },
+            # Keep 0.0 distinct from missing: a phase that was recorded with
+            # zero wall time (e.g. SFT's rollout, which has no generation)
+            # shows as 0.0, while a phase absent from this step shows as null.
+            # This matches whole_run.segments, which never collapses 0 to null.
+            "segments": dict(latest_phases),
             "partial": partial,
             **recon,
         }

--- a/areno/dashboard/timeperf.py
+++ b/areno/dashboard/timeperf.py
@@ -1,0 +1,477 @@
+"""Run-level timing aggregation for the ``areno timing-summary`` CLI.
+
+This module builds a per-phase timing summary (latest update + whole run) on
+top of the segment-tag normalization that the dashboard already owns. To keep
+this change minimal and avoid any risk to other contributors, the four
+segment helpers below are **reused in place** from
+``areno.dashboard.server`` rather than moved:
+
+* ``TIME_SEGMENT_ORDER`` — canonical, display-ordered phase vocabulary
+* ``tensorboard_event_sources`` — locate ``events.out.tfevents.*`` for a run
+* ``tensorboard_time_segment_name`` — map a TB scalar tag to a phase segment
+  (which internally delegates to the dashboard's ``normalize_time_segment_name``)
+
+``server.py`` is therefore left untouched. The aggregation logic defined here
+(``load_step_segments`` / ``load_run_status`` / ``summarize`` / ``format_*``)
+is the only new code; it only reads run artifacts and writes nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+# Re-exported in place from the dashboard so this module is the single import
+# target for the CLI, without duplicating or relocating the source of truth.
+from areno.dashboard.server import (
+    TIME_SEGMENT_ORDER,
+    tensorboard_event_sources,
+    tensorboard_time_segment_name,
+)
+
+# --------------------------------------------------------------------------- #
+# Run-level aggregation (used by the ``areno timing-summary`` CLI).
+#
+# The functions below read a run's TensorBoard event files once (a snapshot),
+# assemble per-step segment dicts using the same tag->segment semantics the
+# dashboard uses, and then aggregate them into a run-level summary covering the
+# latest update and the whole run. Reconciliation (reported vs reconstructed
+# totals) and explicit overlap/missing annotation are produced here.
+# --------------------------------------------------------------------------- #
+
+# Tags that carry a step-level *total* (end-to-end wall time) rather than a
+# single phase. These are the "ground truth" a reconstructed total is compared
+# against during reconciliation.
+_TOTAL_TAGS = {"train/step_e2e_time_s", "time/total", "time/e2e"}
+
+# The dedicated step-level rollup tags. These are the authoritative source for
+# the ``rollout`` / ``train`` phase values; ``time/rollout`` / ``time/train``
+# carry the same numbers in current trainers but are treated as sub-phase
+# echoes (see ``_rollup_tags``). Keeping rollups and ``time/*`` phases separate
+# avoids an order-dependent dict overwrite when the two ever diverge.
+_ROLLUP_TAGS = {
+    "train/step_rollout_time_s": "rollout",
+    "train/step_train_time_s": "train",
+    "train/policy_train_wall_time_s": "train",
+}
+
+
+def _dashboard_state_file(run_dir: Path, pid: int | None) -> Path | None:
+    """Locate the low-latency ``dashboard_state.<pid>.json`` for a run.
+
+    Minimal re-implementation of ``areno.dashboard.server.dashboard_state_source``
+    (kept local so this module stays free of a reverse import of the server).
+    Returns the most recently modified ``dashboard_state.*.json`` when ``pid``
+    is unknown.
+    """
+    if pid is not None:
+        state_file = run_dir / f"dashboard_state.{pid}.json"
+        return state_file if state_file.exists() else None
+    candidates = sorted(run_dir.glob("dashboard_state.*.json"), key=lambda item: item.stat().st_mtime)
+    return candidates[-1] if candidates else None
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return ``True`` if process ``pid`` currently exists.
+
+    Uses ``os.kill(pid, 0)``. ``ProcessLookupError`` means the process is gone
+    (run completed); ``PermissionError`` means it exists but is owned by another
+    user (treated as alive). Any other ``OSError`` is treated conservatively as
+    "not alive" so a stale/unknown pid resolves to ``completed``.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def load_run_status(run_dir: Path, pid: int | None = None) -> str:
+    """Return ``"active"`` or ``"completed"`` for a run, with a status basis.
+
+    The dashboard_state file written by ``MetricsRecorder.record_dashboard_state``
+    always carries ``status == "running"`` (the trainer never writes a terminal
+    status — see issue #256 review, finding 1), so ``status`` alone **cannot**
+    distinguish a finished run from one in progress. This function therefore
+    resolves the run's pid (from the caller or from the state file's ``pid``
+    field) and checks process liveness via ``os.kill(pid, 0)``:
+
+    * process alive  -> ``"active"``
+    * process gone   -> ``"completed"`` (regardless of the stale ``running`` status)
+    * pid unknown / file missing or unreadable -> ``"completed"`` (conservative
+      default: do not over-warn about partial steps that are actually final)
+
+    The returned status (``"active"`` / ``"completed"``) reflects this
+    liveness check rather than the stale ``running`` field, so a finished run
+    is reported as ``completed`` once its process is gone.
+
+    Limitation (heuristic, not a guarantee): pid liveness only proves that
+    *some* process with that pid exists now — not that it is the original
+    training run. It is reliable for the intended local usage (reading a run's
+    own metrics dir on the same host shortly after/while it runs). It can be
+    wrong when (a) the metrics dir is read on a different host than where the
+    run executed (the pid refers to that host's pid space), or (b) the run has
+    exited and its pid has been reused by an unrelated process. The correct
+    fix is for the trainer to write a terminal ``status`` on close (tracked
+    separately, out of this issue's scope); until then this heuristic is the
+    best available signal and falls back to ``"completed"`` conservatively.
+    """
+    state_file = _dashboard_state_file(run_dir, pid)
+    if state_file is None:
+        return "completed"
+    try:
+        payload = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return "completed"
+    resolved_pid = pid if pid is not None else payload.get("pid")
+    if isinstance(resolved_pid, int) and _pid_alive(resolved_pid):
+        return "active"
+    return "completed"
+
+
+def _accumulate_event(
+    bucket: dict[str, float],
+    step: int,
+    tag: str,
+    value: float,
+    rollup_seen: dict[int, dict[str, float]],
+    phase_seen: dict[int, dict[str, float]],
+) -> str | None:
+    """Fold one TensorBoard scalar event into a step's segment ``bucket``.
+
+    Pure (no I/O) so the classification below — which is where findings 3 and 4
+    live — can be unit-tested without the ``tensorboard`` package. Returns a
+    divergence message string when the event conflicts with a prior value for
+    the same phase, else ``None``.
+
+    Classification:
+    * ``_TOTAL_TAGS``           -> rollup key ``"total"``
+    * ``_ROLLUP_TAGS``          -> rollup ``rollout``/``train`` (authoritative)
+    * normalizer maps to a vocab segment -> that phase (echo; rollup value wins)
+    * normalizer maps outside vocab     -> ``"other"`` (kept, not dropped)
+    * normalizer returns ``None``       -> ignored (e.g. e2e/total leaves)
+    """
+    if tag in _TOTAL_TAGS:
+        bucket["total"] = value
+        return None
+    if tag in _ROLLUP_TAGS:
+        rollup_name = _ROLLUP_TAGS[tag]
+        rollup_seen.setdefault(step, {})
+        if (
+            rollup_name in rollup_seen[step]
+            and abs(rollup_seen[step][rollup_name] - value) > 1e-9
+        ):
+            return f"step {step} {rollup_name} rollup diverges"
+        rollup_seen[step][rollup_name] = value
+        bucket[rollup_name] = value
+        return None
+    time_name = tensorboard_time_segment_name(tag)
+    if time_name is None:
+        return None
+    if time_name in TIME_SEGMENT_ORDER:
+        phase_seen.setdefault(step, {})
+        # An echo (time/*) that disagrees with the authoritative rollup value
+        # (train/step_*_time_s) for the same phase is a real divergence
+        # (finding 4) — surface it instead of silently overwriting.
+        rollup_value = rollup_seen.get(step, {}).get(time_name)
+        if rollup_value is not None and abs(rollup_value - value) > 1e-9:
+            return f"step {step} {time_name} phase echo diverges (rollup={rollup_value} echo={value})"
+        if (
+            time_name in phase_seen[step]
+            and abs(phase_seen[step][time_name] - value) > 1e-9
+        ):
+            return f"step {step} {time_name} phase echo diverges"
+        phase_seen[step][time_name] = value
+        if time_name not in bucket:
+            bucket[time_name] = value
+        return None
+    # Out-of-vocab sub-phase (e.g. critic value forward): fold into "other"
+    # so the time is not silently dropped (finding 3).
+    bucket["other"] = bucket.get("other", 0.0) + value
+    return None
+
+
+def load_step_segments(
+    run_dir: Path, pid: int | None = None
+) -> tuple[dict[int, dict[str, float]], list[str]]:
+    """Read TensorBoard scalars and assemble per-step segment dicts.
+
+    Returns ``(by_step, divergences)``.
+
+    ``by_step`` is ``{step: {segment_name: seconds}}`` with two kinds of keys:
+
+    * rollup keys ``"total"`` (step end-to-end, from ``_TOTAL_TAGS``),
+      ``"rollout"`` and ``"train"`` — taken **only** from the dedicated
+      ``train/step_*_time_s`` tags in ``_ROLLUP_TAGS`` so the rollup source is
+      unambiguous (finding 4);
+    * phase keys — every ``time/*`` and ``train/*_time_s`` tag mapped through
+      ``tensorboard_time_segment_name``. Segment names that fall **outside**
+      ``TIME_SEGMENT_ORDER`` (e.g. PPO's ``critic value forward`` /
+      ``critic train`` / ``reward score``) are folded into ``"other"`` and
+      **kept in the reconstructed sum**, so recorded time is never silently
+      dropped and ``missing`` no longer contradicts reality (finding 3).
+
+    ``divergences`` lists steps where the ``rollout``/``train`` rollup value
+    disagreed with the ``time/*`` echo of the same phase (finding 4) — currently
+    empty for all real trainers, since both sources read the same
+    ``_metric_timings`` value, but surfaced instead of silently overwritten.
+
+    ``NaN`` values are skipped. Raises ``RuntimeError`` if ``tensorboard`` is
+    not importable.
+    """
+    try:
+        from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+    except Exception as exc:  # pragma: no cover - depends on env
+        raise RuntimeError("The 'tensorboard' package is required to read run metrics but is not installed.") from exc
+
+    by_step: dict[int, dict[str, float]] = {}
+    rollup_seen: dict[int, dict[str, float]] = {}
+    phase_seen: dict[int, dict[str, float]] = {}
+    divergences: list[str] = []
+
+    for accumulator_path in tensorboard_event_sources(run_dir, pid):
+        try:
+            accumulator = EventAccumulator(str(accumulator_path), size_guidance={"scalars": 10000})
+            accumulator.Reload()
+            tags = accumulator.Tags().get("scalars", [])
+        except Exception:
+            continue
+        for tag in tags:
+            try:
+                events = accumulator.Scalars(tag)[-500:]
+            except Exception:
+                continue
+            for event in events:
+                value = float(event.value)
+                if math.isnan(value):
+                    continue
+                step = int(event.step)
+                bucket = by_step.setdefault(step, {})
+                msg = _accumulate_event(bucket, step, tag, value, rollup_seen, phase_seen)
+                if msg:
+                    divergences.append(msg)
+    return by_step, divergences
+
+
+def _reconcile(step_values: dict[str, float]) -> dict[str, Any]:
+    """Compute the reconciliation columns for a single step's segment dict.
+
+    Returns ``{reported_total, reconstructed_total, diff, total_source}``.
+    ``reconstructed_total`` sums the canonical phases present in
+    ``TIME_SEGMENT_ORDER`` (including ``"other"``, which holds out-of-vocab
+    sub-phase time) but excludes the synthetic ``"total"`` rollup. This keeps
+    reconstructed totals honest even when PPO sub-phases fold into ``"other"``
+    (finding 3).
+    """
+    phases = {name: step_values[name] for name in TIME_SEGMENT_ORDER if name in step_values}
+    reconstructed = sum(v for v in phases.values() if v > 0)
+    reported = step_values.get("total")
+    if reported is None:
+        return {
+            "reported_total": reconstructed,
+            "reconstructed_total": reconstructed,
+            "diff": 0.0,
+            "total_source": "reconstructed",
+        }
+    return {
+        "reported_total": reported,
+        "reconstructed_total": reconstructed,
+        "diff": reported - reconstructed,
+        "total_source": "reported",
+    }
+
+
+def _is_partial(step_values: dict[str, float]) -> bool:
+    """A step is partial when it has phase data but no reported ``total``.
+
+    This is the signature of a still-running step whose rollout segment has
+    landed but whose train/e2e segment has not been written yet.
+    """
+    has_phase = any(name in step_values for name in TIME_SEGMENT_ORDER if name != "other")
+    return has_phase and "total" not in step_values
+
+
+def summarize(run_dir: Path, pid: int | None = None) -> dict[str, Any]:
+    """Build a run-level timing summary for ``run_dir``.
+
+    Produces a plain dict (so it serializes directly to JSON) with:
+
+    * ``run_status``: ``"active"`` | ``"completed"`` (resolved from process
+      liveness, not the stale ``running`` status field — finding 1)
+    * ``run_dir``: the resolved directory
+    * ``num_steps``: number of steps with any timing data
+    * ``latest_update``: per-segment breakdown for the highest step, with
+      reconciliation columns and a ``partial`` flag
+    * ``whole_run``: per-segment sums across all steps (including ``"other"``,
+      which holds out-of-vocab sub-phase time), with reconciliation
+    * ``overlap``: always ``[]`` — current trainers record no overlapping
+      sub-phase timers; ``overlap_note`` explains why (finding 2)
+    * ``missing``: canonical segments (excluding ``"other"``) never seen
+    * ``divergences``: steps where the rollup and ``time/*`` echo of a phase
+      disagreed (finding 4; empty for current trainers)
+
+    The function only reads files; it writes nothing and never mutates the run.
+    """
+    run_dir = Path(run_dir).resolve()
+    run_status = load_run_status(run_dir, pid)
+    by_step, divergences = load_step_segments(run_dir, pid)
+
+    steps = sorted(by_step)
+    # Union of canonical segments actually seen across all steps (excluding the
+    # synthetic "total" rollup key). "other" does not count toward missing.
+    seen_segments: set[str] = set()
+    for values in by_step.values():
+        seen_segments.update(name for name in values if name in TIME_SEGMENT_ORDER)
+    seen_segments.discard("total")
+
+    # Whole-run sums: sum each canonical phase across steps (including "other",
+    # which carries out-of-vocab sub-phase time so reconstructed totals match).
+    whole_phases = {
+        name: sum(by_step[s].get(name, 0.0) for s in steps if by_step[s].get(name, 0.0) > 0)
+        for name in TIME_SEGMENT_ORDER
+    }
+    whole_reported = sum(by_step[s].get("total", 0.0) for s in steps if by_step[s].get("total", 0.0) > 0)
+    whole_reconstructed = sum(v for v in whole_phases.values() if v > 0)
+    if whole_reported > 0:
+        whole_total_source = "reported"
+        whole_diff = whole_reported - whole_reconstructed
+        whole_reported_total = whole_reported
+    else:
+        whole_total_source = "reconstructed"
+        whole_diff = 0.0
+        whole_reported_total = whole_reconstructed
+
+    latest_update: dict[str, Any] = {}
+    partial = False
+    if steps:
+        last = steps[-1]
+        last_values = by_step[last]
+        partial = _is_partial(last_values)
+        recon = _reconcile(last_values)
+        latest_phases = {
+            name: (last_values[name] if name in last_values else None) for name in TIME_SEGMENT_ORDER
+        }
+        latest_update = {
+            "step": last,
+            "segments": {
+                name: (val if val and val > 0 else None) for name, val in latest_phases.items()
+            },
+            "partial": partial,
+            **recon,
+        }
+
+    missing = [name for name in TIME_SEGMENT_ORDER if name not in seen_segments and name != "other"]
+
+    # The trainers currently record no overlapping sub-phase timers (the only
+    # candidate, PPO's critic value/train, normalizes outside the segment
+    # vocabulary and is folded into "other"). So there are no containment
+    # relations to declare; ``overlap`` is always empty and reported honestly
+    # rather than via a hardcoded pair that never triggers (finding 2).
+    overlap: list[Any] = []
+
+    def _share(value: float | None, total: float) -> float | None:
+        if value is None or value <= 0 or total <= 0:
+            return None
+        return round(100.0 * value / total, 2)
+
+    return {
+        "run_status": run_status,
+        "run_dir": str(run_dir),
+        "num_steps": len(steps),
+        "latest_update": latest_update,
+        "whole_run": {
+            "segments": whole_phases,
+            "reported_total": whole_reported_total,
+            "reconstructed_total": whole_reconstructed,
+            "diff": whole_diff,
+            "total_source": whole_total_source,
+        },
+        "overlap": overlap,
+        "overlap_note": "no overlapping sub-phase timers are recorded by current trainers; overlap is always empty",
+        "missing": missing,
+        "divergences": divergences,
+    }
+
+
+def format_json(summary: dict[str, Any]) -> str:
+    """Serialize a summary to a pretty JSON string."""
+    return json.dumps(summary, indent=2, sort_keys=False)
+
+
+def format_table(summary: dict[str, Any]) -> str:
+    """Render a summary as a human-readable fixed-width table.
+
+    Lists each canonical phase with two columns (latest update / whole run),
+    each showing seconds and share-of-total, then a reconciliation footer with
+    reported vs reconstructed totals and the diff. Missing phases and declared
+    overlaps are shown explicitly.
+    """
+    lines: list[str] = []
+    lines.append(
+        f"Run status: {summary['run_status']}    Run dir: {summary['run_dir']}    Steps: {summary['num_steps']}"
+    )
+    lines.append("")
+
+    latest = summary.get("latest_update") or {}
+    whole = summary["whole_run"]
+    latest_total = latest.get("reported_total") or 0.0
+    whole_total = whole["reported_total"] or 0.0
+    latest_segs = latest.get("segments", {})
+    whole_segs = whole["segments"]
+
+    def _share(value: float | None, total: float) -> float | None:
+        if value is None or value <= 0 or total <= 0:
+            return None
+        return round(100.0 * value / total, 2)
+
+    def _cell(value: float | None) -> str:
+        if value is None:
+            return "missing"
+        if value <= 0:
+            return f"{value:.2f}"
+        share = _share(value, latest_total) or 0.0
+        return f"{value:.2f}  {share:5.1f}%"
+
+    def _cell_whole(value: float | None) -> str:
+        if value is None or value == 0:
+            return "missing" if value is None else f"{value:.2f}"
+        share = _share(value, whole_total) or 0.0
+        return f"{value:.2f}  {share:5.1f}%"
+
+    header = f"{'Phase':<22}{'latest update':>22}{'whole run':>22}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for name in TIME_SEGMENT_ORDER:
+        lv = latest_segs.get(name)
+        wv = whole_segs.get(name)
+        lines.append(f"{name:<22}{_cell(lv):>22}{_cell_whole(wv):>22}")
+    lines.append("-" * len(header))
+    lines.append(f"{'reported_total':<22}{latest_total:>22.2f}{whole_total:>22.2f}")
+    lines.append(
+        f"{'reconstructed_total':<22}"
+        f"{(latest.get('reconstructed_total') or 0.0):>22.2f}"
+        f"{whole['reconstructed_total']:>22.2f}"
+    )
+    lines.append(f"{'diff':<22}{(latest.get('diff') or 0.0):>22.2f}{whole['diff']:>22.2f}")
+    lines.append(f"{'total_source':<22}{str(latest.get('total_source', '-')):>22}{whole['total_source']:>22}")
+    if latest.get("partial"):
+        lines.append("")
+        lines.append(f"Note: latest update (step {latest.get('step')}) is partial — some phases not yet recorded.")
+    if summary.get("missing"):
+        lines.append("")
+        lines.append("Missing phases: " + ", ".join(summary["missing"]))
+    note = summary.get("overlap_note")
+    if note:
+        lines.append("")
+        lines.append(f"Overlap: none — {note}")
+    if summary.get("divergences"):
+        lines.append("")
+        lines.append("Divergences (rollup vs time/* echo): " + "; ".join(summary["divergences"]))
+    return "\n".join(lines)

--- a/areno/dashboard/timeperf.py
+++ b/areno/dashboard/timeperf.py
@@ -164,10 +164,7 @@ def _accumulate_event(
     if tag in _ROLLUP_TAGS:
         rollup_name = _ROLLUP_TAGS[tag]
         rollup_seen.setdefault(step, {})
-        if (
-            rollup_name in rollup_seen[step]
-            and abs(rollup_seen[step][rollup_name] - value) > 1e-9
-        ):
+        if rollup_name in rollup_seen[step] and abs(rollup_seen[step][rollup_name] - value) > 1e-9:
             return f"step {step} {rollup_name} rollup diverges"
         rollup_seen[step][rollup_name] = value
         bucket[rollup_name] = value
@@ -183,10 +180,7 @@ def _accumulate_event(
         rollup_value = rollup_seen.get(step, {}).get(time_name)
         if rollup_value is not None and abs(rollup_value - value) > 1e-9:
             return f"step {step} {time_name} phase echo diverges (rollup={rollup_value} echo={value})"
-        if (
-            time_name in phase_seen[step]
-            and abs(phase_seen[step][time_name] - value) > 1e-9
-        ):
+        if time_name in phase_seen[step] and abs(phase_seen[step][time_name] - value) > 1e-9:
             return f"step {step} {time_name} phase echo diverges"
         phase_seen[step][time_name] = value
         if time_name not in bucket:
@@ -198,9 +192,7 @@ def _accumulate_event(
     return None
 
 
-def load_step_segments(
-    run_dir: Path, pid: int | None = None
-) -> tuple[dict[int, dict[str, float]], list[str]]:
+def load_step_segments(run_dir: Path, pid: int | None = None) -> tuple[dict[int, dict[str, float]], list[str]]:
     """Read TensorBoard scalars and assemble per-step segment dicts.
 
     Returns ``(by_step, divergences)``.
@@ -367,9 +359,7 @@ def summarize(run_dir: Path, pid: int | None = None) -> dict[str, Any]:
         last_values = by_step[last]
         partial = _is_partial(last_values)
         recon = _reconcile(last_values)
-        latest_phases = {
-            name: (last_values[name] if name in last_values else None) for name in TIME_SEGMENT_ORDER
-        }
+        latest_phases = {name: (last_values[name] if name in last_values else None) for name in TIME_SEGMENT_ORDER}
         latest_update = {
             "step": last,
             # Keep 0.0 distinct from missing: a phase that was recorded with

--- a/docs/cli/timing_summary.rst
+++ b/docs/cli/timing_summary.rst
@@ -1,0 +1,61 @@
+:orphan:
+
+Timing summary CLI reference
+============================
+
+``areno timing-summary`` aggregates the wall time spent in each RL training
+phase (generation / reward / training / sync / waiting) for a run's existing
+metrics artifacts. It reads ``--metrics-log-dir`` output and reports two views:
+the **latest update** and the **whole run**. It is a read-only snapshot — it
+writes nothing, initializes no models or workers, and can be run against a
+directory even while the run is still in progress.
+
+.. code-block:: bash
+
+   areno timing-summary /tmp/areno/tfevent
+
+For machine-readable output:
+
+.. code-block:: bash
+
+   areno timing-summary /tmp/areno/tfevent --json
+
+The ``RUN_DIR`` argument is the metrics directory written during training (the
+``--metrics-log-dir`` value). It must contain ``events.out.tfevents.*`` or
+``dashboard_state.<pid>.json``; validation runs before TensorBoard loading and
+names the missing input on failure.
+
+Output fields (``--json``)
+--------------------------
+
+* ``run_status`` — ``"active"`` or ``"completed"``, resolved from process
+  liveness.
+* ``num_steps`` — number of steps with timing data.
+* ``latest_update`` — per-phase breakdown for the highest step, with a
+  ``partial`` flag and reconciliation columns.
+* ``whole_run`` — per-phase sums across all steps, with reconciliation columns.
+* ``overlap`` — declared containment relations (currently always empty).
+* ``missing`` — canonical phases never recorded in any step.
+* ``divergences`` — steps where the rollup and ``time/*`` echo disagreed.
+
+Reconciliation columns (``reported_total`` / ``reconstructed_total`` / ``diff``
+/ ``total_source``) let the aggregated totals be checked against the raw
+step-end-to-end events.
+
+Phases follow the dashboard's canonical segment vocabulary (``rollout``,
+``reward``, ``train``, ``advantages``, ``save``, …). Phases that a trainer does
+not time appear as ``missing``; out-of-vocabulary sub-phase timers (e.g. PPO's
+critic forwards) fold into ``other`` and stay in the reconstructed sum.
+
+Limitations
+-----------
+
+* Reading requires the ``tensorboard`` package (the same package the dashboard
+  uses to read events). If it is not installed, the command exits with a clear
+  message rather than emitting an empty report.
+* ``run_status`` uses process liveness, not the ``dashboard_state`` ``status``
+  field (the trainer never writes a terminal status). It may misreport when the
+  metrics dir is read on a different host than where the run executed, or after
+  pid reuse.
+* Only phases already emitted by the trainer are surfaced; this command
+  aggregates existing timing events and does not add new instrumentation.

--- a/tests/test_timing_summary_cpu.py
+++ b/tests/test_timing_summary_cpu.py
@@ -413,6 +413,47 @@ class EndToEndTest(unittest.TestCase):
         self.assertIn("Run status:", res.output)
         self.assertIn("rollout", res.output)
 
+    def test_restarted_run_keeps_only_latest_per_step(self):
+        """A run that restarted into a second event file must not double-count step 0.
+
+        Reproduces the real GSPO run on Kaggle, where the metrics dir held 3
+        event files each rewriting step 0, and the summary summed step 0 three
+        times. Only the values from the most recent (highest-mtime) file are
+        kept; earlier duplicates do not count as divergences.
+        """
+        import time
+
+        SummaryWriter = _summary_writer_cls()
+        # First (older) file: step 0 with rollout 48, train 277, e2e 325.
+        w1 = SummaryWriter(log_dir=str(self.run_dir))
+        w1.add_scalar("train/step_rollout_time_s", 48.0, 0)
+        w1.add_scalar("train/step_train_time_s", 277.0, 0)
+        w1.add_scalar("train/step_e2e_time_s", 325.0, 0)
+        w1.close()
+        # Force a newer mtime on the second file so newest-first picks it.
+        time.sleep(1.1)
+        # Second (newer) file: same step 0 rewritten with rollout 101, train 16, e2e 117.
+        w2 = SummaryWriter(log_dir=str(self.run_dir))
+        w2.add_scalar("train/step_rollout_time_s", 101.0, 0)
+        w2.add_scalar("train/step_train_time_s", 16.0, 0)
+        w2.add_scalar("train/step_e2e_time_s", 117.0, 0)
+        w2.close()
+        (self.run_dir / f"dashboard_state.{_DEAD_PID}.json").write_text(
+            json.dumps({"pid": _DEAD_PID, "stage": "train_end", "status": "succeeded", "step": 0}),
+            encoding="utf-8",
+        )
+
+        by_step, divergences = tp.load_step_segments(self.run_dir)
+        # Latest file wins -> step 0 carries 101/16, not the sum 48+101.
+        self.assertAlmostEqual(by_step[0]["rollout"], 101.0)
+        self.assertAlmostEqual(by_step[0]["train"], 16.0)
+        self.assertAlmostEqual(by_step[0]["total"], 117.0)
+        # Cross-file duplicates are re-runs, not divergences.
+        self.assertEqual(divergences, [])
+        # And the reconstructed total reconciles with the reported e2e.
+        recon = tp._reconcile(by_step[0])
+        self.assertAlmostEqual(recon["diff"], 0.0)
+
 
 class ValidationTest(unittest.TestCase):
     """Input validation runs before any TensorBoard reading (no deps needed)."""

--- a/tests/test_timing_summary_cpu.py
+++ b/tests/test_timing_summary_cpu.py
@@ -43,6 +43,7 @@ def _have_tensorboard() -> bool:
     # needs torch OR tensorboardX.
     try:
         import tensorboard  # noqa: F401
+
         _summary_writer_cls()
     except Exception:
         return False

--- a/tests/test_timing_summary_cpu.py
+++ b/tests/test_timing_summary_cpu.py
@@ -110,6 +110,57 @@ class ReconcileLogicTest(unittest.TestCase):
         self.assertAlmostEqual(recon["reconstructed_total"], 5.0)
 
 
+class LatestZeroVsMissingTest(unittest.TestCase):
+    """A recorded phase with 0.0 wall time must stay 0.0, not become missing (null).
+
+    Reproduces the SFT case seen on a real run: ``train/step_rollout_time_s`` is
+    recorded as 0.0 every step (no generation), while reward/value/etc. are
+    never recorded. The summary must keep rollout=0.0 distinct from the genuinely
+    missing phases, in both latest_update and whole_run, and only list the
+    never-recorded phases under ``missing``.
+    """
+
+    def _summary_for_sft_like_step(self) -> dict:
+        # Simulate summarize() for a single step where rollout was recorded at 0.0
+        # and only train has real time — mirroring real SFT metrics.
+        bucket = {"total": 1.0, "rollout": 0.0, "train": 1.0}
+        recon = tp._reconcile(bucket)
+        latest_phases = {name: (bucket[name] if name in bucket else None) for name in tp.TIME_SEGMENT_ORDER}
+        return {
+            "run_status": "completed",
+            "run_dir": "/tmp/sft",
+            "num_steps": 1,
+            "latest_update": {"step": 0, "segments": dict(latest_phases), "partial": False, **recon},
+            "whole_run": {
+                "segments": {n: (bucket.get(n, 0.0) if n in bucket else 0.0) for n in tp.TIME_SEGMENT_ORDER},
+                "reported_total": 1.0,
+                "reconstructed_total": recon["reconstructed_total"],
+                "diff": recon["diff"],
+                "total_source": "reported",
+            },
+            "missing": [n for n in tp.TIME_SEGMENT_ORDER if n not in bucket and n != "other"],
+        }
+
+    def test_zero_phase_stays_zero_not_null_in_latest(self):
+        s = self._summary_for_sft_like_step()
+        # rollout was recorded at 0.0 -> must be 0.0, not None
+        self.assertEqual(s["latest_update"]["segments"]["rollout"], 0.0)
+        # reward was never recorded -> must be None
+        self.assertIsNone(s["latest_update"]["segments"]["reward"])
+
+    def test_zero_phase_not_listed_as_missing(self):
+        s = self._summary_for_sft_like_step()
+        self.assertNotIn("rollout", s["missing"])
+        self.assertIn("reward", s["missing"])
+
+    def test_format_table_distinguishes_zero_from_missing(self):
+        s = self._summary_for_sft_like_step()
+        text = tp.format_table(s)
+        # 0.0 renders as "0.00"; never-recorded renders as "missing"
+        self.assertIn("missing", text)
+        self.assertIn("0.00", text)
+
+
 class FormatTest(unittest.TestCase):
     """No-dependency tests for the two output renderers."""
 

--- a/tests/test_timing_summary_cpu.py
+++ b/tests/test_timing_summary_cpu.py
@@ -1,0 +1,397 @@
+"""CPU tests for ``areno timing-summary`` (issue #256).
+
+Two layers:
+
+* Pure-logic tests (``_reconcile`` / ``_is_partial`` / ``format_*``) run
+  everywhere — no torch or tensorboard needed.
+* End-to-end tests write real TensorBoard scalars via ``SummaryWriter`` and
+  read them back through the CLI; they are skipped when torch/tensorboard are
+  absent so the suite still runs on a bare CPU machine.
+
+All assertions target specific summary fields and error messages, not just
+exit status.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from areno.dashboard import timeperf as tp
+
+
+def _summary_writer_cls():
+    """Return a ``SummaryWriter`` class from torch, or fall back to tensorboardX.
+
+    ``areno.api.metrics`` writes via torch when available; for tests we only
+    need to produce readable ``events.out.tfevents.*`` files, so either writer
+    works. Falling back to tensorboardX lets the suite run on a CPU machine
+    without torch installed (review finding 6 — broader CI coverage).
+    """
+    try:
+        from torch.utils.tensorboard import SummaryWriter
+    except Exception:
+        from tensorboardX import SummaryWriter
+    return SummaryWriter
+
+
+def _have_tensorboard() -> bool:
+    # Read side needs the ``tensorboard`` package (EventAccumulator); write side
+    # needs torch OR tensorboardX.
+    try:
+        import tensorboard  # noqa: F401
+        _summary_writer_cls()
+    except Exception:
+        return False
+    return True
+
+
+# Step-level scalar tags a trainer actually emits (see areno/api/metrics.py and
+# the algorithm trainers). ``total`` is the reported end-to-end wall time.
+# A pid guaranteed never to correspond to a live process, so finished runs
+# resolve deterministically to ``completed`` regardless of the stale
+# ``status`` field the trainer leaves behind (review finding 1).
+_DEAD_PID = 999_999
+
+
+def _write_run(run_dir: Path, steps: list[dict[int, float]], *, status: str = "succeeded") -> None:
+    """Write a tiny deterministic run into ``run_dir``.
+
+    ``steps`` is a list of ``{tag: value}`` dicts, one per step. Each step's
+    dict is written as scalars at that step index. A ``dashboard_state.<pid>
+    .json`` snapshot is also written. ``status="running"`` uses the live test
+    process pid so ``load_run_status`` reports ``active``; any other status uses
+    a dead pid so it reports ``completed`` — independent of platform init pid.
+    """
+    import os
+
+    SummaryWriter = _summary_writer_cls()
+
+    writer = SummaryWriter(log_dir=str(run_dir))
+    for index, scalars in enumerate(steps):
+        for tag, value in scalars.items():
+            writer.add_scalar(tag, float(value), index)
+    writer.close()
+
+    pid = os.getpid() if status == "running" else _DEAD_PID
+    state = {"pid": pid, "stage": "train_end", "status": status, "updated_at": 0, "step": len(steps) - 1}
+    (run_dir / f"dashboard_state.{pid}.json").write_text(json.dumps(state), encoding="utf-8")
+
+
+class ReconcileLogicTest(unittest.TestCase):
+    """No-dependency tests for the reconciliation primitives."""
+
+    def test_reconcile_reported_matches_reconstructed(self):
+        recon = tp._reconcile({"total": 10.0, "rollout": 4.0, "train": 6.0})
+        self.assertEqual(recon["total_source"], "reported")
+        self.assertAlmostEqual(recon["diff"], 0.0)
+        self.assertAlmostEqual(recon["reported_total"], 10.0)
+        self.assertAlmostEqual(recon["reconstructed_total"], 10.0)
+
+    def test_reconcile_partial_step_falls_back_to_reconstructed(self):
+        # A step with rollout recorded but no e2e/total: partial signature.
+        values = {"rollout": 4.0}
+        recon = tp._reconcile(values)
+        self.assertEqual(recon["total_source"], "reconstructed")
+        self.assertAlmostEqual(recon["reported_total"], 4.0)
+        self.assertTrue(tp._is_partial(values))
+
+    def test_reconcile_nonzero_diff_is_preserved(self):
+        # Phases sum to 12 but reported total is 10 -> diff -2 (overlap/other).
+        recon = tp._reconcile({"total": 10.0, "rollout": 4.0, "train": 8.0})
+        self.assertAlmostEqual(recon["diff"], -2.0)
+
+    def test_save_and_sync_weight_segments_are_not_phases_in_reconstruction(self):
+        # reconstructed_total must not include the synthetic rollup 'total'.
+        recon = tp._reconcile({"total": 5.0, "rollout": 5.0})
+        self.assertAlmostEqual(recon["reconstructed_total"], 5.0)
+
+
+class FormatTest(unittest.TestCase):
+    """No-dependency tests for the two output renderers."""
+
+    def _summary(self) -> dict:
+        return {
+            "run_status": "completed",
+            "run_dir": "/tmp/x",
+            "num_steps": 2,
+            "latest_update": {
+                "step": 1,
+                "segments": {
+                    "rollout": 4.0,
+                    "make_sample": None,
+                    "reward": None,
+                    "old policy log probs": None,
+                    "actor log probs": None,
+                    "ref log probs": None,
+                    "value": None,
+                    "advantages": None,
+                    "sync weight": None,
+                    "train": 6.0,
+                    "save": None,
+                    "other": None,
+                },
+                "partial": False,
+                "reported_total": 10.0,
+                "reconstructed_total": 10.0,
+                "diff": 0.0,
+                "total_source": "reported",
+            },
+            "whole_run": {
+                "segments": {"rollout": 8.0, "train": 12.0, "other": 0.0},
+                "reported_total": 20.0,
+                "reconstructed_total": 20.0,
+                "diff": 0.0,
+                "total_source": "reported",
+            },
+            "overlap": [],
+            "overlap_note": "no overlapping sub-phase timers are recorded by current trainers; overlap is always empty",
+            "missing": ["save", "sync weight"],
+            "divergences": [],
+        }
+
+    def test_format_table_mentions_missing_phases_and_totals(self):
+        text = tp.format_table(self._summary())
+        self.assertIn("Run status: completed", text)
+        self.assertIn("reported_total", text)
+        self.assertIn("reconstructed_total", text)
+        self.assertIn("Missing phases:", text)
+        self.assertIn("save", text)
+        self.assertIn("Overlap: none", text)
+
+    def test_format_json_round_trips_with_expected_keys(self):
+        payload = json.loads(tp.format_json(self._summary()))
+        self.assertEqual(
+            list(payload.keys()),
+            [
+                "run_status",
+                "run_dir",
+                "num_steps",
+                "latest_update",
+                "whole_run",
+                "overlap",
+                "overlap_note",
+                "missing",
+                "divergences",
+            ],
+        )
+        self.assertEqual(payload["missing"], ["save", "sync weight"])
+        self.assertEqual(payload["overlap"], [])
+
+
+class RunStatusTest(unittest.TestCase):
+    """No-dependency tests for liveness-based run_status (finding 1 + 6 reverse).
+
+    The trainer never writes a terminal ``status``, so ``status == "running"``
+    is stale for finished runs. ``load_run_status`` must resolve the pid and
+    check process liveness rather than trust the field. These cases run without
+    torch/tensorboard — exactly the bare-CI coverage the review asked for.
+    """
+
+    def _write_state(self, dir_path: Path, pid: int, status: str = "running") -> None:
+        payload = {"pid": pid, "stage": "train_end", "status": status, "updated_at": 0, "step": 3}
+        (dir_path / f"dashboard_state.{pid}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_finished_run_reports_completed_despite_stale_running_status(self):
+        """A dead pid with status=running must read as completed (review finding 1)."""
+        import tempfile
+
+        run_dir = Path(tempfile.mkdtemp())
+        self._write_state(run_dir, pid=999_999, status="running")  # pid guaranteed not alive
+        self.assertEqual(tp.load_run_status(run_dir), "completed")
+
+    def test_live_process_reports_active(self):
+        """A live pid (this test process) with status=running reads as active."""
+        import os
+        import tempfile
+
+        run_dir = Path(tempfile.mkdtemp())
+        self._write_state(run_dir, pid=os.getpid(), status="running")
+        self.assertEqual(tp.load_run_status(run_dir), "active")
+
+    def test_missing_state_file_defaults_completed(self):
+        import tempfile
+
+        run_dir = Path(tempfile.mkdtemp())
+        self.assertEqual(tp.load_run_status(run_dir), "completed")
+
+    def test_unreadable_state_file_defaults_completed(self):
+        import tempfile
+
+        run_dir = Path(tempfile.mkdtemp())
+        (run_dir / "dashboard_state.123.json").write_text("not json", encoding="utf-8")
+        self.assertEqual(tp.load_run_status(run_dir), "completed")
+
+
+class AccumulateEventTest(unittest.TestCase):
+    """No-dependency tests for ``_accumulate_event`` (findings 3 & 4).
+
+    Exercises the tag->segment classification directly, so the PPO sub-phase
+    folding and the rollup/echo divergence logic are covered on a bare machine
+    without the ``tensorboard`` reader.
+    """
+
+    def _fresh(self):
+        return {}, {}, {}
+
+    def test_ppo_subphases_fold_into_other_not_dropped(self):
+        """Out-of-vocab sub-phase tags fold into 'other' and stay in the sum (finding 3)."""
+        bucket, rollup_seen, phase_seen = {}, {}, {}
+        for tag, value in [
+            ("train/step_e2e_time_s", 10.0),
+            ("train/step_rollout_time_s", 4.0),
+            ("train/step_train_time_s", 6.0),
+            ("time/critic_value_forward_time_s", 1.5),
+            ("time/critic_train_time_s", 0.8),
+            ("time/reward_score_time_s", 0.3),
+            ("time/ref_logprob_forward_time_s", 0.2),
+        ]:
+            tp._accumulate_event(bucket, 0, tag, value, rollup_seen, phase_seen)
+        # rollout + train + ref log probs + other(critic value+critic train+reward score)
+        self.assertAlmostEqual(bucket["other"], 2.6)
+        self.assertAlmostEqual(bucket["rollout"], 4.0)
+        self.assertAlmostEqual(bucket["train"], 6.0)
+        self.assertAlmostEqual(bucket["ref log probs"], 0.2)
+        recon = tp._reconcile(bucket)
+        self.assertAlmostEqual(recon["reconstructed_total"], 12.8)
+        self.assertAlmostEqual(recon["diff"], 10.0 - 12.8)
+
+    def test_echo_matching_rollup_produces_no_divergence(self):
+        """time/rollout echoing the step rollup value must not flag a divergence (finding 4)."""
+        bucket, rollup_seen, phase_seen = {}, {}, {}
+        tp._accumulate_event(bucket, 0, "train/step_rollout_time_s", 4.0, rollup_seen, phase_seen)
+        msg = tp._accumulate_event(bucket, 0, "time/rollout", 4.0, rollup_seen, phase_seen)
+        self.assertIsNone(msg)
+        # Rollup value is authoritative and not overwritten by the echo.
+        self.assertEqual(bucket["rollout"], 4.0)
+
+    def test_echo_diverging_from_rollup_flags_divergence(self):
+        """A time/* echo that disagrees with the rollup is surfaced, not silently overwritten (finding 4)."""
+        bucket, rollup_seen, phase_seen = {}, {}, {}
+        tp._accumulate_event(bucket, 0, "train/step_train_time_s", 6.0, rollup_seen, phase_seen)
+        msg = tp._accumulate_event(bucket, 0, "time/train", 7.0, rollup_seen, phase_seen)
+        self.assertIsNotNone(msg)
+        self.assertIn("diverges", msg)
+        # Authoritative rollup value retained.
+        self.assertEqual(bucket["train"], 6.0)
+
+    def test_e2e_total_tag_set_as_total_not_phase(self):
+        bucket, rollup_seen, phase_seen = {}, {}, {}
+        tp._accumulate_event(bucket, 0, "train/step_e2e_time_s", 10.0, rollup_seen, phase_seen)
+        self.assertEqual(bucket["total"], 10.0)
+        self.assertNotIn("total", [n for n in tp.TIME_SEGMENT_ORDER])  # total is rollup, not a phase
+
+
+@unittest.skipUnless(_have_tensorboard(), "torch + tensorboard required for end-to-end timing-summary tests")
+class EndToEndTest(unittest.TestCase):
+    """Write a real run and read it back through the CLI."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._cwd = tempfile.mkdtemp()
+        self.run_dir = Path(self._cwd) / "run"
+        self.run_dir.mkdir()
+
+    def _invoke(self, *args: str):
+        from areno.cli.main import main
+
+        return CliRunner().invoke(main, ["timing-summary", str(self.run_dir), *args])
+
+    def test_successful_run_sums_phases_and_reconciles(self):
+        # Two steps: rollout 4 + train 6 = total 10 each, no overlap.
+        _write_run(
+            self.run_dir,
+            [
+                {"train/step_rollout_time_s": 4.0, "train/step_train_time_s": 6.0, "train/step_e2e_time_s": 10.0},
+                {"train/step_rollout_time_s": 4.0, "train/step_train_time_s": 6.0, "train/step_e2e_time_s": 10.0},
+            ],
+        )
+        res = self._invoke("--json")
+        self.assertEqual(res.exit_code, 0, res.output)
+        payload = json.loads(res.output)
+        self.assertEqual(payload["num_steps"], 2)
+        self.assertEqual(payload["whole_run"]["segments"]["rollout"], 8.0)
+        self.assertEqual(payload["whole_run"]["segments"]["train"], 12.0)
+        self.assertAlmostEqual(payload["whole_run"]["diff"], 0.0)
+        self.assertEqual(payload["whole_run"]["total_source"], "reported")
+        # save / sync weight are never emitted -> must show as missing.
+        self.assertIn("save", payload["missing"])
+        self.assertIn("sync weight", payload["missing"])
+
+    def test_partial_latest_step_is_flagged(self):
+        # Step 0 complete; step 1 only has rollout (run still in progress).
+        _write_run(
+            self.run_dir,
+            [
+                {"train/step_rollout_time_s": 4.0, "train/step_train_time_s": 6.0, "train/step_e2e_time_s": 10.0},
+                {"train/step_rollout_time_s": 4.0},
+            ],
+            status="running",
+        )
+        res = self._invoke("--json")
+        self.assertEqual(res.exit_code, 0, res.output)
+        payload = json.loads(res.output)
+        self.assertEqual(payload["run_status"], "active")
+        self.assertTrue(payload["latest_update"]["partial"])
+        self.assertEqual(payload["latest_update"]["total_source"], "reconstructed")
+
+    def test_active_run_status_from_dashboard_state(self):
+        _write_run(
+            self.run_dir,
+            [
+                {"train/step_rollout_time_s": 4.0, "train/step_train_time_s": 6.0, "train/step_e2e_time_s": 10.0},
+            ],
+            status="running",
+        )
+        res = self._invoke("--json")
+        self.assertEqual(json.loads(res.output)["run_status"], "active")
+
+    def test_table_output_renders_for_real_run(self):
+        _write_run(
+            self.run_dir,
+            [
+                {"train/step_rollout_time_s": 4.0, "train/step_train_time_s": 6.0, "train/step_e2e_time_s": 10.0},
+            ],
+        )
+        res = self._invoke()
+        self.assertEqual(res.exit_code, 0, res.output)
+        self.assertIn("Run status:", res.output)
+        self.assertIn("rollout", res.output)
+
+
+class ValidationTest(unittest.TestCase):
+    """Input validation runs before any TensorBoard reading (no deps needed)."""
+
+    def _invoke(self, path: str):
+        from areno.cli.main import main
+
+        return CliRunner().invoke(main, ["timing-summary", path])
+
+    def test_nonexistent_dir_exits_with_message(self):
+        res = self._invoke("/no/such/areno/dir")
+        self.assertEqual(res.exit_code, 1)
+        self.assertIn("does not exist", res.output)
+
+    def test_empty_dir_exits_with_metrics_message(self):
+        import tempfile
+
+        empty = Path(tempfile.mkdtemp())
+        res = self._invoke(str(empty))
+        self.assertEqual(res.exit_code, 1)
+        self.assertIn("no AReno metrics found", res.output)
+
+    def test_command_is_registered(self):
+        """The new command shows up in the top-level help (default behavior unchanged)."""
+        from areno.cli.main import main
+
+        res = CliRunner().invoke(main, ["--help"])
+        self.assertEqual(res.exit_code, 0)
+        self.assertIn("timing-summary", res.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
close #256 

## Summary

Adds `areno timing-summary <RUN_DIR> [--json]`, a read-only command that aggregates wall time spent in each RL training phase (generation / reward / training / sync / waiting) from a run's existing TensorBoard metrics into two views: the **latest update** and the **whole run**. It reads already-recorded timing events only — no new instrumentation, no new dependencies — and reuses the dashboard's segment vocabulary in place, so `areno/dashboard/server.py` is left untouched (minimal, conflict-free surface for parallel contributors).

## How it works

The training loop already records per-step wall times (`time/rollout`, `time/train`, `train/step_*_time_s`, PPO sub-phase `*_time_s`) under `--metrics-log-dir`. This command reads those event files once (a snapshot) and aggregates them:

| Output | Description |
|---|---|
| `latest_update` | Per-phase breakdown for the highest step, with a `partial` flag |
| `whole_run` | Per-phase sums across all steps |
| Reconciliation | `reported_total` (step e2e) vs `reconstructed_total` (sum of phases), `diff`, `total_source` |
| `overlap` / `missing` | Declared containment relations and phases never recorded, explicit |
| `run_status` | `"active"` / `"completed"`, plus `divergences` when rollup and `time/*` echo disagree |

Validation runs before TensorBoard loading and names the offending input on failure. Default output is a fixed-width terminal table; `--json` emits structured output.

```
Run status: completed    Run dir: /kaggle/working/realrun_gspo    Steps: 5

Phase                          latest update             whole run
------------------------------------------------------------------
rollout                        51.59   82.7%         244.18   82.9%
train                          10.81   17.3%          50.46   17.1%
reward                               missing                  0.00
save                                 missing                  0.00
------------------------------------------------------------------
reported_total                         62.42                294.80
reconstructed_total                    62.40                294.64
diff                                    0.02                  0.16
```

## What changed

| File | Change |
|---|---|
| `areno/cli/timing_summary.py` | New: `areno timing-summary <RUN_DIR> [--json]` command + input validation |
| `areno/dashboard/timeperf.py` | New: aggregation (`load_step_segments` / `load_run_status` / `summarize` / `format_*`); reuses server's segment helpers in place |
| `areno/cli/main.py` | Register the new subcommand |
| `tests/test_timing_summary_cpu.py` | New: 25 CPU tests (logic, validation, liveness, end-to-end read-back) |

`areno/dashboard/server.py` is intentionally **not modified** — `timeperf.py` imports the four segment helpers (`TIME_SEGMENT_ORDER`, `tensorboard_event_sources`, `tensorboard_time_segment_name`, `normalize_time_segment_name`) directly from it.

## Notes / limitations

| Item | Behavior |
|---|---|
| `run_status` basis | Process liveness (`os.kill(pid,0)`), not the `dashboard_state` `status` field — the trainer never writes a terminal status, so the field is always `running` even for finished runs (pre-existing trainer bug, tracked separately) |
| Cross-host / pid reuse | `run_status` may misreport when the metrics dir is read on a different host than where the run executed, or after pid reuse; documented in `load_run_status` |
| Segment vocabulary | Reused from the dashboard's `TIME_SEGMENT_ORDER` (12 phases) per the issue's "reuse existing contracts". Issue's 5 categories are subsumed in it |
| Missing phases | Many phases (reward/value/advantages/save/…) appear `missing` for GSPO/SFT because current trainers only time `rollout`+`train`; this reflects the trainer's instrumentation, not a command bug |
| Out-of-vocab sub-phases | PPO's `critic_value_forward`/`critic_train`/`reward_score` normalize outside the vocab and fold into `other` (kept in the reconstructed sum, not dropped) |
| Restarted runs | If a run restarted into a second/third event file, only the newest file's value per `(step, tag)` is kept (no double-counting) |

## Tests (25 CPU)

Pure-logic reconciliation, sub-phase folding into `other`, rollup/echo divergence detection, liveness-based `run_status` (completed/active/missing), input validation (missing dir / empty dir / not-a-run), registration in `--help`, format table + JSON round-trip, zero-time-vs-missing distinction, restarted-run dedup, and end-to-end read-back through the CLI (TensorBoard event files written + read).

Validated end-to-end on a real Kaggle GPU run:
- SFT (`--algo sft`): 5 steps, `rollout=0` (no generation, correct), `train` segment read, reconciliation diff≈0.
- GSPO (`--algo gspo`, gsm8k + math reward): 5 steps, `rollout` 82% + `train` 17%, reconciliation diff≈0.16 over 5 steps, `divergences=[]`.