### PR TITLE
feat(engine): identify slow reward hooks and samples (#242)

### DIFF
--- a/areno/api/__init__.py
+++ b/areno/api/__init__.py
@@ -27,6 +27,7 @@ from areno.api.models import (
     TrainSequence,
 )
 from areno.api.rewards import RewardEvent, RewardRecord
+from areno.api.reward_timing import RewardTimingConfig, RewardTimingReport, TimedRewardFn
 from areno.api.trainer import Trainer
 
 # Friendly aliases mirroring the BackendType enum members; `DefaultBackend`
@@ -48,6 +49,9 @@ __all__ = [
     "LossMaskPolicy",
     "RewardEvent",
     "RewardRecord",
+    "RewardTimingConfig",
+    "RewardTimingReport",
+    "TimedRewardFn",
     "RolloutSession",
     "SamplingParams",
     "RolloutResult",

--- a/areno/api/reward_timing.py
+++ b/areno/api/reward_timing.py
@@ -1,0 +1,331 @@
+"""Slow reward hook and sample identification.
+
+Wraps a user reward function with per-hook and per-sample timing, flags
+configurable outliers, and enforces an optional per-sample timeout. The
+wrapper produces human-readable log lines and structured ``RewardTimingReport``
+records without logging full prompts or completions.
+
+When disabled (the default), the wrapper is a transparent passthrough with
+near-zero overhead -- the original callable is called directly and no timing
+data is collected.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from areno.api.rewards import RewardRecord
+
+logger = logging.getLogger(__name__)
+
+# Sentinel returned when a reward sample times out. Using NaN rather than 0.0
+# avoids skewing group-relative advantage computations that assume a valid
+# scalar; downstream advantage code should filter or replace NaN before use.
+TIMEOUT_REWARD = float("nan")
+
+
+@dataclass(slots=True)
+class RewardSampleTiming:
+    """Timing result for a single reward function invocation.
+
+    ``sample_id`` is a short, opaque identifier (e.g. ``"p2_s5"``) that
+    distinguishes samples without exposing prompt or completion text.
+    """
+
+    hook_name: str
+    sample_id: str
+    elapsed_s: float
+    timed_out: bool = False
+
+
+@dataclass(slots=True)
+class RewardTimingReport:
+    """Aggregated timing report for one reward-scoring batch.
+
+    The report is produced after every batch of reward evaluations when
+    timing is enabled. It carries per-sample timings, summary statistics,
+    flagged outliers, and any timeouts -- all without prompts or answers.
+    """
+
+    hook_name: str
+    step: int
+    sample_timings: list[RewardSampleTiming] = field(default_factory=list)
+    total_elapsed_s: float = 0.0
+    mean_elapsed_s: float = 0.0
+    max_elapsed_s: float = 0.0
+    p95_elapsed_s: float = 0.0
+    outliers: list[RewardSampleTiming] = field(default_factory=list)
+    timeouts: list[RewardSampleTiming] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable summary for structured output."""
+
+        return {
+            "hook_name": self.hook_name,
+            "step": self.step,
+            "num_samples": len(self.sample_timings),
+            "total_elapsed_s": round(self.total_elapsed_s, 6),
+            "mean_elapsed_s": round(self.mean_elapsed_s, 6),
+            "max_elapsed_s": round(self.max_elapsed_s, 6),
+            "p95_elapsed_s": round(self.p95_elapsed_s, 6),
+            "outliers": [
+                {"sample_id": s.sample_id, "elapsed_s": round(s.elapsed_s, 6), "timed_out": s.timed_out}
+                for s in self.outliers
+            ],
+            "timeouts": [
+                {"sample_id": s.sample_id, "elapsed_s": round(s.elapsed_s, 6)} for s in self.timeouts
+            ],
+        }
+
+    def format_human(self) -> str:
+        """Return a single-line, human-readable summary for console logs."""
+
+        parts = [
+            f"reward_timing hook={self.hook_name} step={self.step}",
+            f"n={len(self.sample_timings)}",
+            f"total={self.total_elapsed_s:.4f}s",
+            f"mean={self.mean_elapsed_s:.4f}s",
+            f"max={self.max_elapsed_s:.4f}s",
+            f"p95={self.p95_elapsed_s:.4f}s",
+        ]
+        if self.outliers:
+            ids = ",".join(s.sample_id for s in self.outliers)
+            parts.append(f"slow_samples=[{ids}]")
+        if self.timeouts:
+            ids = ",".join(s.sample_id for s in self.timeouts)
+            parts.append(f"timeouts=[{ids}]")
+        return " ".join(parts)
+
+
+@dataclass(slots=True)
+class RewardTimingConfig:
+    """Configuration for reward timing instrumentation.
+
+    All fields default to values that preserve current (untimed) behavior.
+    Set ``enabled=True`` to activate timing collection and reporting.
+
+    Attributes:
+        enabled: Master switch. When ``False`` the wrapper is a transparent
+            passthrough and no timing data is collected.
+        slow_threshold_s: Samples taking longer than this are flagged as
+            outliers in the report. Set to ``None`` or ``0`` to disable
+            outlier flagging.
+        timeout_s: Per-sample wall-clock timeout. Samples exceeding this
+            receive ``TIMEOUT_REWARD`` and are recorded in the report's
+            ``timeouts`` list. Set to ``None`` to disable timeout enforcement.
+            Only effective on POSIX (uses ``SIGALRM``).
+        hook_name: Name used in log lines and reports to identify the reward
+            hook. Defaults to ``"reward_fn"``.
+    """
+
+    enabled: bool = False
+    slow_threshold_s: float | None = None
+    timeout_s: float | None = None
+    hook_name: str = "reward_fn"
+
+    def validate(self) -> None:
+        """Raise ``ValueError`` if the configuration is internally inconsistent."""
+
+        if self.slow_threshold_s is not None and self.slow_threshold_s <= 0:
+            raise ValueError("slow_threshold_s must be positive or None")
+        if self.timeout_s is not None and self.timeout_s <= 0:
+            raise ValueError("timeout_s must be positive or None")
+        if (
+            self.timeout_s is not None
+            and self.slow_threshold_s is not None
+            and self.timeout_s < self.slow_threshold_s
+        ):
+            raise ValueError("timeout_s must be >= slow_threshold_s when both are set")
+
+
+class TimedRewardFn:
+    """Wrap a reward callable with optional timing, outlier flagging, and timeout.
+
+    When ``config.enabled`` is ``False`` (the default), calling this wrapper
+    is equivalent to calling the original function -- no timing data is
+    collected and no overhead is added beyond one ``if`` check.
+
+    When enabled, each invocation is timed. After a batch of calls, call
+    :meth:`finalize_batch` to produce a :class:`RewardTimingReport`. The
+    wrapper also logs the human-readable summary via ``logger.warning`` for
+    outliers and ``logger.info`` for the batch summary.
+
+    Timeout enforcement uses ``signal.SIGALRM`` and is therefore only
+    effective on POSIX platforms. On Windows the timeout is silently ignored
+    (samples run to completion).
+    """
+
+    def __init__(self, reward_fn: Callable[[RewardRecord], float], config: RewardTimingConfig | None = None):
+        self._fn = reward_fn
+        self._config = config or RewardTimingConfig()
+        self._config.validate()
+        self._pending: list[RewardSampleTiming] = []
+
+    @property
+    def config(self) -> RewardTimingConfig:
+        return self._config
+
+    def __call__(self, record: RewardRecord) -> float:
+        """Score one record, optionally timing the call.
+
+        When timing is disabled, this is a transparent passthrough.
+        """
+
+        if not self._config.enabled:
+            return self._fn(record)
+
+        meta = record.metadata if hasattr(record, "metadata") else {}
+        prompt_index = meta.get("prompt_index", -1)
+        sample_index = meta.get("sample_index", -1)
+        sample_id = f"p{prompt_index}_s{sample_index}"
+
+        elapsed, timed_out, result = _timed_call(self._fn, record, self._config.timeout_s)
+        timing = RewardSampleTiming(
+            hook_name=self._config.hook_name,
+            sample_id=sample_id,
+            elapsed_s=elapsed,
+            timed_out=timed_out,
+        )
+        self._pending.append(timing)
+
+        if timed_out:
+            logger.warning(
+                "reward_timeout hook=%s sample=%s elapsed=%.4fs timeout=%.1fs",
+                self._config.hook_name,
+                sample_id,
+                elapsed,
+                self._config.timeout_s or 0.0,
+            )
+            return TIMEOUT_REWARD
+
+        threshold = self._config.slow_threshold_s
+        if threshold is not None and threshold > 0 and elapsed > threshold:
+            logger.warning(
+                "reward_slow hook=%s sample=%s elapsed=%.4fs threshold=%.1fs",
+                self._config.hook_name,
+                sample_id,
+                elapsed,
+                threshold,
+            )
+
+        return result
+
+    def finalize_batch(self, step: int) -> RewardTimingReport | None:
+        """Aggregate pending per-sample timings into a report and clear the buffer.
+
+        Returns ``None`` when timing is disabled or no samples were recorded.
+        """
+
+        if not self._config.enabled or not self._pending:
+            self._pending.clear()
+            return None
+
+        timings = self._pending
+        self._pending = []
+
+        elapsed_values = [t.elapsed_s for t in timings]
+        total = sum(elapsed_values)
+        count = len(elapsed_values)
+        mean = total / count if count else 0.0
+        max_elapsed = max(elapsed_values) if elapsed_values else 0.0
+        p95 = _percentile(elapsed_values, 95) if elapsed_values else 0.0
+
+        threshold = self._config.slow_threshold_s
+        outliers = [
+            t for t in timings
+            if not t.timed_out and threshold is not None and threshold > 0 and t.elapsed_s > threshold
+        ]
+        timeouts = [t for t in timings if t.timed_out]
+
+        report = RewardTimingReport(
+            hook_name=self._config.hook_name,
+            step=step,
+            sample_timings=timings,
+            total_elapsed_s=total,
+            mean_elapsed_s=mean,
+            max_elapsed_s=max_elapsed,
+            p95_elapsed_s=p95,
+            outliers=outliers,
+            timeouts=timeouts,
+        )
+
+        logger.info(report.format_human())
+        return report
+
+
+def _timed_call(
+    fn: Callable[[RewardRecord], float],
+    record: RewardRecord,
+    timeout_s: float | None,
+) -> tuple[float, bool, float]:
+    """Execute *fn(record)* with wall-clock timing and optional timeout.
+
+    Returns ``(elapsed_seconds, timed_out, result)``. On timeout the function
+    is interrupted (POSIX only) and ``timed_out`` is ``True``; *result* is
+    ``TIMEOUT_REWARD`` in that case.
+    """
+
+    if timeout_s is not None and _has_sigalrm():
+        return _timed_call_with_alarm(fn, record, timeout_s)
+
+    start = time.perf_counter()
+    result = fn(record)
+    elapsed = time.perf_counter() - start
+    return elapsed, False, float(result)
+
+
+def _timed_call_with_alarm(
+    fn: Callable[[RewardRecord], float],
+    record: RewardRecord,
+    timeout_s: float,
+) -> tuple[float, bool, float]:
+    """Timeout-enforced call using ``signal.SIGALRM`` (POSIX only)."""
+
+    start = time.perf_counter()
+
+    def _handler(signum, frame):  # noqa: ARG001
+        raise TimeoutError("reward_fn timed out")
+
+    old_handler = signal.signal(signal.SIGALRM, _handler)
+    old_itimer = signal.setitimer(signal.ITIMER_REAL, timeout_s)
+    try:
+        result = fn(record)
+        return time.perf_counter() - start, False, float(result)
+    except TimeoutError:
+        return time.perf_counter() - start, True, TIMEOUT_REWARD
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0.0)
+        signal.signal(signal.SIGALRM, old_handler)
+        # Restore the previous itimer if one was active.
+        if old_itimer != (0.0, 0.0):
+            signal.setitimer(signal.ITIMER_REAL, old_itimer[0], old_itimer[1])
+
+
+def _has_sigalrm() -> bool:
+    """Return ``True`` if ``signal.SIGALRM`` is available (POSIX)."""
+
+    return hasattr(signal, "SIGALRM") and hasattr(signal, "setitimer")
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """Return the *percentile*-th percentile from a list of floats.
+
+    Uses nearest-rank interpolation. ``percentile`` is 0-100.
+    """
+
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    if n == 1:
+        return sorted_vals[0]
+    rank = (percentile / 100.0) * (n - 1)
+    lower = int(rank)
+    upper = min(lower + 1, n - 1)
+    frac = rank - lower
+    return sorted_vals[lower] * (1 - frac) + sorted_vals[upper] * frac

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -145,6 +145,9 @@ class PolicyTrainerConfig(RolloutTrainerConfig):
     reward_fn_path: str | None = None
     gspo_clip_eps: float = 3.0e-4
     grpo_clip_eps: float = 0.2
+    reward_timing_enabled: bool = False
+    reward_slow_threshold_s: float | None = None
+    reward_timeout_s: float | None = None
 
 
 @dataclass(slots=True)

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -63,6 +63,7 @@ class PolicyOnlyTrainer:
         # Replace the public reward_fn so all call sites (including agentic
         # rollout) go through the timed wrapper transparently.
         self.reward_fn = timed
+        self._timed_reward_fn = timed
         return timed
 
     def _finalize_reward_timing(self, step: int) -> None:

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -42,6 +42,39 @@ class PolicyOnlyTrainer:
         self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         self._agent_run_fn = None
+        self._timed_reward_fn = self._build_timed_reward_fn(reward_fn)
+
+    def _build_timed_reward_fn(self, reward_fn):
+        """Wrap the user reward function with optional timing instrumentation.
+
+        When ``reward_timing_enabled`` is ``False`` (the default), the wrapper
+        is a transparent passthrough that adds no overhead.
+        """
+
+        from areno.api.reward_timing import RewardTimingConfig, TimedRewardFn
+
+        timing_config = RewardTimingConfig(
+            enabled=bool(getattr(self.config, "reward_timing_enabled", False)),
+            slow_threshold_s=getattr(self.config, "reward_slow_threshold_s", None),
+            timeout_s=getattr(self.config, "reward_timeout_s", None),
+            hook_name="reward_fn",
+        )
+        timed = TimedRewardFn(reward_fn, timing_config)
+        # Replace the public reward_fn so all call sites (including agentic
+        # rollout) go through the timed wrapper transparently.
+        self.reward_fn = timed
+        return timed
+
+    def _finalize_reward_timing(self, step: int) -> None:
+        """Produce a reward timing report for the current step if enabled."""
+
+        report = self._timed_reward_fn.finalize_batch(step)
+        if report is not None:
+            self.areno.record_dashboard_state(
+                stage="reward_timing",
+                step=step,
+                extra={"reward_timing": report.to_dict()},
+            )
 
     def fit(self) -> None:
         self.areno.init()
@@ -107,6 +140,7 @@ class PolicyOnlyTrainer:
                     self.logger.info(
                         "epoch=%d step=%d metric=reward_mean value=%.6f", epoch, step, float(np.mean(rewards_all))
                     )
+                    self._finalize_reward_timing(step)
                 if rollout_logprobs:
                     self.logger.info(
                         "epoch=%d step=%d metric=rollout_logprob_mean value=%.6f",

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -92,6 +92,9 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "train_tool_results",
             "reward_fn_path",
             "reward_ckpt",
+            "reward_timing_enabled",
+            "reward_slow_threshold_s",
+            "reward_timeout_s",
         ),
     ),
     (
@@ -273,6 +276,17 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         _require_positive_float(args.lam, "--lam")
     if args.critic_warmup_steps < 0:
         raise click.UsageError("--critic-warmup-steps must be non-negative")
+    if getattr(args, "reward_timing_enabled", False):
+        if getattr(args, "reward_slow_threshold_s", None) is not None and args.reward_slow_threshold_s <= 0:
+            raise click.UsageError("--reward-slow-threshold-s must be positive or None")
+        if getattr(args, "reward_timeout_s", None) is not None and args.reward_timeout_s <= 0:
+            raise click.UsageError("--reward-timeout-s must be positive or None")
+        if (
+            getattr(args, "reward_timeout_s", None) is not None
+            and getattr(args, "reward_slow_threshold_s", None) is not None
+            and args.reward_timeout_s < args.reward_slow_threshold_s
+        ):
+            raise click.UsageError("--reward-timeout-s must be >= --reward-slow-threshold-s when both are set")
     _preflight_task_hooks(args, algorithm)
     return _trainer_config_from_args(args)
 
@@ -727,6 +741,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            reward_timing_enabled=getattr(args, "reward_timing_enabled", False),
+            reward_slow_threshold_s=getattr(args, "reward_slow_threshold_s", None),
+            reward_timeout_s=getattr(args, "reward_timeout_s", None),
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -788,6 +805,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
+        reward_timing_enabled=getattr(args, "reward_timing_enabled", False),
+        reward_slow_threshold_s=getattr(args, "reward_slow_threshold_s", None),
+        reward_timeout_s=getattr(args, "reward_timeout_s", None),
     )
 
 
