### PR TITLE
feat(agentic): add elevator dispatch demo with CPU tests (#195)

### DIFF
--- a/examples/agentic/elevator/README.md
+++ b/examples/agentic/elevator/README.md
@@ -1,0 +1,234 @@
+# Elevator Dispatch — Agentic RL Demo
+
+This example builds a focused, independently reviewable **elevator-dispatch
+agentic RL** demo on top of AReno's existing public contracts. It models one
+elevator cab serving N floors under a discrete time-step clock, exposes
+`move` / `open_door` / `close_door` actions, and advances a local event queue
+deterministically — no external services, sandboxes, or databases are used.
+
+The demo targets the acceptance areas from issue #195:
+
+- **Overload protection** — a cab capacity limit refuses extra boarding.
+- **Empty-door invalid actions** — moving with the door open is rejected.
+- **Concurrent requests** — passengers waiting on multiple floors at `t0`.
+- **Peak traffic** — high arrival density over a long horizon.
+- **Termination** — short horizons force early episode cutoff.
+
+A First-Come-First-Served (FCFS) baseline is included to compare a trained
+agent against a hand-coded dispatcher on delivered passengers, mean waiting
+time, and illegal actions.
+
+---
+
+## Files
+
+| File                       | Role                                                                 |
+| -------------------------- | -------------------------------------------------------------------- |
+| `game.py`                  | Deterministic single-cab environment: state, actions, `step`, prompt |
+| `dataset_generator.py`     | Deterministic JSONL scenarios for the five acceptance areas          |
+| `dataset_loader.py`        | `load_training_dataset(dataset_path, *, default_loader, **_)` loader |
+| `reward.py`                | `reward_fn(record)` replays the trajectory and scores the outcome    |
+| `run_agent.py`             | Bounded multi-turn `run_agent(ctx, batch)` agent loop                |
+| `fcfs_baseline.py`         | FCFS baseline runner with human-readable + JSON output               |
+
+CPU tests live under `tests/`:
+
+- `test_elevator_game_cpu.py`
+- `test_elevator_reward_cpu.py`
+- `test_elevator_agentic_cpu.py`
+- `test_elevator_fcfs_baseline_cpu.py`
+- `test_elevator_scenarios_cpu.py`
+
+---
+
+## Input contract
+
+Each record is a JSON object with the following fields. The loader validates
+every field before any model or worker starts, so malformed inputs fail fast.
+
+| Field        | Type            | Default   | Notes                                                    |
+| ------------ | --------------- | --------- | -------------------------------------------------------- |
+| `floors`     | int             | `6`       | `>= 2`; floor ids run `0 .. floors-1`                    |
+| `capacity`   | int             | `4`       | `>= 1`; maximum passengers inside the cab                |
+| `horizon`    | int             | `64`      | `>= 1`; maximum time steps per episode                   |
+| `scenario`   | str             | `"mixed"` | one of the `SCENARIOS` below                             |
+| `door_open`  | bool            | `False`   | initial door state (the `empty_door` scenario forces `True`) |
+| `id`         | str             | auto      | record id; auto-assigned if missing                      |
+| `passengers` | list[object]    | required  | one object per passenger                                 |
+
+Each passenger object:
+
+| Field         | Type | Default | Notes                                              |
+| ------------- | ---- | ------- | -------------------------------------------------- |
+| `pid`         | int  | auto    | passenger id; auto-assigned if missing             |
+| `origin`      | int  | —       | floor where the passenger arrives (`0 .. floors-1`)|
+| `dest`        | int  | —       | destination floor (`0 .. floors-1`, `!= origin`)   |
+| `arrive_time` | int  | `0`     | time step at which the passenger starts waiting    |
+
+Validation rejects: empty passenger lists, out-of-range floors, `origin == dest`,
+non-positive `capacity`/`horizon`, and records missing required passenger fields.
+
+---
+
+## Scenarios
+
+`dataset_generator.py` exposes `SCENARIOS` and emits deterministic records for
+each (same seed → same records):
+
+| Scenario     | Characteristics                                              |
+| ------------ | ------------------------------------------------------------- |
+| `overload`   | `capacity = 1`, `>= 4` passengers at `t0` on random floors   |
+| `empty_door` | `door_open = True` at `t0` so the first move is invalid       |
+| `concurrent` | `>= 2` distinct origins at `arrive_time = 0`                 |
+| `peak`       | `horizon >= 64`, `>= 8` passengers                            |
+| `terminate`  | `horizon <= 4` so most passengers cannot be delivered         |
+| `mixed`      | default blend drawing from the above                          |
+
+---
+
+## Action tools
+
+The environment exposes three deterministic tools to the model. Each tool call
+advances the clock by exactly one step and returns an observation.
+
+| Tool         | Arguments                 | Effect                                                            |
+| ------------ | ------------------------- | ----------------------------------------------------------------- |
+| `move`       | `direction: {+1, -1}`     | Move the cab one floor up/down. Invalid if the door is open.      |
+| `open_door`  | (none)                    | Open the door; alight delivered passengers then board waiting ones up to capacity. Refused boardings are counted. Invalid if already open. |
+| `close_door` | (none)                    | Close the door. Invalid if already closed.                       |
+| `done`       | (none)                    | End the episode early.                                            |
+
+An episode also ends naturally when the horizon is reached or when `is_terminal`
+returns `True` (all passengers delivered).
+
+---
+
+## Reward
+
+`reward_fn(record)` replays the trajectory recorded in `record.tool_calls` against
+`game.build_state(record.source_record)` and combines three signals:
+
+```text
+reward = +DELIVER_WEIGHT  * delivered_passengers / total_passengers
+         - WAIT_WEIGHT    * normalized_total_wait
+         - INVALID_WEIGHT * invalid_actions / total_passengers
+```
+
+- `delivered_passengers / total_passengers` — coverage in `[0, 1]`.
+- `normalized_total_wait` — sum of waiting steps across delivered passengers,
+  divided by an upper bound, in `[0, 1]`.
+- `invalid_actions / total_passengers` — per-passenger illegal-action rate.
+
+Weights are module-level constants (`DELIVER_WEIGHT = 1.0`,
+`WAIT_WEIGHT = 0.3`, `INVALID_WEIGHT = 0.5`) so tuning is centralized. The
+reward is a plain `float`; malformed arguments are caught and treated as an
+invalid action with a `0.5 / total_passengers` penalty, so a bad trajectory
+never crashes training. When `total_passengers == 0` the reward is `0.0` by
+guard (no division by zero).
+
+---
+
+## Quick start
+
+### 1. Generate a dataset
+
+```bash
+python examples/agentic/elevator/dataset_generator.py \
+  --count 256 --seed 2026 --scenario mixed \
+  --out /tmp/elevator_train.jsonl
+```
+
+Any of the scenarios listed above can be passed via `--scenario`. The same
+`--seed` reproduces the exact same records.
+
+### 2. Score the FCFS baseline
+
+```bash
+python examples/agentic/elevator/fcfs_baseline.py \
+  --dataset /tmp/elevator_train.jsonl
+```
+
+Add `--json` for machine-readable output, or omit `--dataset` to run the default
+deterministic dataset.
+
+### 3. Train an agent
+
+Point AReno at the example directory. The exact flags follow AReno's agentic
+training recipe; the example-specific pieces are stable:
+
+- `--dataset-path /tmp/elevator_train.jsonl`
+- `--dataset-loader examples/agentic/elevator/dataset_loader.py`
+- `--reward-fn-path examples/agentic/elevator/reward.py`
+- `--agentic-runner examples/agentic/elevator/run_agent.py`
+
+The agent calls `move` / `open_door` / `close_door` each turn; the environment
+runs in-process and the new state is fed back as a tool result. The loop ends
+on `done`, a terminal state, or the horizon cap.
+
+### 4. Compare against FCFS
+
+After training, re-run `fcfs_baseline.py` on the evaluation split and compare
+the emitted fields (see below) with the trained agent's metrics.
+
+---
+
+## Output fields
+
+`fcfs_baseline.py` and the reward replay expose these fields per episode and
+aggregated:
+
+| Field                     | Level  | Meaning                                          |
+| ------------------------- | ------ | ------------------------------------------------ |
+| `delivered`               | both   | passengers delivered this episode                |
+| `total_passengers`        | both   | initial passenger count                          |
+| `mean_wait`               | ep.    | per-episode mean waiting steps over delivered passengers |
+| `mean_wait_per_passenger` | agg.   | global `sum(total_wait) / sum(total_passengers)` |
+| `invalid_actions`         | both   | count of rejected actions this episode           |
+| `overload_refused`        | both   | boardings refused due to capacity limit          |
+| `delivery_rate`           | agg.   | `sum(delivered) / sum(total_passengers)`         |
+| `by_scenario`             | agg.   | per-scenario breakdown of the above              |
+
+The FCFS baseline intentionally scores low on `terminate` (horizon too short to
+deliver anyone) and `overload` (capacity 1) — this leaves headroom for a
+trained agent to learn a better dispatch policy.
+
+---
+
+## Defaults
+
+Defaults are chosen so the example runs out of the box without any flags:
+
+- `DEFAULT_FLOORS = 6`, `DEFAULT_CAPACITY = 4`, `DEFAULT_HORIZON = 64`.
+- Default scenario is `mixed`.
+- `door_open` defaults to `False` unless the scenario overrides it.
+- Reward weights: `DELIVER_WEIGHT = 1.0`, `WAIT_WEIGHT = 0.3`,
+  `INVALID_WEIGHT = 0.5`.
+
+These follow AReno's default-value guidelines: they are safe, predictable, and
+aligned with the issue's acceptance points.
+
+---
+
+## Limitations
+
+- **Single cab only.** The environment models one elevator; multi-cab central
+  dispatch is out of scope for this demo.
+- **Discrete time steps.** The clock advances one step per action; continuous
+  event queues are not modeled.
+- **No external traffic model.** Passenger arrivals come from the generator's
+  deterministic fixtures, not a real traffic trace.
+- **CPU-only tests.** The five test files run without a GPU; they verify
+  environment semantics, reward monotonicity, the agent loop, the FCFS
+  baseline, and the five scenario fixtures.
+
+---
+
+## Reproducing the tests
+
+```bash
+pytest tests/ -k elevator
+```
+
+All elevator tests are CPU-only and deterministic. Each test loads the example
+modules via `importlib` without importing the `areno` package, so they run in a
+plain Python environment without CUDA or PyTorch.

--- a/examples/agentic/elevator/dataset_generator.py
+++ b/examples/agentic/elevator/dataset_generator.py
@@ -1,0 +1,220 @@
+"""Generate deterministic elevator dispatch scenarios for agentic RL training.
+
+Each scenario targets one acceptance area from issue #195:
+- ``overload``   cab capacity forces refused boarding
+- ``empty_door`` door-state invalid actions
+- ``concurrent`` many near-simultaneous requests on different floors
+- ``peak``       high arrival density over a long horizon
+- ``terminate``  very short horizon forcing early termination
+- ``mixed``      default training set blending the above
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import TextIO
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+DEFAULT_COUNT = 128
+DEFAULT_SEED = 2026
+
+SCENARIOS = ("overload", "empty_door", "concurrent", "peak", "terminate", "mixed")
+
+
+def generate_records(count: int = DEFAULT_COUNT, *, seed: int = DEFAULT_SEED, scenario: str = "mixed") -> list[dict]:
+    """Generate reproducible elevator scenario records.
+
+    ``scenario="mixed"`` samples each of the five focused scenarios plus a few
+    generic records so a single training file exercises every acceptance point.
+    """
+
+    if scenario not in SCENARIOS:
+        raise ValueError(f"scenario must be one of {SCENARIOS}, got {scenario!r}")
+    if count <= 0:
+        raise ValueError("count must be positive")
+
+    rng = random.Random(seed)
+    records: list[dict] = []
+    if scenario == "mixed":
+        focused = ("overload", "empty_door", "concurrent", "peak", "terminate")
+        per_scenario = max(count // (len(focused) + 1), 1)
+        for name in focused:
+            records.extend(_scenario_records(name, per_scenario, rng))
+        # fill the rest with generic mixed traffic
+        while len(records) < count:
+            records.append(_generic_record(rng, count_id=len(records)))
+        return records[:count]
+    return _scenario_records(scenario, count, rng)
+
+
+def _scenario_records(scenario: str, count: int, rng: random.Random) -> list[dict]:
+    """Build ``count`` records for one focused scenario."""
+
+    records: list[dict] = []
+    for i in range(count):
+        if scenario == "overload":
+            records.append(_overload_record(rng, i))
+        elif scenario == "empty_door":
+            records.append(_empty_door_record(rng, i))
+        elif scenario == "concurrent":
+            records.append(_concurrent_record(rng, i))
+        elif scenario == "peak":
+            records.append(_peak_record(rng, i))
+        elif scenario == "terminate":
+            records.append(_terminate_record(rng, i))
+        else:
+            records.append(_generic_record(rng, count_id=i))
+    return records
+
+
+def _overload_record(rng: random.Random, idx: int) -> dict:
+    """Capacity much smaller than demand so boarding is refused at least once."""
+
+    floors = rng.randint(4, 6)
+    capacity = 1
+    horizon = 48
+    n_passengers = rng.randint(4, 6)
+    origin = rng.randint(0, floors - 1)
+    passengers = []
+    for pid in range(n_passengers):
+        dest = _distinct_dest(origin, floors, rng)
+        passengers.append({"pid": pid, "origin": origin, "dest": dest, "arrive_time": 0})
+    return _wrap("overload", idx, floors, capacity, horizon, passengers)
+
+
+def _empty_door_record(rng: random.Random, idx: int) -> dict:
+    """Start with the door open so open_door is immediately invalid."""
+
+    floors = rng.randint(3, 5)
+    capacity = rng.randint(2, 3)
+    horizon = 24
+    passengers = _random_passengers(rng, floors, n=rng.randint(1, 3))
+    record = _wrap("empty_door", idx, floors, capacity, horizon, passengers)
+    record["door_open"] = True
+    return record
+
+
+def _concurrent_record(rng: random.Random, idx: int) -> dict:
+    """Several passengers arrive at the same step on different floors."""
+
+    floors = rng.randint(4, 6)
+    capacity = rng.randint(2, 3)
+    horizon = 40
+    n = rng.randint(4, 6)
+    passengers = []
+    used_floors = list(range(floors))
+    rng.shuffle(used_floors)
+    for pid in range(n):
+        origin = used_floors[pid % floors]
+        dest = _distinct_dest(origin, floors, rng)
+        passengers.append({"pid": pid, "origin": origin, "dest": dest, "arrive_time": 0})
+    return _wrap("concurrent", idx, floors, capacity, horizon, passengers)
+
+
+def _peak_record(rng: random.Random, idx: int) -> dict:
+    """High density arrivals over a long horizon to stress throughput."""
+
+    floors = rng.randint(5, 7)
+    capacity = rng.randint(3, 4)
+    horizon = 96
+    n = rng.randint(10, 14)
+    passengers = []
+    for pid in range(n):
+        origin = rng.randint(0, floors - 1)
+        dest = _distinct_dest(origin, floors, rng)
+        arrive_time = rng.randint(0, max(horizon // 2, 1))
+        passengers.append({"pid": pid, "origin": origin, "dest": dest, "arrive_time": arrive_time})
+    passengers.sort(key=lambda p: p["arrive_time"])
+    # re-assign sequential pids after sorting
+    for new_pid, passenger in enumerate(passengers):
+        passenger["pid"] = new_pid
+    return _wrap("peak", idx, floors, capacity, horizon, passengers)
+
+
+def _terminate_record(rng: random.Random, idx: int) -> dict:
+    """Horizon too short to deliver everyone, forcing termination by timeout."""
+
+    floors = rng.randint(3, 5)
+    capacity = rng.randint(1, 2)
+    horizon = rng.randint(2, 4)
+    passengers = _random_passengers(rng, floors, n=rng.randint(2, 3))
+    return _wrap("terminate", idx, floors, capacity, horizon, passengers)
+
+
+def _generic_record(rng: random.Random, *, count_id: int) -> dict:
+    """A plain mixed-traffic record not tied to one acceptance point."""
+
+    floors = rng.randint(3, 6)
+    capacity = rng.randint(2, 4)
+    horizon = rng.randint(32, 64)
+    passengers = _random_passengers(rng, floors, n=rng.randint(2, 5))
+    return _wrap("mixed", count_id, floors, capacity, horizon, passengers)
+
+
+def _random_passengers(rng: random.Random, floors: int, *, n: int) -> list[dict]:
+    passengers = []
+    for pid in range(n):
+        origin = rng.randint(0, floors - 1)
+        dest = _distinct_dest(origin, floors, rng)
+        arrive_time = rng.randint(0, max(floors, 4))
+        passengers.append({"pid": pid, "origin": origin, "dest": dest, "arrive_time": arrive_time})
+    return passengers
+
+
+def _distinct_dest(origin: int, floors: int, rng: random.Random) -> int:
+    dest = rng.randint(0, floors - 1)
+    while dest == origin:
+        dest = rng.randint(0, floors - 1)
+    return dest
+
+
+def _wrap(scenario: str, idx: int, floors: int, capacity: int, horizon: int, passengers: list[dict]) -> dict:
+    return {
+        "id": f"elevator-{scenario}-{idx:05d}",
+        "scenario": scenario,
+        "floors": floors,
+        "capacity": capacity,
+        "horizon": horizon,
+        "passengers": passengers,
+        "door_open": False,
+    }
+
+
+def write_jsonl(records: list[dict], output: TextIO) -> None:
+    """Write records as one JSON object per line."""
+
+    for record in records:
+        output.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate JSONL elevator scenarios for the AReno agentic example.")
+    parser.add_argument("--output", "-o", default="-", help="Output JSONL path, or '-' for stdout.")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of records to generate.")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed for reproducibility.")
+    parser.add_argument(
+        "--scenario",
+        choices=SCENARIOS,
+        default="mixed",
+        help="Focused scenario or 'mixed' (default) for a blended training set.",
+    )
+    args = parser.parse_args()
+
+    records = generate_records(args.count, seed=args.seed, scenario=args.scenario)
+    if args.output == "-":
+        write_jsonl(records, sys.stdout)
+    else:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            write_jsonl(records, handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/elevator/dataset_loader.py
+++ b/examples/agentic/elevator/dataset_loader.py
@@ -1,0 +1,81 @@
+"""Dataset loader for the elevator dispatch agentic example.
+
+The loader normalizes raw JSONL records produced by ``dataset_generator.py``
+into AReno prompt records. It validates elevator-specific fields before any
+model or worker initialization so malformed inputs fail fast with a clear
+error. Records remain tokenizer-independent: the prompt is built lazily from
+``game.make_prompt`` and the initial state is reconstructed by ``game.build_state``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> list[dict]:
+    """Load and validate elevator scenario records.
+
+    Uses AReno's ``default_loader`` to read the JSONL rows, then validates each
+    record against the elevator contract. Raises ``ValueError`` on the first
+    malformed record so callers see the offending field without expensive setup.
+    """
+
+    records: list[dict] = []
+    for index, row in enumerate(default_loader(dataset_path), start=1):
+        record = _normalize_record(row, index)
+        records.append(record)
+    if not records:
+        raise ValueError("elevator dataset is empty; generate records with dataset_generator.py first")
+    return records
+
+
+def _normalize_record(row: dict, index: int) -> dict:
+    """Validate and normalize one raw record into a training record."""
+
+    record = dict(row)
+    record.setdefault("id", f"elevator-{index:05d}")
+    record["id"] = str(record["id"])
+    record["scenario"] = str(record.get("scenario", "mixed"))
+
+    floors = int(record.get("floors", game.DEFAULT_FLOORS))
+    capacity = int(record.get("capacity", game.DEFAULT_CAPACITY))
+    horizon = int(record.get("horizon", game.DEFAULT_HORIZON))
+    game.validate_config(floors=floors, capacity=capacity, horizon=horizon)
+    record["floors"] = floors
+    record["capacity"] = capacity
+    record["horizon"] = horizon
+    record["door_open"] = bool(record.get("door_open", False))
+
+    raw_passengers = record.get("passengers", [])
+    if not isinstance(raw_passengers, list):
+        raise ValueError(f"record {record['id']}: passengers must be a list")
+    passengers: list[dict] = []
+    for pos, raw in enumerate(raw_passengers):
+        if not isinstance(raw, dict):
+            raise ValueError(f"record {record['id']}: passenger[{pos}] must be an object")
+        pid = int(raw.get("pid", pos))
+        origin = int(raw["origin"])
+        dest = int(raw["dest"])
+        arrive_time = int(raw.get("arrive_time", 0))
+        if not 0 <= origin < floors:
+            raise ValueError(f"record {record['id']}: passenger {pid} origin {origin} out of range 0..{floors - 1}")
+        if not 0 <= dest < floors:
+            raise ValueError(f"record {record['id']}: passenger {pid} dest {dest} out of range 0..{floors - 1}")
+        if origin == dest:
+            raise ValueError(f"record {record['id']}: passenger {pid} origin equals dest")
+        if arrive_time < 0:
+            raise ValueError(f"record {record['id']}: passenger {pid} arrive_time {arrive_time} must be >= 0")
+        passengers.append({"pid": pid, "origin": origin, "dest": dest, "arrive_time": arrive_time})
+    if not passengers:
+        raise ValueError(f"record {record['id']}: at least one passenger is required")
+    record["passengers"] = passengers
+
+    # build the initial user prompt and precompute the fresh state snapshot id
+    record["prompt"] = game.make_prompt(record)
+    # validate the state can be constructed (raises on residual issues)
+    game.build_state(record)
+    return record

--- a/examples/agentic/elevator/fcfs_baseline.py
+++ b/examples/agentic/elevator/fcfs_baseline.py
@@ -1,0 +1,125 @@
+"""First-come-first-served baseline runner for the elevator dispatch demo.
+
+Runs the deterministic FCFS policy (defined in ``game.fcfs_policy``) over a
+JSONL dataset and reports delivered passengers, mean wait, invalid actions,
+and overload refusals. Use it to compare a trained agent against a simple
+hand-coded dispatcher. Output is both human-readable and available as JSON via
+``--json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+import game  # noqa: E402
+
+
+def run_dataset(records: list[dict]) -> dict:
+    """Run FCFS over all records and return aggregated metrics."""
+
+    per_episode: list[dict] = []
+    for record in records:
+        per_episode.append(game.run_fcfs_episode(record))
+    return _aggregate(per_episode)
+
+
+def _aggregate(per_episode: list[dict]) -> dict:
+    if not per_episode:
+        return {"episodes": 0}
+    delivered = sum(m["delivered"] for m in per_episode)
+    total = sum(m["total_passengers"] for m in per_episode)
+    total_wait = sum(m["total_wait"] for m in per_episode)
+    invalid = sum(m["invalid_actions"] for m in per_episode)
+    refused = sum(m["overload_refused"] for m in per_episode)
+    return {
+        "episodes": len(per_episode),
+        "total_delivered": delivered,
+        "total_passengers": total,
+        "delivery_rate": delivered / max(total, 1),
+        "mean_wait_per_passenger": total_wait / max(total, 1),
+        "total_invalid_actions": invalid,
+        "total_overload_refused": refused,
+        "by_scenario": _by_scenario(per_episode),
+    }
+
+
+def _by_scenario(per_episode: list[dict]) -> dict[str, dict]:
+    grouped: dict[str, list[dict]] = {}
+    for m in per_episode:
+        grouped.setdefault(m["scenario"], []).append(m)
+    out: dict[str, dict] = {}
+    for scenario, items in grouped.items():
+        delivered = sum(m["delivered"] for m in items)
+        pax = sum(m["total_passengers"] for m in items)
+        wait = sum(m["total_wait"] for m in items)
+        out[scenario] = {
+            "episodes": len(items),
+            "delivery_rate": delivered / max(pax, 1),
+            "mean_wait_per_passenger": wait / max(pax, 1),
+            "invalid_actions": sum(m["invalid_actions"] for m in items),
+            "overload_refused": sum(m["overload_refused"] for m in items),
+        }
+    return out
+
+
+def _load_records(dataset_path: str | None) -> list[dict]:
+    """Load records from a JSONL file or fall back to the default generator."""
+
+    if not dataset_path:
+        return dataset_generator.generate_records(count=64, seed=2026, scenario="mixed")
+    path = Path(dataset_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"dataset not found: {path}")
+    records = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                records.append(json.loads(stripped))
+    return records
+
+
+def _format_report(metrics: dict) -> str:
+    """Render a human-readable summary string."""
+
+    lines = [
+        "Elevator FCFS baseline",
+        f"  episodes:           {metrics.get('episodes', 0)}",
+        f"  delivered:          {metrics.get('total_delivered', 0)}/{metrics.get('total_passengers', 0)}",
+        f"  delivery_rate:      {metrics.get('delivery_rate', 0.0):.4f}",
+        f"  mean_wait/pax:      {metrics.get('mean_wait_per_passenger', 0.0):.3f}",
+        f"  invalid_actions:    {metrics.get('total_invalid_actions', 0)}",
+        f"  overload_refused:   {metrics.get('total_overload_refused', 0)}",
+    ]
+    by_scenario = metrics.get("by_scenario", {})
+    if by_scenario:
+        lines.append("  by_scenario:")
+        for name, m in sorted(by_scenario.items()):
+            lines.append(
+                f"    {name:12s} ep={m['episodes']:3d} rate={m['delivery_rate']:.3f} "
+                f"wait={m['mean_wait_per_passenger']:.2f} invalid={m['invalid_actions']} refused={m['overload_refused']}"
+            )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the FCFS elevator dispatch baseline over a dataset.")
+    parser.add_argument("--dataset", "-d", default=None, help="JSONL dataset path; omit to use the default generator.")
+    parser.add_argument("--json", action="store_true", help="Emit metrics as JSON instead of human-readable text.")
+    args = parser.parse_args()
+
+    records = _load_records(args.dataset)
+    metrics = run_dataset(records)
+    if args.json:
+        print(json.dumps(metrics, indent=2, sort_keys=True))
+    else:
+        print(_format_report(metrics))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/elevator/game.py
+++ b/examples/agentic/elevator/game.py
@@ -1,0 +1,488 @@
+"""Deterministic single-cab elevator dispatch environment for agentic RL.
+
+The environment models one elevator cab serving N floors under a discrete
+time-step clock. Passengers arrive at floors with destinations; the cab moves,
+opens/closes its door, and picks up or drops off passengers subject to a
+capacity limit. Everything is pure-Python and deterministic so episodes can be
+reproduced without external services.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# defaults
+DEFAULT_FLOORS = 6
+DEFAULT_CAPACITY = 4
+DEFAULT_HORIZON = 64
+
+# action tools exposed to the model
+MOVE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "move",
+        "description": "Move the cab one floor up (+1) or down (-1). Door must be closed.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "integer",
+                    "enum": [-1, 1],
+                    "description": "+1 to move up one floor, -1 to move down one floor.",
+                }
+            },
+            "required": ["direction"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+OPEN_DOOR_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "open_door",
+        "description": "Open the door at the current floor to let passengers board or alight.",
+        "parameters": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+    },
+}
+
+CLOSE_DOOR_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "close_door",
+        "description": "Close the door so the cab can move.",
+        "parameters": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+    },
+}
+
+DONE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "done",
+        "description": "End the episode early once all reachable passengers are delivered.",
+        "parameters": {"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+    },
+}
+
+TOOLS = [MOVE_TOOL, OPEN_DOOR_TOOL, CLOSE_DOOR_TOOL, DONE_TOOL]
+
+
+@dataclass
+class Passenger:
+    """A passenger waiting or riding the elevator."""
+
+    pid: int
+    origin: int
+    dest: int
+    arrive_time: int
+    board_time: int | None = None
+    deliver_time: int | None = None
+
+    @property
+    def wait(self) -> int:
+        """Waiting time in discrete steps before boarding."""
+
+        return max(self.board_time if self.board_time is not None else 0, 0) - self.arrive_time
+
+    @property
+    def ride(self) -> int:
+        """Ride time in discrete steps from boarding to delivery."""
+
+        if self.board_time is None or self.deliver_time is None:
+            return 0
+        return self.deliver_time - self.board_time
+
+
+@dataclass
+class ElevatorState:
+    """Full deterministic state of the single-cab elevator environment."""
+
+    floors: int
+    capacity: int
+    horizon: int
+    floor: int = 0
+    direction: int = 0
+    door_open: bool = False
+    passengers: list[Passenger] = field(default_factory=list)
+    waiting: dict[int, list[Passenger]] = field(default_factory=dict)
+    delivered: int = 0
+    total_wait: int = 0
+    invalid_actions: int = 0
+    overload_refused: int = 0
+    time: int = 0
+    terminated: bool = False
+    scenario: str = "mixed"
+    total_passengers_total: int = 0
+
+    def total_passengers(self) -> int:
+        """Initial passenger count (does not shrink as passengers deliver)."""
+
+        return self.total_passengers_total
+
+
+def validate_config(*, floors: int, capacity: int, horizon: int) -> None:
+    """Validate environment configuration before expensive work."""
+
+    if floors < 2:
+        raise ValueError(f"floors must be >= 2, got {floors}")
+    if capacity < 1:
+        raise ValueError(f"capacity must be >= 1, got {capacity}")
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1, got {horizon}")
+
+
+def build_state(
+    record: dict[str, Any],
+) -> ElevatorState:
+    """Construct an initial ElevatorState from a dataset record."""
+
+    floors = int(record.get("floors", DEFAULT_FLOORS))
+    capacity = int(record.get("capacity", DEFAULT_CAPACITY))
+    horizon = int(record.get("horizon", DEFAULT_HORIZON))
+    validate_config(floors=floors, capacity=capacity, horizon=horizon)
+    state = ElevatorState(
+        floors=floors,
+        capacity=capacity,
+        horizon=horizon,
+        waiting={i: [] for i in range(floors)},
+        scenario=str(record.get("scenario", "mixed")),
+    )
+    for raw in record.get("passengers", []):
+        pid = int(raw["pid"])
+        origin = int(raw["origin"])
+        dest = int(raw["dest"])
+        arrive_time = int(raw.get("arrive_time", 0))
+        if not 0 <= origin < floors:
+            raise ValueError(f"passenger {pid} origin {origin} out of range")
+        if not 0 <= dest < floors:
+            raise ValueError(f"passenger {pid} dest {dest} out of range")
+        if origin == dest:
+            raise ValueError(f"passenger {pid} origin equals dest")
+        passenger = Passenger(pid=pid, origin=origin, dest=dest, arrive_time=arrive_time)
+        state.passengers.append(passenger)
+        state.waiting.setdefault(origin, []).append(passenger)
+    # initial door state for the empty-door scenario
+    state.door_open = bool(record.get("door_open", False))
+    state.total_passengers_total = len(state.passengers)
+    return state
+
+
+def is_terminal(state: ElevatorState) -> bool:
+    """Return whether the episode is over."""
+
+    if state.terminated:
+        return True
+    if state.time >= state.horizon:
+        return True
+    return state.delivered >= state.total_passengers() and state.total_passengers() > 0
+
+
+def step(state: ElevatorState, action: dict[str, Any]) -> dict[str, Any]:
+    """Apply one action and return an observation dict.
+
+    Invalid actions increment ``invalid_actions`` and leave state unchanged.
+    The returned dict is the tool result fed back to the model.
+    """
+
+    if is_terminal(state):
+        return {"terminated": True, "state": format_state(state)}
+
+    name = str(action.get("name", ""))
+    result: dict[str, Any]
+    if name == "move":
+        result = _step_move(state, action)
+    elif name == "open_door":
+        result = _step_open(state)
+    elif name == "close_door":
+        result = _step_close(state)
+    elif name == "done":
+        state.terminated = True
+        result = {"done": True, "state": format_state(state)}
+        return result
+    else:
+        state.invalid_actions += 1
+        result = {"invalid": True, "error": f"unknown action: {name}"}
+
+    # advance clock and waiting times only on a successful state-changing action
+    if not result.get("invalid"):
+        state.time += 1
+        _elapse_waiting(state)
+    if is_terminal(state):
+        result["terminated"] = True
+    result["state"] = format_state(state)
+    return result
+
+
+def _step_move(state: ElevatorState, action: dict[str, Any]) -> dict[str, Any]:
+    direction = action.get("direction")
+    try:
+        direction = int(direction)
+    except (TypeError, ValueError):
+        state.invalid_actions += 1
+        return {"invalid": True, "error": "direction must be -1 or 1"}
+    if state.door_open:
+        state.invalid_actions += 1
+        return {"invalid": True, "error": "cannot move while door is open"}
+    if direction not in (-1, 1):
+        state.invalid_actions += 1
+        return {"invalid": True, "error": "direction must be -1 or 1"}
+    next_floor = state.floor + direction
+    if not 0 <= next_floor < state.floors:
+        state.invalid_actions += 1
+        return {"invalid": True, "error": f"floor {next_floor} out of range 0..{state.floors - 1}"}
+    state.floor = next_floor
+    state.direction = direction
+    return {"moved": True, "floor": state.floor}
+
+
+def _step_open(state: ElevatorState) -> dict[str, Any]:
+    if state.door_open:
+        state.invalid_actions += 1
+        return {"invalid": True, "error": "door already open"}
+    state.door_open = True
+    alighted = _alight(state)
+    boarded, refused = _board(state)
+    state.overload_refused += refused
+    return {"opened": True, "alighted": alighted, "boarded": boarded, "refused": refused}
+
+
+def _step_close(state: ElevatorState) -> dict[str, Any]:
+    if not state.door_open:
+        state.invalid_actions += 1
+        return {"invalid": True, "error": "door already closed"}
+    state.door_open = False
+    return {"closed": True}
+
+
+def _alight(state: ElevatorState) -> int:
+    delivered_here = 0
+    for passenger in state.passengers:
+        if passenger.board_time is not None and passenger.deliver_time is None and passenger.dest == state.floor:
+            passenger.deliver_time = state.time
+            state.delivered += 1
+            delivered_here += 1
+    # drop delivered passengers from the riding list; keep waiting and riding ones
+    state.passengers = [p for p in state.passengers if p.deliver_time is None]
+    return delivered_here
+
+
+def _board(state: ElevatorState) -> tuple[int, int]:
+    boarded = 0
+    refused = 0
+    riding = [p for p in state.passengers if p.board_time is not None and p.deliver_time is None]
+    queue = state.waiting.get(state.floor, [])
+    keep: list[Passenger] = []
+    for passenger in queue:
+        if passenger.arrive_time > state.time:
+            keep.append(passenger)
+            continue
+        if len(riding) + boarded < state.capacity:
+            passenger.board_time = state.time
+            state.total_wait += passenger.wait
+            boarded += 1
+        else:
+            refused += 1
+            keep.append(passenger)
+    state.waiting[state.floor] = keep
+    return boarded, refused
+
+
+def _elapse_waiting(state: ElevatorState) -> None:
+    """Advance time so newly-arrived passengers become eligible to board.
+
+    The discrete clock increments by one step; passengers whose arrive_time is
+    now in the past are visible in the waiting queues. No per-passenger counter
+    is needed because ``wait`` derives from board_time - arrive_time.
+    """
+
+
+def format_state(state: ElevatorState) -> str:
+    """Render the state as a compact prompt fragment for the model."""
+
+    riding = [p.dest for p in state.passengers if p.board_time is not None and p.deliver_time is None]
+    waiting_counts = [
+        sum(1 for p in q if p.arrive_time <= state.time) for q in (state.waiting.get(i, []) for i in range(state.floors))
+    ]
+    direction_label = {1: "up", -1: "down", 0: "idle"}[state.direction]
+    door_label = "OPEN" if state.door_open else "CLOSED"
+    return (
+        f"floor={state.floor}/{state.floors - 1} dir={direction_label} door={door_label} "
+        f"cab=[{','.join(str(d) for d in riding) or 'empty'}] cab_load={len(riding)}/{state.capacity} "
+        f"waiting=[{','.join(str(c) for c in waiting_counts)}] "
+        f"delivered={state.delivered}/{state.total_passengers()} "
+        f"time={state.time}/{state.horizon}"
+    )
+
+
+def make_prompt(record: dict[str, Any]) -> str:
+    """Build the initial user prompt describing the scenario."""
+
+    floors = int(record.get("floors", DEFAULT_FLOORS))
+    capacity = int(record.get("capacity", DEFAULT_CAPACITY))
+    horizon = int(record.get("horizon", DEFAULT_HORIZON))
+    passengers = record.get("passengers", [])
+    scenario = str(record.get("scenario", "mixed"))
+    lines = [
+        f"Run an elevator with {floors} floors (0..{floors - 1}), cab capacity {capacity}, "
+        f"and {horizon} discrete time steps.",
+        f"Scenario: {scenario}.",
+        f"{len(passengers)} passengers need to be delivered to their destinations.",
+        "",
+        "On each turn call exactly one tool: move (door must be closed), open_door, close_door, or done.",
+        "- move(direction): travel one floor; door must be closed.",
+        "- open_door: alight riders whose dest is the current floor, board waiting passengers up to capacity.",
+        "- close_door: required before moving.",
+        "- done: end the episode once you believe the job is finished.",
+        "Maximize delivered passengers, minimize waiting, and avoid invalid actions.",
+    ]
+    return "\n".join(lines)
+
+
+def state_to_dict(state: ElevatorState) -> dict[str, Any]:
+    """Serialize state for JSON fixtures and tests."""
+
+    data = asdict(state)
+    # waiting dict uses int keys that JSON converts to str; normalize for round-trip
+    data["waiting"] = {str(k): [asdict(p) for p in v] for k, v in state.waiting.items()}
+    data["passengers"] = [asdict(p) for p in state.passengers]
+    return data
+
+
+def parse_action(response_message: Any) -> dict[str, Any] | None:
+    """Extract the first actionable tool call from a model response message.
+
+    Accepts either a raw OpenAI-style message object or a dict produced by
+    ``_assistant_message`` helpers. Returns ``{"name": ..., **args}`` or None.
+    """
+
+    calls = _extract_tool_calls(response_message)
+    if not calls:
+        return None
+    call = calls[0]
+    name = call.get("function", {}).get("name") or call.get("name")
+    raw_args = call.get("function", {}).get("arguments") or call.get("arguments") or "{}"
+    try:
+        args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+    except (json.JSONDecodeError, TypeError):
+        args = {}
+    if name is None:
+        return None
+    return {"name": name, **args}
+
+
+def _extract_tool_calls(message: Any) -> list[dict[str, Any]]:
+    """Normalize tool_calls from either an object or a dict."""
+
+    raw = getattr(message, "tool_calls", None)
+    if raw is None and isinstance(message, dict):
+        raw = message.get("tool_calls")
+    if not raw:
+        return []
+    out: list[dict[str, Any]] = []
+    for call in raw:
+        if isinstance(call, dict):
+            out.append(call)
+        else:
+            out.append(
+                {
+                    "id": getattr(call, "id", None),
+                    "type": getattr(call, "type", "function"),
+                    "function": {
+                        "name": call.function.name,
+                        "arguments": call.function.arguments,
+                    },
+                }
+            )
+    return out
+
+
+def fcfs_policy(state: ElevatorState) -> dict[str, Any]:
+    """First-come-first-served baseline action for comparison.
+
+    Greedily serves the earliest-arriving waiting passenger: move toward that
+    passenger's origin, open to board, move toward destination, open to alight.
+    Falls back to closing the door or ending when idle.
+    """
+
+    if is_terminal(state):
+        return {"name": "done"}
+    # close door if needed to move
+    if state.door_open:
+        riding = [p for p in state.passengers if p.board_time is not None and p.deliver_time is None]
+        needs_move = bool(riding) or _has_pending_target(state)
+        if needs_move:
+            return {"name": "close_door"}
+        # nothing to do; close then done
+        return {"name": "close_door"}
+    # pick the earliest waiting passenger or the earliest riding passenger destination
+    target = _fcfs_target(state)
+    if target is None:
+        return {"name": "done"}
+    if target == state.floor:
+        return {"name": "open_door"}
+    direction = 1 if target > state.floor else -1
+    return {"name": "move", "direction": direction}
+
+
+def _has_pending_target(state: ElevatorState) -> bool:
+    riding = [p for p in state.passengers if p.board_time is not None and p.deliver_time is None]
+    if riding:
+        return True
+    for queue in state.waiting.values():
+        if any(p.arrive_time <= state.time for p in queue):
+            return True
+    return False
+
+
+def _fcfs_target(state: ElevatorState) -> int | None:
+    """Return the next target floor for the FCFS policy."""
+
+    riding = [p for p in state.passengers if p.board_time is not None and p.deliver_time is None]
+    eligible_waiters = [
+        p
+        for queue in state.waiting.values()
+        for p in queue
+        if p.arrive_time <= state.time and p.board_time is None
+    ]
+    if not riding and not eligible_waiters:
+        return None
+    # if riding, go to the earliest boarded passenger's destination
+    if riding:
+        earliest = min(riding, key=lambda p: p.board_time if p.board_time is not None else 0)
+        return earliest.dest
+    earliest = min(eligible_waiters, key=lambda p: p.arrive_time)
+    return earliest.origin
+
+
+def run_fcfs_episode(record: dict[str, Any]) -> dict[str, Any]:
+    """Run a full episode under FCFS and return summary metrics."""
+
+    state = build_state(record)
+    steps_taken = 0
+    while not is_terminal(state) and steps_taken <= state.horizon + 2:
+        action = fcfs_policy(state)
+        if action["name"] == "done":
+            break
+        step(state, action)
+        steps_taken += 1
+    return episode_metrics(state)
+
+
+def episode_metrics(state: ElevatorState) -> dict[str, Any]:
+    """Compute comparable metrics for an episode."""
+
+    total = state.total_passengers()
+    mean_wait = state.total_wait / max(total, 1)
+    return {
+        "delivered": state.delivered,
+        "total_passengers": total,
+        "total_wait": state.total_wait,
+        "mean_wait": mean_wait,
+        "invalid_actions": state.invalid_actions,
+        "overload_refused": state.overload_refused,
+        "time": state.time,
+        "horizon": state.horizon,
+        "scenario": state.scenario,
+    }

