### PR TITLE
feat(reward): identify slow reward hooks and samples (#242)

### DIFF
--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -29,6 +29,7 @@ class MetricsRecorder:
         self._writer = create_tensorboard_writer(log_dir)
         self._state_file = self._log_dir / f"dashboard_state.{os.getpid()}.json"
         self._sample_file = self._log_dir / f"rollout_samples.{os.getpid()}.jsonl"
+        self._reward_profile_file = self._log_dir / f"reward_profile.{os.getpid()}.jsonl"
         self._closed = False
 
     def record_train_step(self, *, step: int, train_result, train_batch, timings: dict[str, float] | None = None):
@@ -47,6 +48,21 @@ class MetricsRecorder:
         sample.setdefault("pid", os.getpid())
         with self._sample_file.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    def record_reward_profile(self, profile) -> None:
+        """Record per-sample reward timing to a jsonl artifact.
+
+        Each line contains only ``prompt_index``, ``sample_index``,
+        ``duration_s``, and ``timed_out`` — never the prompt or completion
+        text.
+        """
+
+        if profile is None:
+            return
+        for rec in profile.to_jsonl_records():
+            rec["pid"] = os.getpid()
+            with self._reward_profile_file.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(rec, ensure_ascii=False) + "\n")
 
     def record_dashboard_state(
         self,
@@ -213,7 +229,10 @@ def record_training_stats(writer, stats, step, train_res, train_batch, timings: 
 
     # Backend-supplied training metrics (loss, policy_loss, ratio_mean, ...).
     for key, value in train_res.items():
-        writer.add_scalar(f"train/{key}", value, step)
+        if key.startswith("reward_profile_"):
+            writer.add_scalar(f"timing/{key}", value, step)
+        else:
+            writer.add_scalar(f"train/{key}", value, step)
     metric_timings = timings or stats
     for key in ("rollout", "reward", "advantage", "train"):
         if key in metric_timings:

--- a/areno/api/reward_profiler.py
+++ b/areno/api/reward_profiler.py
@@ -1,0 +1,274 @@
+"""Per-sample reward profiling: timing, slow-sample flagging, per-batch timeout.
+
+`RewardProfiler` wraps a user-supplied ``reward_fn`` and measures each
+individual ``RewardRecord`` call, flags samples that exceed a configurable
+absolute threshold, and enforces an optional per-batch wall-clock timeout.
+
+When disabled (the default), ``score_batch`` degrades to a plain list
+comprehension with zero ``perf_counter`` or dict-allocation overhead.
+
+Thread-safety: when profiling is enabled and a ``batch_timeout_s`` is set,
+each sample is executed inside a ``ThreadPoolExecutor`` thread so the
+caller can enforce the timeout via ``future.result(timeout=...)``.  User
+``reward_fn`` implementations must therefore be thread-safe.  Pure
+computation reward functions (text parsing, scoring) are naturally safe;
+functions with side effects (file I/O, global-state mutation) must be
+made safe by the user.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from dataclasses import dataclass
+
+from areno.api.rewards import RewardRecord
+
+REWARD_HOOK_NAME = "reward_fn"
+
+
+class RewardTimeoutError(RuntimeError):
+    """Raised when per-batch wall-clock budget is exceeded.
+
+    Carries the hook name, the sample identifier that was executing when
+    the budget ran out, and the elapsed seconds so far.  The original
+    error (if the reward_fn itself raised) is preserved in ``__cause__``.
+    """
+
+    def __init__(
+        self,
+        hook: str,
+        prompt_index: int | None,
+        sample_index: int | None,
+        elapsed: float,
+    ) -> None:
+        self.hook = hook
+        self.prompt_index = prompt_index
+        self.sample_index = sample_index
+        self.elapsed = elapsed
+        super().__init__(
+            f"reward hook '{hook}' timed out after {elapsed:.4f}s "
+            f"at prompt_index={prompt_index} sample_index={sample_index}"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"RewardTimeoutError(hook={self.hook!r}, "
+            f"prompt_index={self.prompt_index}, sample_index={self.sample_index}, "
+            f"elapsed={self.elapsed:.4f})"
+        )
+
+
+@dataclass(slots=True)
+class RewardSampleTiming:
+    """Timing record for a single reward_fn call."""
+
+    prompt_index: int | None
+    sample_index: int | None
+    duration_s: float
+    timed_out: bool = False
+
+
+@dataclass(slots=True)
+class RewardBatchProfile:
+    """Aggregated timing profile for one batch of reward_fn calls."""
+
+    total_s: float
+    sample_timings: list[RewardSampleTiming]
+    slow_samples: list[RewardSampleTiming]
+    timeout_count: int
+
+    def to_scalars(self) -> dict[str, float]:
+        """Return a flat dict suitable for TensorBoard ``timing/reward_*`` scalars."""
+
+        durations = [t.duration_s for t in self.sample_timings]
+        return {
+            "reward_slow_count": float(len(self.slow_samples)),
+            "reward_max_s": float(max(durations)) if durations else 0.0,
+            "reward_timeout_count": float(self.timeout_count),
+            "reward_total_s": float(self.total_s),
+        }
+
+    def to_jsonl_records(self) -> list[dict]:
+        """Return a list of dicts for jsonl artifact output.
+
+        Each record contains only ``prompt_index``, ``sample_index``,
+        ``duration_s``, and ``timed_out`` — never the prompt or completion
+        text.
+        """
+
+        return [
+            {
+                "prompt_index": t.prompt_index,
+                "sample_index": t.sample_index,
+                "duration_s": t.duration_s,
+                "timed_out": t.timed_out,
+            }
+            for t in self.sample_timings
+        ]
+
+
+class RewardProfiler:
+    """Wraps a reward_fn with per-sample timing, slow-sample flagging, and per-batch timeout.
+
+    Parameters
+    ----------
+    reward_fn:
+        The user reward callable ``(RewardRecord) -> float``.
+    enabled:
+        When ``False`` (default), ``score_batch`` returns ``(rewards, None)``
+        and avoids all timing overhead.
+    slow_threshold_s:
+        Absolute threshold in seconds.  Samples whose ``duration_s`` is
+        ``>=`` this value are added to ``slow_samples``.  ``None`` disables
+        slow-sample flagging.
+    batch_timeout_s:
+        Per-batch wall-clock budget in seconds.  If the cumulative time of
+        all samples exceeds this value, a ``RewardTimeoutError`` is raised
+        immediately with the current sample's identifier.  ``None`` disables
+        the timeout.
+    logger:
+        Optional ``logging.Logger`` for slow-sample and timeout warnings.
+    """
+
+    def __init__(
+        self,
+        reward_fn: Callable[[RewardRecord], float],
+        *,
+        enabled: bool = False,
+        slow_threshold_s: float | None = None,
+        batch_timeout_s: float | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        if slow_threshold_s is not None and slow_threshold_s <= 0:
+            raise ValueError("reward_slow_threshold_s must be > 0 or None")
+        if batch_timeout_s is not None and batch_timeout_s <= 0:
+            raise ValueError("reward_batch_timeout_s must be > 0 or None")
+
+        self._reward_fn = reward_fn
+        self._enabled = enabled
+        self._slow_threshold_s = slow_threshold_s
+        self._batch_timeout_s = batch_timeout_s
+        self._logger = logger
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def score_batch(self, records: list[RewardRecord]) -> tuple[list[float], RewardBatchProfile | None]:
+        """Score every record through the wrapped reward_fn.
+
+        Returns ``(rewards, profile)``.  When disabled, ``profile`` is
+        ``None`` and no timing is performed.
+        """
+
+        if not self._enabled:
+            rewards = [float(self._reward_fn(r)) for r in records]
+            return rewards, None
+
+        timings: list[RewardSampleTiming] = []
+        rewards: list[float] = []
+        batch_start = time.perf_counter()
+        timeout_count = 0
+        use_timeout = self._batch_timeout_s is not None
+
+        executor = ThreadPoolExecutor(max_workers=1) if use_timeout else None
+        try:
+            for record in records:
+                prompt_index = record.metadata.get("prompt_index")
+                sample_index = record.metadata.get("sample_index")
+
+                if use_timeout:
+                    assert executor is not None
+                    remaining = self._batch_timeout_s - (time.perf_counter() - batch_start)  # type: ignore[operator]
+                    if remaining <= 0:
+                        elapsed = time.perf_counter() - batch_start
+                        raise RewardTimeoutError(
+                            REWARD_HOOK_NAME, prompt_index, sample_index, elapsed
+                        )
+
+                    call_start = time.perf_counter()
+                    future = executor.submit(self._reward_fn, record)
+                    try:
+                        result_val = future.result(timeout=remaining)
+                    except FutureTimeout:
+                        call_duration = time.perf_counter() - call_start
+                        timeout_count += 1
+                        timings.append(
+                            RewardSampleTiming(
+                                prompt_index=prompt_index,
+                                sample_index=sample_index,
+                                duration_s=call_duration,
+                                timed_out=True,
+                            )
+                        )
+                        elapsed = time.perf_counter() - batch_start
+                        raise RewardTimeoutError(
+                            REWARD_HOOK_NAME, prompt_index, sample_index, elapsed
+                        ) from None
+                    except Exception:
+                        call_duration = time.perf_counter() - call_start
+                        timings.append(
+                            RewardSampleTiming(
+                                prompt_index=prompt_index,
+                                sample_index=sample_index,
+                                duration_s=call_duration,
+                            )
+                        )
+                        raise
+
+                    call_duration = time.perf_counter() - call_start
+                    rewards.append(float(result_val))
+                    timings.append(
+                        RewardSampleTiming(
+                            prompt_index=prompt_index,
+                            sample_index=sample_index,
+                            duration_s=call_duration,
+                        )
+                    )
+                else:
+                    call_start = time.perf_counter()
+                    result_val = float(self._reward_fn(record))
+                    call_duration = time.perf_counter() - call_start
+                    rewards.append(result_val)
+                    timings.append(
+                        RewardSampleTiming(
+                            prompt_index=prompt_index,
+                            sample_index=sample_index,
+                            duration_s=call_duration,
+                        )
+                    )
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=False)
+
+        total_s = time.perf_counter() - batch_start
+        slow_samples = self._flag_slow(timings)
+        profile = RewardBatchProfile(
+            total_s=total_s,
+            sample_timings=timings,
+            slow_samples=slow_samples,
+            timeout_count=timeout_count,
+        )
+
+        if self._logger is not None and slow_samples:
+            slowest = max(slow_samples, key=lambda t: t.duration_s)
+            self._logger.warning(
+                "reward_timing hook=%s n=%d slow_count=%d slowest_sample_idx=%s slowest_time_s=%.4f",
+                REWARD_HOOK_NAME,
+                len(timings),
+                len(slow_samples),
+                slowest.sample_index,
+                slowest.duration_s,
+            )
+
+        return rewards, profile
+
+    def _flag_slow(self, timings: list[RewardSampleTiming]) -> list[RewardSampleTiming]:
+        """Return the subset of timings that exceed ``slow_threshold_s``."""
+
+        if self._slow_threshold_s is None:
+            return []
+        return [t for t in timings if t.duration_s >= self._slow_threshold_s]

--- a/areno/api/reward_profiler.py
+++ b/areno/api/reward_profiler.py
@@ -7,13 +7,11 @@ absolute threshold, and enforces an optional per-batch wall-clock timeout.
 When disabled (the default), ``score_batch`` degrades to a plain list
 comprehension with zero ``perf_counter`` or dict-allocation overhead.
 
-Thread-safety: when profiling is enabled and a ``batch_timeout_s`` is set,
-each sample is executed inside a ``ThreadPoolExecutor`` thread so the
-caller can enforce the timeout via ``future.result(timeout=...)``.  User
-``reward_fn`` implementations must therefore be thread-safe.  Pure
-computation reward functions (text parsing, scoring) are naturally safe;
-functions with side effects (file I/O, global-state mutation) must be
-made safe by the user.
+Timeout semantics: the timeout is **soft** — the elapsed wall-clock is
+checked before each sample, and ``RewardTimeoutError`` is raised if the
+budget is exhausted.  ``reward_fn`` always executes on the main thread
+(not in a ``ThreadPoolExecutor``) so that reward functions using
+``signal.alarm()`` (e.g. ``math_verify``) work correctly.
 """
 
 from __future__ import annotations
@@ -21,7 +19,6 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 from dataclasses import dataclass
 
 from areno.api.rewards import RewardRecord
@@ -113,6 +110,9 @@ class RewardBatchProfile:
 class RewardProfiler:
     """Wraps a reward_fn with per-sample timing, slow-sample flagging, and per-batch timeout.
 
+    ``reward_fn`` always runs on the main thread (no ``ThreadPoolExecutor``)
+    so that reward functions using ``signal`` (e.g. ``math_verify``) work.
+
     Parameters
     ----------
     reward_fn:
@@ -125,10 +125,10 @@ class RewardProfiler:
         ``>=`` this value are added to ``slow_samples``.  ``None`` disables
         slow-sample flagging.
     batch_timeout_s:
-        Per-batch wall-clock budget in seconds.  If the cumulative time of
-        all samples exceeds this value, a ``RewardTimeoutError`` is raised
-        immediately with the current sample's identifier.  ``None`` disables
-        the timeout.
+        Per-batch wall-clock budget in seconds.  Checked before each sample;
+        if exhausted, ``RewardTimeoutError`` is raised.  This is a soft
+        timeout — a single long-running sample cannot be interrupted
+        mid-execution.  ``None`` disables the timeout.
     logger:
         Optional ``logging.Logger`` for slow-sample and timeout warnings.
     """
@@ -162,6 +162,15 @@ class RewardProfiler:
 
         Returns ``(rewards, profile)``.  When disabled, ``profile`` is
         ``None`` and no timing is performed.
+
+        Timeout enforcement: when ``batch_timeout_s`` is set, the elapsed
+        wall-clock is checked **before** each sample.  If the budget is
+        exhausted, ``RewardTimeoutError`` is raised immediately.  This is
+        a **soft** timeout — it cannot interrupt a single sample mid-
+        execution.  This is intentional: many reward functions (e.g.
+        ``math_verify``) use ``signal.alarm()`` which only works in the
+        main thread, so the profiler must execute ``reward_fn`` on the
+        main thread rather than in a ``ThreadPoolExecutor``.
         """
 
         if not self._enabled:
@@ -174,75 +183,35 @@ class RewardProfiler:
         timeout_count = 0
         use_timeout = self._batch_timeout_s is not None
 
-        executor = ThreadPoolExecutor(max_workers=1) if use_timeout else None
-        try:
-            for record in records:
-                prompt_index = record.metadata.get("prompt_index")
-                sample_index = record.metadata.get("sample_index")
+        for record in records:
+            prompt_index = record.metadata.get("prompt_index")
+            sample_index = record.metadata.get("sample_index")
 
-                if use_timeout:
-                    assert executor is not None
-                    remaining = self._batch_timeout_s - (time.perf_counter() - batch_start)  # type: ignore[operator]
-                    if remaining <= 0:
-                        elapsed = time.perf_counter() - batch_start
-                        raise RewardTimeoutError(
-                            REWARD_HOOK_NAME, prompt_index, sample_index, elapsed
-                        )
-
-                    call_start = time.perf_counter()
-                    future = executor.submit(self._reward_fn, record)
-                    try:
-                        result_val = future.result(timeout=remaining)
-                    except FutureTimeout:
-                        call_duration = time.perf_counter() - call_start
-                        timeout_count += 1
-                        timings.append(
-                            RewardSampleTiming(
-                                prompt_index=prompt_index,
-                                sample_index=sample_index,
-                                duration_s=call_duration,
-                                timed_out=True,
-                            )
-                        )
-                        elapsed = time.perf_counter() - batch_start
-                        raise RewardTimeoutError(
-                            REWARD_HOOK_NAME, prompt_index, sample_index, elapsed
-                        ) from None
-                    except Exception:
-                        call_duration = time.perf_counter() - call_start
-                        timings.append(
-                            RewardSampleTiming(
-                                prompt_index=prompt_index,
-                                sample_index=sample_index,
-                                duration_s=call_duration,
-                            )
-                        )
-                        raise
-
-                    call_duration = time.perf_counter() - call_start
-                    rewards.append(float(result_val))
-                    timings.append(
-                        RewardSampleTiming(
-                            prompt_index=prompt_index,
-                            sample_index=sample_index,
-                            duration_s=call_duration,
-                        )
+            # Check remaining budget before each sample (soft timeout).
+            if use_timeout:
+                elapsed_so_far = time.perf_counter() - batch_start
+                if elapsed_so_far >= self._batch_timeout_s:  # type: ignore[operator]
+                    timeout_count += 1
+                    raise RewardTimeoutError(
+                        REWARD_HOOK_NAME, prompt_index, sample_index, elapsed_so_far
                     )
-                else:
-                    call_start = time.perf_counter()
-                    result_val = float(self._reward_fn(record))
-                    call_duration = time.perf_counter() - call_start
-                    rewards.append(result_val)
-                    timings.append(
-                        RewardSampleTiming(
-                            prompt_index=prompt_index,
-                            sample_index=sample_index,
-                            duration_s=call_duration,
-                        )
-                    )
-        finally:
-            if executor is not None:
-                executor.shutdown(wait=False)
+
+            call_start = time.perf_counter()
+            result_val = float(self._reward_fn(record))
+            call_duration = time.perf_counter() - call_start
+
+            rewards.append(result_val)
+            timings.append(
+                RewardSampleTiming(
+                    prompt_index=prompt_index,
+                    sample_index=sample_index,
+                    duration_s=call_duration,
+                )
+            )
+
+            # Also check after each sample — if this sample was slow
+            # enough to exhaust the budget, the next iteration's pre-check
+            # will catch it.
 
         total_s = time.perf_counter() - batch_start
         slow_samples = self._flag_slow(timings)

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -362,6 +362,12 @@ class Trainer:
         if self._metrics is not None:
             self._metrics.record_rollout_sample(sample)
 
+    def record_reward_profile(self, profile) -> None:
+        """Persist per-sample reward timing to a jsonl artifact when metrics recording is enabled."""
+
+        if self._metrics is not None:
+            self._metrics.record_reward_profile(profile)
+
     def record_dashboard_state(
         self,
         *,

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -145,6 +145,19 @@ class PolicyTrainerConfig(RolloutTrainerConfig):
     reward_fn_path: str | None = None
     gspo_clip_eps: float = 3.0e-4
     grpo_clip_eps: float = 0.2
+    reward_profile: bool = False
+    reward_slow_threshold_s: float | None = None
+    reward_batch_timeout_s: float | None = None
+
+    def __post_init__(self) -> None:
+        # NOTE: @dataclass(slots=True) rewrites the class, so the no-arg
+        # super() cell points at the pre-rewrite class and fails.  Call the
+        # parent __post_init__ explicitly.
+        TrainerConfig.__post_init__(self)
+        if self.reward_slow_threshold_s is not None and self.reward_slow_threshold_s <= 0:
+            raise ValueError("reward_slow_threshold_s must be > 0 or None")
+        if self.reward_batch_timeout_s is not None and self.reward_batch_timeout_s <= 0:
+            raise ValueError("reward_batch_timeout_s must be > 0 or None")
 
 
 @dataclass(slots=True)

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -258,6 +258,8 @@ class PolicyOnlyTrainer:
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
             rewards, _profile = self._reward_profiler.score_batch(reward_records)
+            if _profile is not None:
+                self.areno.record_reward_profile(_profile)
             rows = ctx._train_rows_from_samples(samples)
             tool_call_count = sum(len(record.tool_calls) for record in reward_records)
             tool_result_count = sum(len(record.tool_results) for record in reward_records)
@@ -558,6 +560,8 @@ class PolicyOnlyTrainer:
                 for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
             ]
             rewards, _profile = self._reward_profiler.score_batch(item_records)
+            if _profile is not None:
+                self.areno.record_reward_profile(_profile)
             rewards_all += rewards
             # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
             # every response token of sample i.

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -25,6 +25,20 @@ from areno.api.dashboard import record_dashboard_state
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
 
+def _build_reward_profiler(trainer):
+    """Construct a RewardProfiler from the trainer's config, guarded for None reward_fn."""
+
+    from areno.api.reward_profiler import RewardProfiler
+
+    return RewardProfiler(
+        trainer.reward_fn,
+        enabled=getattr(trainer.config, "reward_profile", False),
+        slow_threshold_s=getattr(trainer.config, "reward_slow_threshold_s", None),
+        batch_timeout_s=getattr(trainer.config, "reward_batch_timeout_s", None),
+        logger=trainer.logger,
+    )
+
+
 class PolicyOnlyTrainer:
     """Rollout-reward-train loop for policy-only RL algorithms.
 
@@ -42,6 +56,7 @@ class PolicyOnlyTrainer:
         self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         self._agent_run_fn = None
+        self._reward_profiler = _build_reward_profiler(self)
 
     def fit(self) -> None:
         self.areno.init()
@@ -242,7 +257,7 @@ class PolicyOnlyTrainer:
                     f"{self._format_agent_filter_diagnostics(filter_diagnostics)}"
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
-            rewards = [float(self.reward_fn(record)) for record in reward_records]
+            rewards, _profile = self._reward_profiler.score_batch(reward_records)
             rows = ctx._train_rows_from_samples(samples)
             tool_call_count = sum(len(record.tool_calls) for record in reward_records)
             tool_result_count = sum(len(record.tool_results) for record in reward_records)
@@ -527,23 +542,22 @@ class PolicyOnlyTrainer:
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
-            rewards = [
-                float(
-                    self.reward_fn(
-                        make_reward_record(
-                            prompt=item.prompt,
-                            completion=completion,
-                            source_record=item.record,
-                            answer=item.solutions,
-                            tokens=item.input_tokens + seq.resp_tokens,
-                            logprobs=[0.0] * prefix_len + seq.resp_logprobs,
-                            loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
-                            metadata={"prompt_index": item_idx, "sample_index": sample_idx},
-                        )
-                    )
+            # Build reward records in a separate step so _reward_profiler can
+            # receive a pre-built list[RewardRecord].
+            item_records = [
+                make_reward_record(
+                    prompt=item.prompt,
+                    completion=completion,
+                    source_record=item.record,
+                    answer=item.solutions,
+                    tokens=item.input_tokens + seq.resp_tokens,
+                    logprobs=[0.0] * prefix_len + seq.resp_logprobs,
+                    loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
+                    metadata={"prompt_index": item_idx, "sample_index": sample_idx},
                 )
                 for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
             ]
+            rewards, _profile = self._reward_profiler.score_batch(item_records)
             rewards_all += rewards
             # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
             # every response token of sample i.

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -130,8 +130,11 @@ class PPOTrainer(PolicyOnlyTrainer):
         if self.reward_fn is not None:
             self._record_ppo_state(stage="score_start", role="reward")
             reward_start = time.perf_counter()
-            rewards_all = [float(self.reward_fn(record)) for record in reward_records]
+            rewards_all, reward_profile = self._reward_profiler.score_batch(reward_records)
             self._last_ppo_stats["reward_score_time_s"] = time.perf_counter() - reward_start
+            if reward_profile is not None:
+                self._last_ppo_stats["reward_profile_slow_count"] = float(len(reward_profile.slow_samples))
+                self._last_ppo_stats["reward_profile_max_s"] = reward_profile.to_scalars()["reward_max_s"]
             self._record_ppo_state(stage="score_end", role="reward")
         else:
             self.logger.info("role=reward stage=score_start rows=%d", len(token_rows))

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -135,6 +135,7 @@ class PPOTrainer(PolicyOnlyTrainer):
             if reward_profile is not None:
                 self._last_ppo_stats["reward_profile_slow_count"] = float(len(reward_profile.slow_samples))
                 self._last_ppo_stats["reward_profile_max_s"] = reward_profile.to_scalars()["reward_max_s"]
+                self.areno.record_reward_profile(reward_profile)
             self._record_ppo_state(stage="score_end", role="reward")
         else:
             self.logger.info("role=reward stage=score_start rows=%d", len(token_rows))

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -129,7 +129,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
         ),
     ),
     ("Checkpoint", ("save_path", "save_interval")),
-    ("Observability", ("metrics_log_dir",)),
+    ("Observability", ("metrics_log_dir", "reward_profile", "reward_slow_threshold_s", "reward_batch_timeout_s")),
 )
 
 
@@ -727,6 +727,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            reward_profile=args.reward_profile,
+            reward_slow_threshold_s=args.reward_slow_threshold_s,
+            reward_batch_timeout_s=args.reward_batch_timeout_s,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -788,6 +791,9 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
+        reward_profile=args.reward_profile,
+        reward_slow_threshold_s=args.reward_slow_threshold_s,
+        reward_batch_timeout_s=args.reward_batch_timeout_s,
     )
 
 
@@ -951,7 +957,7 @@ def _training_config_settings(config: TrainerConfig) -> dict:
             ],
         ),
         section("Checkpoint", ["save_path", "save_interval"]),
-        section("Observability", ["metrics_log_dir"]),
+        section("Observability", ["metrics_log_dir", "reward_profile", "reward_slow_threshold_s", "reward_batch_timeout_s"]),
     ]
     extras = []
     for field in fields(config):
@@ -1187,6 +1193,15 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 @click.option("--save-interval", type=int, default=100, show_default=True, help="Save checkpoint every N train steps.")
 @click.option(
     "--metrics-log-dir", default=DEFAULT_METRICS_LOG_DIR, show_default=True, help="TensorBoard metrics log directory."
+)
+@click.option(
+    "--reward-profile", is_flag=True, default=False, help="Enable per-sample reward timing and slow-sample detection."
+)
+@click.option(
+    "--reward-slow-threshold-s", type=float, default=None, help="Flag reward samples slower than this many seconds."
+)
+@click.option(
+    "--reward-batch-timeout-s", type=float, default=None, help="Per-batch reward computation timeout in seconds."
 )
 @click.option("--epochs", type=int, default=10, show_default=True, help="Number of dataset epochs to train.")
 @click.option("--max-steps", type=int, default=None, help="Stop after this many trainer steps.")

--- a/docs/troubleshooting/reward_profiling.rst
+++ b/docs/troubleshooting/reward_profiling.rst
@@ -1,0 +1,101 @@
+:orphan:
+
+Reward profiling and slow-sample detection
+===========================================
+
+AReno can measure the time each reward function call takes, flag samples
+that exceed a configurable threshold, and enforce an optional per-batch
+wall-clock timeout.  This helps identify slow reward hooks and samples
+without changing the training loop.
+
+CLI options
+-----------
+
+All three options are off by default, so existing training runs are
+unaffected.
+
+``--reward-profile``
+    Enable per-sample reward timing and slow-sample detection.
+
+``--reward-slow-threshold-s <seconds>``
+    Flag reward samples whose execution time is greater than or equal to
+    this many seconds.  When omitted, no slow-sample flagging is
+    performed.
+
+``--reward-batch-timeout-s <seconds>``
+    Per-batch wall-clock budget for all reward calls.  If exceeded, a
+    ``RewardTimeoutError`` is raised immediately with the hook name
+    (``reward_fn``), the current sample's ``prompt_index`` and
+    ``sample_index``, and the elapsed time.  When omitted, no timeout is
+    enforced.
+
+Example
+-------
+
+.. code-block:: bash
+
+   areno train --ckpt Qwen/Qwen3-0.6B --dataset-path gsm8k:main \
+     --reward-fn-path examples/math/math_verify_reward.py --algo gspo \
+     --tp-size 4 --reward-profile \
+     --reward-slow-threshold-s 0.5 --reward-batch-timeout-s 10.0
+
+Observable output
+-----------------
+
+TensorBoard scalars
+    When reward profiling is enabled, the following scalars are written
+    under the ``timing/`` namespace:
+
+    - ``timing/reward_profile_slow_count`` — number of samples that
+      exceeded the slow threshold in the current step.
+    - ``timing/reward_profile_max_s`` — maximum per-sample reward time
+      in the current step.
+
+JSONL artifact
+    Per-sample timing records are written to
+    ``reward_profile.{pid}.jsonl`` in the metrics log directory.  Each
+    line contains only:
+
+    - ``prompt_index``
+    - ``sample_index``
+    - ``duration_s``
+    - ``timed_out``
+
+    Prompt and completion text are never logged.
+
+Console logs
+    When slow samples are detected, a ``WARNING``-level log line is
+    emitted:
+
+    .. code-block:: text
+
+       reward_timing hook=reward_fn n=8 slow_count=1 slowest_sample_idx=3 slowest_time_s=0.5234
+
+Limitations
+-----------
+
+- **Timeout is a soft enforcement.** The reward function runs in a
+  background thread via ``ThreadPoolExecutor``.  On timeout, the main
+  thread raises immediately, but the background thread cannot be
+  killed — it will finish naturally and its resources are released when
+  the process exits.  This is sufficient for pure-Python reward
+  functions; reward functions that hold locks or network connections
+  may need their own timeout handling.
+
+- **Thread safety.** Because reward calls execute in a
+  ``ThreadPoolExecutor`` thread, user ``reward_fn`` implementations must
+  be thread-safe.
+
+- **No hook name configuration.** AReno has a single reward function;
+  the hook name is the internal constant ``reward_fn`` and cannot be
+  overridden.
+
+Copyable example
+----------------
+
+A self-contained, deterministic demo that runs without GPU, network, or
+sandbox is provided at ``examples/reward_profiling/demo_cpu.py``:
+
+.. code-block:: bash
+
+   python3 examples/reward_profiling/demo_cpu.py

--- a/examples/reward_profiling/demo_cpu.py
+++ b/examples/reward_profiling/demo_cpu.py
@@ -1,0 +1,73 @@
+"""Minimal deterministic example for reward profiling (issue #242).
+
+Run without GPU, network, or sandbox:
+
+    python3 examples/reward_profiling/demo_cpu.py
+
+Demonstrates the successful path (slow-sample detection) and one
+boundary/failure path (timeout enforcement with error identifiers).
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+
+
+def reward_fn(record):
+    """Deterministic reward: 1.0 if 'answer' appears in the completion.
+
+    The second sample (sample_index=1) sleeps 50 ms to trigger the
+    slow-sample threshold.
+    """
+
+    if record.metadata.get("sample_index") == 1:
+        time.sleep(0.05)
+    return 1.0 if "answer" in record.completion else 0.0
+
+
+def main():
+    from areno.api.reward_profiler import RewardProfiler, RewardTimeoutError
+    from areno.api.rewards import RewardRecord
+
+    records = [
+        RewardRecord(
+            prompt="q",
+            completion=f"answer{i}",
+            metadata={"prompt_index": 0, "sample_index": i},
+        )
+        for i in range(4)
+    ]
+
+    # --- Successful path: slow-sample detection ---
+    profiler = RewardProfiler(reward_fn, enabled=True, slow_threshold_s=0.03, batch_timeout_s=1.0)
+    rewards, profile = profiler.score_batch(records)
+    print(f"rewards: {rewards}")
+    print(f"slow_samples: {[(s.sample_index, round(s.duration_s, 4)) for s in profile.slow_samples]}")
+    assert any(s.sample_index == 1 for s in profile.slow_samples), "Expected sample_index=1 to be slow"
+
+    # --- Boundary/failure path: timeout enforcement ---
+    # Non-positive config must raise ValueError with a clear message.
+    tc = unittest.TestCase()
+    try:
+        RewardProfiler(reward_fn, enabled=True, slow_threshold_s=-1)
+        raise AssertionError("Should have raised ValueError")
+    except ValueError as e:
+        tc.assertRegex(str(e), r"reward_slow_threshold_s must be > 0")
+        print(f"Config validation OK: {e}")
+
+    # A tiny batch timeout forces RewardTimeoutError with hook + sample identifiers.
+    slow_profiler = RewardProfiler(reward_fn, enabled=True, batch_timeout_s=0.0001)
+    try:
+        slow_profiler.score_batch(records)
+        raise AssertionError("Should have raised RewardTimeoutError")
+    except RewardTimeoutError as e:
+        assert e.hook == "reward_fn"
+        assert e.sample_index is not None
+        print(f"Timeout enforcement OK: hook={e.hook} sample={e.sample_index} elapsed={e.elapsed:.4f}s")
+
+    print("All paths demonstrated successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reward_profiler_cpu.py
+++ b/tests/test_reward_profiler_cpu.py
@@ -97,15 +97,20 @@ class SlowSampleDetectionTest(unittest.TestCase):
 
 
 class BatchTimeoutTest(unittest.TestCase):
-    """Per-batch wall-clock timeout enforcement via ThreadPoolExecutor."""
+    """Per-batch wall-clock timeout enforcement (soft, main-thread)."""
 
     def test_batch_timeout_raises_with_identifiers(self):
-        """Timeout must raise RewardTimeoutError with hook name and sample index."""
+        """Timeout must raise RewardTimeoutError with hook name and sample index.
+
+        Uses a slow first sample to exhaust the budget; the timeout is
+        checked before the second sample, raising with the second sample's
+        identifier.
+        """
 
         profiler = RewardProfiler(
-            _slow_at_index(0, delay_s=5.0), enabled=True, batch_timeout_s=0.01
+            _slow_at_index(0, delay_s=0.06), enabled=True, batch_timeout_s=0.05
         )
-        records = _make_records(2)
+        records = _make_records(4)
         with self.assertRaises(RewardTimeoutError) as ctx:
             profiler.score_batch(records)
 
@@ -219,7 +224,7 @@ class HookNameOutputTest(unittest.TestCase):
         """RewardTimeoutError repr and jsonl records must contain the hook name."""
 
         profiler = RewardProfiler(
-            _slow_at_index(0, delay_s=5.0), enabled=True, batch_timeout_s=0.01
+            _slow_at_index(0, delay_s=0.06), enabled=True, batch_timeout_s=0.05
         )
         records = _make_records(2)
         with self.assertRaises(RewardTimeoutError) as ctx:

--- a/tests/test_reward_profiler_cpu.py
+++ b/tests/test_reward_profiler_cpu.py
@@ -1,0 +1,286 @@
+"""CPU unit tests for the reward profiler (timing, slow-sample, timeout).
+
+Tests follow the patterns in ``test_losses_rewards_cpu.py``: pure
+unittest, no GPU, no external services.  Deterministic delays are injected
+via ``time.sleep`` so timing assertions are robust on any CPU.
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest.mock import patch
+
+from areno.api.reward_profiler import (
+    REWARD_HOOK_NAME,
+    RewardBatchProfile,
+    RewardProfiler,
+    RewardSampleTiming,
+    RewardTimeoutError,
+)
+from areno.api.rewards import RewardRecord
+from areno.api.trainer_config import PolicyTrainerConfig
+
+
+def _make_records(n: int = 4) -> list[RewardRecord]:
+    """Build ``n`` minimal reward records with prompt/sample identifiers."""
+
+    return [
+        RewardRecord(prompt="q", completion=f"answer{i}", metadata={"prompt_index": 0, "sample_index": i})
+        for i in range(n)
+    ]
+
+
+def _fast_reward(record: RewardRecord) -> float:
+    """Deterministic fast reward — returns 1.0 for all records."""
+
+    return 1.0
+
+
+def _slow_at_index(slow_idx: int, delay_s: float = 0.05):
+    """Return a reward_fn that sleeps ``delay_s`` at ``slow_idx``."""
+
+    def reward_fn(record: RewardRecord) -> float:
+        if record.metadata.get("sample_index") == slow_idx:
+            time.sleep(delay_s)
+        return 1.0
+
+    return reward_fn
+
+
+class DisabledPassthroughTest(unittest.TestCase):
+    """Disabled profiler must behave identically to a bare reward_fn call."""
+
+    def test_disabled_is_passthrough(self):
+        """Disabled profiler returns same rewards and None profile with no perf_counter."""
+
+        with patch("areno.api.reward_profiler.time.perf_counter") as mock_pc:
+            mock_pc.return_value = 0.0
+            profiler = RewardProfiler(_fast_reward, enabled=False)
+            records = _make_records(4)
+            rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(rewards, [1.0, 1.0, 1.0, 1.0])
+        self.assertIsNone(profile)
+        # perf_counter should not be called when disabled.
+        mock_pc.assert_not_called()
+
+
+class SlowSampleDetectionTest(unittest.TestCase):
+    """Slow-sample detection with absolute threshold."""
+
+    def test_slow_sample_flagged(self):
+        """Samples exceeding slow_threshold_s must appear in slow_samples."""
+
+        profiler = RewardProfiler(
+            _slow_at_index(1, delay_s=0.05), enabled=True, slow_threshold_s=0.03
+        )
+        records = _make_records(4)
+        rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(rewards, [1.0, 1.0, 1.0, 1.0])
+        self.assertIsNotNone(profile)
+        self.assertEqual(len(profile.slow_samples), 1)
+        self.assertEqual(profile.slow_samples[0].sample_index, 1)
+
+    def test_boundary_threshold_configured_not_triggered(self):
+        """A high threshold with fast samples must produce empty slow_samples."""
+
+        profiler = RewardProfiler(
+            _fast_reward, enabled=True, slow_threshold_s=10.0
+        )
+        records = _make_records(4)
+        rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(len(profile.slow_samples), 0)
+        self.assertEqual(len(profile.sample_timings), 4)
+
+
+class BatchTimeoutTest(unittest.TestCase):
+    """Per-batch wall-clock timeout enforcement via ThreadPoolExecutor."""
+
+    def test_batch_timeout_raises_with_identifiers(self):
+        """Timeout must raise RewardTimeoutError with hook name and sample index."""
+
+        profiler = RewardProfiler(
+            _slow_at_index(0, delay_s=5.0), enabled=True, batch_timeout_s=0.01
+        )
+        records = _make_records(2)
+        with self.assertRaises(RewardTimeoutError) as ctx:
+            profiler.score_batch(records)
+
+        err = ctx.exception
+        self.assertEqual(err.hook, REWARD_HOOK_NAME)
+        self.assertIsNotNone(err.sample_index)
+        self.assertGreater(err.elapsed, 0)
+
+    def test_boundary_timeout_configured_not_triggered(self):
+        """A generous timeout with fast samples must complete normally."""
+
+        profiler = RewardProfiler(
+            _fast_reward, enabled=True, batch_timeout_s=10.0
+        )
+        records = _make_records(4)
+        rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(len(rewards), 4)
+        self.assertEqual(profile.timeout_count, 0)
+
+    def test_timeout_preserves_original_error(self):
+        """When reward_fn raises, the original exception must be preserved."""
+
+        def faulty_reward(record: RewardRecord) -> float:
+            raise RuntimeError("scheme parse error")
+
+        profiler = RewardProfiler(
+            faulty_reward, enabled=True, batch_timeout_s=10.0
+        )
+        records = _make_records(2)
+        with self.assertRaises(RuntimeError) as ctx:
+            profiler.score_batch(records)
+
+        self.assertIn("scheme parse error", str(ctx.exception))
+
+
+class PrivacyTest(unittest.TestCase):
+    """Profile output must never contain prompt or completion text."""
+
+    def test_no_prompt_or_completion_in_profile(self):
+        """Serialized profile fields must not contain prompt/completion."""
+
+        profiler = RewardProfiler(_fast_reward, enabled=True)
+        records = _make_records(2)
+        _, profile = profiler.score_batch(records)
+
+        jsonl_records = profile.to_jsonl_records()
+        for rec in jsonl_records:
+            keys = set(rec.keys())
+            self.assertNotIn("prompt", keys)
+            self.assertNotIn("completion", keys)
+            self.assertEqual(keys, {"prompt_index", "sample_index", "duration_s", "timed_out"})
+
+
+class ConfigValidationTest(unittest.TestCase):
+    """Config validation rejects non-positive thresholds and timeouts."""
+
+    def test_invalid_config_raises(self):
+        """Invalid slow_threshold_s and batch_timeout_s must raise ValueError with clear messages."""
+
+        with self.assertRaisesRegex(ValueError, r"reward_slow_threshold_s must be > 0"):
+            RewardProfiler(_fast_reward, enabled=True, slow_threshold_s=-1)
+        with self.assertRaisesRegex(ValueError, r"reward_batch_timeout_s must be > 0"):
+            RewardProfiler(_fast_reward, enabled=True, batch_timeout_s=0)
+
+    def test_backward_compatible_default(self):
+        """Default PolicyTrainerConfig must construct without raising."""
+
+        config = PolicyTrainerConfig(algo="gspo", ckpt="unused", dataset_path="unused")
+        self.assertFalse(config.reward_profile)
+        self.assertIsNone(config.reward_slow_threshold_s)
+        self.assertIsNone(config.reward_batch_timeout_s)
+
+        profiler = RewardProfiler(_fast_reward)
+        self.assertFalse(profiler.enabled)
+
+
+class BoundaryValuesTest(unittest.TestCase):
+    """Effective-side boundary inputs — configured but not triggered."""
+
+    def test_boundary_empty_records(self):
+        """Scoring an empty record list must return empty rewards and a valid profile."""
+
+        profiler = RewardProfiler(_fast_reward, enabled=True)
+        rewards, profile = profiler.score_batch([])
+
+        self.assertEqual(rewards, [])
+        self.assertIsNotNone(profile)
+        self.assertEqual(profile.sample_timings, [])
+        self.assertEqual(profile.timeout_count, 0)
+        self.assertAlmostEqual(profile.total_s, 0.0, places=1)
+
+    def test_boundary_enabled_without_threshold_or_timeout(self):
+        """Enabled profiling with no threshold/timeout must produce timing only."""
+
+        profiler = RewardProfiler(_fast_reward, enabled=True)
+        records = _make_records(4)
+        rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(len(rewards), 4)
+        self.assertEqual(len(profile.sample_timings), 4)
+        self.assertEqual(profile.slow_samples, [])
+        self.assertEqual(profile.timeout_count, 0)
+        self.assertGreater(profile.total_s, 0.0)
+
+
+class HookNameOutputTest(unittest.TestCase):
+    """Hook name must appear in timeout error and jsonl output."""
+
+    def test_hook_name_in_output(self):
+        """RewardTimeoutError repr and jsonl records must contain the hook name."""
+
+        profiler = RewardProfiler(
+            _slow_at_index(0, delay_s=5.0), enabled=True, batch_timeout_s=0.01
+        )
+        records = _make_records(2)
+        with self.assertRaises(RewardTimeoutError) as ctx:
+            profiler.score_batch(records)
+
+        err = ctx.exception
+        self.assertIn(REWARD_HOOK_NAME, repr(err))
+        self.assertEqual(err.hook, REWARD_HOOK_NAME)
+
+    def test_hook_name_in_jsonl(self):
+        """jsonl output must carry timing fields via the profile's to_jsonl_records."""
+
+        profiler = RewardProfiler(_fast_reward, enabled=True)
+        records = _make_records(2)
+        _, profile = profiler.score_batch(records)
+
+        jsonl = profile.to_jsonl_records()
+        self.assertEqual(len(jsonl), 2)
+        for rec in jsonl:
+            self.assertIn("duration_s", rec)
+            self.assertIn("prompt_index", rec)
+            self.assertIn("sample_index", rec)
+
+
+class TrainerConfigPostInitTest(unittest.TestCase):
+    """PolicyTrainerConfig.__post_init__ must validate reward_* fields and call super."""
+
+    def test_config_validates_reward_threshold(self):
+        """Non-positive reward_slow_threshold_s must raise ValueError."""
+
+        with self.assertRaisesRegex(ValueError, r"reward_slow_threshold_s must be > 0"):
+            PolicyTrainerConfig(
+                algo="gspo", ckpt="unused", dataset_path="unused", reward_slow_threshold_s=-1
+            )
+
+    def test_config_validates_reward_timeout(self):
+        """Non-positive reward_batch_timeout_s must raise ValueError."""
+
+        with self.assertRaisesRegex(ValueError, r"reward_batch_timeout_s must be > 0"):
+            PolicyTrainerConfig(
+                algo="gspo", ckpt="unused", dataset_path="unused", reward_batch_timeout_s=0
+            )
+
+    def test_config_preserves_parent_validation(self):
+        """Invalid attn_backend must still raise after adding reward_* fields (super call)."""
+
+        with self.assertRaisesRegex(ValueError, r"attn_backend"):
+            PolicyTrainerConfig(
+                algo="gspo", ckpt="unused", dataset_path="unused", attn_backend="invalid"
+            )
+
+    def test_ppo_config_inherits_validation(self):
+        """PPOTrainerConfig must inherit reward_* validation from PolicyTrainerConfig."""
+
+        from areno.api.trainer_config import PPOTrainerConfig
+
+        with self.assertRaisesRegex(ValueError, r"reward_slow_threshold_s"):
+            PPOTrainerConfig(
+                algo="ppo", ckpt="unused", dataset_path="unused", reward_slow_threshold_s=-1
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reward_profiling_integration_cpu.py
+++ b/tests/test_reward_profiling_integration_cpu.py
@@ -1,0 +1,153 @@
+"""Integration test: RewardProfiler across trainer → metrics modules.
+
+Uses ``SimpleNamespace`` stubs for PromptBatch/RolloutResult (no GPU, no
+backend) and verifies that profiling data flows through to MetricsRecorder
+artifacts and TensorBoard scalar names.
+
+GPU/distributed note: orchestration logic is isolated behind fakes.
+The only GPU validation that remains is verifying that the timer does
+not introduce a GPU-CPU sync in real rollout paths — that check is out
+of scope for the CPU test suite.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from areno.api.metrics import MetricsRecorder
+from areno.api.reward_profiler import RewardBatchProfile, RewardProfiler, RewardSampleTiming
+from areno.api.rewards import RewardRecord
+
+
+def _fake_reward(record: RewardRecord) -> float:
+    """Deterministic fast reward for integration testing."""
+
+    return 1.0
+
+
+class RewardProfileMetricsIntegrationTest(unittest.TestCase):
+    """Verify that RewardBatchProfile flows through MetricsRecorder correctly."""
+
+    def test_record_reward_profile_writes_jsonl(self):
+        """MetricsRecorder.record_reward_profile must write a valid jsonl file."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = MetricsRecorder(tmpdir)
+
+            profile = RewardBatchProfile(
+                total_s=0.12,
+                sample_timings=[
+                    RewardSampleTiming(prompt_index=0, sample_index=0, duration_s=0.01),
+                    RewardSampleTiming(prompt_index=0, sample_index=1, duration_s=0.11),
+                ],
+                slow_samples=[
+                    RewardSampleTiming(prompt_index=0, sample_index=1, duration_s=0.11),
+                ],
+                timeout_count=0,
+            )
+
+            recorder.record_reward_profile(profile)
+            recorder.close()
+
+            # Read back the jsonl file and verify fields.
+            import os
+
+            profile_file = os.path.join(tmpdir, f"reward_profile.{os.getpid()}.jsonl")
+            with open(profile_file, encoding="utf-8") as f:
+                lines = [json.loads(line) for line in f]
+
+            self.assertEqual(len(lines), 2)
+            for rec in lines:
+                keys = set(rec.keys())
+                self.assertIn("prompt_index", keys)
+                self.assertIn("sample_index", keys)
+                self.assertIn("duration_s", keys)
+                self.assertIn("timed_out", keys)
+                # Privacy: no prompt or completion text.
+                self.assertNotIn("prompt", keys)
+                self.assertNotIn("completion", keys)
+
+            self.assertEqual(lines[1]["sample_index"], 1)
+            self.assertAlmostEqual(lines[1]["duration_s"], 0.11)
+
+    def test_record_reward_profile_none_is_noop(self):
+        """Calling record_reward_profile(None) must not write anything."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = MetricsRecorder(tmpdir)
+            recorder.record_reward_profile(None)
+            recorder.close()
+
+            import os
+
+            profile_file = os.path.join(tmpdir, f"reward_profile.{os.getpid()}.jsonl")
+            self.assertFalse(os.path.exists(profile_file))
+
+    def test_profile_to_scalars(self):
+        """RewardBatchProfile.to_scalars must return the expected keys."""
+
+        profile = RewardBatchProfile(
+            total_s=0.5,
+            sample_timings=[
+                RewardSampleTiming(prompt_index=0, sample_index=0, duration_s=0.1),
+                RewardSampleTiming(prompt_index=0, sample_index=1, duration_s=0.3),
+            ],
+            slow_samples=[
+                RewardSampleTiming(prompt_index=0, sample_index=1, duration_s=0.3),
+            ],
+            timeout_count=0,
+        )
+
+        scalars = profile.to_scalars()
+        self.assertEqual(scalars["reward_slow_count"], 1.0)
+        self.assertEqual(scalars["reward_max_s"], 0.3)
+        self.assertEqual(scalars["reward_timeout_count"], 0.0)
+        self.assertEqual(scalars["reward_total_s"], 0.5)
+
+
+class RewardProfilerTrainerIntegrationTest(unittest.TestCase):
+    """Verify that RewardProfiler produces correct rewards through the trainer path."""
+
+    def test_disabled_profiler_preserves_trainer_reward_values(self):
+        """When disabled, profiler must return the same rewards as a bare reward_fn."""
+
+        records = [
+            RewardRecord(prompt="q", completion=f"answer{i}",
+                         metadata={"prompt_index": 0, "sample_index": i})
+            for i in range(4)
+        ]
+
+        # Bare call (simulates pre-change behavior)
+        bare_rewards = [float(_fake_reward(r)) for r in records]
+
+        profiler = RewardProfiler(_fake_reward, enabled=False)
+        profiled_rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(profiled_rewards, bare_rewards)
+        self.assertIsNone(profile)
+
+    def test_enabled_profiler_preserves_reward_values(self):
+        """When enabled, profiler must still return the correct reward values."""
+
+        records = [
+            RewardRecord(prompt="q", completion=f"answer{i}",
+                         metadata={"prompt_index": 0, "sample_index": i})
+            for i in range(4)
+        ]
+
+        expected_rewards = [float(_fake_reward(r)) for r in records]
+
+        profiler = RewardProfiler(_fake_reward, enabled=True, slow_threshold_s=10.0)
+        rewards, profile = profiler.score_batch(records)
+
+        self.assertEqual(rewards, expected_rewards)
+        self.assertIsNotNone(profile)
+        self.assertEqual(len(profile.sample_timings), 4)
+        self.assertEqual(len(profile.slow_samples), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add per-sample reward timing, slow-sample flagging, and optional per-batch timeout to help users identify slow reward hooks and samples.

## Changes

- **New**: `areno/api/reward_profiler.py` — `RewardProfiler` wraps `reward_fn` with per-sample `perf_counter` timing, absolute-threshold slow-sample flagging, and soft per-batch wall-clock timeout
- **Config**: `PolicyTrainerConfig` gains `reward_profile`, `reward_slow_threshold_s`, `reward_batch_timeout_s` with `__post_init__` validation (preserves parent via explicit `TrainerConfig.__post_init__(self)`)
- **Trainers**: 3 call sites routed through profiler (policy_only agentic + dense, ppo)
- **Metrics**: `timing/reward_profile_*` TensorBoard scalars + `reward_profile.{pid}.jsonl` artifact (only prompt_index/sample_index/duration_s/timed_out — no prompt/completion logged)
- **CLI**: `--reward-profile`, `--reward-slow-threshold-s`, `--reward-batch-timeout-s` in Observability group + TRAIN_OPTION_GROUPS sync
- **Tests**: 17 unit + 5 integration (CPU-only, deterministic, zero regression on 14 existing tests)
- **Docs**: `docs/troubleshooting/reward_profiling.rst` + `examples/reward_profiling/demo_cpu.py` (runnable, demonstrates success + invalid/timeout paths)

## Design decisions

1. **Main-thread execution** (not `ThreadPoolExecutor`) — `math_verify` and other reward functions use `signal.alarm()` which only works in the main thread. Timeout is checked between samples (soft timeout) and cannot interrupt a single long-running sample.
2. **Soft timeout** — elapsed wall-clock is checked before each sample; if budget exhausted, `RewardTimeoutError` is raised with hook name + sample identifier. This is compatible with all reward functions.
3. **Disabled by default** — zero overhead when `reward_profile=False`; `score_batch` returns `(rewards, None)` without any `perf_counter` calls.
4. **Privacy** — profile data and jsonl never contain prompt or completion text, only identifiers and timing.

## Test results

- **CPU**: 22 new tests pass, 14 existing tests pass (zero regression)
- **GPU (Kaggle T4 single + dual-GPU)**:
  - Normal reward scoring + jsonl output: pass
  - Slow-sample detection (low threshold triggers WARNING): pass
  - Timeout enforcement (`RewardTimeoutError` with hook + sample identifiers): pass
  - `math_verify` compatibility (main thread): pass
  - Privacy assertion (jsonl has no prompt/completion): pass
  - Dual-GPU TP=2 + reward profiling: pass

Closes #242