### PR TITLE
feat(tokenizer): add tokenizer alignment inspector (#219)

### DIFF
--- a/areno/api/tokenizer_inspect.py
+++ b/areno/api/tokenizer_inspect.py
@@ -1,0 +1,520 @@
+"""Tokenizer 对齐检查器 (alignment inspector)。
+
+本模块提供聚焦、可独立评审的 tokenizer 对齐检查能力:把原始片段与
+token IDs、token pieces、special-token 标记、EOS 位置、roles、loss-mask
+spans 并排展示,并把 tokenizer 词表大小与模型 ``config.json`` 的
+``vocab_size`` 对齐比较。
+
+设计原则:
+- 纯函数 + 不可变 dataclass,便于 CPU 单测,不依赖 torch/engine。
+- 复用 ``areno.api.tokenizer`` 的现有编码契约(``encode_generation_prompt``、
+  ``apply_chat_template_with_options``、``eos_token_ids`` 等),不重造 tokenizer 路径。
+- 只读:绝不修改 tokenizer 对象的加载路径或持久配置;仅在用户显式传入
+  ``enable_thinking`` 时才会在内存中设置对应属性(与现有 API 行为一致)。
+- model 侧 ``vocab_size`` 通过内联读取 ``config.json`` 获取(参考
+  ``areno/api/tokenizer.py`` 中读取 EOS 的模式),避免引入 ``areno.models.registry``
+  这类会拉起 torch/engine 的重链。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from areno.api.tokenizer import (
+    apply_chat_template_with_options,
+    configure_chat_template_enable_thinking,
+    eos_token_ids,
+    normalize_token_ids,
+)
+
+# 对齐状态标签:OK=一致,FAIL=不一致(需关注),SKIP=无法比较(缺数据)
+ALIGN_OK = "OK"
+ALIGN_FAIL = "FAIL"
+ALIGN_SKIP = "SKIP"
+
+
+@dataclass(frozen=True)
+class Segment:
+    """单个 token 的对齐视图。
+
+    ``text`` / ``pieces`` 取自 ``convert_ids_to_tokens``;``is_special`` 标记
+    special token(如 BOS/EOS/PAD/模板控制符);``is_eos`` 标记停顿 token;
+    ``role`` / ``loss_mask`` 来自所属 chat turn(纯 prompt 时为 None / False)。
+    """
+
+    text: str
+    token_ids: list[int]
+    pieces: list[str]
+    role: str | None
+    is_special: bool
+    loss_mask: bool
+    is_eos: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        # 序列化为 JSON 友好的 dict(供 CLI --json 输出)
+        return {
+            "text": self.text,
+            "token_ids": list(self.token_ids),
+            "pieces": list(self.pieces),
+            "role": self.role,
+            "is_special": self.is_special,
+            "loss_mask": self.loss_mask,
+            "is_eos": self.is_eos,
+        }
+
+
+@dataclass(frozen=True)
+class RoundTrip:
+    """encode→decode 还原比对结果。
+
+    ``ok`` 为 False 时 ``diff_note`` 描述差异类型(空白/长度/内容),不回显
+    完整原文,避免在日志中泄露训练样本。
+    """
+
+    ok: bool
+    decoded: str
+    diff_note: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"ok": self.ok, "decoded": self.decoded, "diff_note": self.diff_note}
+
+
+@dataclass(frozen=True)
+class VocabAlignment:
+    """tokenizer 词表与模型 ``config.json`` 词表的对齐结果。"""
+
+    status: str
+    tokenizer_size: int | None
+    model_vocab_size: int | None
+    note: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "tokenizer_size": self.tokenizer_size,
+            "model_vocab_size": self.model_vocab_size,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True)
+class InspectionReport:
+    """一次对齐检查的完整结果。"""
+
+    kind: str  # "prompt" | "messages" | "tool_call"
+    raw: str  # 用于 round-trip 比对的原始文本
+    segments: list[Segment]
+    eos_positions: list[int]
+    round_trip: RoundTrip
+    vocab_alignment: VocabAlignment
+    truncated: bool
+    has_unknown: bool
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "raw": self.raw,
+            "segments": [s.to_dict() for s in self.segments],
+            "eos_positions": list(self.eos_positions),
+            "round_trip": self.round_trip.to_dict(),
+            "vocab_alignment": self.vocab_alignment.to_dict(),
+            "truncated": self.truncated,
+            "has_unknown": self.has_unknown,
+            "warnings": list(self.warnings),
+        }
+
+
+# --------------------------------------------------------------------------- #
+# 对外入口
+# --------------------------------------------------------------------------- #
+
+
+def inspect_prompt(
+    tokenizer,
+    prompt: str,
+    *,
+    model_path: str | Path | None = None,
+    max_length: int | None = None,
+) -> InspectionReport:
+    """检查一段 plain prompt 的 token 对齐。
+
+    直接 ``tokenizer.encode`` 编码(不套 chat 模板),与 chat messages 路径区分;
+    这样 round-trip 比对的是纯分词还原而非模板渲染文本。纯 prompt 不属于任何
+    turn,因此所有 token 的 ``role`` 为 None、``loss_mask`` 为 False。
+    """
+
+    # 直接 encode,不套 chat 模板;plain prompt 与 chat messages 路径区分。
+    ids = normalize_token_ids(tokenizer.encode(prompt))
+    return _build_report(
+        kind="prompt",
+        raw_text=prompt,
+        tokenizer=tokenizer,
+        ids=ids,
+        model_path=model_path,
+        max_length=max_length,
+        role_by_index={},
+    )
+
+
+def inspect_messages(
+    tokenizer,
+    messages: list[dict[str, Any]],
+    *,
+    model_path: str | Path | None = None,
+    add_generation_prompt: bool = True,
+    enable_thinking: bool | None = None,
+    max_length: int | None = None,
+) -> InspectionReport:
+    """检查 chat messages 的 token 对齐,标注每段 turn 的 role 与 loss-mask。
+
+    role / loss_mask 通过**前缀差分法**确定:对每个前缀 ``messages[:i]`` 渲染
+    一次模板,相邻前缀的 token 长度差即为第 i 条消息贡献的 token 区间。
+    ``loss_mask`` 仅对 ``assistant`` turn 为 True(计入训练 loss);末尾由
+    ``add_generation_prompt`` 追加的 assistant 头部段 role 为 None、不计 loss。
+    """
+
+    # 仅当用户显式指定 thinking 开关时才设置内存属性;None 保持默认,不改 tokenizer。
+    configure_chat_template_enable_thinking(tokenizer, enable_thinking)
+
+    full_ids, role_by_index = _message_roles(tokenizer, messages, add_generation_prompt)
+    raw_text = _render_text(tokenizer, messages, add_generation_prompt)
+    return _build_report(
+        kind="messages",
+        raw_text=raw_text,
+        tokenizer=tokenizer,
+        ids=full_ids,
+        model_path=model_path,
+        max_length=max_length,
+        role_by_index=role_by_index,
+        # messages 的 raw 是含 special 字面的模板文本,需保留 special 还原比对。
+        round_trip_skip_special=False,
+    )
+
+
+def inspect_tool_call(
+    tokenizer,
+    messages: list[dict[str, Any]],
+    *,
+    model_path: str | Path | None = None,
+    add_generation_prompt: bool = False,
+    enable_thinking: bool | None = None,
+    max_length: int | None = None,
+) -> InspectionReport:
+    """检查 tool-call 场景的 token 对齐。
+
+    这是 ``inspect_messages`` 的便利包装:期望 ``messages`` 中包含带 ``tool_calls``
+    的 assistant turn 以及 ``tool`` 角色的工具返回。``kind`` 标记为 ``tool_call``,
+    默认不追加 generation prompt(工具调用通常已自包含)。
+    """
+
+    report = inspect_messages(
+        tokenizer,
+        messages,
+        model_path=model_path,
+        add_generation_prompt=add_generation_prompt,
+        enable_thinking=enable_thinking,
+        max_length=max_length,
+    )
+    return replace(report, kind="tool_call")
+
+
+# --------------------------------------------------------------------------- #
+# 内部工具
+# --------------------------------------------------------------------------- #
+
+
+def _build_report(
+    *,
+    kind: str,
+    raw_text: str,
+    tokenizer,
+    ids: list[int],
+    model_path: str | Path | None,
+    max_length: int | None,
+    role_by_index: dict[int, tuple[str | None, bool]],
+    round_trip_skip_special: bool = True,
+) -> InspectionReport:
+    """组装 InspectionReport:截断、分段、EOS、round-trip、vocab 对齐。"""
+
+    warnings: list[str] = []
+    truncated = False
+    used_ids = list(ids)
+
+    # 截断探测:仅在用户给出 max_length 且超长时触发,展示裁剪到 max_length 的前缀。
+    if max_length is not None and len(used_ids) > max_length:
+        truncated = True
+        dropped = len(used_ids) - max_length
+        used_ids = used_ids[:max_length]
+        warnings.append(f"input truncated to max_length={max_length}, dropped {dropped} trailing tokens")
+
+    eos_set = _eos_set(tokenizer, model_path)
+    special_set = set(getattr(tokenizer, "all_special_ids", []) or [])
+    segments = _segments_from_ids(tokenizer, used_ids, role_by_index, eos_set, special_set)
+
+    eos_positions = [idx for idx, seg in enumerate(segments) if seg.is_eos]
+    has_unknown = _has_unknown(tokenizer, used_ids)
+    round_trip = _decode_round_trip(tokenizer, used_ids, raw_text, skip_special=round_trip_skip_special)
+    vocab_alignment = _vocab_alignment(tokenizer, model_path)
+
+    # 词表不一致是值得关注的对齐问题,作为 warning 显式提示。
+    if vocab_alignment.status == ALIGN_FAIL:
+        warnings.append(f"vocab size mismatch: {vocab_alignment.note}")
+
+    return InspectionReport(
+        kind=kind,
+        raw=raw_text,
+        segments=segments,
+        eos_positions=eos_positions,
+        round_trip=round_trip,
+        vocab_alignment=vocab_alignment,
+        truncated=truncated,
+        has_unknown=has_unknown,
+        warnings=warnings,
+    )
+
+
+def _message_roles(
+    tokenizer,
+    messages: list[dict[str, Any]],
+    add_generation_prompt: bool,
+) -> tuple[list[int], dict[int, tuple[str | None, bool]]]:
+    """前缀差分法:返回完整 ids 与每个 token index 的 (role, loss_mask)。"""
+
+    n = len(messages)
+    role_by_index: dict[int, tuple[str | None, bool]] = {}
+    prev_end = 0
+
+    # 逐前缀渲染(不含 generation prompt),用长度差定位每条消息的 token 区间。
+    for i in range(1, n + 1):
+        prefix_ids = normalize_token_ids(
+            apply_chat_template_with_options(
+                tokenizer,
+                messages[:i],
+                tokenize=True,
+                add_generation_prompt=False,
+            )
+        )
+        end = len(prefix_ids)
+        role = messages[i - 1].get("role")
+        loss_mask = role == "assistant"
+        for idx in range(prev_end, end):
+            role_by_index[idx] = (role, loss_mask)
+        prev_end = end
+
+    # 完整渲染(可选追加 generation prompt),得到最终 ids 序列。
+    full_ids = normalize_token_ids(
+        apply_chat_template_with_options(
+            tokenizer,
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_generation_prompt,
+        )
+    )
+    # add_generation_prompt 追加的 assistant 头部段不属于任何消息,不计 loss。
+    if add_generation_prompt and len(full_ids) > prev_end:
+        for idx in range(prev_end, len(full_ids)):
+            role_by_index[idx] = (None, False)
+
+    return full_ids, role_by_index
+
+
+def _render_text(tokenizer, messages: list[dict[str, Any]], add_generation_prompt: bool) -> str:
+    """渲染 messages 为文本(tokenize=False),供 round-trip 比对。"""
+
+    text = apply_chat_template_with_options(
+        tokenizer,
+        messages,
+        tokenize=False,
+        add_generation_prompt=add_generation_prompt,
+    )
+    return text if isinstance(text, str) else str(text)
+
+
+def _segments_from_ids(
+    tokenizer,
+    ids: list[int],
+    role_by_index: dict[int, tuple[str | None, bool]],
+    eos_set: set[int],
+    special_set: set[int],
+) -> list[Segment]:
+    """将 id 序列转换为逐 token 的 Segment 列表。"""
+
+    # convert_ids_to_tokens 是 HF tokenizer 的标准接口;缺失时退回逐 id decode。
+    pieces = _convert_ids_to_tokens(tokenizer, ids)
+    segments: list[Segment] = []
+    for idx, (tid, piece) in enumerate(zip(ids, pieces)):
+        role, loss_mask = role_by_index.get(idx, (None, False))
+        segments.append(
+            Segment(
+                text=piece,
+                token_ids=[tid],
+                pieces=[piece],
+                role=role,
+                is_special=tid in special_set,
+                loss_mask=loss_mask,
+                is_eos=tid in eos_set,
+            )
+        )
+    return segments
+
+
+def _convert_ids_to_tokens(tokenizer, ids: list[int]) -> list[str]:
+    """安全获取每个 id 的 piece 字符串。"""
+
+    convert = getattr(tokenizer, "convert_ids_to_tokens", None)
+    if convert is not None:
+        return list(convert(ids))
+    # 退化路径:逐 token decode,保留 special tokens 以反映模板控制符。
+    decode = getattr(tokenizer, "decode", None)
+    if decode is not None:
+        return [decode([tid]) for tid in ids]
+    return [str(tid) for tid in ids]
+
+
+def _eos_set(tokenizer, model_path: str | Path | None) -> set[int]:
+    """收集所有 EOS id:优先复用 eos_token_ids(读 tokenizer + config.json)。"""
+
+    if model_path is not None:
+        try:
+            return set(eos_token_ids(model_path, tokenizer))
+        except (OSError, ValueError, KeyError):
+            # config.json 读取失败时退化为仅用 tokenizer 自身 EOS,不阻断检查。
+            pass
+    eos_id = getattr(tokenizer, "eos_token_id", None)
+    return {int(eos_id)} if eos_id is not None else set()
+
+
+def _has_unknown(tokenizer, ids: list[int]) -> bool:
+    """是否存在 unknown token。"""
+
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    return unk_id is not None and int(unk_id) in ids
+
+
+def _decode_round_trip(tokenizer, ids: list[int], original: str, *, skip_special: bool = True) -> RoundTrip:
+    """encode→decode 还原比对,差异描述不回显完整原文。
+
+    ``skip_special=True`` 去掉 special token 后比对纯文本(适合 plain prompt,
+    其 original 是用户原文);``skip_special=False`` 保留 special token 字面
+    比对完整模板文本(适合 messages,其 original 是 apply_chat_template 渲染出的
+    含 special 字面的文本)。不支持的旧 API 退化为默认解码。
+    """
+
+    decode = getattr(tokenizer, "decode", None)
+    if decode is not None:
+        try:
+            decoded = decode(ids, skip_special_tokens=skip_special)
+        except TypeError:
+            decoded = decode(ids)  # 不支持 skip_special_tokens 的旧 API
+    else:
+        decoded = ""
+    if decoded == original:
+        return RoundTrip(ok=True, decoded=decoded, diff_note="")
+    note = _describe_diff(original, decoded)
+    return RoundTrip(ok=False, decoded=decoded, diff_note=note)
+
+
+def _describe_diff(original: str, decoded: str) -> str:
+    """分类描述 round-trip 差异(空白/长度/内容)。"""
+
+    if original.strip() == decoded.strip():
+        return "whitespace-only round-trip difference (leading/trailing)"
+    if len(original) != len(decoded):
+        return f"length differs: {len(original)} -> {len(decoded)}"
+    return "content differs after encode/decode"
+
+
+def _vocab_alignment(tokenizer, model_path: str | Path | None) -> VocabAlignment:
+    """tokenizer 实际长度与模型 config.json vocab_size 的对齐比较。
+
+    用 ``len(tokenizer)``(含 added tokens,即 tokenizer 实际会用到的最大
+    token id + 1)与模型 ``config.json`` 的 ``vocab_size``(embedding 行数)比较:
+    超过 → FAIL(token id 落在 embedding 之外);等于 → OK;小于 → OK(模型侧
+    预留了 padded/reserved 行,常见于 Qwen 等为 TP 分片对齐而上取整的配置)。
+    """
+
+    tokenizer_len = _safe_len(tokenizer)
+
+    if model_path is None:
+        return VocabAlignment(
+            status=ALIGN_SKIP,
+            tokenizer_size=tokenizer_len,
+            model_vocab_size=None,
+            note="no model_path provided; vocab alignment skipped",
+        )
+
+    model_vocab = _read_model_vocab_size(model_path)
+    if model_vocab is None:
+        return VocabAlignment(
+            status=ALIGN_SKIP,
+            tokenizer_size=tokenizer_len,
+            model_vocab_size=None,
+            note=f"config.json at {model_path} has no vocab_size; vocab alignment skipped",
+        )
+    if tokenizer_len is None:
+        return VocabAlignment(
+            status=ALIGN_SKIP,
+            tokenizer_size=None,
+            model_vocab_size=model_vocab,
+            note="tokenizer length unavailable; vocab alignment skipped",
+        )
+
+    if tokenizer_len > model_vocab:
+        return VocabAlignment(
+            status=ALIGN_FAIL,
+            tokenizer_size=tokenizer_len,
+            model_vocab_size=model_vocab,
+            note=(
+                f"tokenizer length {tokenizer_len} exceeds model config vocab_size {model_vocab}; "
+                "token ids would fall outside embedding rows"
+            ),
+        )
+    if tokenizer_len == model_vocab:
+        return VocabAlignment(
+            status=ALIGN_OK,
+            tokenizer_size=tokenizer_len,
+            model_vocab_size=model_vocab,
+            note=f"vocab sizes match ({model_vocab})",
+        )
+    return VocabAlignment(
+        status=ALIGN_OK,
+        tokenizer_size=tokenizer_len,
+        model_vocab_size=model_vocab,
+        note=(
+            f"tokenizer length {tokenizer_len} within model config vocab_size {model_vocab} "
+            f"({model_vocab - tokenizer_len} reserved/padded rows)"
+        ),
+    )
+
+
+def _safe_len(tokenizer) -> int | None:
+    """安全的 tokenizer 长度(含 added tokens),不可 len 时返回 None。"""
+
+    try:
+        return len(tokenizer)
+    except TypeError:
+        return None
+
+
+def _read_model_vocab_size(model_path: str | Path) -> int | None:
+    """内联读取 <model_path>/config.json 的 vocab_size(含 text_config fallback)。
+
+    与 ``areno/api/tokenizer.py`` 读取 EOS 的模式一致:多模态模型可能把 LM 配置
+    嵌套在 ``text_config`` 下。不依赖 ``areno.models.registry`` 以避免拉起 torch/engine。
+    """
+
+    config_path = Path(model_path) / "config.json"
+    if not config_path.exists():
+        return None
+    with config_path.open("r", encoding="utf-8") as f:
+        config = json.load(f)
+    vocab = config.get("vocab_size")
+    if vocab is None:
+        text_config = config.get("text_config")
+        if isinstance(text_config, dict):
+            vocab = text_config.get("vocab_size")
+    return int(vocab) if vocab is not None else None

--- a/areno/cli/inspect_tokenizer.py
+++ b/areno/cli/inspect_tokenizer.py
@@ -1,0 +1,178 @@
+"""``areno inspect-tokenizer``:tokenizer 对齐检查 CLI。
+
+聚焦、只读的诊断命令:对 plain prompt / chat messages / tool calls 渲染
+token ids、pieces、special-token 标记、EOS 位置、roles、loss-mask spans,
+并把 tokenizer 词表大小与模型 ``config.json`` 的 ``vocab_size`` 对齐比较。
+
+重依赖(transformers / modelscope)在命令函数内才真正触发:模块级只 import
+轻量的函数引用(load_tokenizer / resolve_model_ref 内部延迟 import,
+inspect_* 为纯函数),因此 ``import areno.cli.inspect_tokenizer`` 不会拉起
+torch/engine,与 ``areno.cli.diagnostics`` 的轻量精神一致。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from areno.api.tokenizer_inspect import (
+    InspectionReport,
+    inspect_messages,
+    inspect_prompt,
+    inspect_tool_call,
+)
+from areno.cli.model_refs import resolve_model_ref
+from areno.engine.data.tokenizer import load_tokenizer
+
+
+@click.command(name="inspect-tokenizer", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--model", "model", required=True, metavar="PATH", help="Tokenizer/model path (local dir or hub id).")
+@click.option("--prompt", default=None, help="Plain prompt text to inspect.")
+@click.option(
+    "--messages",
+    default=None,
+    help='JSON array of chat messages, e.g. [{"role":"user","content":"hi"}].',
+)
+@click.option(
+    "--tool-call",
+    "tool_call",
+    default=None,
+    help="JSON array of messages that include assistant tool_calls and tool-role replies.",
+)
+@click.option(
+    "--max-length",
+    type=int,
+    default=None,
+    help="If set, truncate the inspected token sequence to this length and report truncation.",
+)
+@click.option(
+    "--enable-thinking/--disable-thinking",
+    default=None,
+    help="Force the chat template enable_thinking switch on/off (default: tokenizer default).",
+)
+@click.option("--no-vocab-align", is_flag=True, default=False, help="Skip tokenizer vs model config vocab_size comparison.")
+@click.option(
+    "--add-generation-prompt/--no-add-generation-prompt",
+    default=True,
+    help="Append the assistant generation prompt for --messages (default on).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON report.")
+def inspect_tokenizer_command(  # noqa: PLR0913 - 选项数量与 train/serve 风格一致
+    model: str,
+    prompt: str | None,
+    messages: str | None,
+    tool_call: str | None,
+    max_length: int | None,
+    enable_thinking: bool | None,
+    no_vocab_align: bool,
+    add_generation_prompt: bool,
+    as_json: bool,
+) -> None:
+    """Inspect tokenizer alignment for prompts, chat messages, or tool calls."""
+
+    # 1. 输入校验(在加载模型前):恰好一种输入,JSON 必须可解析且形状正确。
+    input_kind, parsed = _parse_inputs(prompt, messages, tool_call)
+
+    # 2. 解析 model ref 并加载 tokenizer(只读,不初始化 engine/worker)。
+    try:
+        path = resolve_model_ref(model)
+        tokenizer = load_tokenizer(path)
+    except Exception as exc:  # noqa: BLE001 - 任何加载失败都转为可读错误,不暴露堆栈
+        click.echo(f"failed to load tokenizer from {model!r}: {exc}", err=True)
+        raise click.exceptions.Exit(1)
+
+    # 3. 生成检查报告(--no-vocab-align 时传 model_path=None 跳过词表对齐)。
+    vocab_path: str | None = None if no_vocab_align else path
+    try:
+        if input_kind == "prompt":
+            report = inspect_prompt(tokenizer, parsed, model_path=vocab_path, max_length=max_length)
+        elif input_kind == "messages":
+            report = inspect_messages(
+                tokenizer,
+                parsed,
+                model_path=vocab_path,
+                add_generation_prompt=add_generation_prompt,
+                enable_thinking=enable_thinking,
+                max_length=max_length,
+            )
+        else:  # tool_call
+            report = inspect_tool_call(
+                tokenizer,
+                parsed,
+                model_path=vocab_path,
+                add_generation_prompt=add_generation_prompt,
+                enable_thinking=enable_thinking,
+                max_length=max_length,
+            )
+    except Exception as exc:  # noqa: BLE001
+        click.echo(f"inspection failed: {exc}", err=True)
+        raise click.exceptions.Exit(1)
+
+    # 4. 输出 + 退出码。
+    if as_json:
+        click.echo(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        _print_report(report)
+    # 词表不一致视为需要关注的失败;invalid input 已在校验阶段以 UsageError 退出(exit 2)。
+    if report.vocab_alignment.status == "FAIL":
+        raise click.exceptions.Exit(1)
+
+
+def _parse_inputs(
+    prompt: str | None,
+    messages: str | None,
+    tool_call: str | None,
+) -> tuple[str, Any]:
+    """校验并解析互斥输入,返回 (kind, value)。失败抛 click.UsageError。"""
+
+    provided = [
+        (name, val)
+        for name, val in (("prompt", prompt), ("messages", messages), ("tool_call", tool_call))
+        if val is not None
+    ]
+    if len(provided) != 1:
+        raise click.UsageError("provide exactly one of --prompt / --messages / --tool-call.")
+    name, raw = provided[0]
+    if name == "prompt":
+        return "prompt", raw
+    # messages / tool_call 走 JSON 解析。
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        flag = "--" + name.replace("_", "-")
+        raise click.UsageError(f"{flag} is not valid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, list):
+        flag = "--" + name.replace("_", "-")
+        raise click.UsageError(f"{flag} must be a JSON array of message objects.")
+    for msg in parsed:
+        if not isinstance(msg, dict) or "role" not in msg:
+            raise click.UsageError(f"each message must be an object with a 'role' field; got {msg!r}")
+    return ("messages" if name == "messages" else "tool_call"), parsed
+
+
+def _print_report(report: InspectionReport) -> None:
+    """人类可读输出:概要 + 逐 token 表 + EOS/警告。"""
+
+    click.echo(f"kind: {report.kind}")
+    rt = report.round_trip
+    click.echo(f"round-trip: {'OK' if rt.ok else 'DIFF'}" + (f"  {rt.diff_note}" if rt.diff_note else ""))
+    va = report.vocab_alignment
+    click.echo(f"vocab: {va.status}  {va.note}")
+    click.echo(f"truncated: {report.truncated}  has_unknown: {report.has_unknown}")
+    click.echo()
+    click.echo(f"{'idx':>3}  {'id':>6}  {'piece':<16}  {'S':>1}  {'E':>1}  {'role':<10}  {'loss':>3}")
+    for idx, seg in enumerate(report.segments):
+        piece = seg.text
+        if len(piece) > 16:
+            piece = piece[:15] + "…"
+        click.echo(
+            f"{idx:>3}  {seg.token_ids[0]:>6}  {piece:<16}  "
+            f"{'S' if seg.is_special else '.':>1}  {'E' if seg.is_eos else '.':>1}  "
+            f"{str(seg.role):<10}  {'Y' if seg.loss_mask else 'N':>3}"
+        )
+    if report.eos_positions:
+        click.echo(f"eos_positions: {report.eos_positions}")
+    for warning in report.warnings:
+        click.echo(f"WARNING: {warning}")

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -21,6 +21,11 @@ class ArenoCli(click.Group):
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
+        "inspect-tokenizer": (
+            "areno.cli.inspect_tokenizer",
+            "inspect_tokenizer_command",
+            "Inspect tokenizer alignment: token ids, pieces, special tokens, EOS, roles, loss masks, and vocab size vs model config.",
+        ),
     }
 
     def list_commands(self, ctx: click.Context) -> list[str]:

--- a/docs/cli/inspect_tokenizer.rst
+++ b/docs/cli/inspect_tokenizer.rst
@@ -1,0 +1,118 @@
+Tokenizer inspector CLI reference
+=================================
+
+``areno inspect-tokenizer`` is a focused, read-only diagnostic that renders how a
+tokenizer encodes plain prompts, chat messages, and tool calls, and checks that
+the tokenizer vocabulary is aligned with the model ``config.json``. It does not
+modify the tokenizer, load model weights, or initialize the AReno engine.
+
+Use it to debug chat-template rendering, EOS placement, loss-mask spans, unknown
+tokens, truncation, and vocab-size mismatches before an expensive training run.
+
+.. code-block:: bash
+
+   areno inspect-tokenizer --model /path/to/model --prompt "Hello 你好"
+
+For a machine-readable report:
+
+.. code-block:: bash
+
+   areno inspect-tokenizer --model /path/to/model --prompt "Hi" --json
+
+Inputs
+------
+
+Provide exactly one of:
+
+* ``--prompt TEXT`` — a plain prompt string.
+* ``--messages JSON`` — a JSON array of chat messages, e.g.
+  ``[{"role":"user","content":"hello"}]``.
+* ``--tool-call JSON`` — a JSON array of messages containing an assistant turn
+  with ``tool_calls`` and a ``tool``-role reply, e.g.::
+
+      [{"role":"assistant","content":null,
+        "tool_calls":[{"id":"c1","type":"function",
+                       "function":{"name":"get_weather","arguments":"{\"city\":\"x\"}"}}]},
+       {"role":"tool","name":"get_weather","content":"sunny"}]
+
+Options
+-------
+
+* ``--model PATH`` (required) — local tokenizer/model directory or hub id.
+* ``--max-length INT`` — truncate the inspected token sequence to this length
+  and report truncation.
+* ``--enable-thinking / --disable-thinking`` — force the chat template
+  ``enable_thinking`` switch (default: tokenizer default).
+* ``--no-vocab-align`` — skip the tokenizer vs model config vocab-size check.
+* ``--add-generation-prompt / --no-add-generation-prompt`` — append the
+  assistant generation prompt for ``--messages`` (default on). Ignored for
+  ``--prompt``.
+* ``--json`` — emit a machine-readable JSON report.
+* ``-h / --help`` — show usage.
+
+Output fields
+-------------
+
+Human-readable mode prints a per-token table:
+
+* ``idx`` — token index in the encoded sequence.
+* ``id`` — token id.
+* ``piece`` — ``convert_ids_to_tokens`` result (truncated to 16 chars).
+* ``S`` — ``S`` marks a special token (BOS/EOS/PAD/template control), ``.`` otherwise.
+* ``E`` — ``E`` marks an EOS token, ``.`` otherwise.
+* ``role`` — chat turn role (``system``/``user``/``assistant``/``tool``), or empty
+  for plain prompts and the generation-prompt header.
+* ``loss`` — ``Y`` if the token is inside an ``assistant`` turn (counts toward
+  training loss), ``N`` otherwise.
+
+The summary line reports:
+
+* ``round-trip`` — ``OK`` if ``decode(encode(input))`` reproduces the input text,
+  else ``DIFF`` with a difference category (whitespace / length / content).
+* ``vocab`` — ``OK`` if ``len(tokenizer)`` is within the model ``config.json``
+  ``vocab_size`` (equal, or smaller when the model reserves padded vocab rows —
+  common in Qwen-style configs aligned to TP sharding); ``FAIL`` if
+  ``len(tokenizer)`` exceeds it (token ids would fall outside the embedding);
+  ``SKIP`` if no model path or no ``vocab_size`` is available.
+* ``truncated`` / ``has_unknown`` — whether truncation or an unknown token occurred.
+* ``eos_positions`` — indices of EOS tokens, when present.
+* ``WARNING`` lines — vocab mismatch and truncation details.
+
+JSON mode emits the same data as a dict with keys ``kind``, ``raw``,
+``segments``, ``eos_positions``, ``round_trip``, ``vocab_alignment``,
+``truncated``, ``has_unknown``, and ``warnings``.
+
+Defaults and backward compatibility
+-----------------------------------
+
+This command is additive: it does not change any existing tokenizer path,
+training, serving, or dashboard behavior. When the feature is not invoked,
+behavior is unchanged. ``enable_thinking`` defaults to the tokenizer default
+(no mutation unless explicitly set).
+
+Limitations
+-----------
+
+* Read-only: the tokenizer object and its on-disk config are never modified.
+* Vocab alignment requires a ``config.json`` with ``vocab_size`` (or a nested
+  ``text_config.vocab_size`` for multimodal models); otherwise the check is
+  ``SKIP`` (not a failure).
+* Role and loss-mask spans use a prefix-differencing approach over the chat
+  template, so cost is quadratic in the number of turns — intended for
+  debugging small prompts, not whole datasets.
+* Hub ids are resolved via modelscope (default) or huggingface_hub and require
+  network access; pass a local directory to avoid downloads.
+
+Example
+-------
+
+Inspect a chat exchange with JSON output::
+
+   areno inspect-tokenizer --model /path/to/model \
+     --messages '[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]' \
+     --json
+
+Observable result: the ``segments`` array marks the ``assistant`` turn tokens
+with ``loss_mask: true`` and the ``user`` turn with ``loss_mask: false``, and
+``vocab_alignment.status`` is ``OK`` when the tokenizer and model vocab sizes
+match.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -12,3 +12,4 @@ Command pages:
 * :doc:`/cli/dataset_loaders`
 * :doc:`/cli/observability`
 * :doc:`/cli/diagnostics`
+* :doc:`/cli/inspect_tokenizer`

--- a/tests/test_tokenizer_inspect_cpu.py
+++ b/tests/test_tokenizer_inspect_cpu.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.api import tokenizer_inspect as ti
+from areno.cli import inspect_tokenizer as inspect_cli
+from areno.cli.main import main
+
+# --------------------------------------------------------------------------- #
+# FakeTokenizer:暴露 inspector 所需的最小 HF 风格 API,行为完全确定性。
+# 普通字符用 ord(c)+1000 编码以避开 special/unk id(0/1/2/99)。
+# --------------------------------------------------------------------------- #
+
+
+class FakeTokenizer:
+    """确定性 tokenizer double,用于 CPU 测试,不依赖 transformers。"""
+
+    eos_token_id = 0
+    unk_token_id = 99
+    chat_template = None  # None -> encode_generation_prompt 走 encode 路径(plain prompt)
+    vocab_size = 100000
+
+    # all_special_ids 涵盖 BOS/EOS/PAD/UNK
+    all_special_ids = [0, 1, 2, 99]
+
+    def __len__(self) -> int:
+        return self.vocab_size
+
+    def encode(self, prompt, add_special_tokens: bool = True) -> list[int]:
+        # BOS(1) 前缀 + 逐字符映射;U+0001 作为 unknown 指示符 -> 99(unk)。
+        ids = [1]
+        for ch in prompt:
+            ids.append(99 if ch == "" else ord(ch) + 1000)
+        return ids
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False, **kwargs):
+        # 每条 turn:BOS(仅首条) + role marker + content ids;assistant turn 末尾追加 EOS(0)。
+        ids: list[int] = []
+        for j, msg in enumerate(messages):
+            if j == 0:
+                ids.append(1)
+            ids.append(self._role_id(msg.get("role")))
+            content = msg.get("content") or ""
+            for ch in content:
+                ids.append(99 if ch == "" else ord(ch) + 1000)
+            if msg.get("role") == "assistant":
+                ids.append(0)
+        if add_generation_prompt:
+            # generation prompt 段:用非 special 的 marker(60) 表示 assistant 头部。
+            ids.extend([60])
+        if tokenize:
+            return ids
+        return "<" + "|".join(str(m.get("role")) for m in messages) + ">"
+
+    def convert_ids_to_tokens(self, ids) -> list[str]:
+        return [self._piece(int(tid)) for tid in ids]
+
+    def decode(self, ids, skip_special_tokens: bool = False) -> str:
+        out: list[str] = []
+        for tid in ids:
+            tid = int(tid)
+            # special 与 role/gen marker 在 skip_special_tokens=True 时一并跳过
+            if tid in (0, 1, 2, 99) or 50 <= tid <= 54 or tid == 60:
+                if not skip_special_tokens:
+                    out.append(self._piece(tid))
+            else:
+                out.append(chr(tid - 1000))
+        return "".join(out)
+
+    def _role_id(self, role) -> int:
+        # role marker 用 50-53,避开 special id 集合。
+        return {"system": 50, "user": 51, "assistant": 52, "tool": 53}.get(role, 54)
+
+    def _piece(self, tid: int) -> str:
+        if tid == 0:
+            return "</s>"
+        if tid == 1:
+            return "<s>"
+        if tid == 2:
+            return "<pad>"
+        if tid == 99:
+            return "<unk>"
+        if tid == 60:
+            return "<gen>"
+        if 50 <= tid <= 54:
+            # role marker token(非 special,仅用于标注 chat turn 边界)
+            return f"<r{tid}>"
+        return chr(tid - 1000)
+
+
+class WhitespaceTruncTokenizer(FakeTokenizer):
+    """decode 时去除首尾空白,用以触发 non-perfect round trip。"""
+
+    def decode(self, ids, skip_special_tokens: bool = False) -> str:
+        return super().decode(ids, skip_special_tokens=skip_special_tokens).strip()
+
+
+def _config_dir(vocab_size: int) -> str:
+    """创建带 config.json 的临时模型目录,用于 vocab 对齐与 EOS 读取。"""
+
+    tmp = tempfile.mkdtemp()
+    Path(tmp, "config.json").write_text(
+        json.dumps({"vocab_size": vocab_size, "eos_token_id": 0}),
+        encoding="utf-8",
+    )
+    return tmp
+
+
+class InspectPromptTest(unittest.TestCase):
+    """inspect_prompt 路径:覆盖 segment/EOS/unicode/unknown/truncation/round-trip。"""
+
+    def test_inspect_prompt_segments_and_eos(self):
+        """plain prompt:ids/pieces/special 标记正确,role 为 None、loss_mask 为 False。"""
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_prompt(tok, "Hi", model_path=model_path)
+
+        self.assertEqual(report.kind, "prompt")
+        # ids = [BOS(1), 'H'(1072), 'i'(1105)]
+        self.assertEqual([s.token_ids[0] for s in report.segments], [1, 1072, 1105])
+        self.assertEqual([s.text for s in report.segments], ["<s>", "H", "i"])
+        self.assertTrue(report.segments[0].is_special)  # BOS
+        self.assertFalse(report.segments[1].is_special)
+        self.assertFalse(any(s.is_eos for s in report.segments))  # 无 EOS
+        self.assertEqual(report.eos_positions, [])
+        self.assertTrue(all(s.role is None for s in report.segments))
+        self.assertTrue(all(not s.loss_mask for s in report.segments))
+
+    def test_inspect_prompt_unicode_whitespace(self):
+        """Unicode 与首尾空白应正确编码还原。"""
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_prompt(tok, " 你好 ", model_path=model_path)
+
+        # BOS + ' ' + '你' + '好' + ' '
+        self.assertEqual([s.text for s in report.segments], ["<s>", " ", "你", "好", " "])
+        self.assertTrue(report.round_trip.ok)  # decode 还原原文(含空白)
+        self.assertEqual(report.vocab_alignment.status, ti.ALIGN_OK)
+
+    def test_inspect_prompt_unknown_token(self):
+        """包含 U+0001 -> unk(99) 时 has_unknown 为 True。"""
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_prompt(tok, "ab", model_path=model_path)
+
+        self.assertTrue(report.has_unknown)
+        unk_seg = [s for s in report.segments if s.token_ids[0] == 99]
+        self.assertEqual(len(unk_seg), 1)
+        self.assertTrue(unk_seg[0].is_special)  # unk 属 special
+
+    def test_inspect_prompt_truncation(self):
+        """max_length 触发截断,truncated 为 True 且 segments 被裁剪。"""
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_prompt(tok, "abcdef", model_path=model_path, max_length=3)
+
+        self.assertTrue(report.truncated)
+        self.assertEqual(len(report.segments), 3)
+        self.assertTrue(any("truncated" in w for w in report.warnings))
+
+    def test_inspect_prompt_round_trip_imperfect(self):
+        """decode 丢空白时 round_trip.ok 为 False 且 diff_note 说明空白差异。"""
+        tok = WhitespaceTruncTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_prompt(tok, " hi ", model_path=model_path)
+
+        self.assertFalse(report.round_trip.ok)
+        self.assertIn("whitespace", report.round_trip.diff_note)
+
+
+class InspectMessagesTest(unittest.TestCase):
+    """inspect_messages:差分法标注 role 与 loss_mask,含 generation prompt 段。"""
+
+    @staticmethod
+    def _messages():
+        return [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "a"},
+        ]
+
+    def test_roles_and_loss_mask(self):
+        """仅 assistant turn 的 token loss_mask 为 True;其它 turn 为 False。"""
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_messages(tok, self._messages(), model_path=model_path, add_generation_prompt=True)
+
+        self.assertEqual(report.kind, "messages")
+        roles = [s.role for s in report.segments]
+        self.assertIn("assistant", roles)
+        self.assertIn("user", roles)
+        # assistant 段计入 loss
+        assistant_segs = [s for s in report.segments if s.role == "assistant"]
+        self.assertTrue(assistant_segs)
+        self.assertTrue(all(s.loss_mask for s in assistant_segs))
+        # user/system 段不计 loss
+        non_assistant = [s for s in report.segments if s.role in {"user", "system"}]
+        self.assertTrue(non_assistant)
+        self.assertTrue(all(not s.loss_mask for s in non_assistant))
+        # assistant EOS 计入 eos_positions
+        self.assertTrue(report.eos_positions)
+
+    def test_add_generation_prompt_segment_is_not_loss(self):
+        """add_generation_prompt 追加的头部段 role=None、loss_mask=False。"""
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+
+        with_gp = ti.inspect_messages(tok, self._messages(), model_path=model_path, add_generation_prompt=True)
+        without_gp = ti.inspect_messages(tok, self._messages(), model_path=model_path, add_generation_prompt=False)
+
+        # 开启 generation prompt 时多出头部段(role=None)
+        gp_segs = [s for s in with_gp.segments if s.role is None and s.token_ids[0] == 60]
+        self.assertEqual(len(gp_segs), 1)
+        self.assertFalse(gp_segs[0].loss_mask)
+        # 关闭时不存在该段
+        self.assertEqual([s for s in without_gp.segments if s.token_ids[0] == 60], [])
+        self.assertGreater(len(with_gp.segments), len(without_gp.segments))
+
+
+class InspectToolCallTest(unittest.TestCase):
+    """inspect_tool_call:assistant tool_calls + tool 角色回复标注。"""
+
+    def test_tool_call_roles(self):
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "name": "get_weather", "content": "sunny"},
+        ]
+        report = ti.inspect_tool_call(tok, messages, model_path=model_path)
+
+        self.assertEqual(report.kind, "tool_call")
+        roles = [s.role for s in report.segments]
+        self.assertIn("assistant", roles)
+        self.assertIn("tool", roles)
+        # tool 段不计 loss,assistant 段计 loss
+        self.assertTrue(all(s.loss_mask for s in report.segments if s.role == "assistant"))
+        self.assertTrue(all(not s.loss_mask for s in report.segments if s.role == "tool"))
+
+
+class VocabAlignmentTest(unittest.TestCase):
+    """tokenizer vocab_size 与 config.json vocab_size 对齐比较。"""
+
+    def test_match(self):
+        tok = FakeTokenizer()
+        model_path = _config_dir(100000)
+        report = ti.inspect_prompt(tok, "Hi", model_path=model_path)
+        self.assertEqual(report.vocab_alignment.status, ti.ALIGN_OK)
+
+    def test_mismatch(self):
+        # tokenizer 实际长度(len)超过模型 config vocab_size -> FAIL
+        tok = FakeTokenizer()
+        tok.vocab_size = 200000  # len(tokenizer)=200000
+        model_path = _config_dir(100000)  # 模型词表更小
+        report = ti.inspect_prompt(tok, "Hi", model_path=model_path)
+        self.assertEqual(report.vocab_alignment.status, ti.ALIGN_FAIL)
+        self.assertIn("200000", report.vocab_alignment.note)
+        self.assertIn("100000", report.vocab_alignment.note)
+
+    def test_no_config_is_skip_not_fail(self):
+        """无 config.json 时对齐为 SKIP,不视为失败。"""
+        tok = FakeTokenizer()
+        tmp = tempfile.mkdtemp()  # 无 config.json
+        report = ti.inspect_prompt(tok, "Hi", model_path=tmp)
+        self.assertEqual(report.vocab_alignment.status, ti.ALIGN_SKIP)
+
+
+class NoMutationTest(unittest.TestCase):
+    """inspector 默认不修改 tokenizer 对象(向后兼容)。"""
+
+    def test_inspect_does_not_mutate_tokenizer(self):
+        tok = FakeTokenizer()
+        before = set(vars(tok).keys())
+        ti.inspect_messages(
+            tok,
+            [{"role": "user", "content": "hi"}],
+            model_path=_config_dir(100000),
+            enable_thinking=None,  # 默认:不应设置 thinking 属性
+        )
+        after = set(vars(tok).keys())
+        self.assertEqual(before, after)
+        self.assertFalse(hasattr(tok, "_areno_chat_template_enable_thinking"))
+
+
+class InspectTokenizerCliTest(unittest.TestCase):
+    """CLI:输入校验、JSON 字段、vocab 失败退出码、命令注册。"""
+
+    @contextlib.contextmanager
+    def _patches(self, tok, path):
+        with patch.object(inspect_cli, "resolve_model_ref", return_value=path), patch.object(
+            inspect_cli, "load_tokenizer", return_value=tok
+        ):
+            yield
+
+    def test_cli_prompt_json_fields(self):
+        tok = FakeTokenizer()
+        path = _config_dir(100000)
+        with self._patches(tok, path) :
+            result = CliRunner().invoke(
+                inspect_cli.inspect_tokenizer_command, ["--model", path, "--prompt", "Hi", "--json"]
+            )
+        self.assertEqual(result.exit_code, 0, result.output)
+        parsed = json.loads(result.output)
+        for key in ("segments", "eos_positions", "round_trip", "vocab_alignment", "kind"):
+            self.assertIn(key, parsed)
+        self.assertEqual(parsed["kind"], "prompt")
+        self.assertEqual(parsed["vocab_alignment"]["status"], ti.ALIGN_OK)
+
+    def test_cli_rejects_missing_input(self):
+        path = _config_dir(100000)
+        with self._patches(FakeTokenizer(), path) :
+            result = CliRunner().invoke(inspect_cli.inspect_tokenizer_command, ["--model", path])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("exactly one", result.output)
+
+    def test_cli_rejects_malformed_json(self):
+        path = _config_dir(100000)
+        with self._patches(FakeTokenizer(), path) :
+            result = CliRunner().invoke(
+                inspect_cli.inspect_tokenizer_command, ["--model", path, "--messages", "{bad"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("not valid JSON", result.output)
+
+    def test_cli_human_readable_shows_fail_on_vocab_mismatch(self):
+        # tokenizer len > config vocab_size -> FAIL -> 非零退出且输出含 FAIL。
+        tok = FakeTokenizer()
+        tok.vocab_size = 200000
+        path = _config_dir(100000)
+        with self._patches(tok, path):
+            result = CliRunner().invoke(
+                inspect_cli.inspect_tokenizer_command, ["--model", path, "--prompt", "Hi"]
+            )
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertIn("FAIL", result.output)
+
+    def test_cli_registered_in_main_help(self):
+        result = CliRunner().invoke(main, ["--help"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("inspect-tokenizer", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #219

## Summary
Add `areno inspect-tokenizer --model <path> --prompt|--messages|--tool-call` — inspect tokenizer alignment: token ids, pieces, special-token markers, EOS placement, roles, and loss-mask spans for plain prompts, chat messages, and tool calls, plus tokenizer vocab size vs model `config.json`. Reads existing local tokenizer/config artifacts via AReno's public contracts; no new dependencies.

## Usage
```bash
areno inspect-tokenizer --model /path/to/model --prompt "Hello 你好"          # terminal per-token table
areno inspect-tokenizer --model /path/to/model --messages '[...]' --json     # machine-readable JSON
areno inspect-tokenizer --model /path/to/model --tool-call '[...]'           # tool-call messages
```

## Output
```
kind: prompt
round-trip: OK
vocab: OK tokenizer length 151669 within model config vocab_size 151936 (267 reserved/padded rows)
truncated: False  has_unknown: False

idx id     piece      S  E  role   loss
0   9707   Hello      .  .  None   N
1   220    Ġ          .  .  None   N
2   108386 ä½łå¥½     .  .  None   N
```
Messages mode marks `assistant` turns `loss=Y`, `user`/`system` `loss=N`, the `add_generation_prompt` header `role=null loss=N`, EOS positions, and special tokens `S`.

## What changed
| File | Change |
|---|---|
| `areno/api/tokenizer_inspect.py` | New: `inspect_prompt` / `inspect_messages` (prefix-differencing for role/loss-mask) / `inspect_tool_call`; reuses `areno.api.tokenizer` contracts; reads `config.json` inline (no torch/engine) |
| `areno/cli/inspect_tokenizer.py` | New: `inspect_tokenizer_command` with human-readable + `--json`, input validation before model load, exit codes; lazy heavy imports |
| `areno/cli/main.py` | +1 line: register `"inspect-tokenizer"` in `_COMMANDS` |
| `tests/test_tokenizer_inspect_cpu.py` | New: 17 CPU tests |
| `docs/cli/inspect_tokenizer.rst` | New: user docs |
| `docs/reference/cli.rst` | +1 line: register doc page |

## Edge cases handled
| Scenario | Behavior |
|---|---|
| None / >1 of `--prompt`/`--messages`/`--tool-call` | UsageError, exit 2 |
| Malformed `--messages`/`--tool-call` JSON | "not valid JSON", exit 2 |
| Tokenizer load failure | readable error, exit 1 |
| Vocab mismatch (`len(tokenizer) > config.vocab_size`) | `FAIL` + exit 1 |
| No `config.json` / no `vocab_size` | `SKIP` (not a failure), exit 0 |
| Non-perfect encode/decode round-trip | `DIFF` + `diff_note` (whitespace/length/content) |
| Truncation (`--max-length`) | `truncated=True`, segments clipped, warning |

## Design decisions
- Reuses existing `areno.api.tokenizer` contracts (`apply_chat_template_with_options`, `eos_token_ids`, `normalize_token_ids`) — no parallel tokenizer path.
- Vocab alignment uses `len(tokenizer)` vs `config.json` `vocab_size`: `OK` when `<=` (Qwen-style configs reserve padded rows for TP sharding), `FAIL` only when token ids exceed embedding rows.
- Role/loss-mask via prefix-differencing over the chat template (quadratic in turns; intended for debugging small prompts, not whole datasets).
- model-side `vocab_size` read inline from `config.json` (with `text_config` fallback for multimodal), avoiding `areno.models.registry` to keep the module torch-free.
- Heavy imports (transformers / modelscope) lazy inside the command; module import stays light, matching `areno.cli.diagnostics`.
- Round-trip: plain prompt uses `skip_special_tokens=True` (compare to user text); messages uses `skip_special_tokens=False` (compare to full template text).

## Tests
17 CPU tests: prompt segments/EOS/unicode/whitespace/unknown/truncation/non-perfect round-trip; messages roles/loss-mask + generation-prompt segment; tool-call; vocab match/mismatch(no-config)/no-mutation; CLI JSON fields / missing input / malformed JSON / vocab-FAIL exit 1 / registered in `--help`.
Existing `test_tokenizer_api_cpu.py` and `test_cli_diagnostics_cpu.py` pass unchanged.
Verified end-to-end on a real Qwen3-0.6B tokenizer (Kaggle CPU): plain prompt, chat messages, and tool-call paths produce correct segments, EOS, roles, loss-mask, round-trip `OK`, vocab `OK`.