--- a/examples/agentic/elevator/reward.py
+++ b/examples/agentic/elevator/reward.py
@@ -1,0 +1,69 @@
+"""Reward function for the elevator dispatch agentic example.
+
+The reward replays the agent's ``tool_calls`` against the deterministic
+``game.build_state`` environment to recover episode metrics, then combines
+delivered passengers, normalized waiting time, and invalid-action penalty.
+This mirrors how DuelGrid/Codebreaker derive outcome scores from trajectories.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+# reward weights (kept module-level so tests and tuning scripts can read them)
+DELIVER_WEIGHT = 1.0
+WAIT_WEIGHT = 0.3
+INVALID_WEIGHT = 0.5
+
+
+def reward_fn(record: Any) -> float:
+    """Score one elevator episode: delivery rate minus waiting and invalid penalties."""
+
+    source = dict(record.source_record)
+    state = game.build_state(source)
+    actions = _tool_actions(record)
+    for action in actions:
+        if game.is_terminal(state):
+            break
+        game.step(state, action)
+    metrics = game.episode_metrics(state)
+    return _score(metrics)
+
+
+def _score(metrics: dict[str, Any]) -> float:
+    """Map episode metrics to a scalar reward in roughly [-1, 1]."""
+
+    total = max(metrics["total_passengers"], 1)
+    delivery_rate = metrics["delivered"] / total
+    wait_norm = metrics["mean_wait"] / max(metrics["horizon"], 1)
+    invalid_rate = metrics["invalid_actions"] / total
+    return DELIVER_WEIGHT * delivery_rate - WAIT_WEIGHT * wait_norm - INVALID_WEIGHT * invalid_rate
+
+
+def _tool_actions(record: Any) -> list[dict[str, Any]]:
+    """Extract ordered elevator actions from the trajectory's tool calls."""
+
+    actions: list[dict[str, Any]] = []
+    for call in record.tool_calls:
+        name = call.get("name") if isinstance(call, dict) else None
+        if name not in ("move", "open_door", "close_door", "done"):
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                # malformed arguments -> treat as an invalid action that errors out
+                actions.append({"name": name, "direction": None} if name == "move" else {"name": name})
+                continue
+        if not isinstance(arguments, dict):
+            arguments = {}
+        action = {"name": name, **arguments}
+        actions.append(action)
+    return actions