@@ -1182,6 +1202,23 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--ref-ckpt", default=None, help="Optional PPO/DPO reference model checkpoint path or remote model repo ID."
 )
 @click.option("--reward-ckpt", default=None, help="Optional PPO reward model checkpoint path or remote model repo ID.")
+@click.option(
+    "--reward-timing-enabled",
+    is_flag=True,
+    help="Enable per-sample reward hook timing, outlier flagging, and optional timeout.",
+)
+@click.option(
+    "--reward-slow-threshold-s",
+    type=float,
+    default=None,
+    help="Flag reward samples slower than this many seconds as outliers (requires --reward-timing-enabled).",
+)
+@click.option(
+    "--reward-timeout-s",
+    type=float,
+    default=None,
+    help="Per-sample reward timeout in seconds; timed-out samples receive NaN (requires --reward-timing-enabled, POSIX only).",
+)
 @click.option("--critic-ckpt", default=None, help="Optional PPO critic model checkpoint path or remote model repo ID.")
 @click.option("--save-path", default=None, help="Optional checkpoint output directory.")
 @click.option("--save-interval", type=int, default=100, show_default=True, help="Save checkpoint every N train steps.")

--- a/docs/cli/observability.rst
+++ b/docs/cli/observability.rst
@@ -175,3 +175,105 @@ When a trajectory is dropped for exceeding the model context window,
 counts, message counts, assistant turn counts, tool-result counts, and a short
 prompt preview. This is the fastest way to debug overlong agentic examples
 without dumping every token in every trajectory.
