### PR TITLE
feat: add weighted reward composition

### DIFF
--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -143,6 +143,9 @@ def collect_train_batch_stats(train_batch) -> dict:
         response_len = len(response_logprobs)
         stats["rewards"].append(seq.reward)
         stats["advantages"].extend(response_advantages)
+        if seq.reward_components:
+            for comp_name, comp_value in seq.reward_components.items():
+                stats["reward_components"].setdefault(comp_name, []).append(comp_value)
         record_rollout_sequence_stats(
             stats,
             prefix_len=prefix_len,
@@ -164,6 +167,7 @@ def init_rollout_stats(skipped_long: int = 0, total_skipped_long: int = 0) -> di
         "response_len": [],
         "skipped_long": skipped_long,
         "total_skipped_long": total_skipped_long,
+        "reward_components": {},
     }
 
 
@@ -206,6 +210,18 @@ def record_training_stats(writer, stats, step, train_res, train_batch, timings: 
         values = stats.get(key, [])
         if values:
             writer.add_scalar(f"rollout/{key}_mean", np.mean(values), step)
+
+    # Per-component reward metrics (only when compose_reward_fn is used).
+    reward_components = stats.get("reward_components", {})
+    for comp_name, comp_values in reward_components.items():
+        # Sanitize: replace '/' and other TensorBoard-special chars to avoid
+        # unintended namespace nesting in the tag path.
+        safe_name = comp_name.replace("/", "_").replace(" ", "_")
+        comp_arr = np.asarray(comp_values, dtype=np.float32)
+        if comp_arr.size:
+            writer.add_scalar(f"rollout/reward_{safe_name}_mean", comp_arr.mean(), step)
+            writer.add_scalar(f"rollout/reward_{safe_name}_std", comp_arr.std(), step)
+
     writer.add_scalar("rollout/num_sequences", len(train_batch), step)
     for key in ("skipped_long", "total_skipped_long"):
         if key in stats:

--- a/areno/api/models.py
+++ b/areno/api/models.py
@@ -70,7 +70,8 @@ class TrainSequence(BaseModel):
     positions, so loss functions can train only on response tokens while still
     conditioning on the prompt. Optional fields (`returns`, `values`,
     `ref_logprobs`) are only populated for algorithms that need them (PPO with
-    a critic and reference model).
+    a critic and reference model). `reward_components` stores per-component
+    scores when ``compose_reward_fn`` is used; empty otherwise.
     """
 
     prompt_mask: list[bool] = Field(default_factory=list)
@@ -82,4 +83,5 @@ class TrainSequence(BaseModel):
     values: list[float] = Field(default_factory=list)
     ref_logprobs: list[float] = Field(default_factory=list)
     reward: float = Field(default=0.0)
+    reward_components: dict[str, float] = Field(default_factory=dict)
     eos_token_id: int = Field(default=0)

--- a/areno/api/rewards.py
+++ b/areno/api/rewards.py
@@ -9,12 +9,16 @@ one scalar score, which keeps prompt and agentic demos on the same contract.
 from __future__ import annotations
 
 import importlib.util
+import logging
+import math
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
 from pydantic import BaseModel, Field
+
+_logger = logging.getLogger(__name__)
 
 
 class RewardEvent(BaseModel):
@@ -111,3 +115,73 @@ def make_reward_record(
         source_record=dict(source_record),
         metadata=dict(metadata or {}),
     )
+
+
+def compose_reward_fn(
+    components: list[tuple[str, Callable[[RewardRecord], float], float]],
+    *,
+    on_error: Literal["raise", "mark_invalid"] = "raise",
+) -> Callable[[RewardRecord], float]:
+    """Combine multiple named reward functions into one weighted callable.
+
+    Each component is a ``(name, fn, weight)`` tuple. The composed function
+    calls every component with the same :class:`RewardRecord`, computes the
+    weighted sum ``total = sum(w_i * r_i)``, and stores per-component values
+    in ``record.metadata["reward_components"]`` for downstream metrics.
+
+    Args:
+        components: List of (name, fn, weight) tuples. Names must be unique.
+            Weights can be any float; no implicit normalization is applied.
+        on_error: Error handling strategy. ``"raise"`` (default) re-raises
+            any exception or non-finite return value immediately. ``"mark_invalid"``
+            sets the offending component's score to 0.0 and continues.
+
+    Returns:
+        A callable ``fn(record) -> float`` with the same contract as a
+        single reward function.
+
+    Raises:
+        ValueError: If component names are duplicated, the list is empty,
+            or any weight is non-finite.
+    """
+
+    if not components:
+        raise ValueError("compose_reward_fn requires at least one component")
+    names = [name for name, _, _ in components]
+    if len(names) != len(set(names)):
+        duplicates = [n for n in names if names.count(n) > 1]
+        raise ValueError(f"duplicate reward component names: {sorted(set(duplicates))}")
+    for name, _, weight in components:
+        if not math.isfinite(weight):
+            raise ValueError(f"weight for component '{name}' must be finite, got {weight}")
+
+    def composed_fn(record: RewardRecord) -> float:
+        component_scores: dict[str, float] = {}
+        total = 0.0
+        for name, fn, weight in components:
+            try:
+                score = float(fn(record))
+                if not math.isfinite(score):
+                    raise ValueError(f"reward component '{name}' returned non-finite value: {score}")
+            except Exception as exc:
+                if on_error == "raise":
+                    raise
+                # mark_invalid: log the failure and treat score as 0.0
+                _logger.warning(
+                    "reward component '%s' failed (%s); treating score as 0.0",
+                    name,
+                    exc,
+                )
+                score = 0.0
+            component_scores[name] = score
+            total += weight * score
+        # Store component values for downstream metrics collection.
+        record.metadata["reward_components"] = dict(component_scores)
+        return total
+
+    # Expose component names and weights for downstream metrics wiring.
+    # Accessed by metrics code to detect whether a reward_fn is composed and
+    # to enumerate component names. The leading underscore signals that the
+    # attribute is set by compose_reward_fn and not part of Callable's type.
+    composed_fn._reward_components = [(name, weight) for name, _, weight in components]  # type: ignore[attr-defined]
+    return composed_fn

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -432,6 +432,7 @@ class PolicyOnlyTrainer:
             advantage = advantages_by_row.get(row_idx, 0.0)
             advantages = [advantage if is_loss else 0.0 for is_loss in loss_mask]
             rollout_logprobs.extend(lp for lp, is_loss in zip(logprobs, loss_mask, strict=True) if is_loss)
+            record = agent_batch.reward_records[row_idx]
             train_batch.append(
                 areno.api.TrainSequence(
                     prompt_mask=prompt_mask,
@@ -440,6 +441,7 @@ class PolicyOnlyTrainer:
                     logprobs=logprobs,
                     advantages=advantages,
                     reward=float(reward),
+                    reward_components=record.metadata.get("reward_components", {}),
                     eos_token_id=tokenizer.eos_token_id,
                 )
             )
@@ -527,28 +529,28 @@ class PolicyOnlyTrainer:
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
-            rewards = [
-                float(
-                    self.reward_fn(
-                        make_reward_record(
-                            prompt=item.prompt,
-                            completion=completion,
-                            source_record=item.record,
-                            answer=item.solutions,
-                            tokens=item.input_tokens + seq.resp_tokens,
-                            logprobs=[0.0] * prefix_len + seq.resp_logprobs,
-                            loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
-                            metadata={"prompt_index": item_idx, "sample_index": sample_idx},
-                        )
-                    )
+            rewards = []
+            reward_records = []
+            for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True)):
+                record = make_reward_record(
+                    prompt=item.prompt,
+                    completion=completion,
+                    source_record=item.record,
+                    answer=item.solutions,
+                    tokens=item.input_tokens + seq.resp_tokens,
+                    logprobs=[0.0] * prefix_len + seq.resp_logprobs,
+                    loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
+                    metadata={"prompt_index": item_idx, "sample_index": sample_idx},
                 )
-                for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
-            ]
+                rewards.append(float(self.reward_fn(record)))
+                reward_records.append(record)
             rewards_all += rewards
             # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
             # every response token of sample i.
             advantages = compute_group_advantages(rewards)
-            for seq, advantage, reward in zip(result.sequences, advantages, rewards, strict=True):
+            for seq, advantage, reward, reward_record in zip(
+                result.sequences, advantages, rewards, reward_records, strict=True
+            ):
                 resp_len = len(seq.resp_tokens)
                 rollout_logprobs += seq.resp_logprobs
                 train_batch.append(
@@ -561,6 +563,7 @@ class PolicyOnlyTrainer:
                         logprobs=[0.0] * prefix_len + seq.resp_logprobs,
                         advantages=[0.0] * prefix_len + [advantage] * resp_len,
                         reward=reward,
+                        reward_components=reward_record.metadata.get("reward_components", {}),
                         eos_token_id=tokenizer.eos_token_id,
                     )
                 )

--- a/examples/math/composed_reward.py
+++ b/examples/math/composed_reward.py
@@ -72,10 +72,20 @@ def brevity_reward(record: RewardRecord) -> float:
 
 
 # Compose: correctness 0.7, format 0.2, brevity 0.1
-reward_fn = compose_reward_fn(
+_composed = compose_reward_fn(
     [
         ("correctness", correctness_reward, 0.7),
         ("format", format_reward, 0.2),
         ("brevity", brevity_reward, 0.1),
     ]
 )
+
+
+def reward_fn(record: RewardRecord) -> float:
+    """Weighted reward composed of correctness, format, and brevity."""
+
+    return _composed(record)
+
+
+# Expose component metadata for downstream metrics wiring.
+reward_fn._reward_components = _composed._reward_components  # type: ignore[attr-defined]

--- a/examples/math/composed_reward.py
+++ b/examples/math/composed_reward.py
@@ -1,0 +1,81 @@
+"""Composed reward example: correctness + format + brevity.
+
+Demonstrates the compose_reward_fn API for combining multiple weighted
+reward dimensions. Use with:
+
+    areno train --reward-fn-path examples/math/composed_reward.py ...
+
+This file still exposes ``reward_fn`` as required by ``load_reward_fn``,
+so the CLI and trainer code are completely unchanged.
+"""
+
+from __future__ import annotations
+
+from areno.api.rewards import RewardRecord, compose_reward_fn
+
+
+def correctness_reward(record: RewardRecord) -> float:
+    """1.0 if the completion contains the boxed ground truth answer."""
+
+    solutions = record.answer
+    if solutions is None:
+        return 0.0
+    ground_truth = solutions[0] if isinstance(solutions, list) else solutions
+    # Extract the last \boxed{...} expression, handling nested braces.
+    boxed = _extract_boxed(record.completion)
+    if not boxed:
+        return 0.0
+    return 1.0 if boxed[-1].strip() == str(ground_truth).strip() else 0.0
+
+
+def _extract_boxed(text: str) -> list[str]:
+    """Extract content inside all \\boxed{...} expressions, handling nested braces."""
+
+    results = []
+    search_from = 0
+    prefix = r"\boxed{"
+    while True:
+        idx = text.find(prefix, search_from)
+        if idx == -1:
+            break
+        brace_start = idx + len(prefix) - 1  # position of the opening '{'
+        depth = 0
+        for i in range(brace_start, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    results.append(text[brace_start + 1 : i])
+                    search_from = i + 1
+                    break
+        else:
+            # Unbalanced braces; stop searching.
+            break
+    return results
+
+
+def format_reward(record: RewardRecord) -> float:
+    """1.0 if the completion contains a \\boxed{} expression, else 0.0."""
+
+    return 1.0 if r"\boxed{" in record.completion else 0.0
+
+
+def brevity_reward(record: RewardRecord) -> float:
+    """Shorter completions score higher, clamped to [0, 1].
+
+    Completions of 2000+ characters score 0.0.
+    """
+
+    # 2000 chars is a rough cap for concise math answers; adjust per use case.
+    return max(0.0, 1.0 - len(record.completion) / 2000.0)
+
+
+# Compose: correctness 0.7, format 0.2, brevity 0.1
+reward_fn = compose_reward_fn(
+    [
+        ("correctness", correctness_reward, 0.7),
+        ("format", format_reward, 0.2),
+        ("brevity", brevity_reward, 0.1),
+    ]
+)

--- a/tests/test_compose_reward_fn_cpu.py
+++ b/tests/test_compose_reward_fn_cpu.py
@@ -1,0 +1,398 @@
+"""CPU tests for weighted reward composition.
+
+Covers normal path, boundary values, invalid input, and error-handling
+strategies (fail-fast vs mark-invalid) for ``compose_reward_fn``.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from areno.api.rewards import (
+    RewardRecord,
+    compose_reward_fn,
+    compute_group_advantages,
+    load_reward_fn,
+    make_reward_record,
+)
+
+
+def _const_1(_record) -> float:
+    return 1.0
+
+
+def _const_half(_record) -> float:
+    return 0.5
+
+
+def _const_zero(_record) -> float:
+    return 0.0
+
+
+def _const_seven_tenths(_record) -> float:
+    return 0.7
+
+
+def _nan_fn(_record) -> float:
+    return float("nan")
+
+
+def _inf_fn(_record) -> float:
+    return float("inf")
+
+
+def _keyword_match_fn(record) -> float:
+    return 1.0 if "good" in record.completion else 0.0
+
+
+class ComposeRewardFnTest(unittest.TestCase):
+    """Tests for weighted reward composition."""
+
+    def _make_record(self, completion: str = "test") -> RewardRecord:
+        return make_reward_record(
+            prompt="prompt",
+            completion=completion,
+            source_record={"answer": "4"},
+        )
+
+    # -- Normal path --
+
+    def test_weighted_sum_matches_hand_calculation(self):
+        """Weighted total should match hand calculation."""
+        composed = compose_reward_fn([("a", _const_1, 0.7), ("b", _const_half, 0.3)])
+        record = self._make_record()
+        # 0.7 * 1.0 + 0.3 * 0.5 = 0.85
+        self.assertAlmostEqual(composed(record), 0.85, places=6)
+
+    def test_component_values_stored_in_metadata(self):
+        """Each component score should be stored in record.metadata."""
+        composed = compose_reward_fn([("correct", _const_1, 0.8), ("format", _const_zero, 0.2)])
+        record = self._make_record()
+        composed(record)
+        components = record.metadata["reward_components"]
+        self.assertEqual(components["correct"], 1.0)
+        self.assertEqual(components["format"], 0.0)
+
+    def test_all_components_share_same_record(self):
+        """All component functions should receive the same RewardRecord."""
+        seen = []
+
+        def spy(record):
+            seen.append(record)
+            return 0.5
+
+        composed = compose_reward_fn([("a", spy, 0.5), ("b", spy, 0.5)])
+        record = self._make_record("hello")
+        composed(record)
+        self.assertEqual(len(seen), 2)
+        self.assertIs(seen[0], seen[1])
+        self.assertEqual(seen[0].completion, "hello")
+
+    def test_single_component_works(self):
+        """A single component should work correctly."""
+        composed = compose_reward_fn([("only", _const_seven_tenths, 1.0)])
+        record = self._make_record()
+        self.assertAlmostEqual(composed(record), 0.7, places=6)
+
+    def test_negative_weights_allowed(self):
+        """Negative weights should be allowed (e.g. penalty terms)."""
+        composed = compose_reward_fn([("reward", _const_1, 1.0), ("penalty", _const_1, -0.5)])
+        record = self._make_record()
+        # 1.0 * 1.0 + (-0.5) * 1.0 = 0.5
+        self.assertAlmostEqual(composed(record), 0.5, places=6)
+
+    # -- Boundary values --
+
+    def test_zero_weight_contributes_nothing(self):
+        """A zero-weight component should not affect the total."""
+        composed = compose_reward_fn([("a", _const_1, 1.0), ("b", _const_1, 0.0)])
+        record = self._make_record()
+        self.assertAlmostEqual(composed(record), 1.0, places=6)
+
+    def test_all_zero_weights_produces_zero_total(self):
+        """All-zero weights should produce a zero total."""
+        composed = compose_reward_fn([("a", _const_1, 0.0)])
+        record = self._make_record()
+        self.assertAlmostEqual(composed(record), 0.0, places=6)
+
+    # -- Invalid input --
+
+    def test_rejects_empty_component_list(self):
+        """An empty component list should raise."""
+        with self.assertRaisesRegex(ValueError, "at least one component"):
+            compose_reward_fn([])
+
+    def test_rejects_duplicate_names(self):
+        """Duplicate component names should raise."""
+        with self.assertRaisesRegex(ValueError, "duplicate reward component names"):
+            compose_reward_fn([("a", _const_half, 0.5), ("a", _const_half, 0.5)])
+
+    def test_rejects_non_finite_weight(self):
+        """Non-finite weights should raise."""
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            compose_reward_fn([("a", _const_half, float("nan"))])
+
+    # -- Error handling strategies --
+
+    def test_fail_fast_on_exception(self):
+        """on_error='raise' should re-raise component exceptions immediately."""
+
+        def bad_fn(_record):
+            raise RuntimeError("boom")
+
+        composed = compose_reward_fn(
+            [("good", _const_1, 0.5), ("bad", bad_fn, 0.5)],
+            on_error="raise",
+        )
+        record = self._make_record()
+        with self.assertRaises(RuntimeError):
+            composed(record)
+
+    def test_mark_invalid_on_exception(self):
+        """on_error='mark_invalid' should set the offending score to 0.0 and continue."""
+
+        def bad_fn(_record):
+            raise RuntimeError("boom")
+
+        composed = compose_reward_fn(
+            [("good", _const_1, 0.8), ("bad", bad_fn, 0.2)],
+            on_error="mark_invalid",
+        )
+        record = self._make_record()
+        # 0.8 * 1.0 + 0.2 * 0.0 = 0.8
+        total = composed(record)
+        self.assertAlmostEqual(total, 0.8, places=6)
+        self.assertEqual(record.metadata["reward_components"]["bad"], 0.0)
+
+    def test_fail_fast_on_non_finite_return(self):
+        """on_error='raise' should raise when a component returns NaN."""
+        composed = compose_reward_fn([("a", _nan_fn, 1.0)], on_error="raise")
+        record = self._make_record()
+        with self.assertRaisesRegex(ValueError, "non-finite"):
+            composed(record)
+
+    def test_mark_invalid_on_non_finite_return(self):
+        """on_error='mark_invalid' should set Inf returns to 0.0."""
+        composed = compose_reward_fn(
+            [("a", _const_1, 0.5), ("b", _inf_fn, 0.5)],
+            on_error="mark_invalid",
+        )
+        record = self._make_record()
+        # 0.5 * 1.0 + 0.5 * 0.0 = 0.5
+        total = composed(record)
+        self.assertAlmostEqual(total, 0.5, places=6)
+
+    # -- Backward compatibility --
+
+    def test_compose_then_compute_advantages(self):
+        """Composed reward should work with compute_group_advantages."""
+        composed = compose_reward_fn([("correct", _keyword_match_fn, 1.0)])
+        records = [
+            self._make_record("good"),
+            self._make_record("bad"),
+            self._make_record("good"),
+        ]
+        rewards = [composed(r) for r in records]
+        advantages = compute_group_advantages(rewards)
+        self.assertEqual(len(advantages), 3)
+        self.assertAlmostEqual(sum(rewards) / 3, 2 / 3, places=6)
+
+    # -- Cross-coverage: Inf weight, mark_invalid + NaN, attribute, isolation --
+
+    def test_rejects_inf_weight(self):
+        """Inf weights should be rejected just like NaN weights."""
+        with self.assertRaisesRegex(ValueError, "must be finite"):
+            compose_reward_fn([("a", _const_half, float("inf"))])
+
+    def test_mark_invalid_on_nan_return(self):
+        """on_error='mark_invalid' should set NaN returns to 0.0."""
+        composed = compose_reward_fn(
+            [("a", _const_1, 0.6), ("b", _nan_fn, 0.4)],
+            on_error="mark_invalid",
+        )
+        record = self._make_record()
+        # 0.6 * 1.0 + 0.4 * 0.0 = 0.6
+        total = composed(record)
+        self.assertAlmostEqual(total, 0.6, places=6)
+        self.assertEqual(record.metadata["reward_components"]["b"], 0.0)
+
+    def test_composed_fn_exposes_component_metadata(self):
+        """The composed function should expose component names and weights."""
+        composed = compose_reward_fn([("correctness", _const_1, 0.7), ("format", _const_half, 0.3)])
+        meta = composed._reward_components  # type: ignore[attr-defined]
+        self.assertEqual(meta, [("correctness", 0.7), ("format", 0.3)])
+
+    def test_repeated_calls_do_not_cross_contaminate(self):
+        """Calling the same composed_fn on different records must not leak metadata."""
+        composed = compose_reward_fn([("a", _const_1, 1.0)])
+        r1 = self._make_record("first")
+        r2 = self._make_record("second")
+        composed(r1)
+        composed(r2)
+        # r1's metadata should still only reflect its own call.
+        self.assertEqual(r1.metadata["reward_components"], {"a": 1.0})
+        self.assertEqual(r2.metadata["reward_components"], {"a": 1.0})
+
+    def test_metadata_overwritten_on_repeated_call_same_record(self):
+        """Calling composed_fn on the same record twice should overwrite, not append."""
+        composed = compose_reward_fn([("a", _const_1, 1.0)])
+        record = self._make_record()
+        composed(record)
+        composed(record)
+        # Should still be a flat dict, not nested or duplicated.
+        self.assertIsInstance(record.metadata["reward_components"], dict)
+        self.assertEqual(record.metadata["reward_components"], {"a": 1.0})
+
+    # -- End-to-end: load_reward_fn with a composed file --
+
+    def test_load_reward_fn_loads_composed_file(self):
+        """load_reward_fn should load a file that uses compose_reward_fn."""
+        example_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "examples",
+            "math",
+            "composed_reward.py",
+        )
+        fn = load_reward_fn(example_path)
+        self.assertTrue(callable(fn))
+        # The loaded function should expose composed component metadata.
+        meta = fn._reward_components  # type: ignore[attr-defined]
+        self.assertEqual(meta, [("correctness", 0.7), ("format", 0.2), ("brevity", 0.1)])
+
+    # -- Explicit backward compatibility --
+
+    def test_record_without_compose_has_no_reward_components(self):
+        """A plain reward_fn that does not use compose_reward_fn should not set reward_components."""
+
+        def plain_fn(record) -> float:
+            return 0.5
+
+        record = self._make_record()
+        result = plain_fn(record)
+        self.assertAlmostEqual(result, 0.5, places=6)
+        self.assertNotIn("reward_components", record.metadata)
+
+    # -- 3-component weighted sum with distinct return values --
+
+    def test_three_component_weighted_sum(self):
+        """Three components with different weights and return values."""
+        composed = compose_reward_fn(
+            [
+                ("correctness", _const_1, 0.7),
+                ("format", _const_half, 0.2),
+                ("brevity", _const_seven_tenths, 0.1),
+            ]
+        )
+        record = self._make_record()
+        total = composed(record)
+        # 0.7*1.0 + 0.2*0.5 + 0.1*0.7 = 0.7 + 0.1 + 0.07 = 0.87
+        self.assertAlmostEqual(total, 0.87, places=6)
+        # Verify each component value in metadata
+        components = record.metadata["reward_components"]
+        self.assertEqual(components["correctness"], 1.0)
+        self.assertEqual(components["format"], 0.5)
+        self.assertAlmostEqual(components["brevity"], 0.7, places=6)
+
+    def test_three_component_all_metadata_present(self):
+        """All three component names should appear in metadata after composition."""
+        composed = compose_reward_fn(
+            [
+                ("a", _const_1, 0.5),
+                ("b", _const_half, 0.3),
+                ("c", _const_zero, 0.2),
+            ]
+        )
+        record = self._make_record()
+        composed(record)
+        components = record.metadata["reward_components"]
+        self.assertEqual(len(components), 3)
+        self.assertIn("a", components)
+        self.assertIn("b", components)
+        self.assertIn("c", components)
+
+    # -- Components with input-dependent return values --
+
+    def test_components_with_input_dependent_values(self):
+        """Components that return different values based on record content."""
+
+        def correctness_fn(record) -> float:
+            """1.0 if answer matches, else 0.0."""
+            return 1.0 if str(record.answer) in record.completion else 0.0
+
+        def format_fn(record) -> float:
+            """0.5 if completion contains 'boxed', else 0.0."""
+            return 0.5 if "boxed" in record.completion else 0.0
+
+        def length_fn(record) -> float:
+            """Shorter completions score higher."""
+            return max(0.0, 1.0 - len(record.completion) / 100.0)
+
+        composed = compose_reward_fn(
+            [
+                ("correctness", correctness_fn, 0.7),
+                ("format", format_fn, 0.2),
+                ("brevity", length_fn, 0.1),
+            ]
+        )
+
+        # Record with correct answer, boxed format, short completion.
+        good_record = make_reward_record(
+            prompt="What is 2+2?",
+            completion="The answer is 4. \\boxed{4}",
+            source_record={},
+            answer="4",
+        )
+        total_good = composed(good_record)
+        # correctness=1.0, format=0.5, brevity=max(0, 1 - 26/100)=0.74
+        # total = 0.7*1.0 + 0.2*0.5 + 0.1*0.74 = 0.7 + 0.1 + 0.074 = 0.874
+        self.assertAlmostEqual(total_good, 0.874, places=5)
+        self.assertEqual(good_record.metadata["reward_components"]["correctness"], 1.0)
+        self.assertEqual(good_record.metadata["reward_components"]["format"], 0.5)
+
+        # Record with wrong answer, no boxed, long completion.
+        bad_record = make_reward_record(
+            prompt="What is 2+2?",
+            completion="I think the answer might be five." + "x" * 200,
+            source_record={},
+            answer="4",
+        )
+        total_bad = composed(bad_record)
+        # correctness=0.0, format=0.0, brevity=max(0, 1 - 231/100)=0.0 (clamped)
+        # total = 0.7*0.0 + 0.2*0.0 + 0.1*0.0 = 0.0
+        self.assertAlmostEqual(total_bad, 0.0, places=6)
+        self.assertEqual(bad_record.metadata["reward_components"]["correctness"], 0.0)
+        self.assertEqual(bad_record.metadata["reward_components"]["format"], 0.0)
+
+    def test_same_composed_fn_different_records_different_totals(self):
+        """The same composed function should produce different totals for different inputs."""
+
+        def keyword_score(record) -> float:
+            return 1.0 if "good" in record.completion else 0.0
+
+        def length_penalty(record) -> float:
+            return -0.5 if len(record.completion) > 50 else 0.0
+
+        composed = compose_reward_fn(
+            [
+                ("keyword", keyword_score, 1.0),
+                ("length_penalty", length_penalty, 1.0),
+            ]
+        )
+
+        short_good = self._make_record("good")
+        long_good = self._make_record("good" + "x" * 100)
+
+        total_short = composed(short_good)
+        total_long = composed(long_good)
+
+        # short_good: keyword=1.0, penalty=0.0 -> 1.0
+        self.assertAlmostEqual(total_short, 1.0, places=6)
+        # long_good: keyword=1.0, penalty=-0.5 -> 0.5
+        self.assertAlmostEqual(total_long, 0.5, places=6)
+        # Different totals confirm input-dependency
+        self.assertNotAlmostEqual(total_short, total_long, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_metrics_cpu.py
+++ b/tests/test_metrics_cpu.py
@@ -67,5 +67,167 @@ class MetricsUtilityTest(unittest.TestCase):
         self.assertEqual(writer.close_count, 1)
 
 
+class TrainSequenceRewardComponentsTest(unittest.TestCase):
+    """Tests for the reward_components field on TrainSequence."""
+
+    def test_default_reward_components_is_empty_dict(self):
+        """TrainSequence should default reward_components to an empty dict."""
+        seq = TrainSequence()
+        self.assertEqual(seq.reward_components, {})
+
+    def test_reward_components_assigned_correctly(self):
+        """reward_components should round-trip assigned values."""
+        seq = TrainSequence(reward=0.85, reward_components={"correctness": 1.0, "format": 0.0})
+        self.assertEqual(seq.reward_components["correctness"], 1.0)
+        self.assertEqual(seq.reward_components["format"], 0.0)
+
+    def test_reward_components_independent_per_instance(self):
+        """Two TrainSequence instances should have independent reward_components."""
+        seq1 = TrainSequence(reward_components={"a": 1.0})
+        seq2 = TrainSequence(reward_components={"b": 2.0})
+        self.assertNotEqual(seq1.reward_components, seq2.reward_components)
+        self.assertNotIn("b", seq1.reward_components)
+
+
+class CollectTrainBatchRewardComponentsTest(unittest.TestCase):
+    """Tests for reward component collection in collect_train_batch_stats."""
+
+    def test_stats_contain_reward_components_key(self):
+        """init_rollout_stats should include a reward_components key."""
+        stats = init_rollout_stats()
+        self.assertIn("reward_components", stats)
+        self.assertEqual(stats["reward_components"], {})
+
+    def test_collect_gathers_reward_components(self):
+        """collect_train_batch_stats should gather per-component values."""
+        seq1 = TrainSequence(
+            prompt_mask=[True, False],
+            tokens=[1, 2],
+            logprobs=[0.0, -0.1],
+            advantages=[0.0, 1.0],
+            reward=0.85,
+            reward_components={"correctness": 1.0, "format": 0.0},
+        )
+        seq2 = TrainSequence(
+            prompt_mask=[True, False],
+            tokens=[1, 2],
+            logprobs=[0.0, -0.2],
+            advantages=[0.0, -1.0],
+            reward=0.3,
+            reward_components={"correctness": 0.0, "format": 1.0},
+        )
+
+        stats = collect_train_batch_stats([seq1, seq2])
+
+        self.assertEqual(stats["reward_components"]["correctness"], [1.0, 0.0])
+        self.assertEqual(stats["reward_components"]["format"], [0.0, 1.0])
+
+    def test_collect_without_reward_components_produces_empty(self):
+        """Sequences without reward_components should not create stats entries."""
+        seq = TrainSequence(
+            prompt_mask=[True, False],
+            tokens=[1, 2],
+            logprobs=[0.0, -0.1],
+            advantages=[0.0, 1.0],
+            reward=1.0,
+        )
+
+        stats = collect_train_batch_stats([seq])
+
+        self.assertEqual(stats["reward_components"], {})
+
+    def test_collect_mixed_composed_and_plain_sequences(self):
+        """A mix of composed and plain sequences should only collect from composed ones."""
+        seq_plain = TrainSequence(
+            prompt_mask=[True, False],
+            tokens=[1, 2],
+            logprobs=[0.0, -0.1],
+            advantages=[0.0, 1.0],
+            reward=1.0,
+        )
+        seq_composed = TrainSequence(
+            prompt_mask=[True, False],
+            tokens=[1, 2],
+            logprobs=[0.0, -0.2],
+            advantages=[0.0, -1.0],
+            reward=0.5,
+            reward_components={"accuracy": 0.5},
+        )
+
+        stats = collect_train_batch_stats([seq_plain, seq_composed])
+
+        self.assertEqual(stats["reward_components"], {"accuracy": [0.5]})
+
+
+class RecordTrainingStatsRewardComponentsTest(unittest.TestCase):
+    """Tests for reward component output in record_training_stats."""
+
+    class _FakeWriter:
+        def __init__(self):
+            self.scalars = []
+
+        def add_scalar(self, tag, value, step):
+            self.scalars.append((tag, value, step))
+
+        def flush(self):
+            pass
+
+    def _make_stats_with_components(self):
+        stats = init_rollout_stats()
+        stats["rewards"] = [0.85, 0.3]
+        stats["reward_components"] = {
+            "correctness": [1.0, 0.0],
+            "format": [0.0, 1.0],
+        }
+        return stats
+
+    def test_outputs_reward_component_mean_and_std(self):
+        """record_training_stats should write mean and std for each component."""
+        writer = self._FakeWriter()
+        stats = self._make_stats_with_components()
+        train_res = {"loss": 0.5}
+
+        from areno.api.metrics import record_training_stats
+
+        record_training_stats(writer, stats, step=0, train_res=train_res, train_batch=[])
+
+        tags = [tag for tag, _value, _step in writer.scalars]
+        self.assertIn("rollout/reward_correctness_mean", tags)
+        self.assertIn("rollout/reward_correctness_std", tags)
+        self.assertIn("rollout/reward_format_mean", tags)
+        self.assertIn("rollout/reward_format_std", tags)
+
+    def test_outputs_correct_mean_values(self):
+        """Component mean values should match hand calculation."""
+        writer = self._FakeWriter()
+        stats = self._make_stats_with_components()
+        train_res = {}
+
+        from areno.api.metrics import record_training_stats
+
+        record_training_stats(writer, stats, step=0, train_res=train_res, train_batch=[])
+
+        scalar_map = {tag: value for tag, value, _step in writer.scalars}
+        # correctness: [1.0, 0.0] -> mean=0.5
+        self.assertAlmostEqual(scalar_map["rollout/reward_correctness_mean"], 0.5, places=6)
+        # format: [0.0, 1.0] -> mean=0.5
+        self.assertAlmostEqual(scalar_map["rollout/reward_format_mean"], 0.5, places=6)
+
+    def test_no_component_output_when_empty(self):
+        """No component scalars should be written when reward_components is empty."""
+        writer = self._FakeWriter()
+        stats = init_rollout_stats()
+        stats["rewards"] = [1.0]
+        train_res = {}
+
+        from areno.api.metrics import record_training_stats
+
+        record_training_stats(writer, stats, step=0, train_res=train_res, train_batch=[])
+
+        tags = [tag for tag, _value, _step in writer.scalars]
+        component_tags = [t for t in tags if t.startswith("rollout/reward_") and t.endswith("_mean")]
+        self.assertEqual(component_tags, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add `compose_reward_fn()` to `areno/api/rewards.py`, enabling users to combine multiple named reward functions with configurable weights. Each component's per-sample score is stored in `RewardRecord.metadata` and surfaced through `TrainSequence.reward_components` to the metrics system, producing `rollout/reward_{name}_mean` and `_std` scalars in TensorBoard.

Error handling supports both fail-fast (default) and mark-invalid strategies. Default behavior is unchanged when the feature is not used — no CLI, config, or trainer changes required.

Closes #207.

## Changes

| File | Change |
|------|-------|
| `areno/api/rewards.py` | New `compose_reward_fn()` + `import math` + `import logging` |
| `areno/api/models.py` | `TrainSequence` new optional `reward_components` field |
| `areno/api/metrics.py` | `init_rollout_stats` / `collect_train_batch_stats` / `record_training_stats` extended |
| `areno/api/trainers/policy_only.py` | Normal + agentic paths pass component info to `TrainSequence` |
| `tests/test_compose_reward_fn_cpu.py` | New — 26 CPU tests |
| `tests/test_metrics_cpu.py` | +10 metrics tests (13 total) |
| `examples/math/composed_reward.py` | New runnable example (correctness + format + brevity) |

## Design

- **Combinator API**: Users call `compose_reward_fn()` in their reward file and assign the result to `reward_fn`. The composed callable has the same `Callable[[RewardRecord], float]` signature — the trainer is completely unaware of composition.
- **Opt-in**: Feature only activates when users explicitly call `compose_reward_fn()`. Existing `reward_fn(record)` files work unchanged.
- **No CLI/config changes**: `--reward-fn-path` and `PolicyTrainerConfig.reward_fn_path` are untouched (per AGENTS.md "Ask first" rules).
- **No new dependencies**: Only uses stdlib `math` and `logging`.

## Error Handling

- `on_error="raise"` (default): any exception or non-finite return value is re-raised immediately (fail-fast).
- `on_error="mark_invalid"`: the offending component's score is set to 0.0, a warning is logged, and remaining components continue.
- Validation at construction time: empty list, duplicate names, non-finite weights all raise `ValueError` before training starts.

## Test Commands

CPU tests (no GPU required):

```bash
pytest tests/test_compose_reward_fn_cpu.py -v
pytest tests/test_metrics_cpu.py -v
pytest tests/ -k cpu -v
```

GPU validation (Kaggle Tesla T4 x2):

```bash
areno train \
  --ckpt Qwen/Qwen3.5-0.8B \
  --world-size 2 \
  --tp-size 1 \
  --model-hub hf \
  --dataset-path AI-MO/NuminaMath-CoT \
  --dataset-loader-fn examples/math/dataset_loader.py \
  --reward-fn-path examples/math/composed_reward.py \
  --algo gspo \
  --batch-size 2 \
  --n-samples 4 \
  --max-running-prompts 8 \
  --max-new-tokens 512 \
  --max-context-len 2048 \
  --mini-bs 8 \
  --max-steps 10 \
  --drop-rollout-state \
  --metrics-log-dir /kaggle/working/tb_logs
```

Backward compatibility (original single reward):

```bash
areno train \
  --ckpt Qwen/Qwen3-0.6B \
  --world-size 2 \
  --tp-size 1 \
  --model-hub hf \
  --dataset-path AI-MO/NuminaMath-CoT \
  --dataset-loader-fn examples/math/dataset_loader.py \
  --reward-fn-path examples/math/math_verify_reward.py \
  --algo gspo \
  --batch-size 2 \
  --n-samples 4 \
  --max-running-prompts 8 \
  --max-new-tokens 512 \
  --max-context-len 2048 \
  --mini-bs 8 \
  --max-steps 2 \
  --drop-rollout-state \
  --metrics-log-dir /kaggle/working/tb_logs_compat
```

## Hardware Limitations

- **Local development** (macOS, no CUDA): CPU tests only — `pytest tests/ -k cpu` (403 passed). No GPU training was run locally.
- **GPU validation**: Kaggle Tesla T4 x2 (16GB each, compute capability 7.5). T4 does not support Flash Attention; `attn_backend` auto-falls back to `native`. T4 lacks native BF16 support; `torch.compile` falls back to eager execution.
- Pre-commit hooks (ruff lint + format, trailing whitespace, Conventional Commits) all passed locally.

## Test Results

| Test | Result |
|------|--------|
| `pytest tests/test_compose_reward_fn_cpu.py -v` | 26 passed |
| `pytest tests/test_metrics_cpu.py -v` | 13 passed |
| `pytest tests/ -k cpu -v` | 403 passed, 0 failed (no regression) |
| `ruff check` (all changed files) | All checks passed |
| `ruff format --check` (all changed files) | 7 files already formatted |
| `pre-commit run` (all changed files) | All hooks passed |
| GPU training (10-step GSPO, T4 x2) | Completed without errors, 6 component tags in TensorBoard |
| Backward compat (2-step GSPO, T4 x2) | Completed, 0 component tags (behavior unchanged) |

## Checklist

- [x] PR title summarizes its contribution
- [x] Addresses issue #207 (linked via "Closes #207")
- [x] Existing tests pass (403 passed, 0 failed)
- [x] New behavior covered by tests (26 + 10 = 36 new CPU tests)
- [x] Description notes test commands and hardware limitations (Kaggle T4, no local GPU)
```