--- a/examples/agentic/elevator/run_agent.py
+++ b/examples/agentic/elevator/run_agent.py
@@ -1,0 +1,135 @@
+"""Bounded multi-turn agent loop for elevator dispatch rollouts.
+
+Each sample is one elevator episode. The agent calls move/open_door/close_door
+each turn; the deterministic environment advances and the new state is fed back
+as a tool result. The loop ends on a ``done`` tool, a terminal state, or the
+horizon cap. No external services are used: the environment runs in-process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import game  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+SYSTEM_PROMPT = (
+    "You are an elevator dispatcher. On every turn call exactly one tool: "
+    "move, open_door, close_door, or done. Move one floor at a time with the door closed. "
+    "Open the door at a floor to alight riders whose destination is the current floor and "
+    "to board waiting passengers up to capacity. Minimize waiting time, maximize delivered "
+    "passengers, and never call a tool when the door is already in the requested state."
+)
+
+
+async def run_agent(ctx, batch):
+    """Run bounded concurrent elevator episodes, preserving exact model outputs."""
+
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "The elevator agentic example requires `openai` and `httpx`. Install them with `pip install openai`."
+        ) from exc
+
+    items = list(batch.iter_samples())
+    logger.info("Elevator agent start episodes=%d max_running_prompts=%d", len(items), ctx.max_running_prompts)
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=httpx.Timeout(900.0, connect=30.0),
+    )
+    client = AsyncOpenAI(base_url=ctx.get_base_url(), api_key=ctx.api_key, http_client=http_client, max_retries=0)
+    try:
+        grouped = await asyncio.gather(*(_run_episode(item, client) for item in items))
+        return AgentTrajectory(turns=[turn for episode in grouped for turn in episode])
+    finally:
+        await client.close()
+
+
+async def _run_episode(item, client) -> list[AgentTrajectoryTurn]:
+    """Drive one episode until done, terminal, or horizon exhaustion."""
+
+    state = game.build_state(item.record)
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": f"{item.prompt}\n\nCurrent state: {game.format_state(state)}"},
+    ]
+    turns: list[AgentTrajectoryTurn] = []
+    # hard cap slightly beyond horizon so a stuck agent still terminates
+    max_steps = state.horizon + 2
+    for _ in range(max_steps):
+        if game.is_terminal(state):
+            break
+        turn_messages = [*messages, {"role": "user", "content": "Pick the next action by calling one tool."}]
+        response = await client.chat.completions.create(
+            model="policy",
+            messages=turn_messages,
+            tools=game.TOOLS,
+            tool_choice="auto",
+            stream=False,
+        )
+        turns.append(
+            AgentTrajectoryTurn(
+                item=item,
+                messages=turn_messages,
+                response=response,
+                tools=game.TOOLS,
+                tool_choice="auto",
+            )
+        )
+        assistant_message = _assistant_message(response)
+        action = game.parse_action(assistant_message)
+        if action is None:
+            # model produced no usable tool call; record the turn and stop the episode
+            logger.warning("Elevator model returned no executable tool call; ending episode")
+            break
+        result = game.step(state, action)
+        messages.extend(_tool_messages(assistant_message, result))
+        if action["name"] == "done" or game.is_terminal(state):
+            break
+    return turns
+
+
+def _assistant_message(response) -> dict:
+    """Normalize the OpenAI response message into a serializable dict."""
+
+    message = response.choices[0].message
+    return {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": call.type,
+                "function": {"name": call.function.name, "arguments": call.function.arguments},
+            }
+            for call in (message.tool_calls or [])
+        ],
+    }
+
+
+def _tool_messages(assistant_message: dict, tool_result: dict) -> list[dict]:
+    """Append the assistant tool call and its environment result to the transcript."""
+
+    messages = [assistant_message]
+    for call in assistant_message.get("tool_calls") or []:
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call["id"],
+                "name": call["function"]["name"],
+                "content": json.dumps(tool_result, ensure_ascii=False),
+            }
+        )
+    return messages

--- a/tests/test_elevator_agentic_cpu.py
+++ b/tests/test_elevator_agentic_cpu.py
@@ -1,0 +1,188 @@
+"""CPU tests for the elevator run_agent loop (examples/agentic/elevator/run_agent.py).
+
+Uses a fake OpenAI client to verify the variable-length episode loop: natural
+termination on delivery, early stop on ``done``, horizon cap, graceful stop
+when the model emits no tool call, concurrent multi-episode dispatch, and that
+tool transcripts carry the environment state back into the message history.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "elevator"
+
+
+def _load_module(name: str):
+    """Load an elevator example module without importing the areno/torch stack."""
+
+    previous_game = sys.modules.pop("game", None)
+    previous_agentic = sys.modules.get("areno.api.agentic")
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    modname = f"agentic_elevator_{name}_for_tests"
+    try:
+        if name == "run_agent":
+            sys.modules["areno.api.agentic"] = SimpleNamespace(
+                AgentTrajectory=type("AgentTrajectory", (), {"__init__": lambda self, turns=None: setattr(self, "turns", turns or [])}),
+                AgentTrajectoryTurn=lambda **kwargs: SimpleNamespace(**kwargs),
+            )
+        spec = importlib.util.spec_from_file_location(modname, EXAMPLE_DIR / f"{name}.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        sys.modules.pop(modname, None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+        if name == "run_agent":
+            sys.modules.pop("areno.api.agentic", None)
+            if previous_agentic is not None:
+                sys.modules["areno.api.agentic"] = previous_agentic
+
+
+def _fake_response(name: str | None, args: dict | None = None, cid: int = 0):
+    """Build a fake OpenAI-style response carrying one tool call (or none)."""
+
+    if name is None:
+        message = SimpleNamespace(content="I have no action", tool_calls=[])
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    call = SimpleNamespace(
+        id=f"call-{cid}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=json.dumps(args or {})),
+    )
+    message = SimpleNamespace(content=None, tool_calls=[call])
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class FakeCompletions:
+    """Replays a scripted sequence of fake responses."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+        self.all_messages = []
+
+    async def create(self, **kwargs):
+        self.calls += 1
+        self.all_messages.append(kwargs["messages"])
+        if self.responses:
+            return self.responses.pop(0)
+        return _fake_response(None)
+
+
+def _fake_client(responses):
+    return SimpleNamespace(chat=SimpleNamespace(completions=FakeCompletions(responses)))
+
+
+def _item(record, prompt=None):
+    game = _load_module("game")
+    return SimpleNamespace(record=record, prompt=prompt or game.make_prompt(record))
+
+
+BASE = {"floors": 4, "capacity": 2, "horizon": 20, "scenario": "test",
+        "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}]}
+
+
+# [单测用例]测试场景：送达后自然终止，turn 数等于动作数
+def test_natural_termination_on_delivery_records_one_turn_per_action():
+    run_agent = _load_module("run_agent")
+    actions = [
+        _fake_response("open_door", cid=0),
+        _fake_response("close_door", cid=1),
+        _fake_response("move", {"direction": 1}, cid=2),
+        _fake_response("move", {"direction": 1}, cid=3),
+        _fake_response("open_door", cid=4),  # alight pid0 -> terminal
+    ]
+    client = _fake_client(actions)
+    turns = asyncio.run(run_agent._run_episode(_item(BASE), client))
+    assert len(turns) == 5
+    assert client.chat.completions.calls == 5
+
+
+# [单测用例]测试场景：done 动作提前结束
+def test_done_action_ends_episode_early():
+    run_agent = _load_module("run_agent")
+    actions = [_fake_response("open_door", cid=0), _fake_response("done", cid=1)]
+    client = _fake_client(actions)
+    turns = asyncio.run(run_agent._run_episode(_item(BASE), client))
+    assert len(turns) == 2
+
+
+# [单测用例]测试场景：horizon 上限防止无限循环
+def test_horizon_caps_episode_length():
+    run_agent = _load_module("run_agent")
+    base = {"floors": 3, "capacity": 1, "horizon": 3, "scenario": "terminate",
+            "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}]}
+    # keep moving legally to exhaust horizon
+    actions = [_fake_response("open_door", cid=0), _fake_response("close_door", cid=1)] + [
+        _fake_response("move", {"direction": 1}, cid=i) for i in range(2, 10)
+    ]
+    client = _fake_client(actions)
+    turns = asyncio.run(run_agent._run_episode(_item(base), client))
+    assert len(turns) <= base["horizon"] + 2
+
+
+# [单测用例]测试场景：模型无 tool call 时优雅停止并记录 1 个 turn
+def test_no_tool_call_stops_gracefully_with_one_turn():
+    run_agent = _load_module("run_agent")
+    actions = [_fake_response(None)]  # no tool call
+    client = _fake_client(actions)
+    turns = asyncio.run(run_agent._run_episode(_item(BASE), client))
+    assert len(turns) == 1
+
+
+# [单测用例]测试场景：tool result 把环境状态回灌到消息历史
+def test_tool_result_feeds_state_back_into_messages():
+    run_agent = _load_module("run_agent")
+    actions = [_fake_response("open_door", cid=0), _fake_response("done", cid=1)]
+    client = _fake_client(actions)
+    asyncio.run(run_agent._run_episode(_item(BASE), client))
+    # second create() call's messages should contain a tool message with state
+    second_messages = client.chat.completions.all_messages[1]
+    tool_msgs = [m for m in second_messages if isinstance(m, dict) and m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    payload = json.loads(tool_msgs[0]["content"])
+    assert "state" in payload
+    assert "floor=0" in payload["state"]
+
+
+# [单测用例]测试场景：多个 episode 并发执行
+def test_concurrent_episodes_dispatch_via_run_agent():
+    run_agent = _load_module("run_agent")
+    base2 = {"floors": 3, "capacity": 1, "horizon": 10, "scenario": "test",
+             "passengers": [{"pid": 0, "origin": 0, "dest": 1, "arrive_time": 0}]}
+
+    async def run_both():
+        c1 = _fake_client([_fake_response("open_door", cid=0), _fake_response("done", cid=1)])
+        c2 = _fake_client([_fake_response("open_door", cid=0), _fake_response("done", cid=1)])
+        grouped = await asyncio.gather(
+            run_agent._run_episode(_item(BASE), c1),
+            run_agent._run_episode(_item(base2), c2),
+        )
+        # AgentTrajectory was imported into run_agent's namespace while the stub was active
+        return run_agent.AgentTrajectory(turns=[t for ep in grouped for t in ep])
+
+    traj = asyncio.run(run_both())
+    assert len(traj.turns) == 4
+
+
+# [单测用例]测试场景：turn 携带 response/tools/tool_choice 字段
+def test_turn_preserves_response_tools_and_tool_choice():
+    run_agent = _load_module("run_agent")
+    actions = [_fake_response("open_door", cid=0), _fake_response("done", cid=1)]
+    client = _fake_client(actions)
+    turns = asyncio.run(run_agent._run_episode(_item(BASE), client))
+    first = turns[0]
+    assert hasattr(first, "response")
+    assert hasattr(first, "tools")
+    assert first.tool_choice == "auto"

--- a/tests/test_elevator_fcfs_baseline_cpu.py
+++ b/tests/test_elevator_fcfs_baseline_cpu.py
@@ -1,0 +1,129 @@
+"""CPU tests for the FCFS baseline runner (examples/agentic/elevator/fcfs_baseline.py).
+
+Asserts emitted metric fields and error messages rather than exit status only:
+delivery rate bounds, overload refusal on overload scenarios, no invalid actions
+on empty-door scenarios, low delivery on terminate scenarios, aggregation by
+scenario, and JSON/human-readable output modes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "elevator"
+
+
+def _load_module(name: str):
+    """Load an elevator example module without importing the areno/torch stack."""
+
+    previous_game = sys.modules.pop("game", None)
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    modname = f"agentic_elevator_{name}_for_tests"
+    try:
+        spec = importlib.util.spec_from_file_location(modname, EXAMPLE_DIR / f"{name}.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        sys.modules.pop(modname, None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+
+
+# [单测用例]测试场景：聚合指标字段齐全且 delivery_rate 在 [0,1]
+def test_aggregate_metrics_contain_all_required_fields():
+    fcfs = _load_module("fcfs_baseline")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=20, seed=2026, scenario="mixed")
+    metrics = fcfs.run_dataset(records)
+    for field in ("episodes", "total_delivered", "total_passengers", "delivery_rate",
+                  "mean_wait_per_passenger", "total_invalid_actions", "total_overload_refused", "by_scenario"):
+        assert field in metrics, f"missing field {field}"
+    assert metrics["episodes"] == 20
+    assert 0.0 <= metrics["delivery_rate"] <= 1.0
+    assert metrics["total_passengers"] >= metrics["total_delivered"]
+
+
+# [单测用例]测试场景：overload 场景产生 overload_refused > 0
+def test_overload_scenario_produces_refused_boardings():
+    fcfs = _load_module("fcfs_baseline")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=8, seed=2026, scenario="overload")
+    metrics = fcfs.run_dataset(records)
+    assert metrics["total_overload_refused"] > 0, "overload scenario should refuse boardings"
+
+
+# [单测用例]测试场景：empty_door 场景 FCFS 不产生非法动作
+def test_empty_door_scenario_produces_no_invalid_actions():
+    fcfs = _load_module("fcfs_baseline")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=8, seed=2026, scenario="empty_door")
+    metrics = fcfs.run_dataset(records)
+    assert metrics["total_invalid_actions"] == 0, f"FCFS knows door state, got {metrics['total_invalid_actions']}"
+
+
+# [单测用例]测试场景：terminate 场景 delivery_rate < 1
+def test_terminate_scenario_does_not_deliver_all():
+    fcfs = _load_module("fcfs_baseline")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=8, seed=2026, scenario="terminate")
+    metrics = fcfs.run_dataset(records)
+    assert metrics["delivery_rate"] < 1.0, "terminate horizon too short to deliver everyone"
+
+
+# [单测用例]测试场景：by_scenario 分组覆盖所有场景名
+def test_by_scenario_groups_per_scenario_metrics():
+    fcfs = _load_module("fcfs_baseline")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=30, seed=2026, scenario="mixed")
+    metrics = fcfs.run_dataset(records)
+    by = metrics["by_scenario"]
+    assert isinstance(by, dict)
+    for name, m in by.items():
+        assert "episodes" in m and "delivery_rate" in m and "mean_wait_per_passenger" in m
+        assert "invalid_actions" in m and "overload_refused" in m
+
+
+# [单测用例]测试场景：空记录返回 episodes=0
+def test_empty_records_return_zero_episodes():
+    fcfs = _load_module("fcfs_baseline")
+    metrics = fcfs.run_dataset([])
+    assert metrics == {"episodes": 0}
+
+
+# [单测用例]测试场景：_format_report 输出含关键字段
+def test_format_report_contains_key_fields():
+    fcfs = _load_module("fcfs_baseline")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=10, seed=2026, scenario="mixed")
+    metrics = fcfs.run_dataset(records)
+    report = fcfs._format_report(metrics)
+    assert "Elevator FCFS baseline" in report
+    assert "delivery_rate" in report
+    assert "by_scenario" in report
+
+
+# [单测用例]测试场景：_load_records 默认 fallback 到 generator
+def test_load_records_defaults_to_generator_when_no_path():
+    fcfs = _load_module("fcfs_baseline")
+    records = fcfs._load_records(None)
+    assert len(records) > 0
+    assert all("passengers" in r for r in records)
+
+
+# [单测用例]测试场景：_load_records 对不存在文件抛 FileNotFoundError
+def test_load_records_raises_on_missing_file(tmp_path):
+    fcfs = _load_module("fcfs_baseline")
+    missing = tmp_path / "nope.jsonl"
+    with pytest.raises(FileNotFoundError):
+        fcfs._load_records(str(missing))