+
+Reward hook timing
+------------------
+
+AReno can measure each reward function invocation, flag slow samples as
+outliers, and enforce an optional per-sample timeout. This feature is
+**disabled by default** and adds near-zero overhead when not enabled.
+
+Enable it with three CLI flags:
+
+.. code-block:: bash
+
+   areno train --algo gspo --ckpt Qwen/Qwen3-0.6B --dataset-path gsm8k:main \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --reward-timing-enabled \
+     --reward-slow-threshold-s 0.5 \
+     --reward-timeout-s 10.0
+
+Input contract
+~~~~~~~~~~~~~~
+
+``--reward-timing-enabled``
+    Master switch. When omitted, reward timing is disabled and the reward
+    function is called directly with no overhead.
+
+``--reward-slow-threshold-s SECONDS``
+    Samples whose reward computation takes longer than this are flagged as
+    outliers in the log and the timing report. Must be positive. Set to
+    ``None`` (the default) to disable outlier flagging.
+
+``--reward-timeout-s SECONDS``
+    Per-sample wall-clock timeout. Samples exceeding this receive ``NaN``
+    as their reward and are listed in the report's ``timeouts`` field. Must
+    be positive and >= ``--reward-slow-threshold-s`` when both are set.
+    Timeout enforcement uses ``signal.SIGALRM`` and is only effective on
+    POSIX platforms; on Windows the timeout is silently ignored.
+
+Defaults and validation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+All three options default to values that preserve current behavior
+(timing disabled). Invalid combinations -- such as a negative threshold or
+``timeout_s < slow_threshold_s`` -- produce a clear ``click.UsageError``
+before any model or worker initialization.
+
+Observable output
+~~~~~~~~~~~~~~~~~
+
+When enabled, the trainer produces two output channels per training step:
+
+1. **Console logs** -- two log levels are emitted:
+
+   .. code-block:: text
+
+      WARNING reward_slow hook=reward_fn sample=p2_s5 elapsed=0.6231s threshold=0.5s
+      INFO reward_timing hook=reward_fn step=3 n=32 total=4.213s mean=0.132s max=0.623s p95=0.401s slow_samples=[p2_s5,p7_s1]
+
+   The ``sample`` identifier is a short opaque tag (``p{prompt_index}_s{sample_index}``)
+   that distinguishes samples **without exposing prompt or completion text**.
+
+2. **Dashboard state** -- the timing report is persisted as structured JSON
+   via ``record_dashboard_state(stage="reward_timing", ...)`` with fields:
+   ``hook_name``, ``step``, ``num_samples``, ``total_elapsed_s``,
+   ``mean_elapsed_s``, ``max_elapsed_s``, ``p95_elapsed_s``, ``outliers``
+   (list of ``{sample_id, elapsed_s, timed_out}``), and ``timeouts``
+   (list of ``{sample_id, elapsed_s}``).
+
+Limitations
+~~~~~~~~~~~
+
+- Timeout enforcement is POSIX-only (``SIGALRM``).
+- ``NaN`` rewards from timeouts propagate through ``compute_group_advantages``
+  and will produce ``NaN`` advantages; filter or replace them downstream if
+  needed.
+- Timing overhead is one ``time.perf_counter()`` call per sample when
+  enabled; it is not collected at all when disabled.
+
+Copyable example
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from areno.api.reward_timing import RewardTimingConfig, TimedRewardFn
+   from areno.api.rewards import RewardRecord
+
+   def my_reward_fn(record: RewardRecord) -> float:
+       return 1.0 if "correct" in record.completion else 0.0
+
+   config = RewardTimingConfig(
+       enabled=True,
+       slow_threshold_s=0.1,
+       timeout_s=5.0,
+       hook_name="my_reward",
+   )
+   timed = TimedRewardFn(my_reward_fn, config)
+
+   record = RewardRecord(prompt="2+2=?", completion="4", metadata={"prompt_index": 0, "sample_index": 0})
+   score = timed(record)
+   report = timed.finalize_batch(step=0)
+   if report is not None:
+       print(report.format_human())
+       # reward_timing hook=my_reward step=0 n=1 total=0.000012s mean=0.000012s max=0.000012s p95=0.000012s

