### PR TITLE
feat(cli): add 'areno run' CLI for listing and inspecting AReno runs

### DIFF
--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -19,6 +19,7 @@ class ArenoCli(click.Group):
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
+        "run": ("areno.cli.run", "run_command", "List and inspect AReno training and serving runs."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
     }

--- a/areno/cli/run.py
+++ b/areno/cli/run.py
@@ -1,0 +1,566 @@
+"""List and inspect AReno training and serving runs from the terminal."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import re
+import textwrap
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import click
+
+from areno.dashboard.server import (
+    TIME_SEGMENT_ORDER,
+    dashboard_state_source,
+    pid_is_running,
+    registered_job_items,
+    rollout_sample_sources,
+    run_config_sources,
+    tensorboard_event_sources,
+    tensorboard_time_segment_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunSummary:
+    """Aggregated information for a single AReno run."""
+
+    run_id: str = ""
+    kind: str = ""
+    name: str = ""
+    pid: int | None = None
+    status: str = "unknown"
+    stage: str = ""
+    step: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    age_s: float | None = None
+    metrics_dir: str | None = None
+    config: dict[str, Any] = field(default_factory=dict)
+    config_text: str = ""
+    metrics: list[dict[str, Any]] = field(default_factory=list)
+    timeperf: list[dict[str, Any]] = field(default_factory=list)
+    samples: list[dict[str, Any]] = field(default_factory=list)
+    returncode: int | None = None
+    command: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_status(entry: dict[str, Any]) -> str:
+    """Determine the effective status of a registered job."""
+    pid = entry.get("pid")
+    if pid is not None and pid_is_running(pid):
+        stage = _read_stage(entry.get("metrics_dir"), pid)
+        return stage or "running"
+    rc = entry.get("returncode")
+    if rc is not None:
+        return "succeeded" if rc == 0 else "failed"
+    return "exited"
+
+
+def _read_stage(metrics_dir: str | None, pid: int) -> str | None:
+    """Read the stage field from dashboard_state.{pid}.json if available."""
+    if not metrics_dir:
+        return None
+    path = Path(metrics_dir)
+    state_file = dashboard_state_source(path, pid)
+    if state_file is None:
+        return None
+    try:
+        payload = json.loads(state_file.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    stage = payload.get("stage")
+    if isinstance(stage, str) and stage:
+        return stage
+    return None
+
+
+def _format_timestamp(value: Any) -> str:
+    """Convert a float epoch or ISO string to a readable timestamp."""
+    if value is None or value == "":
+        return ""
+    try:
+        return dt.datetime.fromtimestamp(float(value), tz=dt.timezone.utc).replace(microsecond=0).isoformat()
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _compute_age(created_at: Any, updated_at: Any) -> float | None:
+    """Compute age in seconds from created_at (or updated_at) to now."""
+    ref = updated_at if updated_at else created_at
+    if ref is None:
+        return None
+    try:
+        return max(0.0, time.time() - float(ref))
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_age(seconds: float | None) -> str:
+    """Format age seconds into a human-readable string."""
+    if seconds is None:
+        return "-"
+    if seconds < 60:
+        return f"{int(seconds)}s ago"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m ago"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h ago"
+    return f"{int(seconds // 86400)}d ago"
+
+
+# ---------------------------------------------------------------------------
+# Data collection
+# ---------------------------------------------------------------------------
+
+
+def _summary_from_item(item: dict[str, Any]) -> RunSummary:
+    """Build a RunSummary from a registry entry."""
+    return RunSummary(
+        run_id=item.get("id", ""),
+        kind=item.get("kind", ""),
+        name=item.get("name", ""),
+        pid=item.get("pid"),
+        status=_resolve_status(item),
+        returncode=item.get("returncode"),
+        created_at=_format_timestamp(item.get("created_at")),
+        updated_at=_format_timestamp(item.get("updated_at")),
+        age_s=_compute_age(item.get("created_at"), item.get("updated_at")),
+        metrics_dir=item.get("metrics_dir"),
+        config=dict(item.get("config") or {}),
+        command=list(item.get("command") or []),
+    )
+
+
+def list_runs() -> list[RunSummary]:
+    """List all registered runs from the dashboard registry, sorted most-recent first."""
+    runs = [_summary_from_item(item) for item in registered_job_items()]
+    runs.sort(
+        key=lambda r: (r.created_at or "", r.pid or 0),
+        reverse=True,
+    )
+    return runs
+
+
+def get_run(run_id: str) -> RunSummary | None:
+    """Get detailed information for a specific run.
+
+    Accepts either a registry ID or a directory path containing run artifacts.
+    """
+    path = Path(run_id)
+    if path.is_dir():
+        summary = RunSummary(
+            run_id=path.name,
+            name=path.name,
+            metrics_dir=str(path),
+        )
+        _load_run_metrics(summary)
+        return summary
+    for item in registered_job_items():
+        if item.get("id") == run_id:
+            summary = _summary_from_item(item)
+            _load_run_metrics(summary)
+            return summary
+    return None
+
+
+def _load_run_metrics(summary: RunSummary) -> None:
+    """Load metrics, samples, state, and config from the metrics directory."""
+    if not summary.metrics_dir:
+        return
+    path = Path(summary.metrics_dir)
+    if not path.exists() or not path.is_dir():
+        return
+    pid = summary.pid
+    _load_dashboard_state(summary, path, pid)
+    _load_tensorboard_scalars(summary, path, pid)
+    _load_rollout_samples(summary, path, pid)
+    _load_run_config(summary, path, pid)
+
+
+def _load_dashboard_state(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load live stage/step/status from dashboard_state.{pid}.json."""
+    state_file = dashboard_state_source(path, pid)
+    if state_file is None:
+        return
+    try:
+        payload = json.loads(state_file.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if not isinstance(payload, dict):
+        return
+    stage = payload.get("stage")
+    if isinstance(stage, str) and stage:
+        summary.stage = stage
+    try:
+        summary.step = max(summary.step, int(payload.get("step", summary.step)))
+    except (TypeError, ValueError):
+        pass
+    status = payload.get("status")
+    if isinstance(status, str) and summary.status not in {"stopped", "failed", "succeeded", "exited"}:
+        summary.status = status
+    summary.updated_at = _format_timestamp(payload.get("updated_at")) or summary.updated_at
+
+
+def _load_tensorboard_scalars(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load scalar metrics and time performance from TensorBoard event files."""
+    try:
+        from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+    except Exception:
+        return
+    by_step: dict[int, dict[str, float]] = {}
+    for event_path in tensorboard_event_sources(path, pid):
+        try:
+            accumulator = EventAccumulator(str(event_path), size_guidance={"scalars": 10000})
+            accumulator.Reload()
+            tags = accumulator.Tags().get("scalars", [])
+        except Exception:
+            continue
+        for tag in tags:
+            try:
+                events = accumulator.Scalars(tag)[-500:]
+            except Exception:
+                continue
+            for event in events:
+                step = int(event.step)
+                value = float(event.value)
+                if math.isnan(value):
+                    continue
+                summary.metrics.append({"name": tag, "value": value, "step": step})
+                summary.step = max(summary.step, step)
+                time_name = tensorboard_time_segment_name(tag)
+                if time_name:
+                    by_step.setdefault(step, {})[time_name] = value
+                if tag in {"train/step_e2e_time_s", "time/total", "time/e2e"}:
+                    by_step.setdefault(step, {})["total"] = value
+                elif tag == "train/step_rollout_time_s":
+                    by_step.setdefault(step, {})["rollout"] = value
+                elif tag in {"train/step_train_time_s", "train/policy_train_wall_time_s"}:
+                    by_step.setdefault(step, {})["train"] = value
+    for step, values in sorted(by_step.items()):
+        total = values.pop("total", None)
+        if total is None:
+            total = sum(v for v in values.values() if v > 0)
+        if total <= 0:
+            continue
+        ordered = sorted(
+            [{"name": name, "seconds": max(v, 0.0)} for name, v in values.items() if v > 0],
+            key=lambda item: (
+                TIME_SEGMENT_ORDER.index(item["name"])
+                if item["name"] in TIME_SEGMENT_ORDER
+                else len(TIME_SEGMENT_ORDER)
+            ),
+        )
+        accounted = sum(item["seconds"] for item in ordered)
+        if total > accounted:
+            ordered.append({"name": "other", "seconds": total - accounted})
+        summary.timeperf.append({"step": step, "segments": ordered, "total_s": total})
+
+
+def _load_rollout_samples(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load rollout samples from JSONL files."""
+    for sample_file in rollout_sample_sources(path, pid):
+        try:
+            lines = sample_file.read_text(encoding="utf-8").splitlines()[-100:]
+        except Exception:
+            continue
+        for line in lines:
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            summary.samples.append(item)
+
+
+def _load_run_config(summary: RunSummary, path: Path, pid: int | None) -> None:
+    """Load run configuration from areno_run_config.{pid}.txt/.json."""
+    text_file, json_file = run_config_sources(path, pid)
+    if text_file.exists():
+        try:
+            summary.config_text = text_file.read_text(encoding="utf-8")
+        except Exception:
+            pass
+    if not json_file.exists():
+        return
+    try:
+        payload = json.loads(json_file.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if isinstance(payload, dict):
+        settings = payload.get("settings")
+        if isinstance(settings, dict):
+            summary.config = settings
+        if not summary.config_text and isinstance(payload.get("summary_text"), str):
+            summary.config_text = payload["summary_text"]
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def collect_metric_summaries(metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group metrics by name, return count/latest_step/latest_value per group."""
+    grouped: dict[str, dict[str, Any]] = {}
+    for point in metrics:
+        name = str(point.get("name") or "")
+        if not name:
+            continue
+        step = int(point.get("step") or 0)
+        value = point.get("value")
+        current = grouped.get(name)
+        if current is None:
+            grouped[name] = {"name": name, "count": 1, "latest_step": step, "latest_value": value}
+            continue
+        current["count"] += 1
+        if step >= int(current.get("latest_step") or 0):
+            current["latest_step"] = step
+            current["latest_value"] = value
+    return sorted(grouped.values(), key=lambda item: item["name"])
+
+
+def collect_timeperf_summary(timeperf: list[dict[str, Any]]) -> list[tuple[str, float]]:
+    """Aggregate average time spent in each RL phase across all steps."""
+    if not timeperf:
+        return []
+    totals: dict[str, list[float]] = {}
+    for row in timeperf:
+        segments = row.get("segments")
+        if not isinstance(segments, list):
+            continue
+        for seg in segments:
+            if not isinstance(seg, dict):
+                continue
+            name = str(seg.get("name", ""))
+            if not name:
+                continue
+            try:
+                totals.setdefault(name, []).append(float(seg.get("seconds", 0)))
+            except (TypeError, ValueError):
+                continue
+    result = [(name, sum(values) / len(values)) for name, values in totals.items() if values]
+    order = {name: i for i, name in enumerate(TIME_SEGMENT_ORDER)}
+    result.sort(key=lambda item: order.get(item[0], len(order)))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_run_info(run: RunSummary) -> str:
+    """Format a RunSummary into a structured terminal-friendly string."""
+    lines: list[str] = []
+
+    # Section 1: Basic Info
+    lines.append(f"Run: {run.run_id}")
+    lines.append(f"  Kind:        {run.kind}")
+    lines.append(f"  Name:        {run.name}")
+    status_line = f"  Status:      {run.status}"
+    if run.returncode is not None:
+        status_line += f" (returncode={run.returncode})"
+    lines.append(status_line)
+    lines.append(f"  Stage:       {run.stage or '-'}")
+    lines.append(f"  Step:        {run.step}")
+    lines.append(f"  PID:         {run.pid or '-'}")
+    lines.append(f"  Created:     {run.created_at or '-'}")
+    lines.append(f"  Updated:     {run.updated_at or '-'}")
+    lines.append(f"  Metrics Dir: {run.metrics_dir or '-'}")
+
+    # Section 2: Configuration
+    if run.config_text:
+        lines.append("")
+        lines.append("Configuration:")
+        lines.append(textwrap.indent(_redact_text(run.config_text), "  "))
+    elif run.config:
+        lines.append("")
+        lines.append("Configuration:")
+        for key, val in sorted(_redact_config(run.config).items()):
+            lines.append(f"  {key}: {val}")
+
+    # Section 3: Metric Summaries
+    summaries = collect_metric_summaries(run.metrics)
+    if summaries:
+        lines.append("")
+        lines.append("Metrics Summary:")
+        lines.append(f"  {'Name':<40} {'Latest':>12} {'Step':>8} {'Count':>6}")
+        lines.append(f"  {'-' * 40} {'-' * 12} {'-' * 8} {'-' * 6}")
+        for m in summaries:
+            latest = m.get("latest_value")
+            latest_str = f"{latest:>12.6f}" if isinstance(latest, (int, float)) else f"{str(latest):>12}"
+            lines.append(
+                f"  {m['name']:<40} {latest_str} "
+                f"{int(m.get('latest_step') or 0):>8} {int(m.get('count') or 0):>6}"
+            )
+
+    # Section 4: Time Performance
+    time_summary = collect_timeperf_summary(run.timeperf)
+    if time_summary:
+        lines.append("")
+        lines.append("Time Breakdown (avg per step):")
+        for name, seconds in time_summary:
+            lines.append(f"  {name:<25} {seconds:>8.2f}s")
+
+    # Section 5: Recent Rollout Samples
+    if run.samples:
+        lines.append("")
+        lines.append(f"Recent Rollout Samples (last {min(len(run.samples), 5)}):")
+        for s in run.samples[-5:]:
+            reward = s.get("reward", "?")
+            resp_len = s.get("response_len", "?")
+            lines.append(f"  step={s.get('step', '?')} reward={reward} resp_len={resp_len}")
+
+    return "\n".join(lines)
+
+
+def format_run_list(runs: list[RunSummary]) -> str:
+    """Format a compact table of all runs."""
+    if not runs:
+        return "No runs found."
+    lines: list[str] = []
+    header = f"  {'ID':<12} {'Kind':<6} {'Status':<12} {'Step':>6} {'Name':<40} {'Age':<10} {'Created'}"
+    lines.append(header)
+    lines.append(f"  {'-' * 12} {'-' * 6} {'-' * 12} {'-' * 6} {'-' * 40} {'-' * 10} {'-' * 20}")
+    for r in runs:
+        lines.append(
+            f"  {r.run_id:<12} {r.kind:<6} {r.status:<12} {r.step:>6} "
+            f"{r.name[:40]:<40} {_format_age(r.age_s):<10} {r.created_at[:19] or '-'}"
+        )
+    return "\n".join(lines)
+
+
+def format_run_list_json(runs: list[RunSummary]) -> str:
+    """Format runs as a JSON array."""
+    items = [
+        {
+            "id": r.run_id,
+            "kind": r.kind,
+            "name": r.name,
+            "pid": r.pid,
+            "status": r.status,
+            "stage": r.stage or None,
+            "step": r.step,
+            "created_at": r.created_at,
+            "updated_at": r.updated_at,
+            "age_s": r.age_s,
+            "metrics_dir": r.metrics_dir,
+            "returncode": r.returncode,
+        }
+        for r in runs
+    ]
+    return json.dumps(items, ensure_ascii=False, indent=2)
+
+
+_SENSITIVE_CONFIG_KEYS = {"api_key", "token", "secret", "password"}
+
+
+def _redact_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Mask values of sensitive config keys."""
+    return {
+        k: ("***" if any(s in k.lower() for s in _SENSITIVE_CONFIG_KEYS) else v)
+        for k, v in config.items()
+    }
+
+
+def _redact_text(text: str) -> str:
+    """Mask values of sensitive keys in free-form text (e.g. 'api_key: sk-secret')."""
+    for key in _SENSITIVE_CONFIG_KEYS:
+        text = re.sub(
+            rf"({re.escape(key)}\s*[:=]\s*)\S+",
+            r"\1***",
+            text,
+            flags=re.IGNORECASE,
+        )
+    return text
+
+
+def format_run_info_json(run: RunSummary) -> str:
+    """Format a RunSummary as a JSON object."""
+    return json.dumps(
+        {
+            "id": run.run_id,
+            "kind": run.kind,
+            "name": run.name,
+            "pid": run.pid,
+            "status": run.status,
+            "stage": run.stage or None,
+            "step": run.step,
+            "created_at": run.created_at,
+            "updated_at": run.updated_at,
+            "metrics_dir": run.metrics_dir,
+            "returncode": run.returncode,
+            "config": _redact_config(run.config),
+            "config_text": _redact_text(run.config_text) if run.config_text else None,
+            "metrics": collect_metric_summaries(run.metrics),
+            "timeperf": collect_timeperf_summary(run.timeperf),
+            "samples": [
+                {"step": s.get("step"), "reward": s.get("reward"), "response_len": s.get("response_len")}
+                for s in run.samples[-5:]
+            ],
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
+@click.group(
+    name="run",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def run_command() -> None:
+    """List and inspect AReno training and serving runs."""
+
+
+@run_command.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON list of runs.")
+@click.option("--limit", default=20, show_default=True, type=click.IntRange(min=0), help="Show last N runs (0 = all).")
+def list_command(as_json: bool, limit: int) -> None:
+    """List active and recent AReno runs."""
+    runs = list_runs()
+    if not runs:
+        click.echo("[]" if as_json else "No runs found.")
+        return
+    if limit and limit > 0:
+        runs = runs[:limit]
+    if as_json:
+        click.echo(format_run_list_json(runs))
+    else:
+        click.echo(format_run_list(runs))
+
+
+@run_command.command("info")
+@click.argument("run_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON object.")
+def info_command(run_id: str, as_json: bool) -> None:
+    """Show detailed information for one run."""
+    run = get_run(run_id)
+    if run is None:
+        if as_json:
+            click.echo(json.dumps({"error": f"Run not found: {run_id}"}), err=True)
+        else:
+            click.echo(f"Run not found: {run_id}", err=True)
+        raise click.Abort()
+    click.echo(format_run_info_json(run) if as_json else format_run_info(run))

--- a/docs/cli/run.rst
+++ b/docs/cli/run.rst
@@ -1,0 +1,153 @@
+:orphan:
+
+Run inspection CLI
+==================
+
+``areno run``
+
+List and inspect AReno training and serving runs from the terminal. The command
+reads the local job registry at ``~/.areno/dashboard-jobs.json``, which is
+written automatically every time ``areno train`` or ``areno serve`` is launched
+via the CLI or SDK. No database or external service is required.
+
+areno run list
+--------------
+
+List active and recent runs in a compact table.
+
+.. code-block:: bash
+
+   areno run list
+
+Example output:
+
+.. code-block:: text
+
+   ID           Kind   Status       Step Name                                     Age        Created
+   ------------ ------ ------------ ------ ---------------------------------------- ---------- --------------------
+   abc123def456 train  rollout         5 gspo Qwen/Qwen3-0.6B                   3m ago     2026-07-30T01:38:00
+   def789abc012 train  succeeded      12 sft my-checkpoint                      1h ago     2026-07-30T00:41:00
+   ghi345def678 serve  exited           0 serve my-model                         2d ago     2026-07-28T01:41:00
+
+Columns:
+
+* **ID** — short registry identifier (12 hex chars).
+* **Kind** — ``train`` or ``serve``.
+* **Status** — derived from PID liveness and ``dashboard_state`` files (see
+  below).
+* **Step** — last known training step (0 for serve runs).
+* **Name** — run name from the registry.
+* **Age** — human-readable elapsed time since the run started.
+* **Created** — UTC timestamp of when the run was registered.
+
+For machine-readable output:
+
+.. code-block:: bash
+
+   areno run list --json
+
+The output is a JSON array with one object per run, including ``id``, ``kind``,
+``name``, ``pid``, ``status``, ``stage``, ``step``, ``created_at``,
+``updated_at``, ``age_s``, ``metrics_dir``, and ``returncode``.
+
+To limit the number of entries:
+
+.. code-block:: bash
+
+   areno run list --limit 5
+
+The default limit is 20. Use ``--limit 0`` to show all entries.
+
+Status derivation
+^^^^^^^^^^^^^^^^^
+
+For each registered job, the status is determined as follows:
+
+* **PID alive** and a ``dashboard_state.{pid}.json`` file with a ``stage`` field
+  is present — the stage name is shown (e.g. ``rollout``, ``train``).
+* **PID alive** but no state file — ``running``.
+* **PID dead** with ``returncode == 0`` — ``succeeded``.
+* **PID dead** with ``returncode != 0`` — ``failed``.
+* **PID dead** with no returncode — ``exited``.
+
+areno run info
+--------------
+
+Show detailed information for a single run, including configuration, metric
+summaries, per-step time breakdown, and recent rollout samples.
+
+Accepts either a registry ID or a directory path containing run artifacts.
+
+.. code-block:: bash
+
+   areno run info abc123def456
+
+By directory path:
+
+.. code-block:: bash
+
+   areno run info /tmp/areno-metrics
+
+For machine-readable output:
+
+.. code-block:: bash
+
+   areno run info abc123def456 --json
+
+Example output (table mode):
+
+.. code-block:: text
+
+   Run: abc123def456
+     Kind:        train
+     Name:        gspo Qwen/Qwen3-0.6B
+     Status:      running
+     Stage:       rollout
+     Step:        5
+     PID:         12345
+     Created:     2026-07-30T01:38:00+00:00
+     Updated:     2026-07-30T01:41:00+00:00
+     Metrics Dir: /tmp/areno-metrics
+
+   Configuration:
+     algo: gspo
+     ckpt: Qwen/Qwen3-0.6B
+
+   Metrics Summary:
+     Name                                       Latest        Step  Count
+     ---------------------------------------- -------- -------- ------
+     loss                                       0.234567        5      50
+
+   Time Breakdown (avg per step):
+     rollout                                    1.50s
+     train                                      2.25s
+
+   Recent Rollout Samples (last 3):
+     step=5 reward=0.8 resp_len=120
+     step=4 reward=0.6 resp_len=85
+     step=3 reward=1.0 resp_len=200
+
+If the run ID is not found, the command exits with a non-zero status and prints
+an error message.
+
+.. code-block:: text
+
+   Run not found: nonexistent
+   Aborted!
+
+Sensitive fields in the configuration (e.g. ``api_key``, ``token``,
+``password``) are masked as ``***`` in both table and JSON output. Rollout
+samples only show ``step``, ``reward``, and ``response_len`` — full prompt and
+response text are never printed.
+
+Limitations
+-----------
+
+* The registry is capped at 200 entries; older entries are dropped
+  automatically.
+* Status is inferred from PID liveness and local state files. If a process was
+  killed externally without writing a returncode, its status will show as
+  ``exited``.
+* ``areno run info`` loads TensorBoard event files, rollout samples, and run
+  config from the ``metrics_dir`` recorded at registration time. If the
+  directory has been moved or deleted, those sections will be empty.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -12,3 +12,4 @@ Command pages:
 * :doc:`/cli/dataset_loaders`
 * :doc:`/cli/observability`
 * :doc:`/cli/diagnostics`
+* :doc:`/cli/run`

--- a/tests/test_cli_run_cpu.py
+++ b/tests/test_cli_run_cpu.py
@@ -1,0 +1,573 @@
+"""CPU-safe tests for the 'areno run' CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.cli.main import main
+from areno.cli.run import (
+    RunSummary,
+    _compute_age,
+    _format_age,
+    _format_timestamp,
+    _redact_config,
+    _redact_text,
+    _resolve_status,
+    collect_metric_summaries,
+    format_run_info,
+    format_run_info_json,
+    format_run_list,
+    format_run_list_json,
+    get_run,
+    list_runs,
+)
+
+
+class RunCliTest(unittest.TestCase):
+    def test_top_level_cli_lists_run_command(self):
+        result = CliRunner().invoke(main, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("run", result.output)
+
+    def test_run_help_shows_list_and_info(self):
+        result = CliRunner().invoke(main, ["run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("list", result.output)
+        self.assertIn("info", result.output)
+
+    # -- list (table) --
+
+    def test_run_list_empty_registry(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No runs found.", result.output)
+
+    def test_run_list_with_entries(self):
+        entries = [
+            {
+                "id": "abc123",
+                "kind": "train",
+                "name": "train gspo Qwen",
+                "pid": None,
+                "created_at": 1700000000.0,
+                "updated_at": 1700000000.0,
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("abc123", result.output)
+        self.assertIn("train gspo Qwen", result.output)
+
+    def test_run_list_shows_age_column(self):
+        entries = [
+            {
+                "id": "age1",
+                "kind": "train",
+                "name": "test",
+                "pid": None,
+                "created_at": time.time() - 180,
+                "updated_at": time.time() - 180,
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Age", result.output)
+        self.assertIn("3m ago", result.output)
+
+    # -- list --json --
+
+    def test_run_list_json_empty(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(json.loads(result.output), [])
+
+    def test_run_list_json_with_entries(self):
+        entries = [
+            {
+                "id": "js1",
+                "kind": "train",
+                "name": "gspo run",
+                "pid": 12345,
+                "created_at": 1700000000.0,
+                "updated_at": 1700000000.0,
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["id"], "js1")
+        self.assertEqual(parsed[0]["kind"], "train")
+        self.assertEqual(parsed[0]["name"], "gspo run")
+        self.assertEqual(parsed[0]["pid"], 12345)
+        self.assertIn("status", parsed[0])
+        self.assertIn("age_s", parsed[0])
+
+    def test_run_list_json_deterministic_order(self):
+        """Entries with same created_at are sorted by created_at desc then pid desc."""
+        entries = [
+            {"id": "a", "kind": "train", "name": "a", "pid": 1, "created_at": 100.0, "updated_at": 100.0},
+            {"id": "b", "kind": "train", "name": "b", "pid": 2, "created_at": 100.0, "updated_at": 100.0},
+            {"id": "c", "kind": "train", "name": "c", "pid": 3, "created_at": 200.0, "updated_at": 200.0},
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        ids = [item["id"] for item in parsed]
+        self.assertEqual(ids, ["c", "b", "a"])
+
+    # -- list --limit --
+
+    def test_run_list_limit(self):
+        entries = [
+            {
+                "id": f"run{i}",
+                "kind": "train",
+                "name": f"run {i}",
+                "pid": i,
+                "created_at": float(1700000000 + i),
+                "updated_at": float(1700000000 + i),
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+            for i in range(5)
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list", "--limit", "2"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("run4", result.output)
+        self.assertIn("run3", result.output)
+        self.assertNotIn("run2", result.output)
+
+    def test_run_list_limit_zero_shows_all(self):
+        entries = [
+            {
+                "id": f"r{i}",
+                "kind": "train",
+                "name": f"r {i}",
+                "pid": i,
+                "created_at": float(1700000000 + i),
+                "updated_at": float(1700000000 + i),
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+            for i in range(3)
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list", "--limit", "0"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("r0", result.output)
+        self.assertIn("r1", result.output)
+        self.assertIn("r2", result.output)
+
+    def test_run_list_limit_default_is_20(self):
+        entries = [
+            {
+                "id": f"x{i}",
+                "kind": "train",
+                "name": f"x {i}",
+                "pid": i,
+                "created_at": float(1700000000 + i),
+                "updated_at": float(1700000000 + i),
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+            for i in range(25)
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(len(parsed), 20)
+
+    # -- info --
+
+    def test_run_info_not_found(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "info", "nonexistent"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Run not found", result.output)
+
+    def test_run_info_with_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pid = os.getpid()
+            # Create dashboard_state file
+            state_file = os.path.join(tmp, f"dashboard_state.{pid}.json")
+            with open(state_file, "w") as f:
+                json.dump({"pid": pid, "stage": "train_end", "status": "running", "step": 10}, f)
+            # Create run config files
+            config_txt = os.path.join(tmp, f"areno_run_config.{pid}.txt")
+            with open(config_txt, "w") as f:
+                f.write("algo: gspo\nckpt: Qwen/Qwen3-0.6B")
+            config_json = os.path.join(tmp, f"areno_run_config.{pid}.json")
+            with open(config_json, "w") as f:
+                json.dump({"settings": {"algo": "gspo", "ckpt": "Qwen/Qwen3-0.6B"}}, f)
+
+            entries = [
+                {
+                    "id": "test123",
+                    "kind": "train",
+                    "name": "test run",
+                    "pid": pid,
+                    "created_at": 1700000000.0,
+                    "updated_at": 1700000000.0,
+                    "metrics_dir": tmp,
+                    "config": {},
+                    "command": [],
+                }
+            ]
+            with patch("areno.cli.run.registered_job_items", return_value=entries):
+                result = CliRunner().invoke(main, ["run", "info", "test123"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Run: test123", result.output)
+        self.assertIn("Configuration:", result.output)
+        self.assertIn("gspo", result.output)
+        self.assertIn("train_end", result.output)
+
+    def test_returncode_populated_from_registry(self):
+        entries = [
+            {
+                "id": "rc1",
+                "kind": "train",
+                "name": "failed run",
+                "pid": None,
+                "returncode": 1,
+                "created_at": 1700000000.0,
+                "updated_at": 1700000000.0,
+                "metrics_dir": None,
+                "config": {},
+                "command": [],
+            }
+        ]
+        with patch("areno.cli.run.registered_job_items", return_value=entries):
+            result = CliRunner().invoke(main, ["run", "info", "rc1"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("returncode=1", result.output)
+
+    # -- status resolution --
+
+    def test_resolve_status_running(self):
+        with patch("areno.cli.run.pid_is_running", return_value=True):
+            self.assertEqual(_resolve_status({"pid": 123}), "running")
+
+    def test_resolve_status_stage_from_dashboard_state(self):
+        """When PID is alive and dashboard_state has a stage, return that stage."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pid = os.getpid()
+            state_file = os.path.join(tmp, f"dashboard_state.{pid}.json")
+            with open(state_file, "w") as f:
+                json.dump({"stage": "rollout"}, f)
+
+            with patch("areno.cli.run.pid_is_running", return_value=True):
+                status = _resolve_status({"pid": pid, "metrics_dir": tmp})
+            self.assertEqual(status, "rollout")
+
+    def test_resolve_status_running_no_state_file(self):
+        """When PID is alive but no dashboard_state file, return 'running'."""
+        with patch("areno.cli.run.pid_is_running", return_value=True):
+            self.assertEqual(_resolve_status({"pid": 123, "metrics_dir": None}), "running")
+
+    def test_resolve_status_exited(self):
+        self.assertEqual(_resolve_status({"pid": None}), "exited")
+
+    def test_resolve_status_succeeded(self):
+        self.assertEqual(_resolve_status({"pid": None, "returncode": 0}), "succeeded")
+
+    def test_resolve_status_failed(self):
+        self.assertEqual(_resolve_status({"pid": None, "returncode": 1}), "failed")
+
+    # -- age helpers --
+
+    def test_compute_age(self):
+        now = time.time()
+        age = _compute_age(now - 300, now - 300)
+        self.assertIsNotNone(age)
+        self.assertGreaterEqual(age, 300)
+
+    def test_compute_age_none(self):
+        self.assertIsNone(_compute_age(None, None))
+
+    def test_format_age_seconds(self):
+        self.assertEqual(_format_age(45), "45s ago")
+
+    def test_format_age_minutes(self):
+        self.assertEqual(_format_age(180), "3m ago")
+
+    def test_format_age_hours(self):
+        self.assertEqual(_format_age(7200), "2h ago")
+
+    def test_format_age_days(self):
+        self.assertEqual(_format_age(172800), "2d ago")
+
+    def test_format_age_none(self):
+        self.assertEqual(_format_age(None), "-")
+
+    # -- formatting --
+
+    def test_format_run_info_contains_all_sections(self):
+        run = RunSummary(
+            run_id="test",
+            kind="train",
+            name="test run",
+            status="succeeded",
+            step=10,
+            config={"algo": "gspo"},
+            config_text="algo: gspo\nckpt: Qwen/Qwen3-0.6B",
+            metrics=[
+                {"name": "loss", "value": 0.5, "step": 1},
+                {"name": "loss", "value": 0.3, "step": 2},
+            ],
+            timeperf=[
+                {"segments": [{"name": "rollout", "seconds": 1.0}, {"name": "train", "seconds": 2.0}]},
+                {"segments": [{"name": "rollout", "seconds": 1.5}, {"name": "train", "seconds": 2.5}]},
+            ],
+            samples=[{"step": 1, "reward": 0.8, "response_len": 100}],
+        )
+        output = format_run_info(run)
+        self.assertIn("Run: test", output)
+        self.assertIn("Configuration:", output)
+        self.assertIn("Metrics Summary:", output)
+        self.assertIn("Time Breakdown", output)
+        self.assertIn("Recent Rollout Samples", output)
+
+    def test_format_run_list_empty(self):
+        self.assertEqual(format_run_list([]), "No runs found.")
+
+    def test_format_run_list_with_entries(self):
+        runs = [RunSummary(run_id="abc", kind="train", name="test", status="running", step=5)]
+        output = format_run_list(runs)
+        self.assertIn("abc", output)
+        self.assertIn("train", output)
+
+    def test_format_run_list_empty_created_at_shows_dash(self):
+        """When created_at is empty, the Created column should show '-' not blank."""
+        runs = [RunSummary(run_id="x", kind="train", name="t", status="exited", created_at="")]
+        output = format_run_list(runs)
+        self.assertIn("-", output)
+        # The dash should appear in the Created column position, not be empty
+        self.assertNotIn("x  train  exited         0  t                                        -          \n",
+                         output)
+
+    def test_format_run_list_json_with_entries(self):
+        runs = [RunSummary(run_id="j1", kind="train", name="json test", status="running", pid=99)]
+        output = format_run_list_json(runs)
+        parsed = json.loads(output)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["id"], "j1")
+        self.assertEqual(parsed[0]["pid"], 99)
+
+    def test_format_run_list_json_empty(self):
+        output = format_run_list_json([])
+        self.assertEqual(json.loads(output), [])
+
+    def test_collect_metric_summaries_groups_by_name(self):
+        metrics = [
+            {"name": "loss", "value": 0.5, "step": 1},
+            {"name": "loss", "value": 0.3, "step": 2},
+            {"name": "reward", "value": 1.0, "step": 2},
+        ]
+        result = collect_metric_summaries(metrics)
+        self.assertEqual(len(result), 2)
+        loss = next(m for m in result if m["name"] == "loss")
+        self.assertEqual(loss["count"], 2)
+        self.assertEqual(loss["latest_step"], 2)
+        self.assertEqual(loss["latest_value"], 0.3)
+
+    def test_format_timestamp_converts_epoch(self):
+        result = _format_timestamp(0)
+        self.assertTrue(result.startswith("1970"))
+
+    def test_format_timestamp_empty(self):
+        self.assertEqual(_format_timestamp(None), "")
+        self.assertEqual(_format_timestamp(""), "")
+
+    def test_returncode_none_not_displayed(self):
+        run = RunSummary(run_id="x", status="exited")
+        output = format_run_info(run)
+        self.assertNotIn("returncode", output)
+
+    # -- malformed registry --
+
+    def test_malformed_registry_returns_empty(self):
+        """Malformed JSON in dashboard-jobs.json should not crash."""
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            runs = list_runs()
+        self.assertEqual(runs, [])
+
+    def test_malformed_registry_list_command(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No runs found.", result.output)
+
+    def test_concurrent_write_partial_json_does_not_crash(self):
+        """Reader should not crash when registry is being written mid-flight (partial JSON)."""
+        from areno.dashboard.server import GLOBAL_REGISTRY_FILE
+        partial = '{"jobs": [{"id": "ab'
+        with patch.object(type(GLOBAL_REGISTRY_FILE), "read_text", return_value=partial):
+            result = CliRunner().invoke(main, ["run", "list"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No runs found.", result.output)
+
+    def test_concurrent_write_empty_file_does_not_crash(self):
+        """Reader should not crash when registry file is empty (e.g. just created, not yet written)."""
+        from areno.dashboard.server import GLOBAL_REGISTRY_FILE
+        with patch.object(type(GLOBAL_REGISTRY_FILE), "read_text", return_value=""):
+            result = CliRunner().invoke(main, ["run", "list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(json.loads(result.output), [])
+
+    # -- info --json --
+
+    def test_run_info_json_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pid = os.getpid()
+            state_file = os.path.join(tmp, f"dashboard_state.{pid}.json")
+            with open(state_file, "w") as f:
+                json.dump({"pid": pid, "stage": "rollout", "step": 3}, f)
+            config_json = os.path.join(tmp, f"areno_run_config.{pid}.json")
+            with open(config_json, "w") as f:
+                json.dump({"settings": {"algo": "gspo", "ckpt": "Qwen/Qwen3-0.6B"}}, f)
+
+            entries = [
+                {
+                    "id": "jinfo",
+                    "kind": "train",
+                    "name": "json info test",
+                    "pid": pid,
+                    "created_at": 1700000000.0,
+                    "updated_at": 1700000000.0,
+                    "metrics_dir": tmp,
+                    "config": {},
+                    "command": [],
+                }
+            ]
+            with patch("areno.cli.run.registered_job_items", return_value=entries):
+                result = CliRunner().invoke(main, ["run", "info", "jinfo", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["id"], "jinfo")
+        self.assertEqual(parsed["kind"], "train")
+        self.assertEqual(parsed["stage"], "rollout")
+        self.assertIn("config", parsed)
+        self.assertIn("metrics", parsed)
+
+    def test_run_info_json_not_found(self):
+        with patch("areno.cli.run.registered_job_items", return_value=[]):
+            result = CliRunner().invoke(main, ["run", "info", "nope", "--json"])
+        self.assertNotEqual(result.exit_code, 0)
+        # Error JSON should be on stderr
+        self.assertIn("Run not found", result.output + result.stderr)
+
+    # -- info accepts directory path --
+
+    def test_run_info_accepts_directory_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pid = os.getpid()
+            state_file = os.path.join(tmp, f"dashboard_state.{pid}.json")
+            with open(state_file, "w") as f:
+                json.dump({"stage": "train_end", "step": 10}, f)
+            result = CliRunner().invoke(main, ["run", "info", tmp])
+        self.assertEqual(result.exit_code, 0)
+        dir_name = os.path.basename(tmp)
+        self.assertIn(f"Run: {dir_name}", result.output)
+        self.assertIn("train_end", result.output)
+
+    # -- sensitive config redaction --
+
+    def test_redact_config_masks_sensitive_keys(self):
+        config = {"algo": "gspo", "api_key": "sk-12345", "password": "secret", "ckpt": "Qwen"}
+        redacted = _redact_config(config)
+        self.assertEqual(redacted["algo"], "gspo")
+        self.assertEqual(redacted["api_key"], "***")
+        self.assertEqual(redacted["password"], "***")
+        self.assertEqual(redacted["ckpt"], "Qwen")
+
+    def test_redact_config_preserves_non_sensitive_keys(self):
+        config = {"algo": "gspo", "ckpt": "Qwen/Qwen3-0.6B", "lr": 1e-5}
+        redacted = _redact_config(config)
+        self.assertEqual(redacted, config)
+
+    def test_run_info_redacts_sensitive_config_in_table(self):
+        run = RunSummary(
+            run_id="r1",
+            kind="train",
+            name="test",
+            config={"algo": "gspo", "api_key": "sk-secret"},
+        )
+        output = format_run_info(run)
+        self.assertIn("algo: gspo", output)
+        self.assertIn("api_key: ***", output)
+        self.assertNotIn("sk-secret", output)
+
+    def test_run_info_json_redacts_sensitive_config(self):
+        run = RunSummary(
+            run_id="r1",
+            kind="train",
+            name="test",
+            config={"algo": "gspo", "api_key": "sk-secret"},
+        )
+        output = format_run_info_json(run)
+        parsed = json.loads(output)
+        self.assertEqual(parsed["config"]["api_key"], "***")
+        self.assertNotIn("sk-secret", output)
+
+    def test_redact_text_masks_sensitive_values(self):
+        text = "algo: gspo\napi_key: sk-secret\nckpt: Qwen"
+        redacted = _redact_text(text)
+        self.assertIn("api_key: ***", redacted)
+        self.assertNotIn("sk-secret", redacted)
+        self.assertIn("algo: gspo", redacted)
+
+    def test_run_info_redacts_config_text_in_table(self):
+        run = RunSummary(
+            run_id="r1",
+            kind="train",
+            name="test",
+            config_text="algo: gspo\napi_key: sk-secret\nckpt: Qwen",
+        )
+        output = format_run_info(run)
+        self.assertIn("api_key: ***", output)
+        self.assertNotIn("sk-secret", output)
+
+    def test_run_info_json_redacts_config_text(self):
+        run = RunSummary(
+            run_id="r1",
+            kind="train",
+            name="test",
+            config_text="algo: gspo\npassword: mypass123",
+        )
+        output = format_run_info_json(run)
+        parsed = json.loads(output)
+        self.assertIn("***", parsed["config_text"])
+        self.assertNotIn("mypass123", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds a new `areno run` CLI command that lets users inspect AReno training and serving runs from the terminal. The command reads the existing local job registry (`~/.areno/dashboard-jobs.json`) — no database or external service is required.

The primary focus is `areno run info` (#251): showing detailed information for a single run. Since `info` depends on shared infrastructure (registry reading, status derivation, metrics loading), `areno run list` is also included as a natural companion — both live in the same `areno/cli/run.py` module and share the same data layer.

Two subcommands:

- **`areno run info <run_id | dir>`** — detailed view of a single run, including configuration, metric summaries, per-step time breakdown, and recent rollout samples.
  - `--json` — emit a structured JSON object.
  - Accepts either a registry ID or a directory path containing run artifacts.

- **`areno run list`** — compact table of active and recent runs, showing ID, kind, status, step, name, age, and created timestamp.
  - `--json` — emit a structured JSON array instead of a table.
  - `--limit N` — show last N runs (default 20, `0` = all).

Status derivation:
- PID alive + `dashboard_state.{pid}.json` with a `stage` field → stage name (e.g. `rollout`, `train`)
- PID alive, no state file → `running`
- PID dead, `returncode == 0` → `succeeded`
- PID dead, `returncode != 0` → `failed`
- PID dead, no returncode → `exited`

Security: sensitive config keys (`api_key`, `token`, `secret`, `password`) are masked as `***` in both table and JSON output, including free-form `config_text`. Rollout samples only show `step`, `reward`, and `response_len` — full prompt and response text are never printed.

Files changed:
- `areno/cli/run.py` (new) — implementation
- `areno/cli/main.py` — register `"run"` in `_COMMANDS`
- `tests/test_cli_run_cpu.py` (new) — 51 CPU tests
- `docs/cli/run.rst` (new) — user documentation
- `docs/reference/cli.rst` — add link to the new page

## Related issue

Fixes #251

This PR also implements `areno run list` which addresses #250. The two capabilities share the same module and data layer, so they are submitted together to avoid file-level conflicts.

## Type of change

- [x] ✨ New feature

## How was it tested?

```
pytest tests/ -k cpu
```

418 tests pass (418 passed, 0 failed) on macOS, no GPU. The 51 new tests cover:
- Running/succeeded/failed/exited/stage status derivation
- `--json` output for both `list` and `info`
- `--limit` truncation (default 20, 0 = all, custom N)
- Deterministic sort order (created_at desc + pid desc)
- Age calculation and formatting (s/m/h/d)
- Empty/malformed registry graceful degradation
- Concurrent write scenarios (partial JSON, empty file)
- Directory path as input to `areno run info`
- Sensitive config redaction in config dict and config_text
- Not-found error handling for both table and JSON modes

Additional GPU validation was performed on Kaggle (NVIDIA T4), where `areno train` was run end-to-end and `areno run list` / `areno run info` correctly displayed live status, stage, metrics, and configuration from the running job.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass `pytest tests/ -k cpu`.
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).