--- a/tests/test_elevator_game_cpu.py
+++ b/tests/test_elevator_game_cpu.py
@@ -1,0 +1,275 @@
+"""CPU tests for the elevator dispatch environment core (examples/agentic/elevator/game.py).
+
+Covers legal state transitions, invalid actions, overload refusal, empty-door
+invalid actions, termination by horizon, done action, FCFS baseline, and
+deterministic state serialization. No GPU, network, or external services.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "elevator"
+
+
+def _load_game():
+    """Load the elevator game module without importing the areno package."""
+
+    previous_game = sys.modules.pop("game", None)
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    modname = "agentic_elevator_game_for_tests"
+    try:
+        spec = importlib.util.spec_from_file_location(modname, EXAMPLE_DIR / "game.py")
+        module = importlib.util.module_from_spec(spec)
+        # register before exec so dataclass decorators can resolve __module__
+        sys.modules[modname] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        sys.modules.pop(modname, None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+
+
+# [单测用例]测试场景：合法路径顺路接送 + 非法动作门未关时移动
+def test_legal_path_delivers_two_passengers_and_rejects_move_with_door_open():
+    game = _load_game()
+    record = {
+        "floors": 4,
+        "capacity": 2,
+        "horizon": 20,
+        "scenario": "test",
+        "passengers": [
+            {"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0},
+            {"pid": 1, "origin": 1, "dest": 3, "arrive_time": 0},
+        ],
+    }
+    state = game.build_state(record)
+    assert state.total_passengers() == 2
+    assert state.floor == 0 and not state.door_open
+
+    game.step(state, {"name": "open_door"})  # board pid0
+    assert state.total_passengers() == 2  # total does not shrink on board
+    # move while door open is invalid
+    result = game.step(state, {"name": "move", "direction": 1})
+    assert result["invalid"] is True
+    assert result["error"] == "cannot move while door is open"
+    assert state.invalid_actions == 1
+    assert state.floor == 0  # unchanged
+
+    game.step(state, {"name": "close_door"})
+    game.step(state, {"name": "move", "direction": 1})  # floor 1
+    assert state.floor == 1
+    result = game.step(state, {"name": "open_door"})  # board pid1
+    assert result["boarded"] == 1
+    game.step(state, {"name": "close_door"})
+    game.step(state, {"name": "move", "direction": 1})  # floor 2
+    result = game.step(state, {"name": "open_door"})  # alight pid0 (dest=2)
+    assert result["alighted"] == 1
+    assert state.delivered == 1
+    game.step(state, {"name": "close_door"})
+    game.step(state, {"name": "move", "direction": 1})  # floor 3
+    game.step(state, {"name": "open_door"})  # alight pid1 (dest=3)
+    assert state.delivered == 2
+    assert game.is_terminal(state)
+
+
+# [单测用例]测试场景：过载防护，capacity 严格小于同时刻候梯人数
+def test_overload_refuses_boarding_beyond_capacity():
+    game = _load_game()
+    record = {
+        "floors": 3,
+        "capacity": 1,
+        "horizon": 30,
+        "scenario": "overload",
+        "passengers": [{"pid": i, "origin": 0, "dest": 2, "arrive_time": 0} for i in range(3)],
+    }
+    state = game.build_state(record)
+    result = game.step(state, {"name": "open_door"})
+    assert result["boarded"] == 1
+    assert result["refused"] == 2
+    assert state.overload_refused == 2
+    assert state.delivered == 0
+
+
+# [单测用例]测试场景：空门操作，door 已开时 open 非法、已关时 close 非法
+def test_empty_door_state_rejects_redundant_open_and_close():
+    game = _load_game()
+    record = {
+        "floors": 3,
+        "capacity": 2,
+        "horizon": 10,
+        "door_open": True,
+        "scenario": "empty_door",
+        "passengers": [{"pid": 0, "origin": 0, "dest": 1, "arrive_time": 0}],
+    }
+    state = game.build_state(record)
+    assert state.door_open is True
+
+    # open while already open -> invalid
+    result = game.step(state, {"name": "open_door"})
+    assert result["invalid"] is True
+    assert state.invalid_actions == 1
+
+    # close, then close again -> invalid
+    game.step(state, {"name": "close_door"})
+    assert state.door_open is False
+    result = game.step(state, {"name": "close_door"})
+    assert result["invalid"] is True
+    assert result["error"] == "door already closed"
+    assert state.invalid_actions == 2
+
+
+# [单测用例]测试场景：terminate 终止条件，horizon 极短强制结束
+def test_horizon_termination_bounds_episode_length():
+    game = _load_game()
+    record = {
+        "floors": 3,
+        "capacity": 1,
+        "horizon": 2,
+        "scenario": "terminate",
+        "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}],
+    }
+    state = game.build_state(record)
+    game.step(state, {"name": "open_door"})
+    assert not game.is_terminal(state)
+    game.step(state, {"name": "close_door"})
+    assert game.is_terminal(state)  # time reached horizon
+    metrics = game.episode_metrics(state)
+    assert metrics["time"] == 2
+    assert metrics["delivered"] == 0  # could not deliver within 2 steps
+
+
+# [单测用例]测试场景：done 动作主动终止
+def test_done_action_terminates_episode_immediately():
+    game = _load_game()
+    record = {
+        "floors": 3,
+        "capacity": 1,
+        "horizon": 10,
+        "scenario": "test",
+        "passengers": [{"pid": 0, "origin": 0, "dest": 1, "arrive_time": 0}],
+    }
+    state = game.build_state(record)
+    result = game.step(state, {"name": "done"})
+    assert result["done"] is True
+    assert state.terminated is True
+    assert game.is_terminal(state)
+
+
+# [单测用例]测试场景：越界移动非法
+def test_move_out_of_bounds_is_invalid():
+    game = _load_game()
+    state = game.build_state({"floors": 3, "capacity": 1, "horizon": 10,
+                              "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}]})
+    result = game.step(state, {"name": "move", "direction": -1})  # floor 0 -> -1
+    assert result["invalid"] is True
+    assert "out of range" in result["error"]
+    assert state.invalid_actions == 1
+    assert state.floor == 0
+
+
+# [单测用例]测试场景：未知动作非法
+def test_unknown_action_is_invalid():
+    game = _load_game()
+    state = game.build_state({"floors": 3, "capacity": 1, "horizon": 10,
+                              "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}]})
+    result = game.step(state, {"name": "fly"})
+    assert result["invalid"] is True
+    assert "unknown action" in result["error"]
+
+
+# [单测用例]测试场景：配置校验拒绝非法 floors/capacity/horizon
+def test_validate_config_rejects_invalid_values():
+    game = _load_game()
+    with pytest.raises(ValueError, match="floors"):
+        game.validate_config(floors=1, capacity=1, horizon=10)
+    with pytest.raises(ValueError, match="capacity"):
+        game.validate_config(floors=3, capacity=0, horizon=10)
+    with pytest.raises(ValueError, match="horizon"):
+        game.validate_config(floors=3, capacity=1, horizon=0)
+
+
+# [单测用例]测试场景：build_state 拒绝 origin==dest 与越界乘客
+def test_build_state_rejects_bad_passengers():
+    game = _load_game()
+    with pytest.raises(ValueError, match="origin equals dest"):
+        game.build_state({"floors": 3, "capacity": 1, "horizon": 5,
+                          "passengers": [{"pid": 0, "origin": 1, "dest": 1, "arrive_time": 0}]})
+    with pytest.raises(ValueError, match="out of range"):
+        game.build_state({"floors": 3, "capacity": 1, "horizon": 5,
+                          "passengers": [{"pid": 0, "origin": 5, "dest": 0, "arrive_time": 0}]})
+
+
+# [单测用例]测试场景：FCFS 基线在简单场景送达所有乘客
+def test_fcfs_baseline_delivers_all_on_simple_record():
+    game = _load_game()
+    record = {
+        "floors": 4,
+        "capacity": 2,
+        "horizon": 20,
+        "scenario": "test",
+        "passengers": [
+            {"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0},
+            {"pid": 1, "origin": 1, "dest": 3, "arrive_time": 0},
+        ],
+    }
+    metrics = game.run_fcfs_episode(record)
+    assert metrics["delivered"] == 2
+    assert metrics["total_passengers"] == 2
+    assert metrics["invalid_actions"] == 0
+    assert metrics["mean_wait"] >= 0
+
+
+# [单测用例]测试场景：format_state 输出含关键字段且可读
+def test_format_state_contains_key_fields():
+    game = _load_game()
+    state = game.build_state({"floors": 4, "capacity": 2, "horizon": 20,
+                              "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}]})
+    text = game.format_state(state)
+    assert "floor=0/3" in text
+    assert "door=CLOSED" in text
+    assert "delivered=0/1" in text
+    assert "time=0/20" in text
+
+
+# [单测用例]测试场景：parse_action 从 OpenAI 消息对象提取动作
+def test_parse_action_extracts_first_tool_call_from_message():
+    game = _load_game()
+    message = SimpleNamespace(
+        tool_calls=[
+            SimpleNamespace(
+                id="c1",
+                type="function",
+                function=SimpleNamespace(name="move", arguments='{"direction": 1}'),
+            )
+        ]
+    )
+    action = game.parse_action(message)
+    assert action == {"name": "move", "direction": 1}
+
+    # empty tool calls -> None
+    assert game.parse_action(SimpleNamespace(tool_calls=[])) is None
+    assert game.parse_action(SimpleNamespace(tool_calls=None)) is None
+
+
+# [单测用例]测试场景：parse_action 容忍非法 JSON 参数
+def test_parse_action_tolerates_malformed_arguments():
+    game = _load_game()
+    message = SimpleNamespace(
+        tool_calls=[
+            SimpleNamespace(id="c1", type="function",
+                            function=SimpleNamespace(name="move", arguments="{bad json"))
+        ]
+    )
+    action = game.parse_action(message)
+    assert action["name"] == "move"  # args default to {}
+    assert action.get("direction") is None

--- a/tests/test_elevator_reward_cpu.py
+++ b/tests/test_elevator_reward_cpu.py
@@ -1,0 +1,156 @@
+"""CPU tests for the elevator reward function (examples/agentic/elevator/reward.py).
+
+Asserts reward fields and monotonicity: more delivered -> higher reward,
+invalid actions penalty, waiting penalty, malformed arguments safety, and
+boundary protection when total_passengers is zero.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "elevator"
+
+
+def _load_module(name: str):
+    """Load an elevator example module without importing the areno package."""
+
+    previous_game = sys.modules.pop("game", None)
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    modname = f"agentic_elevator_{name}_for_tests"
+    try:
+        spec = importlib.util.spec_from_file_location(modname, EXAMPLE_DIR / f"{name}.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        sys.modules.pop(modname, None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+
+
+def _record(source: dict, tool_calls: list[dict]) -> SimpleNamespace:
+    """Build a fake reward record with source_record and aggregated tool_calls."""
+
+    return SimpleNamespace(source_record=source, tool_calls=tool_calls)
+
+
+def _call(name: str, args: dict | None = None) -> dict:
+    return {"name": name, "arguments": json.dumps(args or {})}
+
+
+BASE_SOURCE = {
+    "floors": 4,
+    "capacity": 2,
+    "horizon": 20,
+    "scenario": "test",
+    "passengers": [
+        {"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0},
+        {"pid": 1, "origin": 1, "dest": 3, "arrive_time": 0},
+    ],
+}
+
+
+# [单测用例]测试场景：完美路径 reward 高于半完成高于无动作
+def test_reward_monotonic_in_delivered_passengers():
+    reward = _load_module("reward")
+
+    perfect_calls = [
+        _call("open_door"), _call("close_door"), _call("move", {"direction": 1}),
+        _call("open_door"), _call("close_door"), _call("move", {"direction": 1}),
+        _call("open_door"), _call("close_door"), _call("move", {"direction": 1}),
+        _call("open_door"),
+    ]
+    half_calls = [
+        _call("open_door"), _call("close_door"), _call("move", {"direction": 1}),
+        _call("move", {"direction": 1}), _call("open_door"), _call("close_door"),
+    ]
+    r_perfect = reward.reward_fn(_record(BASE_SOURCE, perfect_calls))
+    r_half = reward.reward_fn(_record(BASE_SOURCE, half_calls))
+    r_empty = reward.reward_fn(_record(BASE_SOURCE, []))
+
+    assert r_empty < r_half < r_perfect, (r_empty, r_half, r_perfect)
+
+
+# [单测用例]测试场景：非法动作降低 reward (门开时多次 move)
+def test_invalid_actions_lower_reward():
+    reward = _load_module("reward")
+
+    bad_calls = [_call("open_door")] + [_call("move", {"direction": 1}) for _ in range(10)]
+    r_bad = reward.reward_fn(_record(BASE_SOURCE, bad_calls))
+    r_empty = reward.reward_fn(_record(BASE_SOURCE, []))
+    assert r_bad < r_empty, (r_bad, r_empty)
+
+
+# [单测用例]测试场景：等待惩罚生效 (故意绕路增加等待)
+def test_waiting_penalty_reduces_reward():
+    reward = _load_module("reward")
+
+    # direct delivery
+    direct = [_call("open_door"), _call("close_door"), _call("move", {"direction": 1}), _call("open_door")]
+    source_one = {"floors": 3, "capacity": 1, "horizon": 20, "scenario": "test",
+                  "passengers": [{"pid": 0, "origin": 0, "dest": 1, "arrive_time": 0}]}
+    r_direct = reward.reward_fn(_record(source_one, direct))
+    # detour: move up then down past destination
+    detour = [_call("open_door"), _call("close_door"), _call("move", {"direction": 1}),
+              _call("move", {"direction": -1}), _call("open_door")]
+    r_detour = reward.reward_fn(_record(source_one, detour))
+    assert r_detour < r_direct, (r_detour, r_direct)
+
+
+# [单测用例]测试场景：0 乘客边界不产生 NaN
+def test_zero_passengers_does_not_crash_or_nan():
+    reward = _load_module("reward")
+    safe = reward._score({"delivered": 0, "total_passengers": 0, "mean_wait": 0.0,
+                          "invalid_actions": 0, "horizon": 1})
+    assert not math.isnan(safe)
+    assert safe == 0.0
+
+
+# [单测用例]测试场景：malformed JSON 参数被当作非法动作处理不崩溃
+def test_malformed_arguments_are_treated_as_invalid_and_do_not_crash():
+    reward = _load_module("reward")
+    calls = [
+        {"name": "move", "arguments": "{bad json"},
+        {"name": "open_door", "arguments": "{}"},
+    ]
+    r = reward.reward_fn(_record(BASE_SOURCE, calls))
+    assert isinstance(r, float)
+
+
+# [单测用例]测试场景：done 动作不影响 reward 计算 (提前结束视为当前状态)
+def test_done_action_produces_reward_for_current_state():
+    reward = _load_module("reward")
+    calls = [_call("open_door"), _call("done")]
+    r = reward.reward_fn(_record(BASE_SOURCE, calls))
+    # one passenger boarded, none delivered -> reward should be negative-ish (invalid default 0, delivery 0)
+    assert r < 0.01  # no delivery, small wait penalty
+
+
+# [单测用例]测试场景：reward 与 episode_metrics 字段对齐
+def test_score_uses_all_metric_fields():
+    reward = _load_module("reward")
+    metrics = {"delivered": 1, "total_passengers": 2, "mean_wait": 2.0,
+               "invalid_actions": 0, "horizon": 10}
+    expected = 1.0 * (1 / 2) - 0.3 * (2.0 / 10) - 0.5 * 0
+    assert abs(reward._score(metrics) - expected) < 1e-9
+
+
+# [单测用例]测试场景：非电梯工具名被忽略不进入动作序列
+def test_non_elevator_tool_calls_are_ignored():
+    reward = _load_module("reward")
+    calls = [_call("guess_code", {"code": "1234"}), _call("open_door"), _call("done")]
+    # only open_door + done count; no delivery
+    r = reward.reward_fn(_record(BASE_SOURCE, calls))
+    assert isinstance(r, float)

--- a/tests/test_elevator_scenarios_cpu.py
+++ b/tests/test_elevator_scenarios_cpu.py
@@ -1,0 +1,162 @@
+"""CPU tests for elevator scenario fixtures crossing game/loader/reward/baseline.
+
+Integration-style tests that run each of the five acceptance scenarios
+(overload, empty_door, concurrent, peak, terminate) through the full pipeline:
+generator -> loader -> game environment -> reward, asserting scenario-specific
+observable fields rather than exit status. Also verifies default behavior is
+unchanged when the feature is not exercised (plain records still load).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "elevator"
+
+
+def _load_module(name: str):
+    """Load an elevator example module without importing the areno/torch stack."""
+
+    previous_game = sys.modules.pop("game", None)
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    modname = f"agentic_elevator_{name}_for_tests"
+    try:
+        spec = importlib.util.spec_from_file_location(modname, EXAMPLE_DIR / f"{name}.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[modname] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        sys.modules.pop(modname, None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+
+
+def _default_loader(rows):
+    def _load(_path):
+        for row in rows:
+            yield row
+    return _load
+
+
+# [单测用例]测试场景：overload fixture 产生 overload_refused > 0
+def test_overload_fixture_refuses_boarding_beyond_capacity():
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=6, seed=2026, scenario="overload")
+    assert all(r["scenario"] == "overload" for r in records)
+    # capacity is 1 but each record has >=4 passengers; opening at the busiest
+    # floor must refuse at least one boarding.
+    refused_seen = False
+    for record in records:
+        state = game.build_state(record)
+        # move to the first floor that has waiting passengers, then open
+        target = next(f for f in range(state.floors) if any(p.arrive_time <= state.time for p in state.waiting.get(f, [])))
+        while state.floor != target:
+            if state.door_open:
+                game.step(state, {"name": "close_door"})
+            direction = 1 if target > state.floor else -1
+            game.step(state, {"name": "move", "direction": direction})
+        result = game.step(state, {"name": "open_door"})
+        if result["refused"] > 0:
+            refused_seen = True
+        assert state.overload_refused >= 0
+    assert refused_seen, "overload fixtures must produce at least one refused boarding"
+
+
+# [单测用例]测试场景：empty_door fixture 起始门开，open 立即非法
+def test_empty_door_fixture_starts_with_open_door():
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=4, seed=2026, scenario="empty_door")
+    for record in records:
+        assert record["door_open"] is True
+        state = game.build_state(record)
+        assert state.door_open is True
+        result = game.step(state, {"name": "open_door"})
+        assert result["invalid"] is True
+
+
+# [单测用例]测试场景：concurrent fixture 多层同时刻到达
+def test_concurrent_fixture_has_multi_floor_simultaneous_arrivals():
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=4, seed=2026, scenario="concurrent")
+    for record in records:
+        t0_origins = {p["origin"] for p in record["passengers"] if p["arrive_time"] == 0}
+        assert len(t0_origins) >= 2, "concurrent fixture should have >=2 floors with t=0 arrivals"
+
+
+# [单测用例]测试场景：peak fixture 长 horizon 高密度
+def test_peak_fixture_has_long_horizon_and_high_density():
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=4, seed=2026, scenario="peak")
+    for record in records:
+        assert record["horizon"] >= 64, "peak horizon should be long"
+        assert len(record["passengers"]) >= 8, "peak should have high passenger density"
+
+
+# [单测用例]测试场景：terminate fixture horizon 极短无法全送达
+def test_terminate_fixture_cannot_deliver_all_within_horizon():
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+    records = generator.generate_records(count=4, seed=2026, scenario="terminate")
+    for record in records:
+        assert record["horizon"] <= 4
+        metrics = game.run_fcfs_episode(record)
+        assert metrics["delivered"] < metrics["total_passengers"], "terminate should not deliver all"
+
+
+# [单测用例]测试场景：loader 接受 generator 全场景并构建 prompt
+def test_loader_accepts_all_scenarios_and_builds_prompts():
+    loader = _load_module("dataset_loader")
+    generator = _load_module("dataset_generator")
+    for scenario in generator.SCENARIOS:
+        rows = generator.generate_records(count=6, seed=2026, scenario=scenario)
+        records = loader.load_training_dataset("unused", default_loader=_default_loader(rows))
+        assert len(records) == 6
+        assert all("prompt" in r and "passengers" in r for r in records)
+
+
+# [单测用例]测试场景：reward 对全场景产出有限浮点
+def test_reward_produces_finite_float_across_scenarios():
+    import math
+    reward = _load_module("reward")
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+    for scenario in generator.SCENARIOS:
+        rows = generator.generate_records(count=4, seed=2026, scenario=scenario)
+        for source in rows:
+            # run a short FCFS episode to get plausible tool calls, then score
+            state = game.build_state(source)
+            actions = []
+            for _ in range(min(source["horizon"], 8)):
+                if game.is_terminal(state):
+                    break
+                action = game.fcfs_policy(state)
+                if action["name"] == "done":
+                    break
+                actions.append(action)
+                game.step(state, action)
+            calls = [{"name": a["name"], "arguments": json.dumps({k: v for k, v in a.items() if k != "name"})}
+                     for a in actions]
+            r = reward.reward_fn(SimpleNamespace(source_record=source, tool_calls=calls))
+            assert isinstance(r, float)
+            assert not math.isnan(r) and not math.isinf(r)
+
+
+# [单测用例]测试场景：默认行为不变——无 scenario 字段的记录仍可加载
+def test_default_behavior_unchanged_without_scenario_field():
+    loader = _load_module("dataset_loader")
+    rows = [{"floors": 3, "capacity": 1, "horizon": 10,
+             "passengers": [{"pid": 0, "origin": 0, "dest": 2, "arrive_time": 0}]}]
+    records = loader.load_training_dataset("unused", default_loader=_default_loader(rows))
+    assert records[0]["scenario"] == "mixed"  # default fills missing scenario
+    assert "prompt" in records[0]


### PR DESCRIPTION
- Deterministic single-cab elevator environment (game.py) with N-floor state machine, move/open_door/close_door actions, capacity limit refusal, empty-door invalid action rejection, horizon termination, done action.
- dataset_generator.py: 6 scenarios (overload/empty_door/concurrent/peak/terminate/mixed) emit deterministic JSONL from a fixed seed.
- dataset_loader.py: fail-fast schema validation, default scenario fill.
- reward.py: replay-based reward (+delivery -normalized wait -invalid penalty).
- run_agent.py: variable-length episode loop on AReno agentic API with three termination conditions (delivery / done / horizon).
- fcfs_baseline.py: FCFS policy runner with per-episode and aggregated metrics, by_scenario breakdown, JSON/human-readable output.
- README.md: quickstart, CLI options, output field reference, scenarios.
- 5 CPU test files (45 cases) under tests/, no GPU/torch/network needed.

<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?

Adds a focused, independently reviewable **elevator-dispatch agentic RL** demo targeting the acceptance areas in #195. It models a deterministic single-cab elevator environment on AReno's public agentic API; no external services, sandboxes, or databases are required.

**Files added** (all under `examples/agentic/elevator/`, tests under `tests/`):

| File | Role |
| --- | --- |
| `game.py` | Deterministic single-cab environment: state machine, `move`/`open_door`/`close_door`, capacity refusal, empty-door rejection, horizon termination, `done` |
| `dataset_generator.py` | 6 deterministic JSONL scenarios (overload/empty_door/concurrent/peak/terminate/mixed) from a fixed seed |
| `dataset_loader.py` | `load_training_dataset(...)` with fail-fast schema validation + default scenario fill |
| `reward.py` | Replay-based `reward_fn(record)`: `+delivery − normalized wait − invalid penalty` |
| `run_agent.py` | Variable-length episode loop on AReno agentic API; terminates on delivery / `done` / horizon |
| `fcfs_baseline.py` | FCFS policy runner with per-episode + aggregated metrics, `by_scenario` breakdown, JSON + human-readable output |
| `README.md` | Quickstart, CLI options, output field reference, scenario catalog |

**Acceptance areas (#195):**

| Area | Coverage |
| --- | --- |
| Overload protection | cab capacity limit refuses extra boarding |
| Empty-door invalid actions | `move` while door open is rejected |
| Concurrent requests | passengers waiting on multiple floors at `t0` |
| Peak traffic | high arrival density over long horizon |
| Termination | short horizons force early episode cutoff |

A First-Come-First-Served (FCFS) baseline is included so a trained agent can be compared against a hand-coded dispatcher on delivered passengers, mean waiting time, and illegal actions.

## Related issue

Fixes #195

## Type of change

- [x] ✨ New feature

## How was it tested?

Five CPU-only test files (45 cases total) were added and run on CPU only — no GPU, no torch, no network.

- [x] `pytest tests/test_elevator_game_cpu.py` — environment state machine (capacity refusal, empty-door rejection, horizon, `done`)
- [x] `pytest tests/test_elevator_scenarios_cpu.py` — deterministic JSONL scenarios for all 6 cases
- [x] `pytest tests/test_elevator_reward_cpu.py` — replay-based reward computation
- [x] `pytest tests/test_elevator_agentic_cpu.py` — agentic episode loop with three termination conditions
- [x] `pytest tests/test_elevator_fcfs_baseline_cpu.py` — FCFS baseline runner + metrics

Hardware: CPU only. No GPU / CUDA / torch / network access required.

Full run command:
```bash
pytest tests/ -k "elevator" -v
```
## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Review dimensions self-assessment

| Dimension | Conclusion | Evidence |
|---|---|---|
| Readability | Pass | `_step_move`/`_step_open`/`_step_close` private helpers use consistent naming; each `_xxx_record` generator function has a docstring stating the scenario's acceptance point; README contains input contract / scenarios / action tools / output fields tables |
| Reusability | Pass (one justified duplication) | `_random_passengers`/`_distinct_dest`/`_wrap` are shared across the 6 scenarios; `fcfs_baseline._load_records` and `dataset_loader.load_training_dataset` each implement JSONL reading independently — a justified duplication that keeps the baseline runner standalone (no dependency on AReno's `default_loader`) |
| Compatibility | Pass | `git diff --stat ea95ea2..HEAD` = 12 files, 2262 lines added, 0 existing files modified; `dataset_loader._normalize_record` uses `setdefault`/`.get(default)` for backward-compatible handling of legacy JSONL records with missing fields |
| Error handling | Pass | `validate_config`/`build_state` validate floors/capacity/horizon/passengers at entry, all `raise ValueError` carry record id; `reward._tool_actions` degrades malformed `json.JSONDecodeError` to `direction=None` so the env records an invalid action instead of crashing reward; locked by `test_malformed_arguments_are_treated_as_invalid_and_do_not_crash` |
| Performance | Pass | Single-episode step is O(passengers) with no nested loops; FCFS baseline on default 64 scenarios / 315 passengers runs in <0.5s; environment is pure in-memory, dataset is a one-shot JSONL stream read |
| Commit scope | Pass | `git diff --stat` touches only `examples/agentic/elevator/` + `tests/test_elevator_*.py`, no existing files modified, no formatting/import reordering bundled in |
| No unrelated changes | Pass | Matches "commit scope": 2262 insertions, 0 deletions, all 12 files land under the `elevator` namespace |