--- a/docs/diagrams/reward_timing_flow.md
+++ b/docs/diagrams/reward_timing_flow.md
@@ -1,0 +1,152 @@
+# Reward Hook Timing — Flow Diagram (Issue #242)
+
+```mermaid
+flowchart TD
+    %% ─── CLI 启动阶段 ───
+    CLI["areno train --algo gspo ...<br/>--reward-timing-enabled<br/>--reward-slow-threshold-s 0.5<br/>--reward-timeout-s 10.0"]
+    VAL["CLI 参数验证<br/>（train.py _trainer_config_from_options）<br/>✓ threshold > 0<br/>✓ timeout > 0<br/>✓ timeout >= threshold"]
+    CLI --> VAL
+
+    %% ─── Trainer 初始化 ───
+    INIT["PolicyOnlyTrainer.__init__"]
+    BUILD["_build_timed_reward_fn(reward_fn)<br/>创建 RewardTimingConfig<br/>创建 TimedRewardFn 包装器<br/>self.reward_fn = TimedRewardFn<br/>self._timed_reward_fn = TimedRewardFn"]
+    VAL --> INIT
+    INIT --> BUILD
+
+    %% ─── 训练循环 ───
+    LOOP["训练循环 _fit_initialized<br/>for epoch → for prompt_batch"]
+    BUILD --> LOOP
+
+    %% ─── Rollout ───
+    ROLLOUT["1. Rollout 阶段<br/>rollout_token_batch_async<br/>每个 prompt 生成 n_samples 个补全"]
+    LOOP --> ROLLOUT
+
+    %% ─── Reward 打分 ───
+    MATERIALIZE["2. _materialize_train_batch<br/>对每个 prompt,completion 构建 RewardRecord<br/>调用 self.reward_fn(record)"]
+    ROLLOUT --> MATERIALIZE
+
+    %% ─── TimedRewardFn.__call__ ───
+    CHECK{"config.enabled?"}
+    MATERIALIZE --> CHECK
+
+    %% ─── 禁用路径 ───
+    DISABLED["直接调用原始 reward_fn(record)<br/>零开销，无计时数据<br/>返回 float score"]
+    CHECK -- "False (默认)" --> DISABLED
+
+    %% ─── 启用路径 ───
+    ENABLED["提取 sample_id<br/>p{prompt_index}_s{sample_index}"]
+    CHECK -- "True" --> ENABLED
+
+    TIMED_CALL["_timed_call(fn, record, timeout_s)"]
+    ENABLED --> TIMED_CALL
+
+    %% ─── 超时判断 ───
+    HAS_ALARM{"timeout_s 设置<br/>且 POSIX?"}
+    TIMED_CALL --> HAS_ALARM
+
+    NO_ALARM["直接计时调用<br/>start = perf_counter<br/>result = fn(record)<br/>elapsed = perf_counter - start"]
+    HAS_ALARM -- "否" --> NO_ALARM
+
+    WITH_ALARM["SIGALRM 计时调用<br/>signal.setitimer(timeout_s)<br/>start = perf_counter<br/>result = fn(record)"]
+    HAS_ALARM -- "是" --> WITH_ALARM
+
+    %% ─── 超时结果 ───
+    TIMEOUT_HIT{"超时?<br/>TimeoutError?"}
+    WITH_ALARM --> TIMEOUT_HIT
+    NO_ALARM --> STORE
+
+    TIMEOUT_RESULT["elapsed = perf_counter - start<br/>timed_out = True<br/>result = NaN (TIMEOUT_REWARD)"]
+    TIMEOUT_HIT -- "是" --> TIMEOUT_RESULT
+
+    NORMAL_RESULT["elapsed = perf_counter - start<br/>timed_out = False<br/>result = float(fn_result)"]
+    TIMEOUT_HIT -- "否" --> NORMAL_RESULT
+
+    %% ─── 存储 timing ───
+    STORE["创建 RewardSampleTiming<br/>hook_name, sample_id, elapsed_s, timed_out<br/>追加到 self._pending"]
+    TIMEOUT_RESULT --> STORE
+    NORMAL_RESULT --> STORE
+
+    %% ─── 超时处理 ───
+    IS_TIMEOUT{"timed_out?"}
+    STORE --> IS_TIMEOUT
+
+    LOG_TIMEOUT["logger.warning<br/>reward_timeout hook=... sample=...<br/>返回 NaN"]
+    IS_TIMEOUT -- "是" --> LOG_TIMEOUT
+
+    %% ─── 慢样本检查 ───
+    SLOW_CHECK{"elapsed > slow_threshold_s?"}
+    IS_TIMEOUT -- "否" --> SLOW_CHECK
+
+    LOG_SLOW["logger.warning<br/>reward_slow hook=... sample=...<br/>elapsed=... threshold=..."]
+    SLOW_CHECK -- "是" --> LOG_SLOW
+
+    RETURN_RESULT["返回 result (float)"]
+    SLOW_CHECK -- "否" --> RETURN_RESULT
+    LOG_SLOW --> RETURN_RESULT
+    LOG_TIMEOUT --> RETURN_RESULT
+
+    %% ─── 循环回到下一个样本 ───
+    NEXT_SAMPLE{"还有更多<br/>样本?"}
+    DISABLED --> NEXT_SAMPLE
+    RETURN_RESULT --> NEXT_SAMPLE
+    NEXT_SAMPLE -- "是" --> MATERIALIZE
+
+    %% ─── 所有 reward 打分完成 ───
+    ALL_DONE["rewards_all 完成<br/>所有 batch_size * n_samples 个样本已打分"]
+    NEXT_SAMPLE -- "否" --> ALL_DONE
+
+    %% ─── Finalize ───
+    FINALIZE["_finalize_reward_timing(step)"]
+    ALL_DONE --> FINALIZE
+
+    FB_CHECK{"config.enabled<br/>且有 pending?"}
+    FINALIZE --> FB_CHECK
+
+    FB_NONE["返回 None<br/>（无报告）"]
+    FB_CHECK -- "否" --> FB_NONE
+
+    FB_AGG["聚合所有 pending timings<br/>计算 total / mean / max / p95<br/>筛选 outliers (elapsed > threshold)<br/>筛选 timeouts (timed_out=True)"]
+    FB_CHECK -- "是" --> FB_AGG
+
+    %% ─── 报告输出 ───
+    REPORT["创建 RewardTimingReport"]
+    FB_AGG --> REPORT
+
+    LOG_SUMMARY["logger.info<br/>reward_timing hook=... step=... n=...<br/>total=... mean=... max=... p95=...<br/>slow_samples=[...] timeouts=[...]"]
+    REPORT --> LOG_SUMMARY
+
+    DASHBOARD["record_dashboard_state<br/>stage=reward_timing<br/>extra={'reward_timing': report.to_dict()}<br/>写入 metrics 目录 JSON"]
+    LOG_SUMMARY --> DASHBOARD
+
+    %% ─── 继续训练 ───
+    ADVANTAGE["3. compute_group_advantages<br/>组内 z-score 归一化 rewards"]
+    FB_NONE --> ADVANTAGE
+    DASHBOARD --> ADVANTAGE
+
+    TRAIN["4. trainer.train(train_batch, loss_fn)<br/>梯度更新"]
+    ADVANTAGE --> TRAIN
+
+    NEXT_STEP{"还有更多<br/>step?"}
+    TRAIN --> NEXT_STEP
+    NEXT_STEP -- "是" --> LOOP
+
+    DONE["训练完成"]
+    NEXT_STEP -- "否" --> DONE
+
+    %% ─── 样式 ───
+    style CLI fill:#e1f5fe,stroke:#01579b
+    style CHECK fill:#fff9c4,stroke:#f57f17
+    style HAS_ALARM fill:#fff9c4,stroke:#f57f17
+    style TIMEOUT_HIT fill:#fff9c4,stroke:#f57f17
+    style IS_TIMEOUT fill:#fff9c4,stroke:#f57f17
+    style SLOW_CHECK fill:#fff9c4,stroke:#f57f17
+    style FB_CHECK fill:#fff9c4,stroke:#f57f17
+    style NEXT_SAMPLE fill:#fff9c4,stroke:#f57f17
+    style NEXT_STEP fill:#fff9c4,stroke:#f57f17
+    style LOG_TIMEOUT fill:#ffcdd2,stroke:#b71c1c
+    style LOG_SLOW fill:#ffe0b2,stroke:#e65100
+    style LOG_SUMMARY fill:#c8e6c9,stroke:#1b5e20
+    style DASHBOARD fill:#c8e6c9,stroke:#1b5e20
+    style DISABLED fill:#f5f5f5,stroke:#9e9e9e
+    style DONE fill:#e1f5fe,stroke:#01579b
+```

