### PR TITLE
feat(data): add streaming JSONL and loader-output quality scanner

### DIFF
--- a/areno/api/data.py
+++ b/areno/api/data.py
@@ -4,12 +4,22 @@
 tokenising a dataset row. `PromptBatch` groups a fixed-size set of items
 together and carries diagnostic counters so the trainer can surface how many
 records were skipped for exceeding the prompt-length budget.
+
+The streaming JSONL quality scanner (`scan_jsonl_stream`) inspects a file or
+stdin line by line without loading the full dataset into memory, reporting blank
+lines, JSON failures, non-object records, and bounded redacted previews of bad
+entries. `scan_loader_output` applies the same checks to records produced by a
+``--dataset-loader-fn`` so users can validate custom normalisation code before
+starting a training run.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TextIO
 
 
 @dataclass(slots=True)
@@ -48,3 +58,338 @@ class PromptBatch:
         """Return raw prompt strings in batch order for rollout."""
 
         return [item.prompt for item in self.items]
+
+
+# ---------------------------------------------------------------------------
+# Streaming JSONL / loader-output quality scanner
+# ---------------------------------------------------------------------------
+
+# Categories reported by the scanner.  ``BLANK`` is a whitespace-only line,
+# ``JSON_ERROR`` is a line that could not be parsed as JSON, ``NON_OBJECT`` is
+# valid JSON that is not a JSON object (e.g. an array or scalar), and
+# ``SCHEMA`` is an object missing keys declared as required.
+SCAN_BLANK = "blank"
+SCAN_JSON_ERROR = "json_error"
+SCAN_NON_OBJECT = "non_object"
+SCAN_SCHEMA = "schema"
+
+# Hard cap on the raw-line preview stored in a ``ScanIssue``.  This keeps
+# memory bounded even for pathological inputs.
+_PREVIEW_MAX_CHARS = 200
+
+
+@dataclass(slots=True)
+class ScanIssue:
+    """A single problem found while scanning one record/line.
+
+    ``line_number`` is 1-based; ``raw_preview`` is a truncated, redacted copy
+    of the offending line or record so logs stay safe to share.
+    """
+
+    category: str
+    line_number: int
+    detail: str
+    raw_preview: str
+
+
+@dataclass(slots=True)
+class ScanReport:
+    """Aggregated result of a streaming scan pass.
+
+    ``total_lines`` counts every physical line inspected (including blanks).
+    ``object_lines`` is how many parsed as JSON objects.  ``issues`` is a
+    bounded list (see ``max_issues``) so memory stays predictable on large
+    files; ``truncated_issues`` records how many additional issues were
+    dropped after the cap.
+    """
+
+    total_lines: int = 0
+    object_lines: int = 0
+    blank_lines: int = 0
+    json_error_lines: int = 0
+    non_object_lines: int = 0
+    schema_error_lines: int = 0
+    issues: list[ScanIssue] = field(default_factory=list)
+    truncated_issues: int = 0
+    source: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """Whether the scan found no issues at all."""
+
+        return not self.issues and self.truncated_issues == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict for JSON / structured output."""
+
+        return {
+            "source": self.source,
+            "total_lines": self.total_lines,
+            "object_lines": self.object_lines,
+            "blank_lines": self.blank_lines,
+            "json_error_lines": self.json_error_lines,
+            "non_object_lines": self.non_object_lines,
+            "schema_error_lines": self.schema_error_lines,
+            "truncated_issues": self.truncated_issues,
+            "issues": [
+                {
+                    "category": issue.category,
+                    "line_number": issue.line_number,
+                    "detail": issue.detail,
+                    "raw_preview": issue.raw_preview,
+                }
+                for issue in self.issues
+            ],
+        }
+
+
+def _truncate_preview(text: str) -> str:
+    """Truncate a raw line/record to a bounded length for safe logging."""
+
+    if len(text) <= _PREVIEW_MAX_CHARS:
+        return text
+    return text[:_PREVIEW_MAX_CHARS] + "..."
+
+
+def _redact_preview(text: str) -> str:
+    """Redact values that look like secrets from a preview string.
+
+    Only applied to raw previews of bad lines so we never expose full training
+    samples in logs or CLI output.  Key-based redaction is intentionally
+    lightweight: it covers common secret key names without pulling in a regex
+    dependency beyond the stdlib.
+    """
+
+    import re
+
+    # Replace the value of keys that commonly carry secrets/tokens.
+    pattern = re.compile(
+        r'("(?:api[_-]?key|token|secret|password|access[_-]?key|credential)"\s*:\s*")([^"]*)(")',
+        re.IGNORECASE,
+    )
+    return pattern.sub(r"\1<redacted>\3", text)
+
+
+def _record_issue(
+    report: ScanReport,
+    *,
+    category: str,
+    line_number: int,
+    detail: str,
+    raw_preview: str,
+    max_issues: int,
+) -> None:
+    """Append an issue to the report, respecting the ``max_issues`` cap."""
+
+    if len(report.issues) < max_issues:
+        report.issues.append(
+            ScanIssue(
+                category=category,
+                line_number=line_number,
+                detail=detail,
+                raw_preview=_redact_preview(_truncate_preview(raw_preview)),
+            )
+        )
+    else:
+        report.truncated_issues += 1
+
+
+def scan_jsonl_stream(
+    source: TextIO | str | Path,
+    *,
+    required_keys: tuple[str, ...] = (),
+    max_issues: int = 50,
+    encoding: str = "utf-8",
+) -> ScanReport:
+    """Stream-scan a JSONL file or stdin, reporting quality issues.
+
+    The file is read line by line so memory stays bounded regardless of file
+    size.  Each non-blank line is parsed as JSON; lines that fail to parse, are
+    not JSON objects, or miss any of *required_keys* are recorded as issues
+    with their 1-based line number and a truncated, redacted preview.
+
+    Parameters
+    ----------
+    source:
+        A path/str to a JSONL file, or a text stream (e.g. ``sys.stdin``).
+    required_keys:
+        Object keys that every record must contain.  Empty by default, meaning
+        only structural checks (blank / JSON / object) are performed.
+    max_issues:
+        Maximum number of :class:`ScanIssue` entries stored in the report.
+        Additional issues are counted in ``truncated_issues``.
+    encoding:
+        File encoding when *source* is a path.
+
+    Returns
+    -------
+    ScanReport
+        Aggregated counts and a bounded list of issues.
+    """
+
+    if max_issues < 0:
+        raise ValueError("max_issues must be non-negative")
+
+    report = ScanReport()
+    owns_handle = False
+    stream: TextIO
+
+    if isinstance(source, str | Path):
+        path = Path(source)
+        report.source = str(path)
+        stream = path.open("r", encoding=encoding)
+        owns_handle = True
+    else:
+        report.source = getattr(source, "name", "<stdin>")
+        stream = source
+
+    try:
+        line_number = 0
+        for raw_line in stream:
+            line_number += 1
+            report.total_lines += 1
+            stripped = raw_line.strip()
+            if not stripped:
+                report.blank_lines += 1
+                _record_issue(
+                    report,
+                    category=SCAN_BLANK,
+                    line_number=line_number,
+                    detail="blank line",
+                    raw_preview="",
+                    max_issues=max_issues,
+                )
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                report.json_error_lines += 1
+                _record_issue(
+                    report,
+                    category=SCAN_JSON_ERROR,
+                    line_number=line_number,
+                    detail=f"invalid JSON: {exc.msg}",
+                    raw_preview=stripped,
+                    max_issues=max_issues,
+                )
+                continue
+            if not isinstance(record, dict):
+                report.non_object_lines += 1
+                _record_issue(
+                    report,
+                    category=SCAN_NON_OBJECT,
+                    line_number=line_number,
+                    detail=f"expected JSON object, got {type(record).__name__}",
+                    raw_preview=stripped,
+                    max_issues=max_issues,
+                )
+                continue
+            missing = [k for k in required_keys if k not in record]
+            if missing:
+                report.schema_error_lines += 1
+                _record_issue(
+                    report,
+                    category=SCAN_SCHEMA,
+                    line_number=line_number,
+                    detail=f"missing required keys: {', '.join(missing)}",
+                    raw_preview=stripped,
+                    max_issues=max_issues,
+                )
+                continue
+            report.object_lines += 1
+    finally:
+        if owns_handle:
+            stream.close()
+
+    return report
+
+
+def scan_loader_output(
+    records: Iterable[Any],
+    *,
+    required_keys: tuple[str, ...] = (),
+    max_issues: int = 50,
+    source: str = "<loader>",
+) -> ScanReport:
+    """Scan records returned by a ``--dataset-loader-fn`` for quality issues.
+
+    This complements :func:`scan_jsonl_stream` for cases where the user has a
+    custom loader that transforms raw data into training rows.  Each record is
+    checked to be a ``dict`` and to contain all *required_keys*.  Non-dict
+    records and schema violations are recorded with their 1-based index.
+
+    Parameters
+    ----------
+    records:
+        An iterable of records produced by a loader function.
+    required_keys:
+        Keys every record must contain.
+    max_issues:
+        Maximum number of issues stored.
+    source:
+        Label used in the report ``source`` field.
+    """
+
+    if max_issues < 0:
+        raise ValueError("max_issues must be non-negative")
+
+    report = ScanReport(source=source)
+    index = 0
+    for record in records:
+        index += 1
+        report.total_lines += 1
+        if not isinstance(record, dict):
+            report.non_object_lines += 1
+            _record_issue(
+                report,
+                category=SCAN_NON_OBJECT,
+                line_number=index,
+                detail=f"expected dict, got {type(record).__name__}",
+                raw_preview=repr(record),
+                max_issues=max_issues,
+            )
+            continue
+        missing = [k for k in required_keys if k not in record]
+        if missing:
+            report.schema_error_lines += 1
+            _record_issue(
+                report,
+                category=SCAN_SCHEMA,
+                line_number=index,
+                detail=f"missing required keys: {', '.join(missing)}",
+                raw_preview=json.dumps(record, ensure_ascii=False, default=str),
+                max_issues=max_issues,
+            )
+            continue
+        report.object_lines += 1
+
+    return report
+
+
+def format_scan_report(report: ScanReport, *, json_output: bool = False) -> str:
+    """Render a :class:`ScanReport` as human-readable text or JSON.
+
+    The human-readable form is a short summary followed by per-issue lines.
+    The JSON form is the ``to_dict`` result pretty-printed.
+    """
+
+    if json_output:
+        return json.dumps(report.to_dict(), indent=2, ensure_ascii=False)
+
+    lines: list[str] = []
+    lines.append(f"source: {report.source or '<stdin>'}")
+    lines.append(
+        f"total_lines: {report.total_lines}  objects: {report.object_lines}  "
+        f"blank: {report.blank_lines}  json_errors: {report.json_error_lines}  "
+        f"non_object: {report.non_object_lines}  schema_errors: {report.schema_error_lines}"
+    )
+    if report.truncated_issues:
+        lines.append(f"(truncated {report.truncated_issues} additional issues)")
+    if report.ok:
+        lines.append("status: OK")
+    else:
+        lines.append("status: ISSUES FOUND")
+        for issue in report.issues:
+            preview = f"  preview: {issue.raw_preview}" if issue.raw_preview else ""
+            lines.append(f"  line {issue.line_number}: [{issue.category}] {issue.detail}{preview}")
+    return "\n".join(lines)

--- a/areno/cli/diagnostics.py
+++ b/areno/cli/diagnostics.py
@@ -482,3 +482,133 @@ def _print_env_report(report: dict[str, Any]) -> None:
     click.echo("  Environment variables:")
     for name, value in report["env"].items():
         click.echo(f"    {name}={value if value is not None else '<unset>'}")
+
+
+# ---------------------------------------------------------------------------
+# scan-dataset command
+# ---------------------------------------------------------------------------
+
+
+@click.command(
+    name="scan-dataset",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.argument("path", type=click.Path(exists=False), required=False)
+@click.option(
+    "--required-keys",
+    "required_keys",
+    default="",
+    help="Comma-separated keys every JSON object must contain (e.g. prompt,response).",
+)
+@click.option(
+    "--max-issues",
+    "max_issues",
+    type=int,
+    default=50,
+    show_default=True,
+    help="Maximum number of issue details to store in the report.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON report instead of human-readable text.",
+)
+@click.option(
+    "--loader-fn",
+    "loader_fn",
+    default=None,
+    help="Path to a dataset loader .py file (same format as --dataset-loader-fn). "
+    "When set, PATH is passed to the loader and the loader's output is scanned.",
+)
+def scan_dataset_command(
+    path: str | None,
+    required_keys: str,
+    max_issues: int,
+    as_json: bool,
+    loader_fn: str | None,
+) -> None:
+    """Stream-scan a JSONL file (or stdin) for quality issues.
+
+    Reports blank lines, JSON parse failures, non-object records, and missing
+    required keys without loading the full dataset into memory.  Bad entries
+    are stored as a bounded, redacted preview.
+
+    \b
+    Examples:
+      areno scan-dataset data.jsonl
+      areno scan-dataset data.jsonl --required-keys prompt,response
+      cat data.jsonl | areno scan-dataset --required-keys prompt
+      areno scan-dataset data.jsonl --loader-fn my_loader.py
+    """
+
+    import sys
+
+    from areno.api.data import format_scan_report, scan_jsonl_stream
+
+    keys = tuple(k.strip() for k in required_keys.split(",") if k.strip())
+
+    if loader_fn is not None:
+        report = _scan_with_loader(
+            loader_fn,
+            dataset_path=path or "",
+            required_keys=keys,
+            max_issues=max_issues,
+        )
+    elif path is not None:
+        report = scan_jsonl_stream(path, required_keys=keys, max_issues=max_issues)
+    else:
+        # Read from stdin so users can pipe data in.
+        report = scan_jsonl_stream(sys.stdin, required_keys=keys, max_issues=max_issues)
+
+    click.echo(format_scan_report(report, json_output=as_json))
+
+    if not report.ok:
+        raise click.exceptions.Exit(1)
+
+
+def _scan_with_loader(loader_fn: str, *, dataset_path: str, required_keys: tuple[str, ...], max_issues: int):
+    """Load a dataset via a user loader function and scan its output."""
+
+    import importlib.util
+    from pathlib import Path
+
+    from areno.api.data import scan_loader_output
+
+    loader_path = Path(loader_fn).resolve()
+    if not loader_path.exists():
+        raise click.UsageError(f"loader file not found: {loader_fn}")
+
+    fn_name = "load_training_dataset"
+    if ":" in loader_fn:
+        path_text, fn_name = loader_fn.rsplit(":", 1)
+        loader_path = Path(path_text).resolve()
+        if not loader_path.exists():
+            raise click.UsageError(f"loader file not found: {path_text}")
+        if not fn_name:
+            raise click.UsageError(f"invalid loader spec: {loader_fn}")
+
+    spec = importlib.util.spec_from_file_location(f"areno_scan_loader_{abs(hash(str(loader_path)))}", loader_path)
+    if spec is None or spec.loader is None:
+        raise click.UsageError(f"could not load loader from {loader_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not hasattr(module, fn_name):
+        raise click.UsageError(f"{loader_path} must define {fn_name}(...)")
+
+    loader = getattr(module, fn_name)
+    if not callable(loader):
+        raise click.UsageError(f"{loader_path}:{fn_name} is not callable")
+
+    # The loader receives a no-op default_loader; scanning only needs the
+    # loader's own normalisation logic, not the heavy HF datasets stack.
+    def _passthrough_default_loader(p):
+        return []
+
+    records = loader(dataset_path, default_loader=_passthrough_default_loader)
+    return scan_loader_output(
+        records,
+        required_keys=required_keys,
+        max_issues=max_issues,
+        source=f"{loader_path}:{fn_name}({dataset_path or '<no-path>'})",
+    )

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -17,6 +17,11 @@ class ArenoCli(click.Group):
     _COMMANDS = {
         "check": ("areno.cli.diagnostics", "check_command", "Check whether this machine is ready to run AReno."),
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
+        "scan-dataset": (
+            "areno.cli.diagnostics",
+            "scan_dataset_command",
+            "Stream-scan a JSONL file or stdin for quality issues.",
+        ),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),

--- a/tests/test_scan_dataset_cpu.py
+++ b/tests/test_scan_dataset_cpu.py
@@ -1,0 +1,426 @@
+"""CPU tests for the streaming JSONL / loader-output quality scanner.
+
+These cover the core scan logic in ``areno.api.data`` (success, malformed
+input, boundary values, redaction, bounded issues) and the
+``areno scan-dataset`` CLI command (file/stdin/json output/loader-fn paths).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from areno.api.data import (
+    SCAN_BLANK,
+    SCAN_JSON_ERROR,
+    SCAN_NON_OBJECT,
+    SCAN_SCHEMA,
+    format_scan_report,
+    scan_jsonl_stream,
+    scan_loader_output,
+)
+from areno.cli.diagnostics import scan_dataset_command
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(tmp: str, lines: list[str], name: str = "data.jsonl") -> str:
+    path = Path(tmp, name)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Core scanner: scan_jsonl_stream
+# ---------------------------------------------------------------------------
+
+
+class ScanJsonlStreamTest(unittest.TestCase):
+    def test_clean_file_reports_ok(self):
+        lines = [
+            json.dumps({"prompt": "hello", "response": "world"}),
+            json.dumps({"prompt": "foo", "response": "bar"}),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        self.assertTrue(report.ok)
+        self.assertEqual(report.total_lines, 2)
+        self.assertEqual(report.object_lines, 2)
+        self.assertEqual(report.issues, [])
+
+    def test_blank_lines_are_reported(self):
+        lines = [
+            json.dumps({"a": 1}),
+            "",
+            "   ",
+            json.dumps({"a": 2}),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        self.assertFalse(report.ok)
+        self.assertEqual(report.blank_lines, 2)
+        self.assertEqual(report.total_lines, 4)
+        self.assertEqual(report.object_lines, 2)
+        blank_issues = [i for i in report.issues if i.category == SCAN_BLANK]
+        self.assertEqual(len(blank_issues), 2)
+        self.assertEqual(blank_issues[0].line_number, 2)
+        self.assertEqual(blank_issues[1].line_number, 3)
+
+    def test_json_parse_errors_are_reported(self):
+        lines = [
+            '{"a": 1}',
+            '{"a": }',  # malformed JSON
+            '{"b": 2}',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        self.assertEqual(report.json_error_lines, 1)
+        err = [i for i in report.issues if i.category == SCAN_JSON_ERROR]
+        self.assertEqual(len(err), 1)
+        self.assertEqual(err[0].line_number, 2)
+        self.assertIn("invalid JSON", err[0].detail)
+
+    def test_non_object_records_are_reported(self):
+        lines = [
+            '{"a": 1}',
+            "[1, 2, 3]",  # array, not object
+            "42",  # scalar
+            '{"b": 2}',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        self.assertEqual(report.non_object_lines, 2)
+        non_obj = [i for i in report.issues if i.category == SCAN_NON_OBJECT]
+        self.assertEqual(len(non_obj), 2)
+        self.assertEqual(non_obj[0].line_number, 2)
+        self.assertEqual(non_obj[0].detail, "expected JSON object, got list")
+        self.assertEqual(non_obj[1].detail, "expected JSON object, got int")
+
+    def test_required_keys_schema_check(self):
+        lines = [
+            '{"prompt": "hi", "response": "yo"}',
+            '{"prompt": "missing response"}',
+            '{"response": "missing prompt"}',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path, required_keys=("prompt", "response"))
+
+        self.assertEqual(report.object_lines, 1)
+        self.assertEqual(report.schema_error_lines, 2)
+        schema = [i for i in report.issues if i.category == SCAN_SCHEMA]
+        self.assertEqual(len(schema), 2)
+        self.assertEqual(schema[0].line_number, 2)
+        self.assertIn("missing required keys: response", schema[0].detail)
+        self.assertIn("missing required keys: prompt", schema[1].detail)
+
+    def test_scanning_continues_after_recoverable_errors(self):
+        """A bad line should not stop the scan; subsequent good lines count."""
+
+        lines = [
+            '{"a": 1}',
+            "BROKEN",
+            '{"a": 2}',
+            "",
+            '{"a": 3}',
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        self.assertEqual(report.total_lines, 5)
+        self.assertEqual(report.object_lines, 3)
+        self.assertEqual(report.json_error_lines, 1)
+        self.assertEqual(report.blank_lines, 1)
+
+    def test_preview_is_truncated(self):
+        long_value = "x" * 500
+        lines = [f'{{"key": "{long_value}"}}']  # valid but we'll make it invalid
+        # Make it invalid by truncating the closing quote
+        lines[0] = lines[0][:-2]  # remove closing "} -- now broken JSON
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        err = [i for i in report.issues if i.category == SCAN_JSON_ERROR]
+        self.assertEqual(len(err), 1)
+        # Preview should be capped at _PREVIEW_MAX_CHARS + "..."
+        self.assertLessEqual(len(err[0].raw_preview), 203)
+        self.assertTrue(err[0].raw_preview.endswith("..."))
+
+    def test_secret_values_are_redacted_in_preview(self):
+        lines = ['{"api_key": "sk-secret-12345", broken']
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path)
+
+        err = [i for i in report.issues if i.category == SCAN_JSON_ERROR]
+        self.assertEqual(len(err), 1)
+        self.assertIn("<redacted>", err[0].raw_preview)
+        self.assertNotIn("sk-secret-12345", err[0].raw_preview)
+
+    def test_max_issues_bounds_stored_issues(self):
+        lines = [f"broken_line_{i}" for i in range(10)]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path, max_issues=3)
+
+        self.assertEqual(len(report.issues), 3)
+        self.assertEqual(report.truncated_issues, 7)
+        self.assertEqual(report.json_error_lines, 10)
+
+    def test_max_issues_zero_stores_nothing(self):
+        lines = ["broken", '{"a": 1}']
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            report = scan_jsonl_stream(path, max_issues=0)
+
+        self.assertEqual(report.issues, [])
+        self.assertEqual(report.truncated_issues, 1)
+        self.assertEqual(report.json_error_lines, 1)
+        self.assertEqual(report.object_lines, 1)
+
+    def test_negative_max_issues_raises(self):
+        with self.assertRaises(ValueError):
+            scan_jsonl_stream(io.StringIO(""), max_issues=-1)
+
+    def test_stream_input_without_path(self):
+        stream = io.StringIO('{"a": 1}\n{"a": 2}\n')
+        report = scan_jsonl_stream(stream)
+
+        self.assertTrue(report.ok)
+        self.assertEqual(report.object_lines, 2)
+        self.assertEqual(report.source, "<stdin>")
+
+    def test_source_is_recorded_from_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, ['{"a": 1}'])
+            report = scan_jsonl_stream(path)
+
+        self.assertEqual(report.source, path)
+
+
+# ---------------------------------------------------------------------------
+# Core scanner: scan_loader_output
+# ---------------------------------------------------------------------------
+
+
+class ScanLoaderOutputTest(unittest.TestCase):
+    def test_clean_records_report_ok(self):
+        records = [{"prompt": "a", "response": "b"}, {"prompt": "c", "response": "d"}]
+        report = scan_loader_output(records, required_keys=("prompt", "response"))
+
+        self.assertTrue(report.ok)
+        self.assertEqual(report.object_lines, 2)
+
+    def test_non_dict_records_reported(self):
+        records = [{"a": 1}, [1, 2], "string", 42]
+        report = scan_loader_output(records)
+
+        self.assertEqual(report.object_lines, 1)
+        self.assertEqual(report.non_object_lines, 3)
+        non_obj = [i for i in report.issues if i.category == SCAN_NON_OBJECT]
+        self.assertEqual(len(non_obj), 3)
+        self.assertEqual(non_obj[0].line_number, 2)
+        self.assertEqual(non_obj[0].detail, "expected dict, got list")
+
+    def test_schema_missing_keys_reported(self):
+        records = [{"prompt": "hi"}, {"prompt": "a", "response": "b"}]
+        report = scan_loader_output(records, required_keys=("prompt", "response"))
+
+        self.assertEqual(report.object_lines, 1)
+        self.assertEqual(report.schema_error_lines, 1)
+
+    def test_source_label(self):
+        report = scan_loader_output([], source="my_loader")
+        self.assertEqual(report.source, "my_loader")
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+
+class FormatScanReportTest(unittest.TestCase):
+    def test_json_output_is_valid_json(self):
+        stream = io.StringIO('{"a": 1}\nbroken\n')
+        report = scan_jsonl_stream(stream)
+        text = format_scan_report(report, json_output=True)
+
+        parsed = json.loads(text)
+        self.assertEqual(parsed["total_lines"], 2)
+        self.assertEqual(parsed["object_lines"], 1)
+        self.assertEqual(len(parsed["issues"]), 1)
+
+    def test_human_output_contains_status(self):
+        stream = io.StringIO('{"a": 1}\n')
+        report = scan_jsonl_stream(stream)
+        text = format_scan_report(report, json_output=False)
+
+        self.assertIn("status: OK", text)
+        self.assertIn("total_lines: 1", text)
+
+    def test_human_output_shows_issue_lines(self):
+        stream = io.StringIO("broken\n")
+        report = scan_jsonl_stream(stream)
+        text = format_scan_report(report, json_output=False)
+
+        self.assertIn("status: ISSUES FOUND", text)
+        self.assertIn("[json_error]", text)
+        self.assertIn("line 1:", text)
+
+
+# ---------------------------------------------------------------------------
+# CLI: areno scan-dataset
+# ---------------------------------------------------------------------------
+
+
+class ScanDatasetCliTest(unittest.TestCase):
+    def test_cli_clean_file_exits_zero(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, [json.dumps({"prompt": "hi", "response": "yo"})])
+            result = runner.invoke(scan_dataset_command, [path])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("status: OK", result.output)
+
+    def test_cli_bad_file_exits_one(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, ["broken_json"])
+            result = runner.invoke(scan_dataset_command, [path])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("status: ISSUES FOUND", result.output)
+        self.assertIn("[json_error]", result.output)
+
+    def test_cli_required_keys_option(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, ['{"prompt": "hi"}'])
+            result = runner.invoke(scan_dataset_command, [path, "--required-keys", "prompt,response"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("schema_errors: 1", result.output)
+
+    def test_cli_json_output(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, ['{"a": 1}', "broken"])
+            result = runner.invoke(scan_dataset_command, [path, "--json"])
+
+        self.assertEqual(result.exit_code, 1)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["total_lines"], 2)
+        self.assertEqual(parsed["json_error_lines"], 1)
+
+    def test_cli_stdin_input(self):
+        runner = CliRunner()
+        result = runner.invoke(scan_dataset_command, input='{"a": 1}\n{"a": 2}\n')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("objects: 2", result.output)
+
+    def test_cli_max_issues_option(self):
+        runner = CliRunner()
+        lines = ["broken"] * 10
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, lines)
+            result = runner.invoke(scan_dataset_command, [path, "--max-issues", "3"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("truncated 7", result.output)
+
+    def test_cli_lists_in_top_level_help(self):
+        from areno.cli.main import main
+
+        result = CliRunner().invoke(main, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("scan-dataset", result.output)
+
+    def test_cli_loader_fn_scans_output(self):
+        """The --loader-fn path loads a .py loader and scans its records."""
+
+        runner = CliRunner()
+        loader_code = (
+            "def load_training_dataset(path, *, default_loader, **_):\n"
+            "    return [\n"
+            "        {'prompt': 'a', 'response': 'b'},\n"
+            "        {'prompt': 'c'},               # missing response\n"
+            "        [1, 2],                          # non-dict\n"
+            "    ]\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            loader_path = Path(tmp, "my_loader.py")
+            loader_path.write_text(loader_code, encoding="utf-8")
+            data_path = Path(tmp, "data.jsonl")
+            data_path.write_text('{"x": 1}\n', encoding="utf-8")
+            result = runner.invoke(
+                scan_dataset_command,
+                [str(data_path), "--loader-fn", str(loader_path), "--required-keys", "prompt,response"],
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("non_object: 1", result.output)
+        self.assertIn("schema_errors: 1", result.output)
+        self.assertIn("objects: 1", result.output)
+
+    def test_cli_loader_fn_missing_file_raises_usage_error(self):
+        runner = CliRunner()
+        result = runner.invoke(scan_dataset_command, ["--loader-fn", "/nonexistent/loader.py"])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("loader file not found", result.output)
+
+
+# ---------------------------------------------------------------------------
+# Bounded memory / large-file simulation
+# ---------------------------------------------------------------------------
+
+
+class BoundedMemoryTest(unittest.TestCase):
+    def test_large_file_line_count_is_correct(self):
+        """Simulate a large file (many lines) and verify counts.
+
+        The scanner reads line by line, so memory does not scale with file
+        size.  We verify the counts match the input exactly.
+        """
+
+        good = json.dumps({"prompt": "x", "response": "y"})
+        lines = [good, "", "broken", good, "[1, 2, 3]"]
+        # Repeat the pattern to simulate a larger file.
+        all_lines = lines * 1000
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_jsonl(tmp, all_lines)
+            report = scan_jsonl_stream(path, max_issues=5)
+
+        self.assertEqual(report.total_lines, 5000)
+        # Per pattern: 2 good objects, 1 blank, 1 json error, 1 non-object (array)
+        self.assertEqual(report.object_lines, 2000)
+        self.assertEqual(report.blank_lines, 1000)
+        self.assertEqual(report.json_error_lines, 1000)
+        self.assertEqual(report.non_object_lines, 1000)
+        # Issues are capped at 5
+        self.assertEqual(len(report.issues), 5)
+        self.assertEqual(report.truncated_issues, 2995)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a streaming JSONL and loader-output quality scanner that inspects dataset files line-by-line without loading the full dataset into memory. Reports blank lines, JSON parse errors, non-object records, and schema surprises (missing required keys) with bounded, redacted previews of bad entries. Enables users to validate data quality before starting expensive training runs.

Closes #213.

## What changed

- **areno/api/data.py** — `scan_jsonl_stream` (stream file/stdin line-by-line), `scan_loader_output` (scan custom loader records), `ScanIssue`/`ScanReport` dataclasses, `format_scan_report` (human-readable + JSON output), redaction (`_redact_preview`) and truncation (`_PREVIEW_MAX_CHARS=200`) helpers
- **areno/cli/diagnostics.py** — `areno scan-dataset` CLI command with `--required-keys`, `--max-issues`, `--json`, `--loader-fn` options, supporting file and stdin input; exit code 1 when issues found
- **areno/cli/main.py** — register `scan-dataset` in the command table
- **tests/test_scan_dataset_cpu.py** — 30 tests covering core scan logic, malformed input, boundary values, redaction, bounded memory (5000-line simulation), CLI paths (file/stdin/json/loader-fn/missing-file), and `--help` listing

## Design

- **Streaming, bounded memory**: File is read line-by-line; memory does not scale with file size. `max_issues` caps stored `ScanIssue` entries; excess counted in `truncated_issues`.
- **Issue categories**: `blank` (whitespace-only line), `json_error` (JSON parse failure), `non_object` (valid JSON but not a dict), `schema` (dict missing required keys). Each issue records 1-based line number, detail string, and truncated/redacted raw preview.
- **Redaction**: `_redact_preview` masks values of common secret keys (`api_key`, `token`, `secret`, `password`, etc.) in previews so sensitive training data never appears in logs or CLI output.
- **Defaults are backward compatible**: `required_keys=()` (no schema check), `max_issues=50`. The command is purely additive — no existing CLI command, trainer, or config is modified.
- **No new dependencies**: Uses only stdlib (`json`, `re`). No external database, no sandbox, no model initialization.
- **Loader-fn path**: `--loader-fn` imports a user `.py` file, calls `load_training_dataset(path, default_loader=...)`, and scans the returned records with `scan_loader_output`. Receives a no-op `default_loader` so scanning doesn't pull in the HF datasets stack.
- **Output formats**: `format_scan_report(report, json_output=False)` for human-readable summary + per-issue lines; `json_output=True` for structured JSON via `ScanReport.to_dict()`.

## Testing

30 CPU tests across 5 test classes:

- `ScanJsonlStreamTest` (13) — clean file, blank lines, JSON errors, non-object, schema check, error recovery, preview truncation, secret redaction, max_issues bounds (including 0 and negative), stdin input, source tracking
- `ScanLoaderOutputTest` (4) — clean records, non-dict, schema missing keys, source label
- `FormatScanReportTest` (3) — JSON output validity, human-readable status, issue line display
- `ScanDatasetCliTest` (9) — clean/bad file exit codes, required-keys, json output, stdin, max-issues, `--help` listing, loader-fn scan, loader-fn missing file
- `BoundedMemoryTest` (1) — 5000-line file with mixed content, verifies counts and issues cap