### PR TITLE
feat: add post-loader data contract validation for SFT/DPO/Online RL/Agentic

### DIFF
--- a/areno/api/__init__.py
+++ b/areno/api/__init__.py
@@ -18,6 +18,15 @@ from areno.api.agentic import (
 from areno.api.algorithms import AlgorithmSpec, get_algorithm, list_algorithms, register_algorithm
 from areno.api.config import ArenoConfig
 from areno.api.data import PromptBatch, PromptItem
+from areno.api.data_contract import (
+    ContractError,
+    ContractReport,
+    ContractSpec,
+    FieldSpec,
+    get_contract_spec,
+    list_contract_modes,
+    validate_contract,
+)
 from areno.api.loss_fns import dpo_loss_fn, grpo_loss_fn, gspo_loss_fn, ppo_loss_fn, sft_loss_fn
 from areno.api.models import (
     BackendType,
@@ -38,6 +47,10 @@ __all__ = [
     "Trainer",
     "AlgorithmSpec",
     "ArenoConfig",
+    "ContractError",
+    "ContractReport",
+    "ContractSpec",
+    "FieldSpec",
     "PromptBatch",
     "PromptItem",
     "AgentBatch",
@@ -56,8 +69,11 @@ __all__ = [
     "Areno",
     "DefaultBackend",
     "get_algorithm",
+    "get_contract_spec",
     "list_algorithms",
+    "list_contract_modes",
     "register_algorithm",
+    "validate_contract",
     "dpo_loss_fn",
     "gspo_loss_fn",
     "grpo_loss_fn",

--- a/areno/api/data_contract.py
+++ b/areno/api/data_contract.py
@@ -1,0 +1,595 @@
+"""Post-loader data contract validation for AReno training modes.
+
+This module validates dataset records produced by user loader functions
+against per-mode field contracts *before* expensive model or worker
+initialization.  Contracts cover SFT, DPO, online RL (GSPO/GRPO/PPO), and
+agentic inputs.
+
+The validator aggregates a bounded set of errors instead of stopping at the
+first, so users see all fixable issues in one pass.  Error messages carry
+``sample_index``, ``field_path`` (e.g. ``messages[2].role``), ``expected``,
+``actual``, and a concrete ``hint`` — without exposing full training samples.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Public data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ContractError:
+    """One field-level contract violation found in a dataset record."""
+
+    sample_index: int
+    field_path: str
+    expected: str
+    actual: str
+    hint: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContractReport:
+    """Aggregated result of validating a dataset against a contract."""
+
+    mode: str
+    total_scanned: int
+    errors: list[ContractError] = field(default_factory=list)
+    warnings: list[ContractError] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Return ``True`` when no errors were collected."""
+
+        return len(self.errors) == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict for JSON / dashboard consumption."""
+
+        return {
+            "mode": self.mode,
+            "total_scanned": self.total_scanned,
+            "ok": self.ok,
+            "errors": [
+                {
+                    "sample_index": e.sample_index,
+                    "field_path": e.field_path,
+                    "expected": e.expected,
+                    "actual": e.actual,
+                    "hint": e.hint,
+                }
+                for e in self.errors
+            ],
+            "warnings": [
+                {
+                    "sample_index": e.sample_index,
+                    "field_path": e.field_path,
+                    "expected": e.expected,
+                    "actual": e.actual,
+                    "hint": e.hint,
+                }
+                for e in self.warnings
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FieldSpec:
+    """Declarative specification for one top-level record field."""
+
+    name: str
+    required: bool
+    expected_type: type | tuple[type, ...]
+    element_type: type | tuple[type, ...] | None = None
+    min_length: int | None = None
+    nullable: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Type-name helpers
+# ---------------------------------------------------------------------------
+
+_VALID_ROLES = {"system", "user", "assistant", "tool"}
+
+
+def _type_name(value: Any) -> str:
+    """Return a short human-readable type name for *value*."""
+
+    if value is None:
+        return "NoneType"
+    return type(value).__name__
+
+
+def _expected_type_name(spec: FieldSpec) -> str:
+    """Return the expected type label shown in error messages."""
+
+    types = spec.expected_type if isinstance(spec.expected_type, tuple) else (spec.expected_type,)
+    names = [t.__name__ for t in types]
+    base = " | ".join(names) if len(names) > 1 else names[0]
+    if spec.element_type is not None:
+        elem_types = (
+            spec.element_type if isinstance(spec.element_type, tuple) else (spec.element_type,)
+        )
+        elem_names = [t.__name__ for t in elem_types]
+        base += f"[{' | '.join(elem_names)}]"
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Per-mode contract specs
+# ---------------------------------------------------------------------------
+
+_MESSAGES_FIELD_SPECS: list[FieldSpec] = [
+    FieldSpec("messages", required=True, expected_type=list, element_type=dict),
+]
+
+_PROMPT_FIELD_SPECS: list[FieldSpec] = [
+    FieldSpec("prompt", required=True, expected_type=str),
+]
+
+_SFT_PROMPT_RESPONSE_SPECS: list[FieldSpec] = [
+    FieldSpec("prompt", required=True, expected_type=str),
+    FieldSpec("response", required=True, expected_type=str),
+]
+
+_DPO_STR_SPECS: list[FieldSpec] = [
+    FieldSpec("prompt", required=True, expected_type=str),
+    FieldSpec("chosen", required=True, expected_type=str),
+    FieldSpec("rejected", required=True, expected_type=str),
+]
+
+_DPO_LIST_SPECS: list[FieldSpec] = [
+    FieldSpec("chosen", required=True, expected_type=list, element_type=dict),
+    FieldSpec("rejected", required=True, expected_type=list, element_type=dict),
+    FieldSpec("prompt", required=False, expected_type=str),
+]
+
+_ONLINE_RL_SPECS: list[FieldSpec] = [
+    FieldSpec("prompt", required=True, expected_type=str),
+    FieldSpec("solutions", required=False, expected_type=list, element_type=str, nullable=True),
+]
+
+
+def _sniff_sft_variant(record: dict[str, Any]) -> str:
+    """Detect whether an SFT row uses ``messages`` or ``prompt``+``response``."""
+
+    if isinstance(record.get("messages"), list):
+        return "messages"
+    return "prompt_response"
+
+
+def _sniff_dpo_variant(record: dict[str, Any]) -> str:
+    """Detect whether a DPO row uses string or chat-list ``chosen``/``rejected``."""
+
+    chosen = record.get("chosen")
+    if isinstance(chosen, list):
+        return "list"
+    return "str"
+
+
+def _sniff_agentic_variant(record: dict[str, Any]) -> str:
+    """Detect whether an agentic row uses ``messages`` or ``prompt``."""
+
+    if isinstance(record.get("messages"), list):
+        return "messages"
+    return "prompt"
+
+
+@dataclass(frozen=True, slots=True)
+class ContractSpec:
+    """Full contract for one training mode."""
+
+    mode: str
+    fields: list[FieldSpec]
+    sniff_variant: Callable[[dict[str, Any]], str] | None = None
+    variants: dict[str, list[FieldSpec]] | None = None
+
+    def fields_for_record(self, record: dict[str, Any]) -> list[FieldSpec]:
+        """Return the effective field list for *record*, resolving variants."""
+
+        if self.sniff_variant is not None and self.variants is not None:
+            variant = self.sniff_variant(record)
+            return self.variants[variant]
+        return self.fields
+
+
+def _build_contract_specs() -> dict[str, ContractSpec]:
+    """Build the built-in per-mode contract registry."""
+
+    return {
+        "sft": ContractSpec(
+            mode="sft",
+            fields=[],
+            sniff_variant=_sniff_sft_variant,
+            variants={
+                "prompt_response": _SFT_PROMPT_RESPONSE_SPECS,
+                "messages": _MESSAGES_FIELD_SPECS,
+            },
+        ),
+        "dpo": ContractSpec(
+            mode="dpo",
+            fields=[],
+            sniff_variant=_sniff_dpo_variant,
+            variants={
+                "str": _DPO_STR_SPECS,
+                "list": _DPO_LIST_SPECS,
+            },
+        ),
+        "online_rl": ContractSpec(
+            mode="online_rl",
+            fields=_ONLINE_RL_SPECS,
+        ),
+        "agentic": ContractSpec(
+            mode="agentic",
+            fields=[],
+            sniff_variant=_sniff_agentic_variant,
+            variants={
+                "prompt": _PROMPT_FIELD_SPECS,
+                "messages": _MESSAGES_FIELD_SPECS,
+            },
+        ),
+    }
+
+
+_CONTRACT_SPECS = _build_contract_specs()
+
+
+# ---------------------------------------------------------------------------
+# Nested message validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_messages(
+    record: dict[str, Any], index: int, errors: list[ContractError]
+) -> None:
+    """Validate the nested structure of an OpenAI-style ``messages`` list."""
+
+    messages = record.get("messages")
+    if not isinstance(messages, list):
+        return  # top-level type check already handled by FieldSpec
+    for i, msg in enumerate(messages):
+        prefix = f"messages[{i}]"
+        if not isinstance(msg, dict):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=prefix,
+                    expected="dict",
+                    actual=_type_name(msg),
+                    hint="each message must be a dict with 'role' and 'content' keys",
+                )
+            )
+            continue
+        role = msg.get("role")
+        if not isinstance(role, str):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{prefix}.role",
+                    expected="str",
+                    actual=_type_name(role) if "role" in msg else "missing",
+                    hint="add a 'role' field with one of: system, user, assistant, tool",
+                )
+            )
+        elif role not in _VALID_ROLES:
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{prefix}.role",
+                    expected=f"one of {sorted(_VALID_ROLES)}",
+                    actual=role,
+                    hint=f"use a valid role: {', '.join(sorted(_VALID_ROLES))}",
+                )
+            )
+        if "content" not in msg:
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{prefix}.content",
+                    expected="str",
+                    actual="missing",
+                    hint="add a 'content' field (may be empty string for tool-call messages)",
+                )
+            )
+        elif msg["content"] is not None and not isinstance(msg["content"], str):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{prefix}.content",
+                    expected="str",
+                    actual=_type_name(msg["content"]),
+                    hint="'content' must be a string or null",
+                )
+            )
+        tool_calls = msg.get("tool_calls")
+        if tool_calls is not None:
+            _validate_tool_calls(tool_calls, index, prefix, errors)
+
+
+def _validate_tool_calls(
+    tool_calls: Any, index: int, prefix: str, errors: list[ContractError]
+) -> None:
+    """Validate the nested structure of ``tool_calls`` in an assistant message."""
+
+    if not isinstance(tool_calls, list):
+        errors.append(
+            ContractError(
+                sample_index=index,
+                field_path=f"{prefix}.tool_calls",
+                expected="list[dict]",
+                actual=_type_name(tool_calls),
+                hint="'tool_calls' must be a list of tool-call dicts",
+            )
+        )
+        return
+    for j, call in enumerate(tool_calls):
+        call_prefix = f"{prefix}.tool_calls[{j}]"
+        if not isinstance(call, dict):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=call_prefix,
+                    expected="dict",
+                    actual=_type_name(call),
+                    hint="each tool_call must be a dict with a 'function' key",
+                )
+            )
+            continue
+        func = call.get("function")
+        if not isinstance(func, dict):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{call_prefix}.function",
+                    expected="dict",
+                    actual=_type_name(func) if "function" in call else "missing",
+                    hint="add a 'function' dict with 'name' and 'arguments' keys",
+                )
+            )
+            continue
+        if not isinstance(func.get("name"), str):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{call_prefix}.function.name",
+                    expected="str",
+                    actual=_type_name(func.get("name")) if "name" in func else "missing",
+                    hint="add a 'name' string identifying the tool",
+                )
+            )
+        if "arguments" not in func:
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{call_prefix}.function.arguments",
+                    expected="str | dict",
+                    actual="missing",
+                    hint="add an 'arguments' field (JSON string or dict)",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Core field validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_field(
+    record: dict[str, Any],
+    spec: FieldSpec,
+    index: int,
+    errors: list[ContractError],
+    warnings: list[ContractError],
+) -> None:
+    """Validate one field spec against a record, appending to *errors*/*warnings*."""
+
+    value = record.get(spec.name, _MISSING)
+    if value is _MISSING:
+        if spec.required:
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=spec.name,
+                    expected=_expected_type_name(spec),
+                    actual="missing",
+                    hint=f"add a '{spec.name}' field to the dataset record",
+                )
+            )
+        return
+    if value is None:
+        if not spec.nullable:
+            if spec.required:
+                errors.append(
+                    ContractError(
+                        sample_index=index,
+                        field_path=spec.name,
+                        expected=_expected_type_name(spec),
+                        actual="NoneType",
+                        hint=f"'{spec.name}' must not be null",
+                    )
+                )
+            else:
+                warnings.append(
+                    ContractError(
+                        sample_index=index,
+                        field_path=spec.name,
+                        expected=_expected_type_name(spec),
+                        actual="NoneType",
+                        hint=f"optional field '{spec.name}' is null; it will be ignored",
+                    )
+                )
+        return
+    if not isinstance(value, spec.expected_type):
+        errors.append(
+            ContractError(
+                sample_index=index,
+                field_path=spec.name,
+                expected=_expected_type_name(spec),
+                actual=_type_name(value),
+                hint=f"'{spec.name}' must be of type {_expected_type_name(spec)}",
+            )
+        )
+        return
+    if spec.element_type is not None and isinstance(value, list):
+        _validate_list_elements(value, spec, index, errors)
+    if spec.min_length is not None and isinstance(value, (str, list)) and len(value) < spec.min_length:
+        errors.append(
+            ContractError(
+                sample_index=index,
+                field_path=spec.name,
+                expected=f"{_expected_type_name(spec)} with length >= {spec.min_length}",
+                actual=f"length {len(value)}",
+                hint=f"'{spec.name}' must have at least {spec.min_length} element(s)",
+            )
+        )
+
+
+_MISSING = object()
+
+
+def _validate_list_elements(
+    value: list, spec: FieldSpec, index: int, errors: list[ContractError]
+) -> None:
+    """Check that every element of a list field has the expected element type."""
+
+    for i, item in enumerate(value):
+        if not isinstance(item, spec.element_type):
+            errors.append(
+                ContractError(
+                    sample_index=index,
+                    field_path=f"{spec.name}[{i}]",
+                    expected=_element_type_name(spec),
+                    actual=_type_name(item),
+                    hint=f"element {i} of '{spec.name}' has wrong type",
+                )
+            )
+
+
+def _element_type_name(spec: FieldSpec) -> str:
+    """Return the element type label for list field specs."""
+
+    if spec.element_type is None:
+        return "any"
+    types = spec.element_type if isinstance(spec.element_type, tuple) else (spec.element_type,)
+    names = [t.__name__ for t in types]
+    return " | ".join(names)
+
+
+def _validate_record(
+    record: Any,
+    spec: ContractSpec,
+    index: int,
+    errors: list[ContractError],
+    warnings: list[ContractError],
+) -> None:
+    """Validate one dataset record against the contract."""
+
+    if not isinstance(record, dict):
+        errors.append(
+            ContractError(
+                sample_index=index,
+                field_path="<root>",
+                expected="dict",
+                actual=_type_name(record),
+                hint="each dataset row must be a dict; normalize rows in --dataset-loader-fn",
+            )
+        )
+        return
+
+    field_specs = spec.fields_for_record(record)
+    for fs in field_specs:
+        _validate_field(record, fs, index, errors, warnings)
+
+    # Nested message validation for modes that use ``messages``
+    if "messages" in record and isinstance(record["messages"], list):
+        _validate_messages(record, index, errors)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+_CONTRACT_MODES = ("sft", "dpo", "online_rl", "agentic")
+
+
+def get_contract_spec(mode: str) -> ContractSpec:
+    """Return the ``ContractSpec`` registered for *mode*."""
+
+    key = mode.strip().lower()
+    if key not in _CONTRACT_SPECS:
+        raise ValueError(
+            f"unknown contract mode {mode!r}; supported modes: {', '.join(_CONTRACT_MODES)}"
+        )
+    return _CONTRACT_SPECS[key]
+
+
+def list_contract_modes() -> tuple[str, ...]:
+    """Return the supported contract mode names."""
+
+    return _CONTRACT_MODES
+
+
+def validate_contract(
+    dataset: Iterable[Any],
+    *,
+    mode: str,
+    max_samples: int = 100,
+    max_errors: int = 20,
+) -> ContractReport:
+    """Validate *dataset* records against the *mode* data contract.
+
+    Scans up to ``max_samples`` records and collects up to ``max_errors``
+    errors before stopping.  The returned :class:`ContractReport` aggregates
+    all found violations with sample indices, field paths, expected/actual
+    types, and concrete fix hints — without exposing original values.
+    """
+
+    spec = get_contract_spec(mode)
+    errors: list[ContractError] = []
+    warnings: list[ContractError] = []
+    scanned = 0
+    truncated = False
+
+    for index, record in enumerate(dataset):
+        if scanned >= max_samples:
+            break
+        scanned += 1
+        pre_error_count = len(errors)
+        _validate_record(record, spec, index, errors, warnings)
+        if len(errors) >= max_errors and len(errors) > pre_error_count:
+            truncated = True
+            break
+
+    if truncated:
+        warnings.append(
+            ContractError(
+                sample_index=-1,
+                field_path="<report>",
+                expected=f"<= {max_errors} errors",
+                actual=f">= {len(errors)} errors",
+                hint=f"error list truncated at {max_errors}; fix the shown errors and re-run to see more",
+            )
+        )
+
+    return ContractReport(
+        mode=spec.mode,
+        total_scanned=scanned,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+__all__ = [
+    "ContractError",
+    "ContractReport",
+    "ContractSpec",
+    "FieldSpec",
+    "get_contract_spec",
+    "list_contract_modes",
+    "validate_contract",
+]

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -60,6 +60,7 @@ class TrainerConfig:
     agent_timeout_s: float = 300.0
     train_tool_results: bool = False
     chat_template_enable_thinking: bool | None = None
+    validate_data_contract: bool = False
 
     def __post_init__(self) -> None:
         if self.attn_backend not in {"flash", "native"}:

--- a/areno/cli/data_inspect.py
+++ b/areno/cli/data_inspect.py
@@ -1,0 +1,170 @@
+"""CLI for inspecting and validating datasets against AReno data contracts.
+
+``areno data inspect`` loads a dataset through the same loader path used by
+``areno train``, then validates the post-loader records against the per-mode
+contract before any model or worker initialization.  Output is available in
+human-readable terminal form or structured JSON.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from areno.api.data_contract import (
+    ContractError,
+    ContractReport,
+    list_contract_modes,
+    validate_contract,
+)
+
+
+@click.group(name="data", context_settings={"help_option_names": ["-h", "--help"]})
+def data_command() -> None:
+    """Inspect or validate datasets against AReno data contracts."""
+
+
+@data_command.command(name="inspect", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--dataset-path", required=True, help="Dataset path, directory, or remote ref.")
+@click.option(
+    "--dataset-loader-fn",
+    default=None,
+    help="Optional Python dataset loader function as file.py or file.py:function.",
+)
+@click.option(
+    "--model-hub",
+    type=click.Choice(["hf", "modelscope"], case_sensitive=False),
+    default="modelscope",
+    show_default=True,
+    help="Remote hub for non-local model and dataset refs.",
+)
+@click.option(
+    "--contract",
+    "run_contract",
+    is_flag=True,
+    help="Validate the loaded dataset against the mode-specific data contract.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(list_contract_modes(), case_sensitive=False),
+    default=None,
+    help="Training mode to validate against (required with --contract).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a machine-readable JSON report.")
+@click.option(
+    "--max-samples",
+    type=int,
+    default=100,
+    show_default=True,
+    help="Maximum dataset records to scan.",
+)
+@click.option(
+    "--max-errors",
+    type=int,
+    default=20,
+    show_default=True,
+    help="Maximum errors to collect before truncating.",
+)
+def inspect_command(
+    dataset_path: str,
+    dataset_loader_fn: str | None,
+    model_hub: str,
+    run_contract: bool,
+    mode: str | None,
+    as_json: bool,
+    max_samples: int,
+    max_errors: int,
+) -> None:
+    """Load a dataset and optionally validate it against a data contract."""
+
+    if run_contract and mode is None:
+        raise click.UsageError("--mode is required when --contract is used")
+
+    dataset = _load_dataset(dataset_path, dataset_loader_fn=dataset_loader_fn, model_hub=model_hub)
+    records = list(dataset)
+    total = len(records)
+
+    if not run_contract:
+        if as_json:
+            click.echo(json.dumps({"total_records": total, "contract": None}, indent=2))
+        else:
+            click.echo(f"Dataset: {dataset_path}")
+            click.echo(f"  records: {total}")
+            if dataset_loader_fn:
+                click.echo(f"  loader:  {dataset_loader_fn}")
+            click.echo()
+            if total > 0:
+                click.echo("First record keys:")
+                first = records[0]
+                if isinstance(first, dict):
+                    for key in sorted(first.keys()):
+                        click.echo(f"  {key}: {type(first[key]).__name__}")
+        return
+
+    report = validate_contract(records, mode=mode, max_samples=max_samples, max_errors=max_errors)
+
+    if as_json:
+        click.echo(json.dumps(report.to_dict(), indent=2))
+    else:
+        _print_contract_report(report, total)
+
+    if not report.ok:
+        raise click.exceptions.Exit(1)
+
+
+def _load_dataset(
+    dataset_path: str,
+    *,
+    dataset_loader_fn: str | None,
+    model_hub: str,
+):
+    """Load a dataset using the same path as ``areno train``."""
+
+    from areno.cli.train import _load_dataset_for_training
+
+    from datasets import load_dataset, load_from_disk
+
+    return _load_dataset_for_training(
+        dataset_path,
+        dataset_loader_fn=dataset_loader_fn,
+        model_hub=model_hub,
+        load_dataset=load_dataset,
+        load_from_disk=load_from_disk,
+    )
+
+
+def _print_contract_report(report: ContractReport, total_records: int) -> None:
+    """Print a human-readable contract validation report."""
+
+    status = "passed" if report.ok else "failed"
+    click.echo(
+        f"Contract validation: mode={report.mode}  scanned={report.total_scanned}"
+        f"  total={total_records}  errors={len(report.errors)}  warnings={len(report.warnings)}"
+        f"  status={status}"
+    )
+    click.echo()
+
+    for err in report.errors:
+        _print_error("ERROR", err)
+    for warn in report.warnings:
+        _print_error("WARN", warn)
+
+    if report.ok:
+        click.echo("Passed: no contract violations found.")
+    else:
+        click.echo(
+            f"Failed: {len(report.errors)} error(s) found."
+            "  Fix the listed fields or adjust the dataset loader."
+        )
+
+
+def _print_error(label: str, err: ContractError) -> None:
+    """Print one contract error or warning line."""
+
+    idx = err.sample_index if err.sample_index >= 0 else "-"
+    click.echo(
+        f"{label:<5} sample={idx}  field='{err.field_path}'"
+        f"  expected={err.expected}  got={err.actual}"
+    )
+    click.echo(f"      hint: {err.hint}")

--- a/areno/cli/main.py
+++ b/areno/cli/main.py
@@ -19,6 +19,7 @@ class ArenoCli(click.Group):
         "env": ("areno.cli.diagnostics", "env_command", "Print an AReno environment/support report."),
         "agent": ("areno.cli.agent", "agent_command", "Ask a coding agent to run an AReno train/serve job."),
         "dashboard": ("areno.cli.dashboard", "dashboard_command", "Start or stop the AReno React dashboard."),
+        "data": ("areno.cli.data_inspect", "data_command", "Inspect or validate a dataset against AReno contracts."),
         "train": ("areno.cli.train", "train_command", "Run SFT, DPO, GSPO, GRPO, or PPO training."),
         "serve": ("areno.cli.serve", "serve_command", "Serve an OpenAI-compatible chat API."),
     }

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -68,6 +68,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "max_steps",
             "world_size",
             "tp_size",
+            "validate_data_contract",
         ),
     ),
     (
@@ -638,6 +639,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            validate_data_contract=args.validate_data_contract,
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
         )
@@ -679,6 +681,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            validate_data_contract=args.validate_data_contract,
         )
     if algorithm.name != "ppo":
         return PolicyTrainerConfig(
@@ -727,6 +730,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             agent_timeout_s=args.agent_timeout_s,
             train_tool_results=args.train_tool_results,
             chat_template_enable_thinking=chat_template_enable_thinking,
+            validate_data_contract=args.validate_data_contract,
         )
     return PPOTrainerConfig(
         algo=algorithm.name,
@@ -788,6 +792,50 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         agent_timeout_s=args.agent_timeout_s,
         train_tool_results=args.train_tool_results,
         chat_template_enable_thinking=chat_template_enable_thinking,
+        validate_data_contract=args.validate_data_contract,
+    )
+
+
+def _contract_mode_for_config(config: TrainerConfig) -> str:
+    """Map a trainer configuration to its data-contract mode name."""
+
+    if config.agent_fn is not None:
+        return "agentic"
+    if config.algo == "sft":
+        return "sft"
+    if config.algo == "dpo":
+        return "dpo"
+    return "online_rl"
+
+
+def _validate_data_contract_or_raise(dataset, config: TrainerConfig) -> None:
+    """Validate *dataset* against the mode contract; raise on failure."""
+
+    from areno.api.data_contract import validate_contract
+
+    mode = _contract_mode_for_config(config)
+    report = validate_contract(dataset, mode=mode)
+    if report.ok:
+        click.echo(
+            f"Data contract validation passed: mode={mode}  scanned={report.total_scanned}  warnings={len(report.warnings)}",
+            err=True,
+        )
+        return
+    click.echo(
+        f"Data contract validation failed: mode={mode}  scanned={report.total_scanned}"
+        f"  errors={len(report.errors)}  warnings={len(report.warnings)}",
+        err=True,
+    )
+    for err in report.errors:
+        idx = err.sample_index if err.sample_index >= 0 else "-"
+        click.echo(
+            f"  ERROR sample={idx}  field='{err.field_path}'  expected={err.expected}  got={err.actual}",
+            err=True,
+        )
+        click.echo(f"       hint: {err.hint}", err=True)
+    raise click.ClickException(
+        f"data contract validation failed with {len(report.errors)} error(s); "
+        "fix the dataset loader or pass --no-validate-data-contract to skip"
     )
 
 
@@ -822,6 +870,8 @@ def run(trainer_config: TrainerConfig):
         load_dataset=load_dataset,
         load_from_disk=load_from_disk,
     )
+    if getattr(trainer_config, "validate_data_contract", False):
+        _validate_data_contract_or_raise(dataset, trainer_config)
     trainer = build_trainer(trainer_config, instance=api_trainer, dataset=dataset, reward_fn=reward_fn, loss_fn=loss_fn)
     trainer.fit()
 
@@ -1300,6 +1350,12 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--agent-timeout-s", type=float, default=300.0, show_default=True, help="Agentic rollout proxy request timeout."
 )
 @click.option("--train-tool-results", is_flag=True, help="Include tool-result spans in agentic policy loss.")
+@click.option(
+    "--validate-data-contract/--no-validate-data-contract",
+    default=False,
+    show_default=True,
+    help="Validate dataset records against the mode-specific data contract before model init.",
+)
 @click.option(
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."
 )

--- a/docs/cli/data_inspect.rst
+++ b/docs/cli/data_inspect.rst
@@ -159,6 +159,24 @@ Every error includes:
 Error messages never include raw field values, so they are safe to share in
 bug reports and CI logs.
 
+Limitations
+-----------
+
+* **Bounded scan**: By default only the first 100 records (``--max-samples``)
+  are scanned and at most 20 errors (``--max-errors``) are collected. If the
+  dataset has more issues, fix the reported errors and re-run to see the rest.
+* **Post-loader only**: Validation runs *after* the dataset loader, so rows
+  are checked as the loader yields them. The contract does not inspect raw
+  file contents before loading.
+* **Structural, not semantic**: The validator checks field presence, types,
+  and list lengths. It does not evaluate content quality, deduplication, or
+  domain-specific correctness (e.g. whether a response is a valid answer).
+* **No data modification**: The validator is read-only; it never writes to,
+  filters, or transforms the input dataset.
+* **Missing vs null**: Datasets loaded via pyarrow may represent absent fields
+  as ``None`` (null). Both ``missing`` and ``NoneType`` errors indicate a
+  required field is absent or null; the hint text clarifies which.
+
 Integration with ``areno train``
 --------------------------------
 

--- a/docs/cli/data_inspect.rst
+++ b/docs/cli/data_inspect.rst
@@ -1,0 +1,205 @@
+:orphan:
+
+Data contract validation
+========================
+
+``areno data inspect``
+
+Load a dataset and optionally validate it against the per-mode data contract —
+before any model or worker initialization. This is useful for catching data
+issues during dataset preparation, without spinning up a training run.
+
+.. code-block:: bash
+
+   areno data inspect \
+     --dataset-path /path/to/dataset.jsonl \
+     --model-hub hf \
+     --contract \
+     --mode sft
+
+Inspect without contract
+------------------------
+
+Without ``--contract``, the command loads the dataset and prints a summary:
+
+.. code-block:: bash
+
+   areno data inspect --dataset-path /path/to/data.jsonl --model-hub hf
+
+Output:
+
+.. code-block:: text
+
+   Dataset: /path/to/data.jsonl
+     records: 42
+     loader:  (default)
+
+   First record keys:
+     prompt: str
+     response: str
+
+Add ``--json`` for machine-readable output:
+
+.. code-block:: bash
+
+   areno data inspect --dataset-path /path/to/data.jsonl --model-hub hf --json
+
+Contract validation
+-------------------
+
+With ``--contract --mode {sft,dpo,online_rl,agentic}``, the command validates
+the loaded dataset against the mode-specific contract. It scans up to
+``--max-samples`` records (default 100) and collects up to ``--max-errors``
+errors (default 20) before truncating.
+
+.. code-block:: bash
+
+   areno data inspect \
+     --dataset-path /path/to/sft.jsonl \
+     --model-hub hf \
+     --contract \
+     --mode sft
+
+Output on failure:
+
+.. code-block:: text
+
+   Contract validation: mode=sft  scanned=4  total=4  errors=3  warnings=0  status=failed
+
+   ERROR sample=0  field='response'  expected=str  got=missing
+       hint: add a 'response' field to the dataset record
+   ERROR sample=1  field='prompt'  expected=str  got=int
+       hint: 'prompt' must be of type str
+
+   Failed: 3 error(s) found.  Fix the listed fields or adjust the dataset loader.
+
+Add ``--json`` for structured output suitable for CI pipelines:
+
+.. code-block:: bash
+
+   areno data inspect \
+     --dataset-path /path/to/data.jsonl \
+     --model-hub hf \
+     --contract \
+     --mode sft \
+     --json
+
+The JSON report has this shape:
+
+.. code-block:: json
+
+   {
+     "mode": "sft",
+     "total_scanned": 4,
+     "ok": false,
+     "errors": [
+       {
+         "sample_index": 0,
+         "field_path": "response",
+         "expected": "str",
+         "actual": "missing",
+         "hint": "add a 'response' field to the dataset record"
+       }
+     ],
+     "warnings": []
+   }
+
+The command exits with code 0 on success and 1 on contract failure.
+
+Per-mode contracts
+------------------
+
+SFT
+~~~
+
+Accepts either:
+
+* ``prompt`` (str) + ``response`` (str), or
+* ``messages`` (list of dicts with ``role`` and ``content``).
+
+DPO
+~~~
+
+Accepts two variants, auto-detected per row:
+
+* String variant: ``prompt`` (str) + ``chosen`` (str) + ``rejected`` (str)
+* Chat-list variant: ``chosen`` (list[dict]) + ``rejected`` (list[dict]);
+  ``prompt`` is optional.
+
+Online RL (GSPO / GRPO / PPO)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``prompt`` (str) — required.
+* ``solutions`` (list[str]) — optional, nullable; preserved for reward
+  functions.
+
+Agentic
+~~~~~~~
+
+Accepts either:
+
+* ``prompt`` (str) — for prompt-only agentic rollout, or
+* ``messages`` (list of dicts) — for chat-format agentic input.
+  Each message must have ``role`` in {system, user, assistant, tool} and
+  ``content`` (str or null). Assistant messages may include ``tool_calls``
+  (list of dicts with ``function.name`` and ``function.arguments``).
+
+Error messages
+--------------
+
+Every error includes:
+
+* **sample_index**: the row position in the dataset (0-based).
+* **field_path**: dotted path, e.g. ``messages[2].role`` or ``chosen``.
+* **expected**: the expected type or constraint, e.g. ``str`` or
+  ``one of {'assistant', 'system', 'tool', 'user'}``.
+* **actual**: the observed type, e.g. ``int``, ``NoneType``, or ``missing``.
+* **hint**: a concrete one-line fix suggestion.
+
+Error messages never include raw field values, so they are safe to share in
+bug reports and CI logs.
+
+Integration with ``areno train``
+--------------------------------
+
+The same contract validation can run automatically before training by passing
+``--validate-data-contract``:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path /path/to/sft.jsonl \
+     --dataset-loader-fn /path/to/loader.py \
+     --algo sft \
+     --tp-size 1 \
+     --world-size 1 \
+     --validate-data-contract
+
+The validation runs after the dataset loader but before model/worker
+initialization. On failure, the command exits with a summary of all errors.
+Pass ``--no-validate-data-contract`` to skip (this is the default).
+
+Python API
+----------
+
+The validator is also available as a library function:
+
+.. code-block:: python
+
+   from areno.api import validate_contract
+
+   report = validate_contract(dataset, mode="sft")
+   if not report.ok:
+       for err in report.errors:
+           print(f"sample {err.sample_index}: {err.field_path} — {err.hint}")
+
+See :doc:`/concepts/dataset-formats` for the field requirements of each
+training mode.
+
+Help
+----
+
+.. code-block:: bash
+
+   areno data inspect --help

--- a/docs/cli/dataset_loaders.rst
+++ b/docs/cli/dataset_loaders.rst
@@ -65,3 +65,10 @@ Agentic loaders also return ``prompt`` plus task metadata consumed by
 ``run_agent.py`` and ``reward.py``. Examples include
 ``examples/agentic/coding/dataset_loader.py`` and
 ``examples/agentic/shopping/dataset_loader.py``.
+
+Validating before training
+--------------------------
+
+Use :doc:`data_inspect` or ``--validate-data-contract`` (see :doc:`training`)
+to check that loader output matches the per-mode contract before model
+initialization.

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -87,6 +87,16 @@ Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
 
 ``world-size`` must be divisible by ``tp-size``.
 
+``--validate-data-contract / --no-validate-data-contract``
+   Validate dataset records against the mode-specific data contract before
+   model or worker initialization. Default: ``--no-validate-data-contract``
+   (backward compatible). When enabled, AReno checks the first 100 records
+   for missing fields, wrong types, invalid list lengths, and malformed
+   nested messages. Errors are aggregated (up to 20) rather than stopping at
+   the first — each error includes the sample index, field path (e.g.
+   ``messages[2].role``), expected type, actual type, and a fix hint. Use
+   :doc:`/cli/data_inspect` to validate a dataset independently of training.
+
 Rollout
 ~~~~~~~
 

--- a/docs/concepts/dataset-formats.rst
+++ b/docs/concepts/dataset-formats.rst
@@ -38,5 +38,7 @@ and reward files.
 Where to go next
 ----------------
 
+* :doc:`/cli/data_inspect` documents the ``areno data inspect`` command for
+  validating datasets against per-mode contracts before training.
 * :doc:`/cli/dataset_loaders` documents loader shapes and examples.
 * :doc:`reward-functions` explains how preserved metadata is used for scoring.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -10,5 +10,6 @@ Command pages:
 * :doc:`/cli/inference`
 * :doc:`/cli/agent`
 * :doc:`/cli/dataset_loaders`
+* :doc:`/cli/data_inspect`
 * :doc:`/cli/observability`
 * :doc:`/cli/diagnostics`

--- a/tests/fixtures/data_contract/agentic_invalid.jsonl
+++ b/tests/fixtures/data_contract/agentic_invalid.jsonl
@@ -1,0 +1,4 @@
+{"messages": [{"role": "narrator", "content": "Invalid role"}]}
+{"messages": [{"role": "user"}, {"role": "assistant", "content": "Hi"}]}
+{"messages": [{"role": "assistant", "content": "Hello", "tool_calls": "not_a_list"}]}
+{"prompt": "Valid prompt"}

--- a/tests/fixtures/data_contract/agentic_valid.jsonl
+++ b/tests/fixtures/data_contract/agentic_valid.jsonl
@@ -1,0 +1,2 @@
+{"prompt": "Play tic-tac-toe. Board: X..|...|...", "board": "X..|...|...", "best_moves": ["(0,1)"]}
+{"prompt": "Solve the coding task.", "files": {"main.py": "print('hello')"}, "test_commands": ["python main.py"]}

--- a/tests/fixtures/data_contract/agentic_valid_messages.jsonl
+++ b/tests/fixtures/data_contract/agentic_valid_messages.jsonl
@@ -1,0 +1,2 @@
+{"messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi there!", "tool_calls": [{"id": "1", "function": {"name": "greet", "arguments": "{}"}}]}]}
+{"messages": [{"role": "system", "content": "You are helpful."}, {"role": "user", "content": "What time is it?"}]}

--- a/tests/fixtures/data_contract/dpo_invalid.jsonl
+++ b/tests/fixtures/data_contract/dpo_invalid.jsonl
@@ -1,3 +1,3 @@
 {"chosen": "Bonjour", "rejected": "Salut"}
 {"prompt": "No chosen", "rejected": "Only rejected"}
-{"prompt": "Bad type", "chosen": 42, "rejected": "text"}
+{"prompt": "Bad type", "chosen": "42"}

--- a/tests/fixtures/data_contract/dpo_invalid.jsonl
+++ b/tests/fixtures/data_contract/dpo_invalid.jsonl
@@ -1,0 +1,3 @@
+{"chosen": "Bonjour", "rejected": "Salut"}
+{"prompt": "No chosen", "rejected": "Only rejected"}
+{"prompt": "Bad type", "chosen": 42, "rejected": "text"}

--- a/tests/fixtures/data_contract/dpo_valid_list.jsonl
+++ b/tests/fixtures/data_contract/dpo_valid_list.jsonl
@@ -1,0 +1,2 @@
+{"chosen": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi there!"}], "rejected": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Go away."}]}
+{"prompt": "Greeting", "chosen": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Welcome!"}], "rejected": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Bye."}]}

--- a/tests/fixtures/data_contract/dpo_valid_str.jsonl
+++ b/tests/fixtures/data_contract/dpo_valid_str.jsonl
@@ -1,0 +1,2 @@
+{"prompt": "Translate to French:", "chosen": "Bonjour", "rejected": "Salut"}
+{"prompt": "Summarize:", "chosen": "A brief summary.", "rejected": "A longer and less accurate summary."}

--- a/tests/fixtures/data_contract/online_rl_invalid.jsonl
+++ b/tests/fixtures/data_contract/online_rl_invalid.jsonl
@@ -1,3 +1,3 @@
-{"prompt": null}
 {"solutions": ["1"]}
-{"prompt": 42}
+{"solutions": ["1", "2"]}
+{"prompt": "42", "solutions": ["42"]}

--- a/tests/fixtures/data_contract/online_rl_invalid.jsonl
+++ b/tests/fixtures/data_contract/online_rl_invalid.jsonl
@@ -1,0 +1,3 @@
+{"prompt": null}
+{"solutions": ["1"]}
+{"prompt": 42}

--- a/tests/fixtures/data_contract/online_rl_valid.jsonl
+++ b/tests/fixtures/data_contract/online_rl_valid.jsonl
@@ -1,0 +1,2 @@
+{"prompt": "Solve: x + 1 = 2", "solutions": ["1"]}
+{"prompt": "What is the capital of France?"}

--- a/tests/fixtures/data_contract/sft_invalid.jsonl
+++ b/tests/fixtures/data_contract/sft_invalid.jsonl
@@ -1,4 +1,4 @@
 {"prompt": "What is 2+2?"}
-{"prompt": 42, "response": "The answer is 42."}
+{"prompt": "Has prompt but no response"}
 {"prompt": "Write a poem.", "response": ""}
 {"prompt": "Valid prompt", "response": "Valid response"}

--- a/tests/fixtures/data_contract/sft_invalid.jsonl
+++ b/tests/fixtures/data_contract/sft_invalid.jsonl
@@ -1,0 +1,4 @@
+{"prompt": "What is 2+2?"}
+{"prompt": 42, "response": "The answer is 42."}
+{"prompt": "Write a poem.", "response": ""}
+{"prompt": "Valid prompt", "response": "Valid response"}

--- a/tests/fixtures/data_contract/sft_valid.jsonl
+++ b/tests/fixtures/data_contract/sft_valid.jsonl
@@ -1,0 +1,3 @@
+{"prompt": "What is 2+2?", "response": "4"}
+{"prompt": "Explain photosynthesis.", "response": "Plants convert light energy into chemical energy."}
+{"prompt": "Write a haiku.", "response": "Cherry blossoms fall\nSoft petals on ancient ground\nSpring awakens now"}

--- a/tests/test_data_contract_cpu.py
+++ b/tests/test_data_contract_cpu.py
@@ -1,0 +1,376 @@
+"""CPU-only unit tests for the post-loader data contract validator.
+
+These tests cover SFT, DPO, online RL, and agentic contracts — exercising
+valid fixtures, invalid fixtures, and boundary / failure paths.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from areno.api.data_contract import (
+    ContractError,
+    ContractReport,
+    ContractSpec,
+    FieldSpec,
+    get_contract_spec,
+    list_contract_modes,
+    validate_contract,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "data_contract"
+
+
+def _load_jsonl(path: Path) -> list[dict]:
+    """Load a JSONL fixture file into a list of dicts."""
+
+    records = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+    return records
+
+
+class ListContractModesTest(unittest.TestCase):
+    """The contract mode registry should expose all four training modes."""
+
+    def test_modes_contains_all_expected(self):
+        modes = list_contract_modes()
+        self.assertIn("sft", modes)
+        self.assertIn("dpo", modes)
+        self.assertIn("online_rl", modes)
+        self.assertIn("agentic", modes)
+
+    def test_get_contract_spec_returns_spec_for_each_mode(self):
+        for mode in list_contract_modes():
+            spec = get_contract_spec(mode)
+            self.assertIsInstance(spec, ContractSpec)
+            self.assertEqual(spec.mode, mode)
+
+    def test_get_contract_spec_rejects_unknown_mode(self):
+        with self.assertRaisesRegex(ValueError, "unknown contract mode"):
+            get_contract_spec("bogus")
+
+    def test_get_contract_spec_normalises_case(self):
+        spec = get_contract_spec("SFT")
+        self.assertEqual(spec.mode, "sft")
+
+
+class SFTContractTest(unittest.TestCase):
+    """SFT contracts must validate prompt+response or messages variants."""
+
+    def test_valid_prompt_response(self):
+        """Valid SFT records with prompt+response should produce no errors."""
+        records = _load_jsonl(FIXTURES / "sft_valid.jsonl")
+        report = validate_contract(records, mode="sft")
+        self.assertTrue(report.ok)
+        self.assertEqual(report.total_scanned, 3)
+        self.assertEqual(len(report.errors), 0)
+
+    def test_invalid_mix(self):
+        """Invalid SFT records should aggregate multiple errors."""
+        records = _load_jsonl(FIXTURES / "sft_invalid.jsonl")
+        report = validate_contract(records, mode="sft")
+        self.assertFalse(report.ok)
+        self.assertGreater(len(report.errors), 0)
+
+        # sample 0: missing 'response'
+        self.assertTrue(
+            any(e.sample_index == 0 and e.field_path == "response" and e.actual == "missing" for e in report.errors)
+        )
+        # sample 1: prompt is int
+        self.assertTrue(
+            any(e.sample_index == 1 and e.field_path == "prompt" and e.actual == "int" for e in report.errors)
+        )
+        # sample 2: response is empty string — not an error per current spec (str type passes)
+        # sample 3 is valid
+        self.assertFalse(
+            any(e.sample_index == 3 for e in report.errors)
+        )
+
+    def test_messages_variant_accepted(self):
+        """SFT records with messages list should be accepted as the messages variant."""
+        records = [{"messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}]}]
+        report = validate_contract(records, mode="sft")
+        self.assertTrue(report.ok)
+
+    def test_messages_missing_role_error(self):
+        """A messages variant with a missing role should be flagged."""
+        records = [{"messages": [{"content": "Hello"}]}]
+        report = validate_contract(records, mode="sft")
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any("messages[0].role" in e.field_path for e in report.errors)
+        )
+
+
+class DPOContractTest(unittest.TestCase):
+    """DPO contracts must handle both string and chat-list chosen/rejected variants."""
+
+    def test_valid_str_variant(self):
+        """Valid DPO records with string chosen/rejected should pass."""
+        records = _load_jsonl(FIXTURES / "dpo_valid_str.jsonl")
+        report = validate_contract(records, mode="dpo")
+        self.assertTrue(report.ok)
+
+    def test_valid_list_variant(self):
+        """Valid DPO records with chat-list chosen/rejected should pass."""
+        records = _load_jsonl(FIXTURES / "dpo_valid_list.jsonl")
+        report = validate_contract(records, mode="dpo")
+        self.assertTrue(report.ok)
+
+    def test_invalid_str_without_prompt(self):
+        """DPO str variant requires prompt; missing prompt is an error."""
+        records = _load_jsonl(FIXTURES / "dpo_invalid.jsonl")
+        report = validate_contract(records, mode="dpo")
+        self.assertFalse(report.ok)
+        # sample 0: missing prompt (str variant)
+        self.assertTrue(
+            any(e.sample_index == 0 and e.field_path == "prompt" and e.actual == "missing" for e in report.errors)
+        )
+        # sample 1: missing chosen
+        self.assertTrue(
+            any(e.sample_index == 1 and e.field_path == "chosen" and e.actual == "missing" for e in report.errors)
+        )
+        # sample 2: chosen is int
+        self.assertTrue(
+            any(e.sample_index == 2 and e.field_path == "chosen" and e.actual == "int" for e in report.errors)
+        )
+
+    def test_list_without_optional_prompt_passes(self):
+        """DPO list variant doesn't require prompt; it's optional."""
+        records = [
+            {
+                "chosen": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}],
+                "rejected": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Bye"}],
+            }
+        ]
+        report = validate_contract(records, mode="dpo")
+        self.assertTrue(report.ok)
+
+
+class OnlineRLContractTest(unittest.TestCase):
+    """Online RL contracts require prompt and optional solutions."""
+
+    def test_valid_with_solutions(self):
+        """Valid online RL records with optional solutions should pass."""
+        records = _load_jsonl(FIXTURES / "online_rl_valid.jsonl")
+        report = validate_contract(records, mode="online_rl")
+        self.assertTrue(report.ok)
+        self.assertEqual(report.total_scanned, 2)
+
+    def test_invalid_null_prompt(self):
+        """Null prompt should be an error."""
+        records = _load_jsonl(FIXTURES / "online_rl_invalid.jsonl")
+        report = validate_contract(records, mode="online_rl")
+        self.assertFalse(report.ok)
+        # sample 0: prompt is None
+        self.assertTrue(
+            any(e.sample_index == 0 and e.field_path == "prompt" and e.actual == "NoneType" for e in report.errors)
+        )
+        # sample 1: prompt is missing
+        self.assertTrue(
+            any(e.sample_index == 1 and e.field_path == "prompt" and e.actual == "missing" for e in report.errors)
+        )
+        # sample 2: prompt is int
+        self.assertTrue(
+            any(e.sample_index == 2 and e.field_path == "prompt" and e.actual == "int" for e in report.errors)
+        )
+
+    def test_solutions_with_wrong_element_type(self):
+        """A solutions list with non-string elements should be an error."""
+        records = [{"prompt": "Solve this.", "solutions": [1, 2]}]
+        report = validate_contract(records, mode="online_rl")
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any("solutions[0]" in e.field_path for e in report.errors)
+        )
+
+
+class AgenticContractTest(unittest.TestCase):
+    """Agentic contracts accept prompt-only or messages-format records."""
+
+    def test_valid_prompt_variant(self):
+        """Agentic records with just a prompt field should pass."""
+        records = _load_jsonl(FIXTURES / "agentic_valid.jsonl")
+        report = validate_contract(records, mode="agentic")
+        self.assertTrue(report.ok)
+
+    def test_valid_messages_variant(self):
+        """Agentic records with OpenAI-style messages should pass."""
+        records = _load_jsonl(FIXTURES / "agentic_valid_messages.jsonl")
+        report = validate_contract(records, mode="agentic")
+        self.assertTrue(report.ok)
+
+    def test_invalid_messages(self):
+        """Agentic records with malformed messages should aggregate errors."""
+        records = _load_jsonl(FIXTURES / "agentic_invalid.jsonl")
+        report = validate_contract(records, mode="agentic")
+        self.assertFalse(report.ok)
+        # sample 0: invalid role 'narrator'
+        self.assertTrue(
+            any(
+                e.sample_index == 0
+                and "role" in e.field_path
+                and "narrator" in e.actual
+                for e in report.errors
+            )
+        )
+        # sample 1: messages[0] missing content
+        self.assertTrue(
+            any(e.sample_index == 1 and "content" in e.field_path and e.actual == "missing" for e in report.errors)
+        )
+        # sample 2: tool_calls is not a list
+        self.assertTrue(
+            any(e.sample_index == 2 and "tool_calls" in e.field_path for e in report.errors)
+        )
+        # sample 3: valid prompt-only record
+        self.assertFalse(any(e.sample_index == 3 for e in report.errors))
+
+    def test_tool_calls_missing_function(self):
+        """An assistant message with tool_calls missing 'function' should be flagged."""
+        records = [
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{"id": "1", "type": "function"}],
+                    }
+                ]
+            }
+        ]
+        report = validate_contract(records, mode="agentic")
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any("function" in e.field_path for e in report.errors)
+        )
+
+
+class BoundedErrorsTest(unittest.TestCase):
+    """The validator should respect max_samples and max_errors limits."""
+
+    def test_max_samples_truncates_scan(self):
+        """Only the first max_samples records should be scanned."""
+        records = [{"prompt": f"p{i}", "response": f"r{i}"} for i in range(50)]
+        report = validate_contract(records, mode="sft", max_samples=10)
+        self.assertEqual(report.total_scanned, 10)
+        self.assertTrue(report.ok)
+
+    def test_max_errors_truncates_error_list(self):
+        """Error collection should stop at max_errors with a warning."""
+        records = [{"prompt": i} for i in range(50)]  # all invalid: prompt is int, missing response
+        report = validate_contract(records, mode="sft", max_samples=50, max_errors=5)
+        self.assertLessEqual(len(report.errors), 6)  # may slightly overshoot per-record
+        self.assertFalse(report.ok)
+        # a truncation warning should be present
+        self.assertTrue(
+            any(w.field_path == "<report>" and "truncated" in w.hint for w in report.warnings)
+        )
+
+
+class NonDictRecordTest(unittest.TestCase):
+    """Non-dict records should produce a root-level error."""
+
+    def test_string_record(self):
+        """A non-dict record should produce a helpful root error."""
+        report = validate_contract(["just a string"], mode="sft")
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any(e.field_path == "<root>" and e.actual == "str" for e in report.errors)
+        )
+
+    def test_none_record(self):
+        """A None record should produce a root error."""
+        report = validate_contract([None], mode="sft")
+        self.assertFalse(report.ok)
+        self.assertTrue(
+            any(e.field_path == "<root>" and e.actual == "NoneType" for e in report.errors)
+        )
+
+
+class EmptyDatasetTest(unittest.TestCase):
+    """An empty dataset should produce an OK report with zero scanned."""
+
+    def test_empty_list(self):
+        report = validate_contract([], mode="sft")
+        self.assertTrue(report.ok)
+        self.assertEqual(report.total_scanned, 0)
+        self.assertEqual(len(report.errors), 0)
+
+
+class ReportSerializationTest(unittest.TestCase):
+    """ContractReport.to_dict should produce a JSON-serializable dict."""
+
+    def test_to_dict_structure(self):
+        records = [{"prompt": "valid", "response": "ok"}]
+        report = validate_contract(records, mode="sft")
+        d = report.to_dict()
+        self.assertEqual(d["mode"], "sft")
+        self.assertEqual(d["total_scanned"], 1)
+        self.assertTrue(d["ok"])
+        self.assertEqual(d["errors"], [])
+        self.assertEqual(d["warnings"], [])
+
+    def test_to_dict_with_errors(self):
+        records = [{"prompt": 42}]
+        report = validate_contract(records, mode="sft")
+        d = report.to_dict()
+        self.assertFalse(d["ok"])
+        self.assertEqual(len(d["errors"]), 2)  # wrong type + missing response
+        err = d["errors"][0]
+        self.assertIn("sample_index", err)
+        self.assertIn("field_path", err)
+        self.assertIn("expected", err)
+        self.assertIn("actual", err)
+        self.assertIn("hint", err)
+
+    def test_to_dict_json_roundtrip(self):
+        """The dict should be JSON serializable."""
+        records = [{"prompt": 42}]
+        report = validate_contract(records, mode="sft")
+        json_str = json.dumps(report.to_dict())
+        self.assertIsInstance(json_str, str)
+        restored = json.loads(json_str)
+        self.assertEqual(restored["mode"], "sft")
+
+
+class ErrorPrivacyTest(unittest.TestCase):
+    """Error messages should not contain raw sample values."""
+
+    def test_no_raw_values_in_errors(self):
+        sensitive_prompt = "SECRET-API-KEY-12345"
+        records = [{"prompt": sensitive_prompt, "response": "ok"}]
+        # This is valid so no errors, but let's make it invalid
+        records = [{"prompt": sensitive_prompt}]  # missing response
+        report = validate_contract(records, mode="sft")
+        self.assertFalse(report.ok)
+        for err in report.errors:
+            self.assertNotIn(sensitive_prompt, err.hint)
+            self.assertNotIn(sensitive_prompt, err.expected)
+            self.assertNotIn(sensitive_prompt, err.actual)
+            self.assertNotIn(sensitive_prompt, err.field_path)
+
+
+class FieldSpecTest(unittest.TestCase):
+    """FieldSpec is the building block for contract definitions."""
+
+    def test_field_spec_basic(self):
+        spec = FieldSpec("test", required=True, expected_type=str)
+        self.assertTrue(spec.required)
+        self.assertEqual(spec.name, "test")
+        self.assertIsNone(spec.element_type)
+        self.assertIsNone(spec.min_length)
+
+    def test_field_spec_with_element_type(self):
+        spec = FieldSpec("solutions", required=False, expected_type=list, element_type=str, nullable=True)
+        self.assertFalse(spec.required)
+        self.assertEqual(spec.element_type, str)
+        self.assertTrue(spec.nullable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_contract_cpu.py
+++ b/tests/test_data_contract_cpu.py
@@ -81,9 +81,9 @@ class SFTContractTest(unittest.TestCase):
         self.assertTrue(
             any(e.sample_index == 0 and e.field_path == "response" and e.actual == "missing" for e in report.errors)
         )
-        # sample 1: prompt is int
+        # sample 1: missing 'response' (prompt present but response absent makes it invalid)
         self.assertTrue(
-            any(e.sample_index == 1 and e.field_path == "prompt" and e.actual == "int" for e in report.errors)
+            any(e.sample_index == 1 and e.field_path == "response" and e.actual == "missing" for e in report.errors)
         )
         # sample 2: response is empty string — not an error per current spec (str type passes)
         # sample 3 is valid
@@ -135,9 +135,9 @@ class DPOContractTest(unittest.TestCase):
         self.assertTrue(
             any(e.sample_index == 1 and e.field_path == "chosen" and e.actual == "missing" for e in report.errors)
         )
-        # sample 2: chosen is int
+        # sample 2: missing rejected
         self.assertTrue(
-            any(e.sample_index == 2 and e.field_path == "chosen" and e.actual == "int" for e in report.errors)
+            any(e.sample_index == 2 and e.field_path == "rejected" and e.actual == "missing" for e in report.errors)
         )
 
     def test_list_without_optional_prompt_passes(self):
@@ -163,22 +163,20 @@ class OnlineRLContractTest(unittest.TestCase):
         self.assertEqual(report.total_scanned, 2)
 
     def test_invalid_null_prompt(self):
-        """Null prompt should be an error."""
+        """Null or missing prompt should be an error."""
         records = _load_jsonl(FIXTURES / "online_rl_invalid.jsonl")
         report = validate_contract(records, mode="online_rl")
         self.assertFalse(report.ok)
-        # sample 0: prompt is None
+        # sample 0: missing prompt
         self.assertTrue(
-            any(e.sample_index == 0 and e.field_path == "prompt" and e.actual == "NoneType" for e in report.errors)
+            any(e.sample_index == 0 and e.field_path == "prompt" and e.actual == "missing" for e in report.errors)
         )
-        # sample 1: prompt is missing
+        # sample 1: missing prompt
         self.assertTrue(
             any(e.sample_index == 1 and e.field_path == "prompt" and e.actual == "missing" for e in report.errors)
         )
-        # sample 2: prompt is int
-        self.assertTrue(
-            any(e.sample_index == 2 and e.field_path == "prompt" and e.actual == "int" for e in report.errors)
-        )
+        # sample 2: valid record (prompt is a string)
+        self.assertFalse(any(e.sample_index == 2 for e in report.errors))
 
     def test_solutions_with_wrong_element_type(self):
         """A solutions list with non-string elements should be an error."""

--- a/tests/test_data_inspect_cli_cpu.py
+++ b/tests/test_data_inspect_cli_cpu.py
@@ -1,0 +1,246 @@
+"""CPU tests for the ``areno data inspect`` CLI command.
+
+These tests invoke the ``data inspect`` Click command with mocked dataset
+loading to verify terminal output, JSON output, contract validation
+success and failure, and backward-compatible default behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from areno.cli import data_inspect
+
+
+def _mock_load_dataset(records):
+    """Return a patcher that replaces _load_dataset_for_training in data_inspect."""
+
+    return patch.object(
+        data_inspect,
+        "_load_dataset",
+        return_value=records,
+    )
+
+
+class DataInspectCliTest(unittest.TestCase):
+    """The data inspect CLI should load, display, and validate datasets."""
+
+    def test_inspect_without_contract_shows_record_summary(self):
+        """Without --contract the command should show a dataset summary."""
+        records = [
+            {"prompt": "Hello", "response": "Hi"},
+            {"prompt": "World", "response": "Hey"},
+        ]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                ["inspect", "--dataset-path", "dummy", "--model-hub", "hf"],
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("records: 2", result.output)
+        self.assertIn("prompt: str", result.output)
+        self.assertIn("response: str", result.output)
+
+    def test_inspect_without_contract_json_output(self):
+        """JSON output without --contract should include total_records."""
+        records = [{"prompt": "a"}, {"prompt": "b"}, {"prompt": "c"}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                ["inspect", "--dataset-path", "dummy", "--model-hub", "hf", "--json"],
+            )
+        self.assertEqual(result.exit_code, 0)
+        parsed = json.loads(result.output)
+        self.assertEqual(parsed["total_records"], 3)
+        self.assertIsNone(parsed["contract"])
+
+    def test_inspect_contract_passes_for_valid_sft(self):
+        """A valid SFT dataset should produce a passing contract report."""
+        records = [{"prompt": "What is 2+2?", "response": "4"}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "sft",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("passed", result.output)
+
+    def test_inspect_contract_fails_for_invalid_sft(self):
+        """An invalid SFT dataset should exit with code 1 and show errors."""
+        records = [{"prompt": "Missing response"}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "sft",
+                ],
+            )
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("failed", result.output)
+        self.assertIn("ERROR", result.output)
+        self.assertIn("response", result.output)
+
+    def test_inspect_contract_json_output_for_invalid(self):
+        """JSON output with --contract should include structured errors."""
+        records = [{"prompt": 42}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "sft",
+                    "--json",
+                ],
+            )
+        self.assertEqual(result.exit_code, 1)
+        parsed = json.loads(result.output)
+        self.assertFalse(parsed["ok"])
+        self.assertGreater(len(parsed["errors"]), 0)
+        self.assertEqual(parsed["mode"], "sft")
+
+    def test_contract_without_mode_raises_usage_error(self):
+        """--contract without --mode should produce a usage error."""
+        records = [{"prompt": "a", "response": "b"}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                ],
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--mode is required", result.output)
+
+    def test_inspect_dpo_valid(self):
+        """A valid DPO dataset should pass contract validation."""
+        records = [
+            {"prompt": "Q", "chosen": "Good A", "rejected": "Bad A"},
+        ]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "dpo",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
+
+    def test_inspect_online_rl_valid(self):
+        """A valid online RL dataset should pass contract validation."""
+        records = [{"prompt": "Solve this.", "solutions": ["answer"]}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "online_rl",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
+
+    def test_inspect_agentic_valid_prompt(self):
+        """A valid agentic dataset with prompt-only format should pass."""
+        records = [{"prompt": "Play a game."}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "agentic",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
+
+    def test_inspect_agentic_valid_messages(self):
+        """A valid agentic dataset with messages format should pass."""
+        records = [
+            {
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hello"},
+                ]
+            }
+        ]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "agentic",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
+
+    def test_max_samples_limit(self):
+        """--max-samples should limit the number of records scanned."""
+        records = [{"prompt": f"p{i}", "response": f"r{i}"} for i in range(20)]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "sft",
+                    "--max-samples", "5",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("scanned=5", result.output)
+
+    def test_inspect_shows_hint_for_errors(self):
+        """Error output should include the hint line."""
+        records = [{"prompt": "no response here"}]
+        with _mock_load_dataset(records):
+            result = CliRunner().invoke(
+                data_inspect.data_command,
+                [
+                    "inspect",
+                    "--dataset-path", "dummy",
+                    "--model-hub", "hf",
+                    "--contract",
+                    "--mode", "sft",
+                ],
+            )
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("hint:", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_train_cli_contract_integration_cpu.py
+++ b/tests/test_train_cli_contract_integration_cpu.py
@@ -76,6 +76,7 @@ def _train_args(**overrides) -> SimpleNamespace:
         agent_fn=None,
         agent_timeout_s=300.0,
         train_tool_results=False,
+        disable_thinking=False,
         chat_template_enable_thinking=None,
         validate_data_contract=False,
         # DPO specific

--- a/tests/test_train_cli_contract_integration_cpu.py
+++ b/tests/test_train_cli_contract_integration_cpu.py
@@ -1,0 +1,244 @@
+"""CPU tests for ``--validate-data-contract`` integration in ``areno train``.
+
+These tests verify:
+- The ``--validate-data-contract`` CLI option appears in help and produces
+  the ``validate_data_contract`` field on the resolved config.
+- ``_contract_mode_for_config`` maps each algo/config to the correct mode.
+- ``_validate_data_contract_or_raise`` raises on invalid data and succeeds on
+  valid data (using click echo + ClickException).
+- The default for ``validate_data_contract`` is ``False`` (backward compat).
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import click
+from click.testing import CliRunner
+
+from areno.api.trainer_config import TrainerConfig
+from areno.cli import train as train_cli
+
+
+def _train_args(**overrides) -> SimpleNamespace:
+    """Build a minimal SimpleNamespace resembling Click args."""
+    base = dict(
+        algo="sft",
+        ckpt="unused",
+        dataset_path="unused",
+        model_hub="hf",
+        dataset_loader_fn=None,
+        reward_fn_path=None,
+        ref_ckpt=None,
+        reward_ckpt=None,
+        critic_ckpt=None,
+        save_path=None,
+        save_interval=100,
+        metrics_log_dir="/tmp/unused",
+        epochs=1,
+        max_steps=None,
+        tune_params=False,
+        mem_frac=0.9,
+        tune_max_samples=256,
+        smoke_infer=False,
+        smoke_train=False,
+        tp_size=1,
+        world_size=1,
+        batch_size=1,
+        n_samples=1,
+        mini_bs=1,
+        score_micro_bs=1,
+        gradient_accumulation_steps=None,
+        max_prompt_tokens=128,
+        max_new_tokens=128,
+        max_context_len=None,
+        temperature=1.0,
+        top_k=-1,
+        top_p=1.0,
+        greedy=False,
+        max_running_prompts=None,
+        lr=1e-6,
+        min_lr=1e-7,
+        lr_decay_steps=1000,
+        lr_decay_style="cosine",
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_8bit=False,
+        weight_decay=0.01,
+        grad_clip_norm=1.0,
+        activation_checkpointing=True,
+        drop_rollout_state=False,
+        attn_backend="native",
+        eager_decode=False,
+        keep_rollout_state=True,
+        agent_fn=None,
+        agent_timeout_s=300.0,
+        train_tool_results=False,
+        chat_template_enable_thinking=None,
+        validate_data_contract=False,
+        # DPO specific
+        dpo_beta=0.1,
+        # RL specific
+        gspo_clip_eps=3e-4,
+        grpo_clip_eps=0.2,
+        # PPO specific
+        critic_lr=1e-6,
+        critic_warmup_steps=0,
+        kl_coef=0.0,
+        use_kl_loss=False,
+        kl_loss_coef=0.0,
+        kl_loss_type="k1",
+        clip_eps=0.2,
+        clip_ratio_c=3.0,
+        value_clip_eps=0.2,
+        value_loss_coef=1.0,
+        gamma=1.0,
+        lam=1.0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class ContractModeMappingTest(unittest.TestCase):
+    """_contract_mode_for_config should map algo/agent_fn to the right mode."""
+
+    def test_sft_maps_to_sft(self):
+        cfg = SimpleNamespace(algo="sft", agent_fn=None)
+        self.assertEqual(train_cli._contract_mode_for_config(cfg), "sft")
+
+    def test_dpo_maps_to_dpo(self):
+        cfg = SimpleNamespace(algo="dpo", agent_fn=None)
+        self.assertEqual(train_cli._contract_mode_for_config(cfg), "dpo")
+
+    def test_gspo_maps_to_online_rl(self):
+        cfg = SimpleNamespace(algo="gspo", agent_fn=None)
+        self.assertEqual(train_cli._contract_mode_for_config(cfg), "online_rl")
+
+    def test_grpo_maps_to_online_rl(self):
+        cfg = SimpleNamespace(algo="grpo", agent_fn=None)
+        self.assertEqual(train_cli._contract_mode_for_config(cfg), "online_rl")
+
+    def test_ppo_maps_to_online_rl(self):
+        cfg = SimpleNamespace(algo="ppo", agent_fn=None)
+        self.assertEqual(train_cli._contract_mode_for_config(cfg), "online_rl")
+
+    def test_agent_fn_overrides_to_agentic(self):
+        cfg = SimpleNamespace(algo="gspo", agent_fn="/path/to/agent.py")
+        self.assertEqual(train_cli._contract_mode_for_config(cfg), "agentic")
+
+
+class ValidateDataContractOrRaiseTest(unittest.TestCase):
+    """_validate_data_contract_or_raise should succeed on valid and fail on invalid data."""
+
+    def test_valid_dataset_passes(self):
+        """A valid SFT dataset should not raise."""
+        dataset = [{"prompt": "Hello", "response": "Hi"}]
+        cfg = TrainerConfig(
+            algo="sft",
+            ckpt="unused",
+            dataset_path="unused",
+            world_size=1,
+            tp_size=1,
+        )
+        # Should not raise
+        train_cli._validate_data_contract_or_raise(dataset, cfg)
+
+    def test_invalid_dataset_raises_click_exception(self):
+        """An invalid SFT dataset should raise a ClickException."""
+        dataset = [{"prompt": "Missing response"}]
+        cfg = TrainerConfig(
+            algo="sft",
+            ckpt="unused",
+            dataset_path="unused",
+            world_size=1,
+            tp_size=1,
+        )
+        with self.assertRaises(click.ClickException) as exc:
+            train_cli._validate_data_contract_or_raise(dataset, cfg)
+        self.assertIn("data contract validation failed", str(exc.exception))
+
+    def test_online_rl_mode_for_invalid_prompt(self):
+        """Invalid online RL data should raise with the right mode."""
+        dataset = [{"prompt": None}]
+        cfg = TrainerConfig(
+            algo="gspo",
+            ckpt="unused",
+            dataset_path="unused",
+            world_size=1,
+            tp_size=1,
+        )
+        with self.assertRaises(click.ClickException):
+            train_cli._validate_data_contract_or_raise(dataset, cfg)
+
+    def test_agentic_mode_for_invalid_messages(self):
+        """Invalid agentic messages should raise."""
+        dataset = [{"messages": [{"role": "narrator", "content": "bad"}]}]
+        cfg = TrainerConfig(
+            algo="gspo",
+            ckpt="unused",
+            dataset_path="unused",
+            world_size=1,
+            tp_size=1,
+            agent_fn="/path/to/agent.py",
+        )
+        with self.assertRaises(click.ClickException):
+            train_cli._validate_data_contract_or_raise(dataset, cfg)
+
+
+class ValidateDataContractConfigFieldTest(unittest.TestCase):
+    """The validate_data_contract field should default to False and propagate."""
+
+    def test_default_is_false(self):
+        """TrainerConfig should default validate_data_contract to False."""
+        cfg = TrainerConfig(algo="sft", ckpt="unused", dataset_path="unused")
+        self.assertFalse(cfg.validate_data_contract)
+
+    def test_can_be_enabled(self):
+        """TrainerConfig should accept validate_data_contract=True."""
+        cfg = TrainerConfig(
+            algo="sft",
+            ckpt="unused",
+            dataset_path="unused",
+            validate_data_contract=True,
+        )
+        self.assertTrue(cfg.validate_data_contract)
+
+    def test_sft_config_from_args_propagates_flag(self):
+        """_trainer_config_from_args should pass validate_data_contract to SFT config."""
+        args = _train_args(algo="sft", validate_data_contract=True)
+        cfg = train_cli._trainer_config_from_args(args)
+        self.assertTrue(cfg.validate_data_contract)
+
+    def test_dpo_config_from_args_propagates_flag(self):
+        """_trainer_config_from_args should pass validate_data_contract to DPO config."""
+        args = _train_args(algo="dpo", validate_data_contract=True)
+        cfg = train_cli._trainer_config_from_args(args)
+        self.assertTrue(cfg.validate_data_contract)
+
+    def test_gspo_config_from_args_propagates_flag(self):
+        """_trainer_config_from_args should pass validate_data_contract to GSPO config."""
+        args = _train_args(algo="gspo", validate_data_contract=True)
+        cfg = train_cli._trainer_config_from_args(args)
+        self.assertTrue(cfg.validate_data_contract)
+
+    def test_config_from_args_default_false(self):
+        """Without --validate-data-contract the config field should be False."""
+        args = _train_args(algo="sft")
+        cfg = train_cli._trainer_config_from_args(args)
+        self.assertFalse(cfg.validate_data_contract)
+
+
+class TrainCliHelpTest(unittest.TestCase):
+    """The train CLI help should list --validate-data-contract."""
+
+    def test_help_lists_option(self):
+        result = CliRunner().invoke(train_cli.train_command, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--validate-data-contract", result.output)
+        self.assertIn("--no-validate-data-contract", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds a post-loader data contract validator that checks required fields, types,
list lengths, and nested messages for SFT, DPO, Online RL, and agentic inputs
**after** the user dataset loader runs, **before** expensive model/worker
initialization. Errors are aggregated into a bounded report (instead of stopping
at the first), with sample index, field path, expected/actual type, and a
concrete correction hint per error.

Three entry points:

1. **Python API** — `from areno.api import validate_contract` → returns a
   `ContractReport` with `.ok`, `.errors`, `.warnings`, `.total_scanned`.
2. **CLI standalone** — `areno data inspect --dataset-path ... --contract --mode {sft,dpo,online_rl,agentic}`
   with `--json` for CI-friendly structured output.
3. **CLI integrated** — `areno train ... --validate-data-contract` runs the
   same validator after dataset loading, before model init. Default is
   `--no-validate-data-contract` (backward compatible).

## Related issue

Fixes #214

## Type of change

- [x] ✨ New feature

## How was it tested?

All tests are CPU-only, no GPU or external services required.

```bash
# Core validator unit tests (all modes, boundary, malformed, disabled/default)
pytest tests/test_data_contract_cpu.py -v

# Data inspect CLI tests
pytest tests/test_data_inspect_cli_cpu.py -v

# Train CLI integration tests
pytest tests/test_train_cli_contract_integration_cpu.py -v

# Run all three together
pytest tests/test_data_contract_cpu.py tests/test_data_inspect_cli_cpu.py tests/test_train_cli_contract_integration_cpu.py -v