--- a/examples/math/timing_test_reward.py
+++ b/examples/math/timing_test_reward.py
@@ -1,0 +1,46 @@
+"""Test reward function for verifying slow-reward-hook timing (issue #242).
+
+This reward function deliberately introduces per-sample delays so that
+the --reward-timing-enabled / --reward-slow-threshold-s / --reward-timeout-s
+flags produce observable outliers and timeouts.
+
+Usage:
+    areno train --algo gspo \
+      --reward-fn-path examples/math/timing_test_reward.py \
+      --reward-timing-enabled \
+      --reward-slow-threshold-s 0.3 \
+      --reward-timeout-s 2.0 \
+      ...
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def reward_fn(record) -> float:
+    """Score one completion with an artificial delay based on sample index.
+
+    Samples with an even sample_index sleep 0.01s (fast).
+    Samples with an odd sample_index sleep 0.5s (slow, will be flagged as outlier).
+    Sample (prompt_index=2, sample_index=3) sleeps 3s (will trigger timeout if
+    --reward-timeout-s < 3).
+    """
+
+    meta = record.metadata if hasattr(record, "metadata") else {}
+    prompt_index = int(meta.get("prompt_index", -1))
+    sample_index = int(meta.get("sample_index", -1))
+
+    # Special case: this sample will timeout if timeout_s < 3
+    if prompt_index == 2 and sample_index == 3:
+        time.sleep(3.0)
+        return 1.0
+
+    # Odd samples are slow
+    if sample_index % 2 == 1:
+        time.sleep(0.5)
+        return 0.5
+
+    # Even samples are fast
+    time.sleep(0.01)
+    return 1.0 if "correct" in record.completion.lower() else 0.0

--- a/tests/test_reward_timing_cpu.py
+++ b/tests/test_reward_timing_cpu.py
@@ -1,0 +1,320 @@
+"""CPU tests for the slow-reward-hook timing instrumentation (issue #242).
+
+These tests cover the core logic, disabled/default behavior, outlier
+flagging, timeout enforcement, boundary values, malformed input, and
+deterministic output -- all without a GPU or external services.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from areno.api.reward_timing import (
+    TIMEOUT_REWARD,
+    RewardSampleTiming,
+    RewardTimingConfig,
+    RewardTimingReport,
+    TimedRewardFn,
+)
+from areno.api.rewards import RewardRecord
+
+
+def _record(prompt_index: int = 0, sample_index: int = 0) -> RewardRecord:
+    """Build a minimal RewardRecord with metadata for sample identification."""
+
+    return RewardRecord(
+        prompt="test",
+        completion="test",
+        metadata={"prompt_index": prompt_index, "sample_index": sample_index},
+    )
+
+
+class DisabledTimingTest(unittest.TestCase):
+    """When timing is disabled (the default), the wrapper is a transparent passthrough."""
+
+    def test_disabled_returns_raw_result(self):
+        """The wrapper should return the exact value from the underlying function."""
+
+        def reward_fn(record):
+            return 0.75
+
+        timed = TimedRewardFn(reward_fn, RewardTimingConfig(enabled=False))
+        self.assertAlmostEqual(timed(_record()), 0.75)
+
+    def test_disabled_finalize_returns_none(self):
+        """finalize_batch should return None when timing is disabled."""
+
+        timed = TimedRewardFn(lambda r: 1.0, RewardTimingConfig(enabled=False))
+        timed(_record())
+        self.assertIsNone(timed.finalize_batch(0))
+
+    def test_default_config_is_disabled(self):
+        """A bare RewardTimingConfig should default to disabled."""
+
+        config = RewardTimingConfig()
+        self.assertFalse(config.enabled)
+
+
+class EnabledTimingTest(unittest.TestCase):
+    """Core timing, outlier flagging, and report generation."""
+
+    def test_enabled_records_per_sample_timing(self):
+        """Each call should produce one sample timing entry."""
+
+        timed = TimedRewardFn(lambda r: 1.0, RewardTimingConfig(enabled=True))
+        timed(_record(0, 0))
+        timed(_record(1, 2))
+        report = timed.finalize_batch(5)
+        self.assertIsNotNone(report)
+        self.assertEqual(len(report.sample_timings), 2)
+        self.assertEqual(report.step, 5)
+        self.assertEqual(report.sample_timings[0].sample_id, "p0_s0")
+        self.assertEqual(report.sample_timings[1].sample_id, "p1_s2")
+
+    def test_slow_threshold_flags_outliers(self):
+        """Samples above slow_threshold_s should appear in outliers."""
+
+        def slow_fn(record):
+            time.sleep(0.05)
+            return 1.0
+
+        config = RewardTimingConfig(enabled=True, slow_threshold_s=0.01)
+        timed = TimedRewardFn(slow_fn, config)
+        timed(_record(0, 0))
+        report = timed.finalize_batch(0)
+        self.assertEqual(len(report.outliers), 1)
+        self.assertEqual(report.outliers[0].sample_id, "p0_s0")
+        self.assertGreater(report.outliers[0].elapsed_s, 0.01)
+
+    def test_fast_samples_not_flagged(self):
+        """Samples below slow_threshold_s should not appear in outliers."""
+
+        config = RewardTimingConfig(enabled=True, slow_threshold_s=10.0)
+        timed = TimedRewardFn(lambda r: 1.0, config)
+        timed(_record(0, 0))
+        report = timed.finalize_batch(0)
+        self.assertEqual(len(report.outliers), 0)
+
+    def test_report_summary_statistics(self):
+        """Report should carry total, mean, max, and p95 elapsed times."""
+
+        def fn(record):
+            # Deterministic-ish: fast call
+            return 1.0
+
+        config = RewardTimingConfig(enabled=True)
+        timed = TimedRewardFn(fn, config)
+        for i in range(5):
+            timed(_record(i, 0))
+        report = timed.finalize_batch(0)
+        self.assertIsNotNone(report)
+        self.assertEqual(report.hook_name, "reward_fn")
+        self.assertGreater(report.total_elapsed_s, 0.0)
+        self.assertGreater(report.mean_elapsed_s, 0.0)
+        self.assertGreaterEqual(report.max_elapsed_s, report.mean_elapsed_s)
+        self.assertGreaterEqual(report.p95_elapsed_s, 0.0)
+
+    def test_finalize_clears_pending(self):
+        """After finalize, a second call should produce a fresh report."""
+
+        timed = TimedRewardFn(lambda r: 1.0, RewardTimingConfig(enabled=True))
+        timed(_record())
+        report1 = timed.finalize_batch(0)
+        self.assertIsNotNone(report1)
+        self.assertEqual(len(report1.sample_timings), 1)
+        report2 = timed.finalize_batch(1)
+        self.assertIsNone(report2)
+
+    def test_no_samples_returns_none(self):
+        """finalize_batch with no pending samples returns None."""
+
+        timed = TimedRewardFn(lambda r: 1.0, RewardTimingConfig(enabled=True))
+        self.assertIsNone(timed.finalize_batch(0))
+
+
+class ReportFormatTest(unittest.TestCase):
+    """Human-readable and structured output."""
+
+    def test_to_dict_has_expected_fields(self):
+        """to_dict should produce JSON-serializable fields without prompts."""
+
+        timing = RewardSampleTiming(hook_name="reward_fn", sample_id="p0_s0", elapsed_s=0.123)
+        report = RewardTimingReport(
+            hook_name="reward_fn",
+            step=3,
+            sample_timings=[timing],
+            total_elapsed_s=0.123,
+            mean_elapsed_s=0.123,
+            max_elapsed_s=0.123,
+            p95_elapsed_s=0.123,
+            outliers=[timing],
+        )
+        d = report.to_dict()
+        self.assertEqual(d["hook_name"], "reward_fn")
+        self.assertEqual(d["step"], 3)
+        self.assertEqual(d["num_samples"], 1)
+        self.assertEqual(d["outliers"][0]["sample_id"], "p0_s0")
+        # No prompt or completion text should leak.
+        for key in d:
+            self.assertNotIn("prompt", key.lower())
+            self.assertNotIn("completion", key.lower())
+
+    def test_format_human_includes_outliers(self):
+        """format_human should list slow sample IDs."""
+
+        timing = RewardSampleTiming(hook_name="reward_fn", sample_id="p0_s0", elapsed_s=0.5)
+        report = RewardTimingReport(
+            hook_name="reward_fn",
+            step=1,
+            sample_timings=[timing],
+            outliers=[timing],
+        )
+        text = report.format_human()
+        self.assertIn("slow_samples=[p0_s0]", text)
+        self.assertIn("hook=reward_fn", text)
+
+    def test_format_human_includes_timeouts(self):
+        """format_human should list timeout sample IDs."""
+
+        timing = RewardSampleTiming(hook_name="reward_fn", sample_id="p1_s3", elapsed_s=2.0, timed_out=True)
+        report = RewardTimingReport(
+            hook_name="reward_fn",
+            step=1,
+            sample_timings=[timing],
+            timeouts=[timing],
+        )
+        text = report.format_human()
+        self.assertIn("timeouts=[p1_s3]", text)
+
+
+class ConfigValidationTest(unittest.TestCase):
+    """Configuration validation and error messages."""
+
+    def test_negative_slow_threshold_raises(self):
+        """A negative slow_threshold_s should raise ValueError."""
+
+        with self.assertRaisesRegex(ValueError, "slow_threshold_s must be positive"):
+            RewardTimingConfig(slow_threshold_s=-1.0).validate()
+
+    def test_zero_slow_threshold_raises(self):
+        """A zero slow_threshold_s should raise ValueError."""
+
+        with self.assertRaisesRegex(ValueError, "slow_threshold_s must be positive"):
+            RewardTimingConfig(slow_threshold_s=0.0).validate()
+
+    def test_negative_timeout_raises(self):
+        """A negative timeout_s should raise ValueError."""
+
+        with self.assertRaisesRegex(ValueError, "timeout_s must be positive"):
+            RewardTimingConfig(timeout_s=-0.5).validate()
+
+    def test_timeout_less_than_threshold_raises(self):
+        """timeout_s < slow_threshold_s should raise ValueError."""
+
+        with self.assertRaisesRegex(ValueError, "timeout_s must be >= slow_threshold_s"):
+            RewardTimingConfig(slow_threshold_s=1.0, timeout_s=0.5).validate()
+
+    def test_none_threshold_and_timeout_are_valid(self):
+        """None values for threshold and timeout should be valid."""
+
+        RewardTimingConfig(slow_threshold_s=None, timeout_s=None).validate()
+        RewardTimingConfig(slow_threshold_s=1.0, timeout_s=None).validate()
+        RewardTimingConfig(slow_threshold_s=None, timeout_s=1.0).validate()
+
+    def test_constructor_validates(self):
+        """TimedRewardFn constructor should validate the config."""
+
+        with self.assertRaises(ValueError):
+            TimedRewardFn(lambda r: 1.0, RewardTimingConfig(slow_threshold_s=-1.0))
+
+
+class TimeoutTest(unittest.TestCase):
+    """Per-sample timeout enforcement (POSIX only)."""
+
+    def test_timeout_returns_nan(self):
+        """A timed-out sample should return NaN."""
+
+        def slow_fn(record):
+            time.sleep(0.3)
+            return 1.0
+
+        config = RewardTimingConfig(enabled=True, timeout_s=0.05)
+        timed = TimedRewardFn(slow_fn, config)
+        result = timed(_record(0, 0))
+        self.assertTrue(math.isnan(result))
+
+    def test_timeout_recorded_in_report(self):
+        """Timed-out samples should appear in the report's timeouts list."""
+
+        def slow_fn(record):
+            time.sleep(0.2)
+            return 1.0
+
+        config = RewardTimingConfig(enabled=True, timeout_s=0.05)
+        timed = TimedRewardFn(slow_fn, config)
+        timed(_record(0, 0))
+        report = timed.finalize_batch(0)
+        self.assertIsNotNone(report)
+        self.assertEqual(len(report.timeouts), 1)
+        self.assertTrue(report.timeouts[0].timed_out)
+
+    def test_no_timeout_when_disabled(self):
+        """Without timeout_s, even slow functions should complete normally."""
+
+        def slow_fn(record):
+            time.sleep(0.05)
+            return 0.42
+
+        config = RewardTimingConfig(enabled=True)
+        timed = TimedRewardFn(slow_fn, config)
+        result = timed(_record())
+        self.assertAlmostEqual(result, 0.42)
+        report = timed.finalize_batch(0)
+        self.assertEqual(len(report.timeouts), 0)
+
+
+class PercentileTest(unittest.TestCase):
+    """The _percentile helper."""
+
+    def test_single_value(self):
+        """A single value should return itself for any percentile."""
+
+        from areno.api.reward_timing import _percentile
+
+        self.assertEqual(_percentile([5.0], 95), 5.0)
+
+    def test_multiple_values(self):
+        """The 95th percentile of [1,2,3,4,5] should be near 5."""
+
+        from areno.api.reward_timing import _percentile
+
+        result = _percentile([1.0, 2.0, 3.0, 4.0, 5.0], 95)
+        self.assertGreaterEqual(result, 4.0)
+        self.assertLessEqual(result, 5.0)
+
+    def test_empty_list(self):
+        """An empty list should return 0.0."""
+
+        from areno.api.reward_timing import _percentile
+
+        self.assertEqual(_percentile([], 95), 0.0)
+
+
+class MissingMetadataTest(unittest.TestCase):
+    """Samples without prompt_index/sample_index metadata."""
+
+    def test_missing_metadata_produces_default_id(self):
+        """When metadata lacks indices, sample_id should use -1."""
+
+        record = RewardRecord(prompt="test", completion="test")
+        timed = TimedRewardFn(lambda r: 1.0, RewardTimingConfig(enabled=True))
+        timed(record)
+        report = timed.finalize_batch(0)
+        self.assertEqual(report.sample_timings[0].sample_id, "p-1_s-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reward_timing_integration_cpu.py
+++ b/tests/test_reward_timing_integration_cpu.py
@@ -1,0 +1,99 @@
+"""Integration test for reward timing in the trainer loop (issue #242).
+
+This test uses fakes to exercise the orchestration logic that wires
+``TimedRewardFn`` into ``PolicyOnlyTrainer``, verifying that timing reports
+are produced and dashboard state is recorded -- all on CPU without a GPU.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from areno.api.reward_timing import RewardTimingConfig, TimedRewardFn
+from areno.api.rewards import RewardRecord
+
+
+class TrainerTimingIntegrationTest(unittest.TestCase):
+    """Verify PolicyOnlyTrainer wires TimedRewardFn and reports correctly."""
+
+    def test_build_timed_reward_fn_disabled_by_default(self):
+        """The default config should produce a transparent passthrough."""
+
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        config = SimpleNamespace(reward_timing_enabled=False, reward_slow_threshold_s=None, reward_timeout_s=None)
+        trainer = PolicyOnlyTrainer.__new__(PolicyOnlyTrainer)
+        trainer.config = config
+
+        def reward_fn(record):
+            return 0.5
+
+        timed = trainer._build_timed_reward_fn(reward_fn)
+        self.assertIsInstance(timed, TimedRewardFn)
+        self.assertFalse(timed.config.enabled)
+        # The public reward_fn should be replaced.
+        self.assertIs(trainer.reward_fn, timed)
+
+    def test_build_timed_reward_fn_enabled(self):
+        """When enabled, the wrapper should carry the config settings."""
+
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        config = SimpleNamespace(
+            reward_timing_enabled=True,
+            reward_slow_threshold_s=0.1,
+            reward_timeout_s=5.0,
+        )
+        trainer = PolicyOnlyTrainer.__new__(PolicyOnlyTrainer)
+        trainer.config = config
+
+        timed = trainer._build_timed_reward_fn(lambda r: 1.0)
+        self.assertTrue(timed.config.enabled)
+        self.assertEqual(timed.config.slow_threshold_s, 0.1)
+        self.assertEqual(timed.config.timeout_s, 5.0)
+
+    def test_finalize_reward_timing_records_dashboard_state(self):
+        """_finalize_reward_timing should record dashboard state when enabled."""
+
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        config = SimpleNamespace(reward_timing_enabled=True, reward_slow_threshold_s=None, reward_timeout_s=None)
+        trainer = PolicyOnlyTrainer.__new__(PolicyOnlyTrainer)
+        trainer.config = config
+        trainer.areno = MagicMock()
+
+        # Build a real timed fn and prime it with one sample.
+        timed = trainer._build_timed_reward_fn(lambda r: 1.0)
+        timed(RewardRecord(prompt="x", completion="y", metadata={"prompt_index": 0, "sample_index": 0}))
+        trainer._finalize_reward_timing(7)
+
+        # Dashboard state should have been recorded with timing data.
+        trainer.areno.record_dashboard_state.assert_called_once()
+        call_kwargs = trainer.areno.record_dashboard_state.call_args
+        self.assertEqual(call_kwargs.kwargs["stage"], "reward_timing")
+        self.assertEqual(call_kwargs.kwargs["step"], 7)
+        timing_dict = call_kwargs.kwargs["extra"]["reward_timing"]
+        self.assertEqual(timing_dict["num_samples"], 1)
+        self.assertEqual(timing_dict["hook_name"], "reward_fn")
+
+    def test_finalize_reward_timing_noop_when_disabled(self):
+        """When disabled, _finalize_reward_timing should not record dashboard state."""
+
+        from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+        config = SimpleNamespace(reward_timing_enabled=False, reward_slow_threshold_s=None, reward_timeout_s=None)
+        trainer = PolicyOnlyTrainer.__new__(PolicyOnlyTrainer)
+        trainer.config = config
+        trainer.areno = MagicMock()
+
+        timed = trainer._build_timed_reward_fn(lambda r: 1.0)
+        timed(RewardRecord(prompt="x", completion="y"))
+        trainer._finalize_reward_timing(0)
+
+        trainer.areno.record_dashboard_state.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add per-sample reward function timing, configurable outlier flagging, and optional per-sample timeout with hook and sample identifiers. The feature is disabled by default (backward compatible) and adds near-zero overhead when not enabled.

New module: areno/api/reward_timing.py
- TimedRewardFn wraps user reward_fn with timing instrumentation
- RewardTimingConfig controls enabled/slow_threshold_s/timeout_s/hook_name
- RewardTimingReport carries per-sample timings, summary stats, outliers, and timeouts -- all without logging prompts or completions
- Timeout enforcement uses signal.SIGALRM (POSIX only); timed-out samples receive NaN (TIMEOUT_REWARD)

CLI options (areno/cli/train.py):
- --reward-timing-enabled: master switch
- --reward-slow-threshold-s: flag samples slower than this as outliers
- --reward-timeout-s: per-sample wall-clock timeout All validated before model/worker initialization.

Trainer integration (areno/api/trainers/policy_only.py):
- PolicyOnlyTrainer wraps reward_fn with TimedRewardFn in __init__
- _finalize_reward_timing called after each step's reward computation
- Dashboard state recorded with structured timing report

Config (areno/api/trainer_config.py):
- PolicyTrainerConfig gains reward_timing_enabled, reward_slow_threshold_s, reward_timeout_s (PPOTrainerConfig inherits these)

Tests:
- tests/test_reward_timing_cpu.py: core logic, disabled/default behavior, outlier flagging, timeout, validation, boundary values, report format
- tests/test_reward_timing_integration_cpu.py: trainer wiring, dashboard state recording

Docs: docs/cli/observability.rst updated with reward timing section

Closes #242

<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?

<!-- A clear and concise description of the change and its motivation. -->

## Related issue

<!-- Link the issue this PR addresses so GitHub closes it on merge, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

<!-- Select ONE that best describes this PR. -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

<!-- Note the test commands you ran (e.g. `pytest tests/ -k cpu`) and any hardware limitations. New behavior must be covered by tests — no testing, no merge. -->

## Checklist

- [ ] The PR title summarizes the contribution.
- [ ] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [ ] New behavior is covered by tests.
- [ ] Described the test commands run and any hardware limitations.
- [ ] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Breaking change details

<!-- If this is a breaking change, describe what breaks and how users should migrate. Otherwise delete this section. -->
