### PR TITLE
feat(engine): support independent rollout policy sync

### DIFF
--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -127,6 +127,7 @@ class ArenoBackend(Backend):
         self._policy_sync_lock = Lock()
         self._rollout_session_active = False
         self._policy_sync_bucket_bytes = 64 * 1024 * 1024
+        self._pending_policy_sync_metrics: dict[str, float] = {}
         # Per-step wall-time accumulators used to print the
         # rollout/train/end-to-end breakdown after `train` completes.
         self._step_e2e_start: float | None = None
@@ -152,6 +153,7 @@ class ArenoBackend(Backend):
         self._rollout_engine = None
         self._separate_rollout = False
         self._rollout_session_active = False
+        self._pending_policy_sync_metrics = {}
         for engine in engines:
             engine.close()
 
@@ -301,6 +303,7 @@ class ArenoBackend(Backend):
         with self._policy_sync_lock:
             if self._train_policy_version == self._rollout_policy_version:
                 return
+            sync_started = time.perf_counter()
             self._validate_policy_plans()
             from areno.engine.protocol import Op, PolicySyncPayload
 
@@ -313,12 +316,26 @@ class ArenoBackend(Backend):
             self._rollout_policy_version = version
             summary = next((result for result in rollout_results if isinstance(result, dict)), None)
             if summary is not None:
+                total_s = time.perf_counter() - sync_started
+                transfer_s = max(float(result["elapsed_s"]) for result in rollout_results if isinstance(result, dict))
+                transferred_bytes = int(summary["bytes"])
+                tensors = int(summary["tensors"])
+                throughput_gbps = transferred_bytes * 8 / max(transfer_s, 1e-12) / 1e9
+                self._pending_policy_sync_metrics = {
+                    "policy_sync_time_s": total_s,
+                    "policy_sync_transfer_time_s": transfer_s,
+                    "policy_sync_bytes": float(transferred_bytes),
+                    "policy_sync_tensors": float(tensors),
+                    "policy_sync_throughput_gbps": throughput_gbps,
+                }
                 logger.info(
-                    "policy sync complete version=%d bytes=%d tensors=%d elapsed_s=%.6f",
+                    "policy_sync version=%d total_s=%.6f transfer_s=%.6f bytes=%d tensors=%d throughput_gbps=%.3f",
                     version,
-                    int(summary["bytes"]),
-                    int(summary["tensors"]),
-                    float(summary["elapsed_s"]),
+                    total_s,
+                    transfer_s,
+                    transferred_bytes,
+                    tensors,
+                    throughput_gbps,
                 )
 
     def rollout_batch(
@@ -545,6 +562,8 @@ class ArenoBackend(Backend):
         metrics.update(first_policy_metrics)
         result = {"loss": sum(losses) / max(len(losses), 1)}
         result.update(metrics)
+        result.update(self._pending_policy_sync_metrics)
+        self._pending_policy_sync_metrics = {}
         if self._step_e2e_start is not None:
             step_e2e_time_s = time.perf_counter() - self._step_e2e_start
             self._step_e2e_start = None

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -211,9 +211,6 @@ class ArenoBackend(Backend):
             raise ValueError("rollout_devices must be non-empty")
         if len(rollout_devices) % rollout_tp_size != 0:
             raise ValueError("len(rollout_devices) must be divisible by rollout_tp_size")
-        overlap = sorted(set(devices or ()) & set(rollout_devices))
-        if overlap:
-            raise ValueError(f"train and rollout devices must not overlap: {overlap}")
         train_partition = ClusterPartition(
             role="train",
             global_rank_offset=0,

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -15,6 +15,7 @@ This file is the thin glue that:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
 import time
@@ -118,25 +119,40 @@ class ArenoBackend(Backend):
         """Create an adapter; workers are started by `initialize`."""
 
         super().__init__()
-        self._engine = None
+        self._train_engine = None
+        self._rollout_engine = None
+        self._separate_rollout = False
+        self._train_policy_version = 0
+        self._rollout_policy_version = 0
+        self._policy_sync_lock = Lock()
+        self._rollout_session_active = False
+        self._policy_sync_bucket_bytes = 64 * 1024 * 1024
         # Per-step wall-time accumulators used to print the
         # rollout/train/end-to-end breakdown after `train` completes.
         self._step_e2e_start: float | None = None
         self._step_rollout_time_s = 0.0
 
-    def _require_engine(self):
-        """Return the initialized engine or raise a consistent error."""
+    def _require_train_engine(self):
+        """Return the initialized training engine."""
 
-        if self._engine is None:
+        if self._train_engine is None:
             raise RuntimeError("ArenoBackend is not initialized")
-        return self._engine
+        return self._train_engine
+
+    def _require_rollout_engine(self):
+        """Return the independent rollout engine or the colocated engine."""
+
+        return self._rollout_engine or self._require_train_engine()
 
     def close(self) -> None:
         """Stop backend worker processes and release engine resources."""
 
-        engine = self._engine
-        self._engine = None
-        if engine is not None:
+        engines = tuple(engine for engine in (self._rollout_engine, self._train_engine) if engine is not None)
+        self._train_engine = None
+        self._rollout_engine = None
+        self._separate_rollout = False
+        self._rollout_session_active = False
+        for engine in engines:
             engine.close()
 
     def initialize(self, ctx: Context):
@@ -162,19 +178,151 @@ class ArenoBackend(Backend):
         devices = cfg.devices
         if devices is None and ctx.world_size:
             devices = list(range(world_size))
+        if devices is None or len(devices) != world_size:
+            raise ValueError(f"training device count must equal world_size={world_size}")
+        if cfg.rollout_tp_size is not None and cfg.rollout_devices is None:
+            raise ValueError("rollout_tp_size requires rollout_devices")
 
-        # ArenoEngine construction is synchronous and CUDA-heavy. The SDK is
-        # intentionally synchronous because engine IPC is blocking as well.
-        self._engine = ArenoEngine.from_pretrained(
+        if not cfg.uses_separate_rollout_engine():
+            self._train_engine = ArenoEngine.from_pretrained(
+                cfg.model_path or ctx.model_path,
+                tp_size=tp_size,
+                dp_size=dp_size,
+                devices=devices,
+                dummy_load=cfg.dummy_load,
+                optimizer_config=OptimizerConfig(**cfg.optimizer),
+                runtime_config=RuntimeConfig(**cfg.runtime),
+                loss_fn=_external_loss_dispatcher,
+                policy_sync_bucket_mb=cfg.policy_sync_bucket_mb,
+            )
+            return
+        self._policy_sync_bucket_bytes = cfg.policy_sync_bucket_mb * 1024 * 1024
+
+        from areno.engine.protocol import (
+            ClusterPartition,
+            DistributedWorldSpec,
+            find_free_port,
+            start_partitioned_clusters,
+        )
+
+        rollout_devices = list(cfg.rollout_devices or ())
+        rollout_tp_size = cfg.resolved_rollout_tp_size()
+        if not rollout_devices:
+            raise ValueError("rollout_devices must be non-empty")
+        if len(rollout_devices) % rollout_tp_size != 0:
+            raise ValueError("len(rollout_devices) must be divisible by rollout_tp_size")
+        overlap = sorted(set(devices or ()) & set(rollout_devices))
+        if overlap:
+            raise ValueError(f"train and rollout devices must not overlap: {overlap}")
+        train_partition = ClusterPartition(
+            role="train",
+            global_rank_offset=0,
+            local_world_size=world_size,
+            tp_size=tp_size,
+            devices=tuple(devices or ()),
+        )
+        rollout_partition = ClusterPartition(
+            role="rollout",
+            global_rank_offset=world_size,
+            local_world_size=len(rollout_devices),
+            tp_size=rollout_tp_size,
+            devices=tuple(rollout_devices),
+        )
+        world_spec = DistributedWorldSpec(
+            master_addr="127.0.0.1",
+            master_port=find_free_port(),
+            global_world_size=world_size + len(rollout_devices),
+            train=train_partition,
+            rollout=rollout_partition,
+        )
+        common = {
+            "dummy_load": cfg.dummy_load,
+            "runtime_config": RuntimeConfig(**cfg.runtime),
+            "start": False,
+            "policy_sync_bucket_mb": cfg.policy_sync_bucket_mb,
+        }
+        self._train_engine = ArenoEngine.from_pretrained(
             cfg.model_path or ctx.model_path,
             tp_size=tp_size,
             dp_size=dp_size,
             devices=devices,
-            dummy_load=cfg.dummy_load,
             optimizer_config=OptimizerConfig(**cfg.optimizer),
-            runtime_config=RuntimeConfig(**cfg.runtime),
             loss_fn=_external_loss_dispatcher,
+            role="train",
+            cluster_kwargs={"world_spec": world_spec, "partition": train_partition},
+            **common,
         )
+        rollout_runtime = RuntimeConfig(**cfg.runtime)
+        self._rollout_engine = ArenoEngine.from_pretrained(
+            cfg.model_path or ctx.model_path,
+            tp_size=rollout_tp_size,
+            dp_size=len(rollout_devices) // rollout_tp_size,
+            devices=rollout_devices,
+            dummy_load=cfg.dummy_load,
+            runtime_config=rollout_runtime,
+            loss_fn=None,
+            role="rollout",
+            policy_sync_bucket_mb=cfg.policy_sync_bucket_mb,
+            start=False,
+            cluster_kwargs={"world_spec": world_spec, "partition": rollout_partition},
+        )
+        try:
+            start_partitioned_clusters(
+                self._train_engine.cluster,
+                self._rollout_engine.cluster,
+                world_spec,
+            )
+        except BaseException:
+            self.close()
+            raise
+        self._separate_rollout = True
+
+    def _validate_policy_plans(self) -> None:
+        """Refresh live tensor views and reject any cross-rank layout mismatch."""
+
+        # Model onload/offload replaces Parameter storage. Rebuild the plan for
+        # every version so tasks always reference the currently-live tensors;
+        # the metadata comparison is cheap and also guards adapter drift.
+        from areno.engine.protocol import Op
+
+        train_results = self._require_train_engine().cluster.call(Op.POLICY_SYNC_PLAN)
+        rollout_results = self._require_rollout_engine().cluster.call(Op.POLICY_SYNC_PLAN)
+        train_plan = train_results[0]
+        rollout_plan = rollout_results[0]
+        if any(result != train_plan for result in train_results):
+            raise RuntimeError("training ranks produced inconsistent policy synchronization plans")
+        if any(result != rollout_plan for result in rollout_results):
+            raise RuntimeError("rollout ranks produced inconsistent policy synchronization plans")
+        if train_plan != rollout_plan:
+            raise RuntimeError("train and rollout policy synchronization layouts do not match")
+
+    def _sync_policy_if_needed(self) -> None:
+        """Synchronize one new optimizer version before rollout starts."""
+
+        if not self._separate_rollout or self._train_policy_version == self._rollout_policy_version:
+            return
+        with self._policy_sync_lock:
+            if self._train_policy_version == self._rollout_policy_version:
+                return
+            self._validate_policy_plans()
+            from areno.engine.protocol import Op, PolicySyncPayload
+
+            version = self._train_policy_version
+            payload = PolicySyncPayload(version=version, bucket_bytes=self._policy_sync_bucket_bytes)
+            train_call = self._require_train_engine().cluster.submit(Op.POLICY_SYNC_PUBLISH, payload)
+            rollout_call = self._require_rollout_engine().cluster.submit(Op.POLICY_SYNC_RECEIVE, payload)
+            train_call.result()
+            rollout_results = rollout_call.result()
+            self._rollout_policy_version = version
+            summary = next((result for result in rollout_results if isinstance(result, dict)), None)
+            if summary is not None:
+                logger.info(
+                    "policy sync complete version=%d bytes=%d tensors=%d elapsed_s=%.6f",
+                    version,
+                    int(summary["bytes"]),
+                    int(summary["tensors"]),
+                    float(summary["elapsed_s"]),
+                )
 
     def rollout_batch(
         self,
@@ -183,9 +331,11 @@ class ArenoBackend(Backend):
         n_samples: int,
         sampling_params: SamplingParams,
     ) -> list[RolloutResult]:
-        engine = self._require_engine()
+        engine = self._require_rollout_engine()
         if not prompt_tokens:
             return []
+        if not self._rollout_session_active:
+            self._sync_policy_if_needed()
         # Replicate each already-tokenized prompt `n_samples` times so the
         # engine treats each completion as independent while preserving the
         # `[prompt0_sample0, prompt0_sample1, ..., promptN_sampleK]` layout.
@@ -229,31 +379,35 @@ class ArenoBackend(Backend):
         """Prepare colocated actor state before rollout requests are issued."""
 
         del ctx
-        self._require_engine().begin_rollout_session()
+        self._sync_policy_if_needed()
+        self._require_rollout_engine().begin_rollout_session()
+        self._rollout_session_active = True
 
     async def begin_rollout_session_async(self, ctx: Context) -> None:
         """Async rollout-session begin hook for agentic callers."""
 
         del ctx
-        await self._require_engine().begin_rollout_session_async()
+        await asyncio.to_thread(self._sync_policy_if_needed)
+        await self._require_rollout_engine().begin_rollout_session_async()
+        self._rollout_session_active = True
 
     async def sync_rollout_session_async(self, ctx: Context) -> None:
         """Synchronize worker TP groups before agentic request rollout."""
 
         del ctx
-        await self._require_engine().sync_rollout_session_async()
+        await self._require_rollout_engine().sync_rollout_session_async()
 
     def dp_size(self, ctx: Context) -> int:
         """Return the engine's effective DP size after backend initialization."""
 
         del ctx
-        return int(self._require_engine().config.dp_size)
+        return int(self._require_rollout_engine().config.dp_size)
 
     def model_context_len(self, ctx: Context) -> int | None:
         """Return the checkpoint's max position embeddings from the loaded engine config."""
 
         del ctx
-        return int(self._require_engine().config.model.max_position_embeddings)
+        return int(self._require_rollout_engine().config.model.max_position_embeddings)
 
     def probe_rollout_cache(
         self,
@@ -266,7 +420,7 @@ class ArenoBackend(Backend):
         """Allocate rollout cache and capture decode graphs without generating."""
 
         del ctx
-        return self._require_engine().probe_rollout_cache(
+        return self._require_rollout_engine().probe_rollout_cache(
             max_new_tokens=max_new_tokens,
             max_running_prompts=max_running_prompts,
             max_prompt_len=max_prompt_len,
@@ -276,13 +430,15 @@ class ArenoBackend(Backend):
         """Finalize rollout-only state before scoring or training."""
 
         del ctx
-        self._require_engine().end_rollout_session()
+        self._require_rollout_engine().end_rollout_session()
+        self._rollout_session_active = False
 
     async def end_rollout_session_async(self, ctx: Context) -> None:
         """Async rollout-session end hook for agentic callers."""
 
         del ctx
-        await self._require_engine().end_rollout_session_async()
+        await self._require_rollout_engine().end_rollout_session_async()
+        self._rollout_session_active = False
 
     async def rollout_batch_async(
         self,
@@ -293,9 +449,11 @@ class ArenoBackend(Backend):
     ) -> list[RolloutResult]:
         """Async rollout entry for serving/agentic callers."""
 
-        engine = self._require_engine()
+        engine = self._require_rollout_engine()
         if not prompt_tokens:
             return []
+        if not self._rollout_session_active:
+            await asyncio.to_thread(self._sync_policy_if_needed)
         prompts = [tokens for tokens in prompt_tokens for _ in range(n_samples)]
         options = _rollout_options(ctx, sampling_params)
         if self._step_e2e_start is None:
@@ -335,9 +493,11 @@ class ArenoBackend(Backend):
         mini_bs: int,
         gradient_accumulation_steps: int | None = None,
     ) -> dict[str, float]:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         if not callable(loss_fn):
             raise ValueError("ArenoBackend requires a callable loss_fn")
+        if self._separate_rollout and self._rollout_session_active:
+            raise RuntimeError("cannot update policy weights during an active rollout session")
 
         train_start = time.perf_counter()
         if self._step_e2e_start is None:
@@ -365,6 +525,8 @@ class ArenoBackend(Backend):
                 gradient_accumulation_steps=gradient_accumulation_steps,
             )
         stats_list = engine.step(packs, gradient_accumulation_steps=gradient_accumulation_steps)
+        if self._separate_rollout and any(bool(stats.stepped) for stats in stats_list):
+            self._train_policy_version += 1
         train_time_s = time.perf_counter() - train_start
         # `first_policy_metrics` keeps the per-step rollout/policy diagnostics
         # untouched (we want the value seen on the first microbatch, not the
@@ -401,17 +563,17 @@ class ArenoBackend(Backend):
         return result
 
     def save_checkpoint(self, ctx: Context, path: str) -> str:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         return engine.save_checkpoint(path)
 
     def ensure_roles(self, ctx: Context, roles: dict[str, ModelRole]) -> None:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         engine.ensure_roles(roles)
 
     def score_logprobs(
         self, ctx: Context, role: str, token_rows: list[list[int]], *, microbatch_size: int = 8
     ) -> list[list[float]]:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         return engine.score_logprobs(
             role,
             token_rows,
@@ -420,11 +582,11 @@ class ArenoBackend(Backend):
         )
 
     def score_values(self, ctx: Context, role: str, token_rows: list[list[int]]) -> list[list[float]]:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         return engine.score_values(role, token_rows, pad_token_id=_pad_token_id(ctx))
 
     def score_rewards(self, ctx: Context, role: str, token_rows: list[list[int]]) -> list[float]:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         return engine.score_rewards(role, token_rows, pad_token_id=_pad_token_id(ctx))
 
     def train_values(
@@ -438,7 +600,7 @@ class ArenoBackend(Backend):
         cliprange_value: float = 0.5,
         value_loss_coef: float = 0.5,
     ) -> dict[str, float]:
-        engine = self._require_engine()
+        engine = self._require_train_engine()
         # The critic shares the pack layout with the actor; we reuse the same
         # packer but drop the loss-function pointer (the engine has a dedicated
         # value loss path that takes (cliprange_value, value_loss_coef)).

--- a/areno/api/config.py
+++ b/areno/api/config.py
@@ -23,11 +23,24 @@ class ArenoConfig:
     tp_size: int = 1
     dp_size: int | None = None
     devices: list[int] | None = None
+    rollout_tp_size: int | None = None
+    rollout_devices: list[int] | None = None
+    policy_sync_bucket_mb: int = 64
     dummy_load: bool = False
     optimizer: dict[str, Any] = field(default_factory=dict)
     runtime: dict[str, Any] = field(default_factory=dict)
     max_running_prompts: int = 64
     decode_progress_interval_s: float = 10.0
+
+    def uses_separate_rollout_engine(self) -> bool:
+        """Return whether rollout runs on its own CUDA device partition."""
+
+        return self.rollout_devices is not None
+
+    def resolved_rollout_tp_size(self) -> int:
+        """Return the explicit rollout TP size or the training TP size."""
+
+        return self.tp_size if self.rollout_tp_size is None else self.rollout_tp_size
 
 
 BackendConfig = ArenoConfig

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -35,6 +35,7 @@ class TrainerConfig:
     max_steps: int | None = None
     tp_size: int = 4
     world_size: int = 8
+    train_devices: list[int] | None = None
     batch_size: int = 32
     mini_bs: int = 16
     score_micro_bs: int = 8
@@ -92,6 +93,7 @@ class TrainerConfig:
 
         return ArenoConfig(
             tp_size=self.tp_size,
+            devices=self.train_devices,
             optimizer=self.optimizer_config(),
             runtime={
                 "activation_checkpointing": self.activation_checkpointing,
@@ -112,6 +114,9 @@ class RolloutTrainerConfig(TrainerConfig):
     top_k: int = -1
     top_p: float = 1.0
     max_running_prompts: int | None = None
+    rollout_tp_size: int | None = None
+    rollout_devices: list[int] | None = None
+    policy_sync_bucket_mb: int = 64
 
     def resolved_max_running_prompts(self) -> int:
         """Return explicit or full-batch rollout concurrency."""
@@ -127,6 +132,10 @@ class RolloutTrainerConfig(TrainerConfig):
 
         return ArenoConfig(
             tp_size=self.tp_size,
+            devices=self.train_devices,
+            rollout_tp_size=self.rollout_tp_size,
+            rollout_devices=self.rollout_devices,
+            policy_sync_bucket_mb=self.policy_sync_bucket_mb,
             max_running_prompts=self.resolved_max_running_prompts(),
             optimizer=self.optimizer_config(),
             runtime={

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -68,12 +68,16 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "max_steps",
             "world_size",
             "tp_size",
+            "train_devices",
         ),
     ),
     (
         "Rollout",
         (
             "batch_size",
+            "rollout_tp_size",
+            "rollout_devices",
+            "policy_sync_bucket_mb",
             "n_samples",
             "max_running_prompts",
             "max_prompt_tokens",
@@ -176,6 +180,14 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     args.model_hub = getattr(args, "model_hub", "modelscope")
+    args.train_devices = getattr(args, "train_devices", None)
+    args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
+    args.rollout_devices = getattr(args, "rollout_devices", None)
+    args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
+    args.train_devices = _parse_cuda_devices(getattr(args, "train_devices", None), "--train-devices")
+    args.rollout_devices = _parse_cuda_devices(getattr(args, "rollout_devices", None), "--rollout-devices")
+    args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
+    args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
     smoke_infer = bool(getattr(args, "smoke_infer", False))
     smoke_train = bool(getattr(args, "smoke_train", False))
     if smoke_infer or smoke_train:
@@ -223,6 +235,26 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--world-size must be positive")
     if args.world_size % args.tp_size != 0:
         raise click.UsageError("--world-size must be divisible by --tp-size")
+    if args.train_devices is not None and len(args.train_devices) != args.world_size:
+        raise click.UsageError("--train-devices count must equal --world-size")
+    has_rollout_topology = args.rollout_devices is not None or args.rollout_tp_size is not None
+    if has_rollout_topology and not algorithm.requires_rollout:
+        raise click.UsageError("independent rollout devices are only valid for rollout-based algorithms")
+    if args.rollout_tp_size is not None and args.rollout_tp_size <= 0:
+        raise click.UsageError("--rollout-tp-size must be positive")
+    if args.rollout_tp_size is not None and args.rollout_devices is None:
+        raise click.UsageError("--rollout-tp-size requires --rollout-devices")
+    if args.rollout_devices is not None:
+        rollout_tp_size = args.tp_size if args.rollout_tp_size is None else args.rollout_tp_size
+        if len(args.rollout_devices) % rollout_tp_size != 0:
+            raise click.UsageError("--rollout-devices count must be divisible by --rollout-tp-size")
+        train_devices = args.train_devices if args.train_devices is not None else list(range(args.world_size))
+        overlap = sorted(set(train_devices) & set(args.rollout_devices))
+        if overlap:
+            rendered = ",".join(str(device) for device in overlap)
+            raise click.UsageError(f"train and rollout devices must not overlap: {rendered}")
+    if args.policy_sync_bucket_mb <= 0:
+        raise click.UsageError("--policy-sync-bucket-mb must be positive")
     if args.batch_size <= 0:
         raise click.UsageError("--batch-size must be positive")
     if algorithm.requires_rollout and args.n_samples <= 0:
@@ -282,6 +314,25 @@ def _require_positive_float(value: float, option_name: str) -> None:
         raise click.UsageError(f"{option_name} must be positive")
 
 
+def _parse_cuda_devices(value: str | None, option_name: str) -> list[int] | None:
+    """Parse a comma-separated list of visible CUDA device indices."""
+
+    if value is None:
+        return None
+    parts = [part.strip() for part in value.split(",")]
+    if not parts or any(not part for part in parts):
+        raise click.UsageError(f"{option_name} must be a comma-separated list of CUDA device indices")
+    try:
+        devices = [int(part) for part in parts]
+    except ValueError as exc:
+        raise click.UsageError(f"{option_name} must contain only integer CUDA device indices") from exc
+    if any(device < 0 for device in devices):
+        raise click.UsageError(f"{option_name} must not contain negative CUDA device indices")
+    if len(devices) != len(set(devices)):
+        raise click.UsageError(f"{option_name} must not contain duplicate CUDA device indices")
+    return devices
+
+
 def _format_training_config_summary(
     config: TrainerConfig,
     *,
@@ -323,6 +374,12 @@ def _format_training_config_summary(
                 ("world_size", str(config.world_size)),
                 ("tp_size", str(config.tp_size)),
                 ("dp_size", _resolved_dp_size_for_summary(config)),
+                (
+                    "devices",
+                    ",".join(str(device) for device in config.train_devices)
+                    if config.train_devices is not None
+                    else f"0..{config.world_size - 1}",
+                ),
                 ("attn_backend", attn_backend),
                 (
                     "thinking",
@@ -445,6 +502,27 @@ def _rollout_summary_rows(config: TrainerConfig) -> list[tuple[str, str]]:
         ]
     return [
         *base,
+        (
+            "topology",
+            (
+                "shared with train engine"
+                if config.rollout_devices is None
+                else (
+                    f"world={len(config.rollout_devices)}, "
+                    f"tp={config.rollout_tp_size or config.tp_size}, "
+                    f"dp={len(config.rollout_devices) // (config.rollout_tp_size or config.tp_size)}, "
+                    f"devices={','.join(str(device) for device in config.rollout_devices)}"
+                )
+            ),
+        ),
+        (
+            "policy_sync",
+            (
+                "shared weights"
+                if config.rollout_devices is None
+                else f"NCCL direct, lazy, bucket={config.policy_sync_bucket_mb} MiB"
+            ),
+        ),
         ("n_samples", str(config.n_samples)),
         ("max_running_prompts", str(config.resolved_max_running_prompts())),
         (
@@ -598,6 +676,10 @@ def _trainer_config_from_args(args) -> TrainerConfig:
     args.max_steps = getattr(args, "max_steps", None)
     args.score_micro_bs = getattr(args, "score_micro_bs", 8)
     args.model_hub = getattr(args, "model_hub", "modelscope")
+    args.train_devices = getattr(args, "train_devices", None)
+    args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
+    args.rollout_devices = getattr(args, "rollout_devices", None)
+    args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
     algorithm = get_algorithm(args.algo)
     chat_template_enable_thinking = False if args.disable_thinking else None
     if algorithm.name == "dpo":
@@ -613,6 +695,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             max_steps=args.max_steps,
             tp_size=args.tp_size,
             world_size=args.world_size,
+            train_devices=args.train_devices,
             batch_size=args.batch_size,
             mini_bs=args.mini_bs,
             score_micro_bs=args.score_micro_bs,
@@ -654,6 +737,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             max_steps=args.max_steps,
             tp_size=args.tp_size,
             world_size=args.world_size,
+            train_devices=args.train_devices,
             batch_size=args.batch_size,
             mini_bs=args.mini_bs,
             score_micro_bs=args.score_micro_bs,
@@ -694,6 +778,10 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             max_steps=args.max_steps,
             tp_size=args.tp_size,
             world_size=args.world_size,
+            train_devices=args.train_devices,
+            rollout_tp_size=args.rollout_tp_size,
+            rollout_devices=args.rollout_devices,
+            policy_sync_bucket_mb=args.policy_sync_bucket_mb,
             batch_size=args.batch_size,
             n_samples=args.n_samples,
             mini_bs=args.mini_bs,
@@ -741,6 +829,10 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         max_steps=args.max_steps,
         tp_size=args.tp_size,
         world_size=args.world_size,
+        train_devices=args.train_devices,
+        rollout_tp_size=args.rollout_tp_size,
+        rollout_devices=args.rollout_devices,
+        policy_sync_bucket_mb=args.policy_sync_bucket_mb,
         batch_size=args.batch_size,
         n_samples=args.n_samples,
         mini_bs=args.mini_bs,
@@ -1223,6 +1315,31 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option("--tp-size", type=int, default=4, show_default=True, help="Tensor parallel size for the backend.")
 @click.option("--world-size", type=int, default=8, show_default=True, help="Total device count for the backend.")
+@click.option(
+    "--train-devices",
+    type=str,
+    default=None,
+    help="Comma-separated CUDA device indices for training; count must equal --world-size.",
+)
+@click.option(
+    "--rollout-tp-size",
+    type=int,
+    default=None,
+    help="Tensor parallel size for the independent rollout engine; defaults to --tp-size.",
+)
+@click.option(
+    "--rollout-devices",
+    type=str,
+    default=None,
+    help="Comma-separated CUDA device indices for the independent rollout engine.",
+)
+@click.option(
+    "--policy-sync-bucket-mb",
+    type=int,
+    default=64,
+    show_default=True,
+    help="Maximum GPU buffer size used by direct NCCL policy synchronization.",
+)
 @click.option("--batch-size", type=int, default=32, show_default=True, help="Prompt/pair batch size.")
 @click.option(
     "--n-samples", type=int, default=8, show_default=True, help="Rollout samples per prompt for RL algorithms."

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -248,11 +248,6 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         rollout_tp_size = args.tp_size if args.rollout_tp_size is None else args.rollout_tp_size
         if len(args.rollout_devices) % rollout_tp_size != 0:
             raise click.UsageError("--rollout-devices count must be divisible by --rollout-tp-size")
-        train_devices = args.train_devices if args.train_devices is not None else list(range(args.world_size))
-        overlap = sorted(set(train_devices) & set(args.rollout_devices))
-        if overlap:
-            rendered = ",".join(str(device) for device in overlap)
-            raise click.UsageError(f"train and rollout devices must not overlap: {rendered}")
     if args.policy_sync_bucket_mb <= 0:
         raise click.UsageError("--policy-sync-bucket-mb must be positive")
     if args.batch_size <= 0:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -310,17 +310,28 @@ def _require_positive_float(value: float, option_name: str) -> None:
 
 
 def _parse_cuda_devices(value: str | None, option_name: str) -> list[int] | None:
-    """Parse a comma-separated list of visible CUDA device indices."""
+    """Parse CUDA indices and inclusive ranges such as ``0..3,8``."""
 
     if value is None:
         return None
     parts = [part.strip() for part in value.split(",")]
     if not parts or any(not part for part in parts):
-        raise click.UsageError(f"{option_name} must be a comma-separated list of CUDA device indices")
+        raise click.UsageError(f"{option_name} must be a comma-separated list of CUDA indices or ranges")
+    devices = []
     try:
-        devices = [int(part) for part in parts]
+        for part in parts:
+            if ".." not in part:
+                devices.append(int(part))
+                continue
+            endpoints = part.split("..")
+            if len(endpoints) != 2 or not all(endpoints):
+                raise ValueError
+            start, end = (int(endpoint) for endpoint in endpoints)
+            if start > end:
+                raise click.UsageError(f"{option_name} range start must not exceed range end: {part}")
+            devices.extend(range(start, end + 1))
     except ValueError as exc:
-        raise click.UsageError(f"{option_name} must contain only integer CUDA device indices") from exc
+        raise click.UsageError(f"{option_name} must contain only integer CUDA indices or ranges") from exc
     if any(device < 0 for device in devices):
         raise click.UsageError(f"{option_name} must not contain negative CUDA device indices")
     if len(devices) != len(set(devices)):
@@ -1314,7 +1325,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--train-devices",
     type=str,
     default=None,
-    help="Comma-separated CUDA device indices for training; count must equal --world-size.",
+    help="CUDA devices for training, with inclusive ranges such as 0..7,10; count must equal --world-size.",
 )
 @click.option(
     "--rollout-tp-size",
@@ -1326,7 +1337,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--rollout-devices",
     type=str,
     default=None,
-    help="Comma-separated CUDA device indices for the independent rollout engine.",
+    help="CUDA devices for the independent rollout engine, with inclusive ranges such as 0..7,10.",
 )
 @click.option(
     "--policy-sync-bucket-mb",

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -186,6 +186,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
     args.train_devices = _parse_cuda_devices(getattr(args, "train_devices", None), "--train-devices")
     args.rollout_devices = _parse_cuda_devices(getattr(args, "rollout_devices", None), "--rollout-devices")
+    if args.train_devices is not None:
+        args.world_size = len(args.train_devices)
     args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
     args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
     smoke_infer = bool(getattr(args, "smoke_infer", False))
@@ -235,8 +237,6 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--world-size must be positive")
     if args.world_size % args.tp_size != 0:
         raise click.UsageError("--world-size must be divisible by --tp-size")
-    if args.train_devices is not None and len(args.train_devices) != args.world_size:
-        raise click.UsageError("--train-devices count must equal --world-size")
     has_rollout_topology = args.rollout_devices is not None or args.rollout_tp_size is not None
     if has_rollout_topology and not algorithm.requires_rollout:
         raise click.UsageError("independent rollout devices are only valid for rollout-based algorithms")
@@ -1319,13 +1319,21 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     is_flag=True,
     help="Dummy-load the model and run one minimal synthetic train step, then exit.",
 )
-@click.option("--tp-size", type=int, default=4, show_default=True, help="Tensor parallel size for the backend.")
+@click.option(
+    "--tp-size",
+    "--train-tp-size",
+    "tp_size",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Tensor parallel size for training.",
+)
 @click.option("--world-size", type=int, default=8, show_default=True, help="Total device count for the backend.")
 @click.option(
     "--train-devices",
     type=str,
     default=None,
-    help="CUDA devices for training, with inclusive ranges such as 0..7,10; count must equal --world-size.",
+    help="CUDA devices for training, with inclusive ranges such as 0..7,10; overrides --world-size.",
 )
 @click.option(
     "--rollout-tp-size",

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -131,7 +131,13 @@ class ArenoEngine:
       rollout paths.
     """
 
-    def __init__(self, config: EngineConfig):
+    def __init__(
+        self,
+        config: EngineConfig,
+        *,
+        start: bool = True,
+        cluster_kwargs: dict[str, Any] | None = None,
+    ):
         """Start rank workers for a validated engine config.
 
         Constructs the :class:`TPCluster` and starts the underlying worker
@@ -140,13 +146,14 @@ class ArenoEngine:
 
         # Loss function is required because the engine always carries a trainer
         # path; pure-inference engines should still set a no-op loss.
-        if config.train_loss_fn is None:
+        if config.role == "train" and config.train_loss_fn is None:
             raise ValueError("ArenoEngine requires train_loss_fn")
         self.config = config
         # TPCluster owns the per-rank worker processes and the IPC channels;
         # ``ArenoWorker`` is the rank-side command loop.
-        self.cluster = TPCluster(config, ArenoWorker)
-        self.cluster.start()
+        self.cluster = TPCluster(config, ArenoWorker, **(cluster_kwargs or {}))
+        if start:
+            self.cluster.start()
         self._async_dp_cursor = count()
 
     def begin_rollout_session(self) -> None:
@@ -186,6 +193,10 @@ class ArenoEngine:
         optimizer_config: OptimizerConfig | None = None,
         runtime_config: RuntimeConfig | None = None,
         loss_fn: Callable[[Any, torch.Tensor], torch.Tensor | tuple[torch.Tensor, dict[str, Any]]] | None = None,
+        role: str = "train",
+        start: bool = True,
+        cluster_kwargs: dict[str, Any] | None = None,
+        policy_sync_bucket_mb: int = 64,
     ) -> ArenoEngine:
         """Build an engine by reading model config from a checkpoint path.
 
@@ -213,8 +224,10 @@ class ArenoEngine:
             dummy_load=dummy_load,
             optimizer=optimizer_config or OptimizerConfig(),
             runtime=runtime_config or RuntimeConfig(),
+            role=role,
+            policy_sync_bucket_mb=policy_sync_bucket_mb,
         )
-        return cls(cfg)
+        return cls(cfg, start=start, cluster_kwargs=cluster_kwargs)
 
     def generate_rollout(
         self,

--- a/areno/engine/checkpoints/common.py
+++ b/areno/engine/checkpoints/common.py
@@ -30,14 +30,19 @@ from torch import nn
 
 from areno.engine.checkpoints.io import (
     CheckpointTensorStore,
+    PolicyTensorLayout,
+    PolicyTensorPiece,
+    PolicyTensorStore,
     SafetensorsIndex,
     _copy_column,
     _copy_row,
     _owns_checkpoint_tensor,
     _tensor_to_cpu,
     gather_tensor_parallel_column_tensors,
+    gather_tensor_parallel_ranged_tensor,
     gather_tensor_parallel_split_column_tensor,
     gather_tensor_parallel_tensor,
+    policy_plan_scope,
     rank0_tensor,
     write_hf_safetensors_checkpoint,
 )
@@ -409,6 +414,19 @@ def save_checkpoint_weights(
             source_path, saved_path, protected_prefix=_protected_prefix_from_top_level(spec.top_level)
         )
     return saved_path
+
+
+def build_checkpoint_policy_plan(model: nn.Module, spec: CheckpointSpec) -> PolicyTensorStore:
+    """Build the canonical checkpoint layout while retaining live GPU views."""
+
+    tensors = PolicyTensorStore()
+    with policy_plan_scope():
+        save_embedding_norm_head(tensors, model, spec.top_level)
+        delayed_column_tensors: list[tuple[str, torch.Tensor]] = []
+        save_layer_specs(tensors, model, spec.layer, context=delayed_column_tensors)
+        if delayed_column_tensors:
+            save_column_tensors(tensors, delayed_column_tensors)
+    return tensors
 
 
 def copy_source_passthrough_weights(source_path: str | Path, output_path: str | Path, protected_prefix: str) -> None:
@@ -783,28 +801,10 @@ def _gather_ranged_column_tensors(
 ) -> list[torch.Tensor | None]:
     """Gather column tensors when each rank reports an explicit row range."""
 
-    ctx = get_tp_context()
-    if ctx.dp_rank != 0:
-        return [None for _ in tensors]
-    outputs: list[torch.Tensor | None] = []
-    for tensor, (start, end), global_size in zip(tensors, ranges, global_sizes, strict=True):
-        local = tensor.detach().contiguous()
-        if ctx.world_size == 1:
-            outputs.append(_tensor_to_cpu(local))
-            continue
-        gathered = torch.empty((ctx.world_size, *local.shape), dtype=local.dtype, device=local.device)
-        dist.all_gather_into_tensor(gathered, local, group=ctx.group)
-        all_ranges: list[tuple[int, int] | None] = [None for _ in range(ctx.world_size)]
-        dist.all_gather_object(all_ranges, (start, end), group=ctx.group)
-        global_tensor = torch.empty((global_size, *local.shape[1:]), dtype=local.dtype, device=local.device)
-        for rank in range(ctx.world_size):
-            rank_range = all_ranges[rank]
-            if rank_range is None:
-                raise RuntimeError(f"missing TP shard range for rank {rank}")
-            range_start, range_end = rank_range
-            global_tensor[range_start:range_end].copy_(gathered[rank, : range_end - range_start])
-        outputs.append(_tensor_to_cpu(global_tensor.contiguous()))
-    return outputs
+    return [
+        gather_tensor_parallel_ranged_tensor(tensor, start=start, end=end, global_size=global_size)
+        for tensor, (start, end), global_size in zip(tensors, ranges, global_sizes, strict=True)
+    ]
 
 
 def load_row_parallel_tensors(
@@ -1162,6 +1162,14 @@ def save_moe_spec(tensors: dict[str, torch.Tensor | None], prefix: str, module: 
     if spec.expert_bias_key is not None and spec.expert_bias_attr is not None:
         tensors[key(spec.expert_bias_key, prefix)] = rank0_tensor(attr_path(module, spec.expert_bias_attr))
 
+    if isinstance(tensors, PolicyTensorStore):
+        _stage_policy_moe_experts(tensors, prefix, module, spec)
+        if spec.shared_experts_attr is not None and spec.shared_experts_prefix is not None:
+            shared_experts = attr_path(module, spec.shared_experts_attr)
+            if shared_experts is not None:
+                save_dense_mlp(tensors, key(spec.shared_experts_prefix, prefix), shared_experts)
+        return
+
     # One TP/EP all-gather collects every expert's gate/up/down at once.
     full_weights = gather_moe_expert_weights(attr_path(module, spec.experts_attr))
     if full_weights is None:
@@ -1187,6 +1195,47 @@ def save_moe_spec(tensors: dict[str, torch.Tensor | None], prefix: str, module: 
         shared_experts = attr_path(module, spec.shared_experts_attr)
         if shared_experts is not None:
             save_dense_mlp(tensors, key(spec.shared_experts_prefix, prefix), shared_experts)
+
+
+def _stage_policy_moe_experts(
+    tensors: PolicyTensorStore,
+    prefix: str,
+    module: nn.Module,
+    spec: MoeSpec,
+) -> None:
+    """Map expert-parallel live views to one canonical key per expert."""
+
+    experts = attr_path(module, spec.experts_attr)
+    gate_weights, up_weights, down_weights = experts.expert_weights()
+    local_start = int(getattr(experts, "local_expert_start"))
+    num_experts = int(attr_path(module, spec.num_experts_attr))
+    if not gate_weights or not up_weights or not down_weights:
+        raise RuntimeError("policy sync requires at least one local expert per TP rank")
+    templates = (spec.expert_gate_key, spec.expert_up_key, spec.expert_down_key)
+    locals_by_kind = (gate_weights, up_weights, down_weights)
+    for expert_id in range(num_experts):
+        local_index = expert_id - local_start
+        for template, local_weights in zip(templates, locals_by_kind, strict=True):
+            sample = local_weights[0]
+            pieces = ()
+            if 0 <= local_index < len(local_weights):
+                local = local_weights[local_index].detach()
+                shape = tuple(local.shape)
+                pieces = (
+                    PolicyTensorPiece(
+                        local,
+                        shape,
+                        0,
+                        0,
+                        shape[0] if shape else 1,
+                    ),
+                )
+            else:
+                shape = tuple(sample.shape)
+            tensors.add_layout(
+                expert_key(template, prefix, expert_id),
+                PolicyTensorLayout(shape=shape, dtype=sample.dtype, pieces=pieces),
+            )
 
 
 @torch.no_grad()

--- a/areno/engine/checkpoints/io.py
+++ b/areno/engine/checkpoints/io.py
@@ -687,8 +687,9 @@ class SafetensorsIndex:
         """Broadcast one tensor from rank 0 to the rest of the TP group."""
 
         ctx = get_tp_context()
-        # In multi-DP setups, each DP replica needs its own broadcast root.
-        src = ctx.dp_rank * ctx.world_size
+        # PyTorch's ``src`` is a default-world rank even when ``group`` is
+        # supplied. Partitioned train/rollout TP groups may start above rank 0.
+        src = ctx.tp_global_rank(0)
         tensor = None
         meta = [None]
         if ctx.rank == 0:

--- a/areno/engine/checkpoints/io.py
+++ b/areno/engine/checkpoints/io.py
@@ -18,6 +18,9 @@ import shutil
 import zlib
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
 
 import torch
@@ -30,6 +33,7 @@ from areno.engine.parallel.context import get_tp_context
 
 _ASYNC_CPU_COPY_MAX_BYTES = 2 * 1024**3
 _PENDING_CPU_COPY_BUCKETS: list[tuple[torch.cuda.Stream, int, torch.Tensor]] = []
+_POLICY_PLAN_ACTIVE: ContextVar[bool] = ContextVar("areno_policy_plan_active", default=False)
 
 try:
     from tqdm.auto import tqdm
@@ -42,6 +46,88 @@ class _CheckpointTensorTask:
 
     def materialize(self, key: str) -> torch.Tensor | None:
         raise NotImplementedError
+
+    def policy_layout(self) -> PolicyTensorLayout:
+        """Describe this task as canonical tensor ranges for policy sync."""
+
+        raise NotImplementedError
+
+
+@dataclass(slots=True, frozen=True)
+class PolicyTensorPiece:
+    """One local tensor view mapped into a canonical flattened tensor."""
+
+    tensor: torch.Tensor
+    canonical_shape: tuple[int, ...]
+    shard_dim: int
+    shard_start: int
+    shard_end: int
+    publish: bool = True
+
+
+@dataclass(slots=True, frozen=True)
+class PolicyFlatPiece:
+    """A local tensor mapped to one contiguous canonical flat interval."""
+
+    tensor: torch.Tensor
+    canonical_offset: int
+    publish: bool = True
+
+
+@dataclass(slots=True, frozen=True)
+class PolicyTensorLayout:
+    """Canonical metadata and local views for one checkpoint tensor."""
+
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    pieces: tuple[PolicyTensorPiece, ...]
+    flat_pieces: tuple[PolicyFlatPiece, ...] = ()
+    replicated: bool = False
+
+    @property
+    def numel(self) -> int:
+        """Return canonical element count."""
+
+        result = 1
+        for size in self.shape:
+            result *= size
+        return result
+
+    @property
+    def nbytes(self) -> int:
+        """Return canonical byte size."""
+
+        return self.numel * torch.empty((), dtype=self.dtype).element_size()
+
+    def read_chunk(self, offset: int, output: torch.Tensor, *, include_replicated: bool = True) -> None:
+        """Copy local contributions intersecting one canonical flat chunk."""
+
+        output.zero_()
+        if self.replicated and not include_replicated:
+            return
+        if self.replicated:
+            flat = self.pieces[0].tensor.reshape(-1)
+            output.copy_(flat[offset : offset + output.numel()])
+            return
+        for piece in self.pieces:
+            if not piece.publish:
+                continue
+            _copy_piece_to_chunk(piece, offset, output)
+        for piece in self.flat_pieces:
+            if piece.publish:
+                _copy_flat_piece_to_chunk(piece, offset, output)
+
+    def write_chunk(self, offset: int, source: torch.Tensor) -> None:
+        """Copy one canonical flat chunk into intersecting local tensor views."""
+
+        if self.replicated:
+            flat = self.pieces[0].tensor.reshape(-1)
+            flat[offset : offset + source.numel()].copy_(source.to(dtype=flat.dtype))
+            return
+        for piece in self.pieces:
+            _copy_chunk_to_piece(piece, offset, source)
+        for piece in self.flat_pieces:
+            _copy_chunk_to_flat_piece(piece, offset, source)
 
 
 class _ReplicatedTensorTask(_CheckpointTensorTask):
@@ -56,6 +142,22 @@ class _ReplicatedTensorTask(_CheckpointTensorTask):
         # Replicated tensors are identical across ranks, so only the global
         # rank 0 writes them to disk.
         return _tensor_to_cpu(self.tensor) if ctx.dp_rank == 0 and ctx.rank == 0 else None
+
+    def policy_layout(self) -> PolicyTensorLayout:
+        return PolicyTensorLayout(
+            shape=tuple(self.tensor.shape),
+            dtype=self.tensor.dtype,
+            pieces=(
+                PolicyTensorPiece(
+                    tensor=self.tensor,
+                    canonical_shape=tuple(self.tensor.shape),
+                    shard_dim=0,
+                    shard_start=0,
+                    shard_end=self.tensor.shape[0] if self.tensor.ndim else 1,
+                ),
+            ),
+            replicated=True,
+        )
 
 
 class _TensorParallelGatherTask(_CheckpointTensorTask):
@@ -74,6 +176,25 @@ class _TensorParallelGatherTask(_CheckpointTensorTask):
         if self._gathered is None:
             self._gathered = _all_gather_tensor_parallel(self.local)
         return _gathered_tensor_to_cpu(self._gathered, dim=self.dim) if _owns_checkpoint_tensor(key) else None
+
+    def policy_layout(self) -> PolicyTensorLayout:
+        ctx = get_tp_context()
+        shape = list(self.local.shape)
+        shape[self.dim] *= ctx.world_size
+        start = ctx.rank * self.local.shape[self.dim]
+        return PolicyTensorLayout(
+            shape=tuple(shape),
+            dtype=self.local.dtype,
+            pieces=(
+                PolicyTensorPiece(
+                    tensor=self.local,
+                    canonical_shape=tuple(shape),
+                    shard_dim=self.dim,
+                    shard_start=start,
+                    shard_end=start + self.local.shape[self.dim],
+                ),
+            ),
+        )
 
 
 class _ColumnGatherTask:
@@ -119,6 +240,17 @@ class _ColumnGatherResult(_CheckpointTensorTask):
     def materialize(self, key: str) -> torch.Tensor | None:
         return self.task.materialize(key, self.index)
 
+    def policy_layout(self) -> PolicyTensorLayout:
+        ctx = get_tp_context()
+        local = self.task.locals[self.index]
+        shape = (local.shape[0] * ctx.world_size, *local.shape[1:])
+        start = ctx.rank * local.shape[0]
+        return PolicyTensorLayout(
+            shape=shape,
+            dtype=local.dtype,
+            pieces=(PolicyTensorPiece(local, shape, 0, start, start + local.shape[0]),),
+        )
+
 
 class _SplitColumnGatherTask(_CheckpointTensorTask):
     """All-gather a fused tensor and re-split into the original sub-tensors.
@@ -152,6 +284,68 @@ class _SplitColumnGatherTask(_CheckpointTensorTask):
             offset += row_size
         return _tensor_to_cpu(torch.cat(outputs, dim=0).contiguous())
 
+    def policy_layout(self) -> PolicyTensorLayout:
+        ctx = get_tp_context()
+        total_rows = sum(part.shape[0] * ctx.world_size for part in self.parts)
+        shape = (total_rows, *self.parts[0].shape[1:])
+        pieces = []
+        part_offset = 0
+        for part in self.parts:
+            start = part_offset + ctx.rank * part.shape[0]
+            pieces.append(PolicyTensorPiece(part, shape, 0, start, start + part.shape[0]))
+            part_offset += part.shape[0] * ctx.world_size
+        return PolicyTensorLayout(shape=shape, dtype=self.parts[0].dtype, pieces=tuple(pieces))
+
+
+class _RangedTensorParallelGatherTask(_CheckpointTensorTask):
+    """Column shard with an explicit global range, including replicated ranges."""
+
+    def __init__(self, local: torch.Tensor, start: int, end: int, global_size: int):
+        self.local = local.detach().contiguous()
+        self.start = start
+        self.end = end
+        self.global_size = global_size
+
+    def materialize(self, key: str) -> torch.Tensor | None:
+        ctx = get_tp_context()
+        if ctx.world_size == 1:
+            return _tensor_to_cpu(self.local) if _owns_checkpoint_tensor(key) else None
+        gathered = torch.empty((ctx.world_size, *self.local.shape), dtype=self.local.dtype, device=self.local.device)
+        dist.all_gather_into_tensor(gathered, self.local, group=ctx.group)
+        all_ranges: list[tuple[int, int] | None] = [None] * ctx.world_size
+        dist.all_gather_object(all_ranges, (self.start, self.end), group=ctx.group)
+        output = torch.empty(
+            (self.global_size, *self.local.shape[1:]), dtype=self.local.dtype, device=self.local.device
+        )
+        for rank, rank_range in enumerate(all_ranges):
+            if rank_range is None:
+                raise RuntimeError(f"missing TP shard range for rank {rank}")
+            start, end = rank_range
+            output[start:end].copy_(gathered[rank, : end - start])
+        return _tensor_to_cpu(output) if _owns_checkpoint_tensor(key) else None
+
+    def policy_layout(self) -> PolicyTensorLayout:
+        ctx = get_tp_context()
+        shape = (self.global_size, *self.local.shape[1:])
+        local_width = self.end - self.start
+        unique_shards = self.global_size // local_width
+        repeats = ctx.world_size // unique_shards
+        owner_rank = (self.start // local_width) * repeats
+        return PolicyTensorLayout(
+            shape=shape,
+            dtype=self.local.dtype,
+            pieces=(
+                PolicyTensorPiece(
+                    self.local,
+                    shape,
+                    0,
+                    self.start,
+                    self.end,
+                    publish=ctx.rank == owner_rank,
+                ),
+            ),
+        )
+
 
 class CheckpointTensorStore(dict[str, torch.Tensor | _CheckpointTensorTask | None]):
     """Dict-like staging area for distributed HF safetensors writing.
@@ -174,6 +368,116 @@ class CheckpointTensorStore(dict[str, torch.Tensor | _CheckpointTensorTask | Non
 
     def close_progress(self) -> None:
         return
+
+
+class PolicyTensorStore(dict[str, _CheckpointTensorTask]):
+    """Ordered in-memory checkpoint layout without materialization or CPU I/O."""
+
+    def __setitem__(self, key: str, value: torch.Tensor | _CheckpointTensorTask | None) -> None:
+        if value is None:
+            return
+        task = value if isinstance(value, _CheckpointTensorTask) else _ReplicatedTensorTask(value)
+        super().__setitem__(key, task)
+
+    def add_layout(self, key: str, layout: PolicyTensorLayout) -> None:
+        """Insert a precomputed layout task."""
+
+        super().__setitem__(key, _PolicyLayoutTask(layout))
+
+
+class _PolicyLayoutTask(_CheckpointTensorTask):
+    """Policy-only task for layouts that checkpoint save materializes eagerly."""
+
+    def __init__(self, layout: PolicyTensorLayout):
+        self.layout = layout
+
+    def materialize(self, key: str) -> torch.Tensor | None:
+        raise RuntimeError(f"policy-only tensor task {key!r} cannot be materialized as a checkpoint")
+
+    def policy_layout(self) -> PolicyTensorLayout:
+        return self.layout
+
+
+@contextmanager
+def policy_plan_scope():
+    """Keep gather tasks on every DP replica while building a sync plan."""
+
+    token = _POLICY_PLAN_ACTIVE.set(True)
+    try:
+        yield
+    finally:
+        _POLICY_PLAN_ACTIVE.reset(token)
+
+
+def _copy_piece_to_chunk(piece: PolicyTensorPiece, chunk_offset: int, output: torch.Tensor) -> None:
+    """Copy contiguous shard blocks from a local tensor into a flat chunk."""
+
+    local = piece.tensor.reshape(-1)
+    chunk_end = chunk_offset + output.numel()
+    dim = piece.shard_dim
+    inner = _shape_numel(piece.canonical_shape[dim + 1 :])
+    outer = _shape_numel(piece.canonical_shape[:dim])
+    canonical_width = piece.canonical_shape[dim] * inner
+    local_width = (piece.shard_end - piece.shard_start) * inner
+    for outer_idx in range(outer):
+        canonical_start = outer_idx * canonical_width + piece.shard_start * inner
+        canonical_end = canonical_start + local_width
+        start = max(canonical_start, chunk_offset)
+        end = min(canonical_end, chunk_end)
+        if start >= end:
+            continue
+        local_start = outer_idx * local_width + start - canonical_start
+        output[start - chunk_offset : end - chunk_offset].copy_(local[local_start : local_start + end - start])
+
+
+def _copy_chunk_to_piece(piece: PolicyTensorPiece, chunk_offset: int, source: torch.Tensor) -> None:
+    """Copy intersecting flat chunk blocks into a local tensor view."""
+
+    local = piece.tensor.reshape(-1)
+    chunk_end = chunk_offset + source.numel()
+    dim = piece.shard_dim
+    inner = _shape_numel(piece.canonical_shape[dim + 1 :])
+    outer = _shape_numel(piece.canonical_shape[:dim])
+    canonical_width = piece.canonical_shape[dim] * inner
+    local_width = (piece.shard_end - piece.shard_start) * inner
+    for outer_idx in range(outer):
+        canonical_start = outer_idx * canonical_width + piece.shard_start * inner
+        canonical_end = canonical_start + local_width
+        start = max(canonical_start, chunk_offset)
+        end = min(canonical_end, chunk_end)
+        if start >= end:
+            continue
+        local_start = outer_idx * local_width + start - canonical_start
+        local[local_start : local_start + end - start].copy_(
+            source[start - chunk_offset : end - chunk_offset].to(dtype=local.dtype)
+        )
+
+
+def _copy_flat_piece_to_chunk(piece: PolicyFlatPiece, chunk_offset: int, output: torch.Tensor) -> None:
+    local = piece.tensor.reshape(-1)
+    start = max(piece.canonical_offset, chunk_offset)
+    end = min(piece.canonical_offset + local.numel(), chunk_offset + output.numel())
+    if start < end:
+        output[start - chunk_offset : end - chunk_offset].copy_(
+            local[start - piece.canonical_offset : end - piece.canonical_offset]
+        )
+
+
+def _copy_chunk_to_flat_piece(piece: PolicyFlatPiece, chunk_offset: int, source: torch.Tensor) -> None:
+    local = piece.tensor.reshape(-1)
+    start = max(piece.canonical_offset, chunk_offset)
+    end = min(piece.canonical_offset + local.numel(), chunk_offset + source.numel())
+    if start < end:
+        local[start - piece.canonical_offset : end - piece.canonical_offset].copy_(
+            source[start - chunk_offset : end - chunk_offset].to(dtype=local.dtype)
+        )
+
+
+def _shape_numel(shape: tuple[int, ...]) -> int:
+    result = 1
+    for size in shape:
+        result *= size
+    return result
 
 
 def _checkpoint_tensor_owner(key: str) -> int:
@@ -468,7 +772,7 @@ def gather_tensor_parallel_tensor(tensor: torch.Tensor, dim: int) -> _Checkpoint
 
     ctx = get_tp_context()
     # Non-DP-rank-0 replicas skip checkpoint saving entirely.
-    if ctx.dp_rank != 0:
+    if ctx.dp_rank != 0 and not _POLICY_PLAN_ACTIVE.get():
         return None
     local = tensor.detach().contiguous()
     if ctx.world_size == 1:
@@ -480,7 +784,7 @@ def gather_tensor_parallel_column_tensors(tensors: list[torch.Tensor]) -> list[_
     """Build fused-gather tasks for a list of column-parallel tensors."""
 
     ctx = get_tp_context()
-    if ctx.dp_rank != 0:
+    if ctx.dp_rank != 0 and not _POLICY_PLAN_ACTIVE.get():
         return [None for _ in tensors]
     if not tensors:
         return []
@@ -495,9 +799,24 @@ def gather_tensor_parallel_split_column_tensor(tensor: torch.Tensor, sizes: list
     """Build a lazy gather for a fused tensor that must be re-split before save."""
 
     ctx = get_tp_context()
-    if ctx.dp_rank != 0:
+    if ctx.dp_rank != 0 and not _POLICY_PLAN_ACTIVE.get():
         return None
     return _SplitColumnGatherTask(list(tensor.detach().split(sizes, dim=0)))
+
+
+def gather_tensor_parallel_ranged_tensor(
+    tensor: torch.Tensor,
+    *,
+    start: int,
+    end: int,
+    global_size: int,
+) -> _CheckpointTensorTask | None:
+    """Build a lazy task for an explicit possibly-replicated column range."""
+
+    ctx = get_tp_context()
+    if ctx.dp_rank != 0 and not _POLICY_PLAN_ACTIVE.get():
+        return None
+    return _RangedTensorParallelGatherTask(tensor, start, end, global_size)
 
 
 def _gathered_tensor_to_cpu(gathered: torch.Tensor, dim: int) -> torch.Tensor:
@@ -576,7 +895,7 @@ def rank0_tensor(tensor: torch.Tensor) -> _CheckpointTensorTask | None:
     """Wrap a replicated tensor for saving; returns None on non-DP-rank-0."""
 
     ctx = get_tp_context()
-    return _ReplicatedTensorTask(tensor) if ctx.dp_rank == 0 else None
+    return _ReplicatedTensorTask(tensor) if ctx.dp_rank == 0 or _POLICY_PLAN_ACTIVE.get() else None
 
 
 def write_hf_safetensors_checkpoint(

--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -223,6 +223,8 @@ class EngineConfig:
     dp_size: int | None = None
     devices: list[int] | None = None
     dummy_load: bool = False
+    role: Literal["train", "rollout"] = "train"
+    policy_sync_bucket_mb: int = 64
 
     def __post_init__(self) -> None:
         """Infer DP/devices and validate the distributed layout."""
@@ -238,6 +240,14 @@ class EngineConfig:
                 self.devices = list(range(self.tp_size if self.dp_size is None else self.tp_size * self.dp_size))
         if len(self.devices) < 1:
             raise ValueError("devices must be non-empty")
+        if any(device < 0 for device in self.devices):
+            raise ValueError("devices must contain non-negative CUDA indices")
+        if len(self.devices) != len(set(self.devices)):
+            raise ValueError("devices must not contain duplicate CUDA indices")
+        if torch.cuda.is_available():
+            invalid = [device for device in self.devices if device >= torch.cuda.device_count()]
+            if invalid:
+                raise ValueError(f"devices are outside CUDA_VISIBLE_DEVICES: {invalid}")
         if len(self.devices) % self.tp_size != 0:
             raise ValueError("len(devices) must be divisible by tp_size")
         inferred_dp_size = len(self.devices) // self.tp_size
@@ -247,6 +257,8 @@ class EngineConfig:
             raise ValueError("dp_size must equal len(devices) // tp_size")
         if self.dp_size < 1:
             raise ValueError("dp_size must be >= 1")
+        if self.policy_sync_bucket_mb < 1:
+            raise ValueError("policy_sync_bucket_mb must be >= 1")
         if self.runtime.kv_block_size < 1:
             raise ValueError("runtime.kv_block_size must be >= 1")
         if self.runtime.kv_block_size % 256 != 0:

--- a/areno/engine/parallel/collectives.py
+++ b/areno/engine/parallel/collectives.py
@@ -134,10 +134,7 @@ def broadcast_object(obj: object | None, src: int = 0) -> object:
 def _tp_local_to_global_rank(rank: int) -> int:
     """Translate a TP-local rank (0..tp_size-1) into a global process rank."""
 
-    ctx = get_tp_context()
-    if rank < 0 or rank >= ctx.world_size:
-        raise ValueError(f"rank={rank} is outside TP group size {ctx.world_size}")
-    return ctx.dp_rank * ctx.world_size + rank
+    return get_tp_context().tp_global_rank(rank)
 
 
 class _AllReduceSum(torch.autograd.Function):

--- a/areno/engine/parallel/context.py
+++ b/areno/engine/parallel/context.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from threading import Lock
+from typing import Literal
 
 import torch
 import torch.distributed as dist
@@ -30,6 +31,11 @@ class TPContext:
     dp_rank: int = 0
     dp_size: int = 1
     dp_group: dist.ProcessGroup | None = None
+    role: Literal["train", "rollout"] = "train"
+    policy_publisher_groups: tuple[dist.ProcessGroup | None, ...] = ()
+    policy_publisher_ranks: tuple[tuple[int, ...], ...] = ()
+    train_tp_size: int = 1
+    rollout_tp_size: int = 1
 
     @property
     def is_rank0(self) -> bool:
@@ -69,6 +75,14 @@ def init_process_group(
     master_port: int,
     device_id: int,
     tp_size: int,
+    *,
+    global_rank: int | None = None,
+    global_world_size: int | None = None,
+    train_world_size: int | None = None,
+    train_tp_size: int | None = None,
+    rollout_world_size: int | None = None,
+    rollout_tp_size: int | None = None,
+    role: Literal["train", "rollout"] = "train",
 ) -> TPContext:
     """Initialize process groups and derive local TP/DP rank coordinates."""
     if torch.cuda.is_available():
@@ -79,11 +93,13 @@ def init_process_group(
         device = torch.device("cpu")
         backend = "gloo"
 
+    resolved_global_rank = rank if global_rank is None else global_rank
+    resolved_global_world_size = world_size if global_world_size is None else global_world_size
     dist.init_process_group(
         backend=backend,
         init_method=f"tcp://{master_addr}:{master_port}",
-        rank=rank,
-        world_size=world_size,
+        rank=resolved_global_rank,
+        world_size=resolved_global_world_size,
     )
     if world_size % tp_size != 0:
         raise ValueError("distributed world_size must be divisible by tp_size")
@@ -93,38 +109,87 @@ def init_process_group(
     dp_rank = rank // tp_size
     tp_rank = rank % tp_size
 
-    # Create one TP group per DP row. Every rank participates in `new_group`
-    # for every row so all ranks agree on group construction order, but only
-    # keeps a handle to the group that contains this rank.
-    tp_group = None
-    for group_dp_rank in range(dp_size):
-        ranks = list(range(group_dp_rank * tp_size, (group_dp_rank + 1) * tp_size))
-        group = dist.new_group(ranks=ranks)
-        if group_dp_rank == dp_rank:
-            tp_group = group
+    resolved_train_world = world_size if train_world_size is None else train_world_size
+    resolved_train_tp = tp_size if train_tp_size is None else train_tp_size
+    resolved_rollout_world = 0 if rollout_world_size is None else rollout_world_size
+    resolved_rollout_tp = resolved_train_tp if rollout_tp_size is None else rollout_tp_size
+    train_tp_groups, train_dp_groups = _create_partition_groups(
+        offset=0,
+        world_size=resolved_train_world,
+        tp_size=resolved_train_tp,
+        global_rank=resolved_global_rank,
+    )
+    rollout_tp_groups, rollout_dp_groups = _create_partition_groups(
+        offset=resolved_train_world,
+        world_size=resolved_rollout_world,
+        tp_size=resolved_rollout_tp,
+        global_rank=resolved_global_rank,
+    )
+    if role == "train":
+        tp_group = train_tp_groups[dp_rank]
+        dp_group = train_dp_groups[tp_rank]
+    else:
+        tp_group = rollout_tp_groups[dp_rank]
+        dp_group = rollout_dp_groups[tp_rank]
 
-    # Create one DP group per TP column; same all-ranks-participate pattern as
-    # above so collective initialization is symmetric across the cluster.
-    dp_group = None
-    for group_tp_rank in range(tp_size):
-        ranks = [group_dp_rank * tp_size + group_tp_rank for group_dp_rank in range(dp_size)]
-        group = dist.new_group(ranks=ranks)
-        if group_tp_rank == tp_rank:
-            dp_group = group
+    publisher_groups = []
+    publisher_ranks = []
+    rollout_ranks = list(range(resolved_train_world, resolved_train_world + resolved_rollout_world))
+    if resolved_rollout_world:
+        for train_dp_rank in range(resolved_train_world // resolved_train_tp):
+            ranks = [
+                *range(train_dp_rank * resolved_train_tp, (train_dp_rank + 1) * resolved_train_tp),
+                *rollout_ranks,
+            ]
+            group = dist.new_group(ranks=ranks)
+            publisher_ranks.append(tuple(ranks))
+            publisher_groups.append(group if resolved_global_rank in ranks else None)
 
     ctx = TPContext(
         rank=tp_rank,
         world_size=tp_size,
         device=device,
         group=tp_group,
-        global_rank=rank,
-        global_world_size=world_size,
+        global_rank=resolved_global_rank,
+        global_world_size=resolved_global_world_size,
         dp_rank=dp_rank,
         dp_size=dp_size,
         dp_group=dp_group,
+        role=role,
+        policy_publisher_groups=tuple(publisher_groups),
+        policy_publisher_ranks=tuple(publisher_ranks),
+        train_tp_size=resolved_train_tp,
+        rollout_tp_size=resolved_rollout_tp,
     )
     set_tp_context(ctx)
     return ctx
+
+
+def _create_partition_groups(
+    *,
+    offset: int,
+    world_size: int,
+    tp_size: int,
+    global_rank: int,
+) -> tuple[list[dist.ProcessGroup | None], list[dist.ProcessGroup | None]]:
+    """Create all TP/DP groups for one contiguous partition."""
+
+    if world_size == 0:
+        return [], []
+    if world_size % tp_size != 0:
+        raise ValueError("partition world_size must be divisible by tp_size")
+    dp_size = world_size // tp_size
+    tp_groups: list[dist.ProcessGroup | None] = []
+    for dp_rank in range(dp_size):
+        ranks = list(range(offset + dp_rank * tp_size, offset + (dp_rank + 1) * tp_size))
+        group = dist.new_group(ranks=ranks)
+        tp_groups.append(group if global_rank in ranks else None)
+    dp_groups: list[dist.ProcessGroup | None] = []
+    for tp_rank in range(tp_size):
+        ranks = [offset + dp_rank * tp_size + tp_rank for dp_rank in range(dp_size)]
+        group = dist.new_group(ranks=ranks)
+        dp_groups.append(group if global_rank in ranks else None)
+    return tp_groups, dp_groups
 
 
 def destroy_process_group() -> None:

--- a/areno/engine/parallel/context.py
+++ b/areno/engine/parallel/context.py
@@ -43,6 +43,13 @@ class TPContext:
 
         return self.rank == 0
 
+    def tp_global_rank(self, rank: int) -> int:
+        """Translate a rank local to this TP group into a default-world rank."""
+
+        if rank < 0 or rank >= self.world_size:
+            raise ValueError(f"rank={rank} is outside TP group size {self.world_size}")
+        return self.global_rank - self.rank + rank
+
 
 _TP_CONTEXT = TPContext(
     rank=0,

--- a/areno/engine/parallel/context.py
+++ b/areno/engine/parallel/context.py
@@ -34,6 +34,9 @@ class TPContext:
     role: Literal["train", "rollout"] = "train"
     policy_publisher_groups: tuple[dist.ProcessGroup | None, ...] = ()
     policy_publisher_ranks: tuple[tuple[int, ...], ...] = ()
+    policy_source_ranks: tuple[int, ...] = ()
+    policy_bridge_ranks: tuple[int, ...] = ()
+    policy_bridge_dp_ranks: tuple[int, ...] = ()
     train_tp_size: int = 1
     rollout_tp_size: int = 1
 
@@ -49,6 +52,12 @@ class TPContext:
         if rank < 0 or rank >= self.world_size:
             raise ValueError(f"rank={rank} is outside TP group size {self.world_size}")
         return self.global_rank - self.rank + rank
+
+    def partition_global_rank(self, rank: int) -> int:
+        """Translate a role-partition-local rank into a default-world rank."""
+
+        partition_rank = self.dp_rank * self.world_size + self.rank
+        return self.global_rank - partition_rank + rank
 
 
 _TP_CONTEXT = TPContext(
@@ -89,6 +98,8 @@ def init_process_group(
     train_tp_size: int | None = None,
     rollout_world_size: int | None = None,
     rollout_tp_size: int | None = None,
+    train_devices: tuple[int, ...] | None = None,
+    rollout_devices: tuple[int, ...] | None = None,
     role: Literal["train", "rollout"] = "train",
 ) -> TPContext:
     """Initialize process groups and derive local TP/DP rank coordinates."""
@@ -141,16 +152,29 @@ def init_process_group(
 
     publisher_groups = []
     publisher_ranks = []
-    rollout_ranks = list(range(resolved_train_world, resolved_train_world + resolved_rollout_world))
+    source_ranks = []
+    bridge_ranks = []
+    bridge_dp_ranks = []
     if resolved_rollout_world:
+        resolved_train_devices = train_devices or tuple(range(resolved_train_world))
+        resolved_rollout_devices = rollout_devices or tuple(range(resolved_rollout_world))
         for train_dp_rank in range(resolved_train_world // resolved_train_tp):
-            ranks = [
-                *range(train_dp_rank * resolved_train_tp, (train_dp_rank + 1) * resolved_train_tp),
-                *rollout_ranks,
-            ]
+            pair = _select_policy_relay_pair(
+                train_dp_rank=train_dp_rank,
+                train_tp_size=resolved_train_tp,
+                train_devices=resolved_train_devices,
+                rollout_devices=resolved_rollout_devices,
+                rollout_rank_offset=resolved_train_world,
+                rollout_tp_size=resolved_rollout_tp,
+            )
+            source_rank, bridge_rank, bridge_dp_rank = pair
+            ranks = [source_rank, bridge_rank]
             group = dist.new_group(ranks=ranks)
             publisher_ranks.append(tuple(ranks))
             publisher_groups.append(group if resolved_global_rank in ranks else None)
+            source_ranks.append(source_rank)
+            bridge_ranks.append(bridge_rank)
+            bridge_dp_ranks.append(bridge_dp_rank)
 
     ctx = TPContext(
         rank=tp_rank,
@@ -165,6 +189,9 @@ def init_process_group(
         role=role,
         policy_publisher_groups=tuple(publisher_groups),
         policy_publisher_ranks=tuple(publisher_ranks),
+        policy_source_ranks=tuple(source_ranks),
+        policy_bridge_ranks=tuple(bridge_ranks),
+        policy_bridge_dp_ranks=tuple(bridge_dp_ranks),
         train_tp_size=resolved_train_tp,
         rollout_tp_size=resolved_rollout_tp,
     )
@@ -197,6 +224,32 @@ def _create_partition_groups(
         group = dist.new_group(ranks=ranks)
         dp_groups.append(group if global_rank in ranks else None)
     return tp_groups, dp_groups
+
+
+def _select_policy_relay_pair(
+    *,
+    train_dp_rank: int,
+    train_tp_size: int,
+    train_devices: tuple[int, ...],
+    rollout_devices: tuple[int, ...],
+    rollout_rank_offset: int,
+    rollout_tp_size: int,
+) -> tuple[int, int, int]:
+    """Choose train/rollout ranks on different GPUs for one NCCL relay."""
+
+    train_start = train_dp_rank * train_tp_size
+    for train_local_rank in range(train_start, train_start + train_tp_size):
+        for rollout_local_rank, rollout_device in enumerate(rollout_devices):
+            if train_devices[train_local_rank] == rollout_device:
+                continue
+            return (
+                train_local_rank,
+                rollout_rank_offset + rollout_local_rank,
+                rollout_local_rank // rollout_tp_size,
+            )
+    raise ValueError(
+        "overlapping train and rollout engines need at least two distinct CUDA devices for NCCL policy sync"
+    )
 
 
 def destroy_process_group() -> None:

--- a/areno/engine/policy_sync.py
+++ b/areno/engine/policy_sync.py
@@ -93,9 +93,9 @@ def transfer_policy_weights(worker, payload: PolicySyncPayload) -> dict[str, obj
         element_size = torch.empty((), dtype=layout.dtype).element_size()
         capacity = max(bucket_bytes // element_size, 1)
         publisher_group = ctx.policy_publisher_groups[owner]
-        if publisher_group is None:
-            raise RuntimeError(f"rank {ctx.global_rank} is missing policy publisher group {owner}")
-        source_rank = owner * ctx.train_tp_size
+        source_rank = ctx.policy_source_ranks[owner]
+        bridge_rank = ctx.policy_bridge_ranks[owner]
+        bridge_dp_rank = ctx.policy_bridge_dp_ranks[owner]
         for offset in range(0, layout.numel, capacity):
             count = min(capacity, layout.numel - offset)
             if buffer is None or buffer.dtype != layout.dtype or buffer.device != ctx.device or buffer.numel() < count:
@@ -103,11 +103,23 @@ def transfer_policy_weights(worker, payload: PolicySyncPayload) -> dict[str, obj
                 worker._policy_sync_buffer = buffer
             chunk = buffer[:count]
             if ctx.role == "train":
-                layout.read_chunk(offset, chunk, include_replicated=ctx.rank == 0)
+                layout.read_chunk(offset, chunk, include_replicated=ctx.global_rank == source_rank)
                 if ctx.world_size > 1:
                     dist.reduce(chunk, dst=source_rank, group=ctx.group)
-            dist.broadcast(chunk, src=source_rank, group=publisher_group)
+            if ctx.global_rank in (source_rank, bridge_rank):
+                if publisher_group is None:
+                    raise RuntimeError(f"rank {ctx.global_rank} is missing policy relay group {owner}")
+                dist.broadcast(chunk, src=source_rank, group=publisher_group)
             if ctx.role == "rollout":
+                # The bridge first fans the canonical chunk across its rollout
+                # TP row. Each TP column then broadcasts down its rollout DP
+                # group, so every rollout rank receives the chunk without ever
+                # putting duplicate physical GPUs in one NCCL communicator.
+                if ctx.dp_rank == bridge_dp_rank and ctx.world_size > 1:
+                    dist.broadcast(chunk, src=bridge_rank, group=ctx.group)
+                if ctx.dp_size > 1:
+                    dp_source = ctx.partition_global_rank(bridge_dp_rank * ctx.world_size + ctx.rank)
+                    dist.broadcast(chunk, src=dp_source, group=ctx.dp_group)
                 layout.write_chunk(offset, chunk)
         published_by_dp[owner] += meta.nbytes
 

--- a/areno/engine/policy_sync.py
+++ b/areno/engine/policy_sync.py
@@ -1,0 +1,122 @@
+"""Direct GPU policy synchronization between train and rollout partitions."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+
+from areno.engine.checkpoints.io import PolicyTensorLayout
+from areno.engine.parallel.context import get_tp_context
+from areno.engine.protocol import PolicySyncPayload
+from areno.models.registry import build_policy_weight_plan
+
+
+@dataclass(slots=True, frozen=True)
+class PolicyTensorMeta:
+    """Canonical metadata shared by every train and rollout rank."""
+
+    key: str
+    shape: tuple[int, ...]
+    dtype: str
+    nbytes: int
+
+
+def build_policy_plan(worker) -> tuple[dict[str, object], tuple[PolicyTensorMeta, ...]]:
+    """Build and cache live adapter tasks plus transport metadata."""
+
+    plan = build_policy_weight_plan(worker.model, worker.config.model)
+    metadata = []
+    for key, task in plan.items():
+        layout = task.policy_layout()
+        metadata.append(
+            PolicyTensorMeta(
+                key=key,
+                shape=layout.shape,
+                dtype=str(layout.dtype).removeprefix("torch."),
+                nbytes=layout.nbytes,
+            )
+        )
+    worker._policy_sync_plan = plan
+    worker._policy_sync_metadata = tuple(metadata)
+    return plan, tuple(metadata)
+
+
+def policy_plan_metadata(worker) -> tuple[PolicyTensorMeta, ...]:
+    """Return canonical metadata without transferring weights."""
+
+    _, metadata = build_policy_plan(worker)
+    return metadata
+
+
+def assign_policy_owners(metadata: tuple[PolicyTensorMeta, ...], train_dp_size: int) -> tuple[int, ...]:
+    """Greedily balance canonical bytes over train DP publishers."""
+
+    if train_dp_size < 1:
+        raise ValueError("train_dp_size must be positive")
+    loads = [0] * train_dp_size
+    owners = [0] * len(metadata)
+    for index in sorted(range(len(metadata)), key=lambda item: (-metadata[item].nbytes, metadata[item].key)):
+        owner = min(range(train_dp_size), key=lambda candidate: (loads[candidate], candidate))
+        owners[index] = owner
+        loads[owner] += metadata[index].nbytes
+    return tuple(owners)
+
+
+@torch.no_grad()
+def transfer_policy_weights(worker, payload: PolicySyncPayload) -> dict[str, object]:
+    """Publish or receive every canonical chunk through NCCL groups."""
+
+    ctx = get_tp_context()
+    if not ctx.policy_publisher_groups:
+        raise RuntimeError("policy synchronization requires partitioned publisher groups")
+    plan = getattr(worker, "_policy_sync_plan", None)
+    metadata = getattr(worker, "_policy_sync_metadata", None)
+    if plan is None or metadata is None:
+        plan, metadata = build_policy_plan(worker)
+    train_dp_size = len(ctx.policy_publisher_groups)
+    owners = assign_policy_owners(metadata, train_dp_size)
+    bucket_bytes = int(payload.bucket_bytes)
+    if bucket_bytes < 1:
+        raise ValueError("policy sync bucket_bytes must be positive")
+    started = time.perf_counter()
+    published_by_dp = [0] * train_dp_size
+    buffer = getattr(worker, "_policy_sync_buffer", None)
+
+    for meta, owner in zip(metadata, owners, strict=True):
+        if ctx.role == "train" and ctx.dp_rank != owner:
+            continue
+        task = plan[meta.key]
+        layout: PolicyTensorLayout = task.policy_layout()
+        element_size = torch.empty((), dtype=layout.dtype).element_size()
+        capacity = max(bucket_bytes // element_size, 1)
+        publisher_group = ctx.policy_publisher_groups[owner]
+        if publisher_group is None:
+            raise RuntimeError(f"rank {ctx.global_rank} is missing policy publisher group {owner}")
+        source_rank = owner * ctx.train_tp_size
+        for offset in range(0, layout.numel, capacity):
+            count = min(capacity, layout.numel - offset)
+            if buffer is None or buffer.dtype != layout.dtype or buffer.device != ctx.device or buffer.numel() < count:
+                buffer = torch.empty(capacity, dtype=layout.dtype, device=ctx.device)
+                worker._policy_sync_buffer = buffer
+            chunk = buffer[:count]
+            if ctx.role == "train":
+                layout.read_chunk(offset, chunk, include_replicated=ctx.rank == 0)
+                if ctx.world_size > 1:
+                    dist.reduce(chunk, dst=source_rank, group=ctx.group)
+            dist.broadcast(chunk, src=source_rank, group=publisher_group)
+            if ctx.role == "rollout":
+                layout.write_chunk(offset, chunk)
+        published_by_dp[owner] += meta.nbytes
+
+    if ctx.device.type == "cuda":
+        torch.cuda.synchronize(ctx.device)
+    return {
+        "version": payload.version,
+        "bytes": sum(meta.nbytes for meta in metadata),
+        "tensors": len(metadata),
+        "elapsed_s": time.perf_counter() - started,
+        "published_bytes_by_train_dp": tuple(published_by_dp),
+    }

--- a/areno/engine/protocol.py
+++ b/areno/engine/protocol.py
@@ -19,7 +19,7 @@ import traceback
 from dataclasses import dataclass
 from enum import Enum, auto
 from itertools import count
-from typing import Any
+from typing import Any, Literal
 
 import torch
 
@@ -43,6 +43,9 @@ class Op(Enum):
     ROLLOUT_SESSION_SYNC = auto()
     ROLLOUT_SESSION_END = auto()
     SAVE_CHECKPOINT = auto()
+    POLICY_SYNC_PLAN = auto()
+    POLICY_SYNC_PUBLISH = auto()
+    POLICY_SYNC_RECEIVE = auto()
     SHUTDOWN = auto()
 
 
@@ -151,6 +154,42 @@ class SaveCheckpointPayload:
     path: str
 
 
+@dataclass(slots=True, frozen=True)
+class PolicySyncPayload:
+    """Version and fixed GPU bucket bound for one policy transfer."""
+
+    version: int
+    bucket_bytes: int
+
+
+@dataclass(slots=True, frozen=True)
+class ClusterPartition:
+    """One role-local rank range inside a shared distributed world."""
+
+    role: Literal["train", "rollout"]
+    global_rank_offset: int
+    local_world_size: int
+    tp_size: int
+    devices: tuple[int, ...]
+
+    @property
+    def dp_size(self) -> int:
+        """Return this partition's data-parallel size."""
+
+        return self.local_world_size // self.tp_size
+
+
+@dataclass(slots=True, frozen=True)
+class DistributedWorldSpec:
+    """Shared rendezvous and rank layout for train and rollout partitions."""
+
+    master_addr: str
+    master_port: int
+    global_world_size: int
+    train: ClusterPartition
+    rollout: ClusterPartition | None = None
+
+
 @dataclass(slots=True)
 class _PendingClusterCall:
     """Coordinator-side accumulator for one in-flight cluster request."""
@@ -162,6 +201,26 @@ class _PendingClusterCall:
     future: asyncio.Future | None = None
     loop: asyncio.AbstractEventLoop | None = None
     error: BaseException | None = None
+
+
+class ClusterCallHandle:
+    """Small blocking handle returned by :meth:`TPCluster.submit`."""
+
+    def __init__(self, cluster: TPCluster, request_id: int, pending: _PendingClusterCall):
+        self._cluster = cluster
+        self._request_id = request_id
+        self._pending = pending
+
+    def result(self, timeout: float | None = None) -> list[Any]:
+        """Wait for the submitted cluster call and return rank-ordered results."""
+
+        if not self._pending.event.wait(timeout=timeout):
+            with self._cluster._pending_lock:
+                self._cluster._pending_calls.pop(self._request_id, None)
+            raise TimeoutError(f"timed out waiting for {self._pending.op}")
+        if self._pending.error is not None:
+            raise self._pending.error
+        return self._pending.results
 
 
 def find_free_port() -> int:
@@ -205,11 +264,22 @@ class TPCluster:
     has reported success or one rank reports an error.
     """
 
-    def __init__(self, config: EngineConfig, worker_cls: type):
+    def __init__(
+        self,
+        config: EngineConfig,
+        worker_cls: type,
+        *,
+        world_spec: DistributedWorldSpec | None = None,
+        partition: ClusterPartition | None = None,
+    ):
         """Create an unstarted process cluster for a worker class."""
 
         self.config = config
         self.worker_cls = worker_cls
+        if (world_spec is None) != (partition is None):
+            raise ValueError("world_spec and partition must be provided together")
+        self.world_spec = world_spec
+        self.partition = partition
         # `spawn` start method is required by CUDA-aware workers; do not
         # inherit fds/CUDA state from the parent.
         self.ctx = mp.get_context("spawn")
@@ -229,24 +299,56 @@ class TPCluster:
 
         if self.started:
             return
-        # Reserve a unique TCP port for torch.distributed rendezvous; ranks
-        # discover each other through this port over loopback.
-        port = find_free_port()
-        assert self.config.devices is not None
-        devices = self.config.devices
+        if self.world_spec is not None:
+            raise RuntimeError("partitioned clusters must be started with start_partitioned_clusters()")
         world_size = self.config.tp_size * int(self.config.dp_size)
-        if len(devices) != world_size:
-            raise ValueError("len(devices) must equal tp_size * dp_size")
-        for rank in range(world_size):
+        world_spec = DistributedWorldSpec(
+            master_addr="127.0.0.1",
+            master_port=find_free_port(),
+            global_world_size=world_size,
+            train=ClusterPartition(
+                role="train",
+                global_rank_offset=0,
+                local_world_size=world_size,
+                tp_size=self.config.tp_size,
+                devices=tuple(self.config.devices or ()),
+            ),
+        )
+        self.world_spec = world_spec
+        self.partition = world_spec.train
+        self._spawn_workers()
+        try:
+            self._wait_for_worker_ready(set(range(world_size)))
+        except BaseException:
+            self._abort_start()
+            raise
+        else:
+            self.started = True
+            self._start_result_pump()
+
+    def _spawn_workers(self) -> None:
+        """Spawn this partition without waiting for the shared world."""
+
+        if self.processes:
+            return
+        if self.world_spec is None or self.partition is None:
+            raise RuntimeError("cluster partition is not configured")
+        partition = self.partition
+        if len(partition.devices) != partition.local_world_size:
+            raise ValueError("partition devices must equal local_world_size")
+        if partition.local_world_size != self.config.tp_size * int(self.config.dp_size):
+            raise ValueError("partition world size must equal tp_size * dp_size")
+        for rank in range(partition.local_world_size):
             cmd_q = self.ctx.Queue()
             proc = self.ctx.Process(
                 target=_worker_entry,
                 args=(
                     self.worker_cls,
                     rank,
-                    world_size,
-                    devices[rank],
-                    port,
+                    partition.local_world_size,
+                    partition.devices[rank],
+                    self.world_spec,
+                    partition,
                     self.config,
                     cmd_q,
                     self.result_queue,
@@ -256,23 +358,20 @@ class TPCluster:
             proc.start()
             self.cmd_queues.append(cmd_q)
             self.processes.append(proc)
-        try:
-            self._wait_for_worker_ready(set(range(world_size)))
-        except BaseException:
-            for proc in self.processes:
-                if proc.is_alive():
-                    proc.terminate()
-            for proc in self.processes:
-                proc.join(timeout=0)
-            for q in self.cmd_queues:
-                _close_queue(q)
-            _close_queue(self.result_queue)
-            self.cmd_queues = []
-            self.processes = []
-            raise
-        else:
-            self.started = True
-            self._start_result_pump()
+
+    def _abort_start(self) -> None:
+        """Terminate workers and release queues after startup failure."""
+
+        for proc in self.processes:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in self.processes:
+            proc.join(timeout=0)
+        for q in self.cmd_queues:
+            _close_queue(q)
+        _close_queue(self.result_queue)
+        self.cmd_queues = []
+        self.processes = []
 
     def _start_result_pump(self) -> None:
         """Start the single result-demux thread for all concurrent calls."""
@@ -306,15 +405,14 @@ class TPCluster:
         timeout: float | None = None,
     ) -> list[Any]:
         """Broadcast one command and collect one ordered result from every rank."""
+        return self.submit(op, payload).result(timeout=timeout)
+
+    def submit(self, op: Op, payload: Any = None) -> ClusterCallHandle:
+        """Submit a command without waiting, allowing paired collectives."""
+
         request_id = next(self._request_ids)
         pending = self._submit_call(op, payload, request_id=request_id)
-        if not pending.event.wait(timeout=timeout):
-            with self._pending_lock:
-                self._pending_calls.pop(request_id, None)
-            raise TimeoutError(f"timed out waiting for {op}")
-        if pending.error is not None:
-            raise pending.error
-        return pending.results
+        return ClusterCallHandle(self, request_id, pending)
 
     async def call_async(
         self,
@@ -487,7 +585,8 @@ def _worker_entry(
     rank: int,
     world_size: int,
     device_id: int,
-    port: int,
+    world_spec: DistributedWorldSpec,
+    partition: ClusterPartition,
     config: EngineConfig,
     cmd_q: mp.Queue,
     result_q: mp.Queue,
@@ -505,10 +604,17 @@ def _worker_entry(
         init_process_group(
             rank=rank,
             world_size=world_size,
-            master_addr="127.0.0.1",
-            master_port=port,
+            master_addr=world_spec.master_addr,
+            master_port=world_spec.master_port,
             device_id=device_id,
             tp_size=config.tp_size,
+            global_rank=partition.global_rank_offset + rank,
+            global_world_size=world_spec.global_world_size,
+            train_world_size=world_spec.train.local_world_size,
+            train_tp_size=world_spec.train.tp_size,
+            rollout_world_size=world_spec.rollout.local_world_size if world_spec.rollout is not None else None,
+            rollout_tp_size=world_spec.rollout.tp_size if world_spec.rollout is not None else None,
+            role=partition.role,
         )
         torch.set_float32_matmul_precision("high")
         worker = worker_cls(config)
@@ -578,3 +684,28 @@ def _set_async_exception(future: asyncio.Future, exc: BaseException) -> None:
 
     if not future.done():
         future.set_exception(exc)
+
+
+def start_partitioned_clusters(
+    train_cluster: TPCluster,
+    rollout_cluster: TPCluster,
+    world_spec: DistributedWorldSpec,
+) -> None:
+    """Spawn both partitions before waiting for their shared rendezvous."""
+
+    clusters = (train_cluster, rollout_cluster)
+    if train_cluster.world_spec != world_spec or rollout_cluster.world_spec != world_spec:
+        raise ValueError("both clusters must use the supplied world_spec")
+    try:
+        for cluster in clusters:
+            cluster._spawn_workers()
+        for cluster in clusters:
+            assert cluster.partition is not None
+            cluster._wait_for_worker_ready(set(range(cluster.partition.local_world_size)))
+    except BaseException:
+        for cluster in clusters:
+            cluster._abort_start()
+        raise
+    for cluster in clusters:
+        cluster.started = True
+        cluster._start_result_pump()

--- a/areno/engine/protocol.py
+++ b/areno/engine/protocol.py
@@ -614,6 +614,8 @@ def _worker_entry(
             train_tp_size=world_spec.train.tp_size,
             rollout_world_size=world_spec.rollout.local_world_size if world_spec.rollout is not None else None,
             rollout_tp_size=world_spec.rollout.tp_size if world_spec.rollout is not None else None,
+            train_devices=world_spec.train.devices,
+            rollout_devices=world_spec.rollout.devices if world_spec.rollout is not None else None,
             role=partition.role,
         )
         torch.set_float32_matmul_precision("high")

--- a/areno/engine/runtime/recompute.py
+++ b/areno/engine/runtime/recompute.py
@@ -49,3 +49,35 @@ def checkpoint_layer(
         use_reentrant=False,
         preserve_rng_state=True,
     )
+
+
+def checkpoint_routed_moe_layer(
+    attention_fn: Callable[..., torch.Tensor],
+    post_attention_norm: Callable[[torch.Tensor], torch.Tensor],
+    route_fn: Callable[[torch.Tensor], tuple[torch.Tensor, torch.Tensor]],
+    expert_fn: Callable[[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor],
+    hidden_states: torch.Tensor,
+    *attention_args: Any,
+    train_meta: TrainMeta | None = None,
+    infer_meta: InferMeta | None = None,
+) -> torch.Tensor:
+    """Checkpoint attention and experts while keeping dynamic routing fixed."""
+
+    attended = checkpoint_layer(
+        attention_fn,
+        hidden_states,
+        *attention_args,
+        train_meta=train_meta,
+        infer_meta=infer_meta,
+    )
+    normalized = post_attention_norm(attended)
+    topk_idx, topk_weight = route_fn(normalized)
+    expert_output = checkpoint_layer(
+        expert_fn,
+        normalized,
+        topk_idx,
+        topk_weight,
+        train_meta=train_meta,
+        infer_meta=infer_meta,
+    )
+    return attended + expert_output

--- a/areno/engine/runtime/recompute.py
+++ b/areno/engine/runtime/recompute.py
@@ -51,6 +51,7 @@ def checkpoint_layer(
     )
 
 
+@_disable_dynamo_frame
 def checkpoint_routed_moe_layer(
     attention_fn: Callable[..., torch.Tensor],
     post_attention_norm: Callable[[torch.Tensor], torch.Tensor],

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -26,9 +26,11 @@ from areno.engine.data.sampling import _truncate_generated
 from areno.engine.inference import InferCacheSpec, InferenceManager
 from areno.engine.modeling import build_model_on_device, build_optimizer, param_grad
 from areno.engine.parallel.context import get_tp_context
+from areno.engine.policy_sync import policy_plan_metadata, transfer_policy_weights
 from areno.engine.protocol import (
     Command,
     Op,
+    PolicySyncPayload,
     RolloutCacheProbePayload,
     RolloutPayload,
     SaveCheckpointPayload,
@@ -63,7 +65,7 @@ class ArenoWorker:
         if config.runtime.compile_model:
             self.model = torch.compile(self.model)
         opt = config.optimizer
-        self.optimizer = build_optimizer(self.model.parameters(), opt, ctx)
+        self.optimizer = build_optimizer(self.model.parameters(), opt, ctx) if config.role == "train" else None
         self.grad_clip_norm = opt.grad_clip_norm
         self.base_lr = opt.lr
         self.min_lr = opt.min_lr
@@ -88,10 +90,14 @@ class ArenoWorker:
         self._train_state_ready = False
         self._actor_on_device = True
         self._current_request_ids: list[int | None] = []
+        self._policy_sync_plan = None
+        self._policy_sync_metadata = None
+        self._policy_sync_buffer = None
+        self._loaded_policy_version = 0
         self.inference = InferenceManager(self)
         self.roles = RoleManager(self)
-        self.training = TrainingManager(self)
-        if config.train_loss_fn is None:
+        self.training = TrainingManager(self) if config.role == "train" else None
+        if config.role == "train" and config.train_loss_fn is None:
             raise ValueError("ArenoEngine requires train_loss_fn")
         self.loss_fn = config.train_loss_fn
 
@@ -110,6 +116,8 @@ class ArenoWorker:
         if cmd.op is Op.ROLLOUT_SESSION_END:
             return self.rollout_session_end(cmd.payload)
         if cmd.op is Op.TRAIN:
+            if self.training is None:
+                raise RuntimeError("rollout workers cannot execute training operations")
             return self.train(cmd.payload)
         if cmd.op is Op.SCORE_LOGPROBS:
             return self.score_logprobs(cmd.payload)
@@ -121,7 +129,53 @@ class ArenoWorker:
             return self.train_values(cmd.payload)
         if cmd.op is Op.SAVE_CHECKPOINT:
             return self.save_checkpoint(cmd.payload)
+        if cmd.op is Op.POLICY_SYNC_PLAN:
+            return self.policy_sync_plan(cmd.payload)
+        if cmd.op is Op.POLICY_SYNC_PUBLISH:
+            return self.publish_policy(cmd.payload)
+        if cmd.op is Op.POLICY_SYNC_RECEIVE:
+            return self.receive_policy(cmd.payload)
         raise ValueError(f"unsupported areno op: {cmd.op}")
+
+    def policy_sync_plan(self, payload: None):
+        """Build canonical metadata before paired cross-partition collectives."""
+
+        del payload
+        if self.config.role == "rollout":
+            self._prepare_policy_receive()
+        else:
+            self._prepare_actor_onloaded()
+            self.model.onload_train_weights(self.device)
+        return policy_plan_metadata(self)
+
+    def publish_policy(self, payload: PolicySyncPayload) -> dict[str, object]:
+        """Publish authoritative train shards to the rollout partition."""
+
+        self._prepare_actor_onloaded()
+        self.model.onload_train_weights(self.device)
+        return transfer_policy_weights(self, payload)
+
+    @torch.no_grad()
+    def receive_policy(self, payload: PolicySyncPayload) -> dict[str, object]:
+        """Replace rollout shards in place and rebuild inference weights."""
+
+        self._prepare_policy_receive()
+        result = transfer_policy_weights(self, payload)
+        self.model.prepare_infer_weights()
+        self.model.offload_train_weights()
+        self._train_state_ready = False
+        self._loaded_policy_version = payload.version
+        return result
+
+    def _prepare_policy_receive(self) -> None:
+        """Release stale derived rollout state before receiving live weights."""
+
+        self._prepare_actor_onloaded()
+        self._release_decode_graphs()
+        self._infer_cache_spec = None
+        self.model.clear_infer_weights()
+        self.model.clear_kv_caches()
+        self.model.onload_train_weights(self.device)
 
     def ensure_roles(self, payload: dict) -> None:
         """Delegate non-actor role lifecycle to `RoleManager`."""
@@ -354,7 +408,8 @@ class ArenoWorker:
         del payload
         if not self.config.runtime.keep_rollout_state:
             self._drop_rollout_hbm()
-        self._prepare_for_train()
+        if self.config.role == "train":
+            self._prepare_for_train()
 
     def _prepare_for_train(self) -> None:
         """Ensure the actor is on-device and train weights are loaded."""
@@ -368,7 +423,8 @@ class ArenoWorker:
             return
         self.model.to(self.device)
         self.model.onload_train_weights(self.device)
-        self.optimizer.onload_state(self.device)
+        if self.optimizer is not None:
+            self.optimizer.onload_state(self.device)
         self._actor_on_device = True
 
     def _prepare_actor_offloaded(self) -> None:
@@ -385,7 +441,8 @@ class ArenoWorker:
         self.model.clear_kv_caches()
         self.model.offload_train_weights()
         self.model.to("cpu")
-        self.optimizer.offload_state()
+        if self.optimizer is not None:
+            self.optimizer.offload_state()
         self._train_state_ready = False
         self._actor_on_device = False
         if self.device.type == "cuda":
@@ -434,6 +491,8 @@ class ArenoWorker:
 
     def train(self, payload: dict) -> list[dict | None]:
         """Delegate actor training to `TrainingManager`."""
+        if self.training is None:
+            raise RuntimeError("rollout workers cannot execute training operations")
         return self.training.train(payload)
 
     def _sync_role_grads(self, role: WorkerRole) -> None:

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -363,8 +363,7 @@ class ArenoWorker:
             request_id = -1 if cmd.request_id is None else int(cmd.request_id)
         header = torch.tensor([has_command, op_value, request_id], device=ctx.device, dtype=torch.long)
         if ctx.world_size > 1:
-            src = ctx.dp_rank * ctx.world_size
-            dist.broadcast(header, src=src, group=ctx.group)
+            dist.broadcast(header, src=ctx.tp_global_rank(0), group=ctx.group)
         if int(header[0].item()) == 0:
             return None
         return Op(int(header[1].item())), None if int(header[2].item()) < 0 else int(header[2].item())

--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -411,8 +411,16 @@ class BailingGroupedExperts(nn.Module):
         )
         if x.shape[0] == 0:
             # No tokens routed to this rank — still need to all_reduce to keep
-            # collective sync with peers.
-            return all_reduce(flat.new_zeros(flat.shape))
+            # collective and gradient sync with peers. The zero-valued graph
+            # edges ensure expert and router gradients exist on every rank.
+            fc1_param = next(self.linear_fc1.parameters())
+            fc2_param = next(self.linear_fc2.parameters())
+            zero = (
+                fc1_param.reshape(-1)[0] * 0
+                + fc2_param.reshape(-1)[0] * 0
+                + topk_weight.sum().to(dtype=fc1_param.dtype) * 0
+            )
+            return all_reduce(flat.new_zeros(flat.shape) + zero)
         hidden, _ = _grouped_linear_forward(self.linear_fc1, x.contiguous(), tokens_per_expert)
         # Apply routing weight before fc2 so it stays inside the fp32 reduction.
         hidden = (

--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -62,7 +62,11 @@ from areno.accel.ops import (
     log_once,
     seg_la_fwd,
 )
-from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
+from areno.engine.checkpoints.common import (
+    build_checkpoint_policy_plan,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention_backend.infer import FlashAttnInferBackend, build_infer_attention_backend
 from areno.engine.layers.attention_backend.train import build_train_attention_backend
@@ -1356,6 +1360,9 @@ class BailingMoeLinearV2Adapter(ModelAdapter):
         if not isinstance(model, BailingMoeLinearV2ForCausalLM):
             raise TypeError(f"BailingMoeLinearV2Adapter cannot save weights from {type(model)!r}")
         return save_checkpoint_weights(model, output_path, source_path, CHECKPOINT_SPEC)
+
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, CHECKPOINT_SPEC)
 
 
 def _is_softmax_layer(config: ModelConfig, layer_idx: int) -> bool:

--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -597,11 +597,12 @@ def _gather_expert_parallel_tensor(tensor: torch.Tensor) -> torch.Tensor | None:
     local = tensor.detach().contiguous()
     if ctx.world_size == 1:
         return local.cpu()
+    dst = ctx.tp_global_rank(0)
     if ctx.rank == 0:
         chunks = [torch.empty_like(local) for _ in range(ctx.world_size)]
-        dist.gather(local, gather_list=chunks, dst=ctx.dp_rank * ctx.world_size, group=ctx.group)
+        dist.gather(local, gather_list=chunks, dst=dst, group=ctx.group)
         return torch.cat(chunks, dim=0).cpu()
-    dist.gather(local, dst=ctx.dp_rank * ctx.world_size, group=ctx.group)
+    dist.gather(local, dst=dst, group=ctx.group)
     return None
 
 

--- a/areno/models/base.py
+++ b/areno/models/base.py
@@ -68,3 +68,8 @@ class ModelAdapter(ABC):
         """Save weights back to an HF-compatible checkpoint at ``output_path``."""
 
         raise NotImplementedError
+
+    def build_policy_plan(self, model: nn.Module):
+        """Return live canonical weight-layout tasks for direct policy sync."""
+
+        raise NotImplementedError(f"{type(self).__name__} does not provide a policy synchronization plan")

--- a/areno/models/gemma4/checkpoint.py
+++ b/areno/models/gemma4/checkpoint.py
@@ -40,7 +40,14 @@ from areno.engine.checkpoints.common import (
     save_split_column_spec,
     split_local_tensors,
 )
-from areno.engine.checkpoints.io import _owns_checkpoint_tensor, _tensor_to_cpu
+from areno.engine.checkpoints.io import (
+    PolicyFlatPiece,
+    PolicyTensorLayout,
+    PolicyTensorStore,
+    _owns_checkpoint_tensor,
+    _tensor_to_cpu,
+)
+from areno.engine.parallel.context import get_tp_context
 
 
 def top_level_spec(prefix: str) -> TopLevelSpec:
@@ -210,7 +217,11 @@ def save_gemma4_attention(tensors, prefix: str, layer, context) -> None:
     parts = split_local_tensors(qkv.weight, qkv.local_out_features)
     gathered = _gather_ranged_column_tensors(list(parts), qkv.shard_ranges, qkv.out_features)
     templates = QKV_SAVE_SPEC.keys
-    if attention.attention_k_eq_v and attention.layer_type == "full_attention":
+    if (
+        not isinstance(tensors, PolicyTensorStore)
+        and attention.attention_k_eq_v
+        and attention.layer_type == "full_attention"
+    ):
         templates = templates[:2]
         gathered = gathered[:2]
     for template, tensor in zip(templates, gathered, strict=True):
@@ -219,7 +230,11 @@ def save_gemma4_attention(tensors, prefix: str, layer, context) -> None:
         bias_parts = split_local_tensors(qkv.bias, qkv.local_out_features)
         bias_gathered = _gather_ranged_column_tensors(list(bias_parts), qkv.shard_ranges, qkv.out_features)
         bias_templates = QKV_BIAS_SAVE_SPEC.keys
-        if attention.attention_k_eq_v and attention.layer_type == "full_attention":
+        if (
+            not isinstance(tensors, PolicyTensorStore)
+            and attention.attention_k_eq_v
+            and attention.layer_type == "full_attention"
+        ):
             bias_templates = bias_templates[:2]
             bias_gathered = bias_gathered[:2]
         for template, tensor in zip(bias_templates, bias_gathered, strict=True):
@@ -294,6 +309,47 @@ def _save_gemma4_moe(tensors, prefix: str, layer) -> None:
     tensors[f"{prefix}.router.scale"] = rank0_tensor(router.scale)
     tensors[f"{prefix}.router.proj.weight"] = rank0_tensor(router.proj.weight)
     tensors[f"{prefix}.router.per_expert_scale"] = rank0_tensor(moe.per_expert_scale)
+    if isinstance(tensors, PolicyTensorStore):
+        gate_weights, up_weights, down_weights = moe.experts.expert_weights()
+        local_start = int(moe.experts.local_expert_start)
+        num_experts = int(moe.experts.local_num_experts) * get_tp_context().world_size
+        gate_shape = tuple(gate_weights[0].shape)
+        up_shape = tuple(up_weights[0].shape)
+        down_shape = tuple(down_weights[0].shape)
+        gate_up_shape = (num_experts, gate_shape[0] + up_shape[0], *gate_shape[1:])
+        gate_up_stride = (gate_shape[0] + up_shape[0]) * _numel(gate_shape[1:])
+        gate_stride = gate_shape[0] * _numel(gate_shape[1:])
+        gate_up_pieces = []
+        down_pieces = []
+        for local_index, (gate, up, down) in enumerate(zip(gate_weights, up_weights, down_weights, strict=True)):
+            expert_id = local_start + local_index
+            base = expert_id * gate_up_stride
+            gate_up_pieces.extend(
+                (
+                    PolicyFlatPiece(gate.detach(), base),
+                    PolicyFlatPiece(up.detach(), base + gate_stride),
+                )
+            )
+            down_pieces.append(PolicyFlatPiece(down.detach(), expert_id * down.numel()))
+        tensors.add_layout(
+            f"{prefix}.experts.gate_up_proj",
+            PolicyTensorLayout(
+                shape=gate_up_shape,
+                dtype=gate_weights[0].dtype,
+                pieces=(),
+                flat_pieces=tuple(gate_up_pieces),
+            ),
+        )
+        tensors.add_layout(
+            f"{prefix}.experts.down_proj",
+            PolicyTensorLayout(
+                shape=(num_experts, *down_shape),
+                dtype=down_weights[0].dtype,
+                pieces=(),
+                flat_pieces=tuple(down_pieces),
+            ),
+        )
+        return
     full_weights = gather_moe_expert_weights(moe.experts)
     gate_up_key = f"{prefix}.experts.gate_up_proj"
     down_key = f"{prefix}.experts.down_proj"
@@ -305,6 +361,13 @@ def _save_gemma4_moe(tensors, prefix: str, layer) -> None:
     gate_up = torch.cat((gate_weights, up_weights), dim=1).contiguous()
     tensors[gate_up_key] = _tensor_to_cpu(gate_up) if _owns_checkpoint_tensor(gate_up_key) else None
     tensors[down_key] = _tensor_to_cpu(down_weights.contiguous()) if _owns_checkpoint_tensor(down_key) else None
+
+
+def _numel(shape: tuple[int, ...]) -> int:
+    result = 1
+    for size in shape:
+        result *= size
+    return result
 
 
 def checkpoint_spec(prefix: str) -> CheckpointSpec:

--- a/areno/models/gemma4/model.py
+++ b/areno/models/gemma4/model.py
@@ -39,7 +39,11 @@ from areno.accel import (
     areno_topk_softmax,
 )
 from areno.accel.ops import FusedMoeConfig, areno_fused_experts, areno_gelu_tanh_and_mul, log_once
-from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
+from areno.engine.checkpoints.common import (
+    build_checkpoint_policy_plan,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention_backend.infer import FlashAttnInferBackend, build_infer_attention_backend
 from areno.engine.layers.attention_backend.train import build_train_attention_backend
@@ -920,6 +924,9 @@ class Gemma4Adapter(ModelAdapter):
         if not isinstance(model, Gemma4ForCausalLM):
             raise TypeError(f"Gemma4Adapter cannot save weights from {type(model)!r}")
         return save_checkpoint_weights(model, output_path, source_path, checkpoint_spec(model.config.checkpoint_prefix))
+
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, checkpoint_spec(model.config.checkpoint_prefix))
 
 
 def _layer_type(config: ModelConfig, layer_idx: int) -> str:

--- a/areno/models/gemma4/model.py
+++ b/areno/models/gemma4/model.py
@@ -575,31 +575,12 @@ class Gemma4DecoderLayer(nn.Module):
         residual = hidden_states
         dense_input = self.pre_feedforward_layernorm(hidden_states)
         if self.moe is not None:
-            if (
-                self.router is None
-                or self.pre_feedforward_layernorm_2 is None
-                or self.post_feedforward_layernorm_1 is None
-                or self.post_feedforward_layernorm_2 is None
-            ):
-                raise RuntimeError("Gemma4 MoE layer is missing router or MoE norms")
-            dense_hidden = checkpoint_layer(
-                self.mlp,
+            hidden_states = _gemma4_moe_feedforward_no_compile(
+                self,
+                residual,
                 dense_input,
-                train_meta=train_meta,
-                infer_meta=infer_meta,
-            )
-            router_logits = self.router(residual)
-            topk_idx, topk_weight = self.moe.route(router_logits)
-            moe_hidden = checkpoint_layer(
-                self.moe.forward_with_routes,
-                self.pre_feedforward_layernorm_2(residual),
-                topk_idx,
-                topk_weight,
-                train_meta=train_meta,
-                infer_meta=infer_meta,
-            )
-            hidden_states = self.post_feedforward_layernorm_1(dense_hidden) + self.post_feedforward_layernorm_2(
-                moe_hidden
+                train_meta,
+                infer_meta,
             )
         else:
             hidden_states = self.mlp(dense_input)
@@ -1094,6 +1075,43 @@ def _gemma4_per_layer_inputs_no_compile(
     # Dynamo-disabled wrapper around the PLE pipeline because get/project rely
     # on data-dependent indexing and reshapes.
     return model.project_per_layer_inputs(hidden_states, model.get_per_layer_inputs(input_ids))
+
+
+@torch._dynamo.disable
+def _gemma4_moe_feedforward_no_compile(
+    layer: Gemma4DecoderLayer,
+    residual: torch.Tensor,
+    dense_input: torch.Tensor,
+    train_meta: TrainMeta | None,
+    infer_meta: InferMeta | None,
+) -> torch.Tensor:
+    """Keep dynamic MoE checkpoint callables out of Dynamo's guard cache."""
+
+    if (
+        layer.moe is None
+        or layer.router is None
+        or layer.pre_feedforward_layernorm_2 is None
+        or layer.post_feedforward_layernorm_1 is None
+        or layer.post_feedforward_layernorm_2 is None
+    ):
+        raise RuntimeError("Gemma4 MoE layer is missing router or MoE norms")
+    dense_hidden = checkpoint_layer(
+        layer.mlp,
+        dense_input,
+        train_meta=train_meta,
+        infer_meta=infer_meta,
+    )
+    router_logits = layer.router(residual)
+    topk_idx, topk_weight = layer.moe.route(router_logits)
+    moe_hidden = checkpoint_layer(
+        layer.moe.forward_with_routes,
+        layer.pre_feedforward_layernorm_2(residual),
+        topk_idx,
+        topk_weight,
+        train_meta=train_meta,
+        infer_meta=infer_meta,
+    )
+    return layer.post_feedforward_layernorm_1(dense_hidden) + layer.post_feedforward_layernorm_2(moe_hidden)
 
 
 @torch._dynamo.disable

--- a/areno/models/gemma4/model.py
+++ b/areno/models/gemma4/model.py
@@ -183,7 +183,12 @@ class Gemma4MoeExperts(nn.Module):
             self.local_num_experts,
         )
         if x.shape[0] == 0:
-            return all_reduce(flat.new_zeros(flat.shape))
+            zero = (
+                self.gate_up_weight.reshape(-1)[0] * 0
+                + self.down_weight.reshape(-1)[0] * 0
+                + topk_weight.sum().to(dtype=self.gate_up_weight.dtype) * 0
+            )
+            return all_reduce(flat.new_zeros(flat.shape) + zero)
         hidden = _areno_grouped_linear_no_compile(x.contiguous(), self.gate_up_weight, tokens_per_expert)
         hidden = (
             _areno_gelu_tanh_and_mul_no_compile(hidden) * route_weight.unsqueeze(-1).to(dtype=hidden.dtype)
@@ -249,18 +254,34 @@ class Gemma4MoeMLP(nn.Module):
             routed_scaling_factor=config.routed_scaling_factor,
         )
 
-    def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
-        batch, seqlen, hidden = hidden_states.shape
-        flat = hidden_states.reshape(-1, hidden)
+    def route(self, router_logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute dynamic expert routing once outside activation recompute."""
+
         topk_idx, topk_weight = _areno_topk_softmax_no_compile(
             router_logits.reshape(-1, self.num_experts), self.top_k, self.norm_topk_prob
         )
         topk_weight = topk_weight * self.per_expert_scale[topk_idx].to(dtype=topk_weight.dtype)
+        return topk_idx, topk_weight
+
+    def forward_with_routes(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run routed experts with a fixed top-k assignment."""
+
+        batch, seqlen, hidden = hidden_states.shape
+        flat = hidden_states.reshape(-1, hidden)
         if self.training:
             out = self.experts(flat, topk_idx.to(torch.long), topk_weight)
         else:
             out = self._forward_fused_moe(flat, topk_idx, topk_weight)
         return out.view(batch, seqlen, hidden)
+
+    def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
+        topk_idx, topk_weight = self.route(router_logits)
+        return self.forward_with_routes(hidden_states, topk_idx, topk_weight)
 
     @torch.no_grad()
     def prepare_infer_weights(self) -> None:
@@ -508,6 +529,20 @@ class Gemma4DecoderLayer(nn.Module):
         # Learnable per-layer scalar multiplier on the block output; persistent
         # so it round-trips through the checkpoint as ``{prefix}.layer_scalar``.
         self.register_buffer("layer_scalar", torch.ones(1), persistent=True)
+        self.handles_activation_checkpointing = config.enable_moe_block
+
+    def _attention_block(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        shared_kv: tuple[torch.Tensor, torch.Tensor] | None,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
+        residual = hidden_states
+        normalized = self.input_layernorm(hidden_states)
+        attended, kv_for_share = self.self_attn(normalized, position_ids, shared_kv, train_meta, infer_meta)
+        return self.post_attention_layernorm(attended) + residual, kv_for_share
 
     def forward(
         self,
@@ -518,12 +553,24 @@ class Gemma4DecoderLayer(nn.Module):
         train_meta: TrainMeta | None = None,
         infer_meta: InferMeta | None = None,
     ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
-        # Pre-norm attention path (note: norm comes both before AND after attn).
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
-        hidden_states, kv_for_share = self.self_attn(hidden_states, position_ids, shared_kv, train_meta, infer_meta)
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = hidden_states + residual
+        # KV-sharing layers retain the existing direct path. Other MoE layers
+        # checkpoint attention separately so routing can remain outside the
+        # recomputed region.
+        if self.moe is not None and shared_kv is None:
+            hidden_states, kv_for_share = checkpoint_layer(
+                self._attention_block,
+                hidden_states,
+                position_ids,
+                shared_kv,
+                train_meta,
+                infer_meta,
+                train_meta=train_meta,
+                infer_meta=infer_meta,
+            )
+        else:
+            hidden_states, kv_for_share = self._attention_block(
+                hidden_states, position_ids, shared_kv, train_meta, infer_meta
+            )
         # Pre-norm FF path with matching sandwich norm on output.
         residual = hidden_states
         dense_input = self.pre_feedforward_layernorm(hidden_states)
@@ -535,9 +582,22 @@ class Gemma4DecoderLayer(nn.Module):
                 or self.post_feedforward_layernorm_2 is None
             ):
                 raise RuntimeError("Gemma4 MoE layer is missing router or MoE norms")
-            dense_hidden = self.mlp(dense_input)
+            dense_hidden = checkpoint_layer(
+                self.mlp,
+                dense_input,
+                train_meta=train_meta,
+                infer_meta=infer_meta,
+            )
             router_logits = self.router(residual)
-            moe_hidden = self.moe(self.pre_feedforward_layernorm_2(residual), router_logits)
+            topk_idx, topk_weight = self.moe.route(router_logits)
+            moe_hidden = checkpoint_layer(
+                self.moe.forward_with_routes,
+                self.pre_feedforward_layernorm_2(residual),
+                topk_idx,
+                topk_weight,
+                train_meta=train_meta,
+                infer_meta=infer_meta,
+            )
             hidden_states = self.post_feedforward_layernorm_1(dense_hidden) + self.post_feedforward_layernorm_2(
                 moe_hidden
             )
@@ -640,7 +700,7 @@ class Gemma4ForCausalLM(nn.Module):
                 shared_idx = layer.self_attn.kv_shared_layer_index
                 if shared_idx is not None:
                     shared_kv = shared_kv_by_layer.get(shared_idx)
-                if shared_kv is None:
+                if shared_kv is None and not getattr(layer, "handles_activation_checkpointing", False):
                     hidden_states, kv_for_share = checkpoint_layer(
                         layer,
                         hidden_states,

--- a/areno/models/llama/model.py
+++ b/areno/models/llama/model.py
@@ -13,7 +13,11 @@ from typing import Any
 import torch
 from torch import nn
 
-from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
+from areno.engine.checkpoints.common import (
+    build_checkpoint_policy_plan,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.models.base import ModelAdapter
 from areno.models.llama.checkpoint import CHECKPOINT_SPEC
@@ -68,3 +72,6 @@ class LlamaAdapter(ModelAdapter):
         if not isinstance(model, Qwen3ForCausalLM):
             raise TypeError(f"LlamaAdapter cannot save weights from {type(model)!r}")
         return save_checkpoint_weights(model, output_path, source_path, CHECKPOINT_SPEC)
+
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, CHECKPOINT_SPEC)

--- a/areno/models/minicpmv46/checkpoint.py
+++ b/areno/models/minicpmv46/checkpoint.py
@@ -21,7 +21,16 @@ from areno.engine.checkpoints.common import (
     save_embedding_norm_head,
     write_hf_safetensors_checkpoint,
 )
-from areno.engine.checkpoints.io import SafetensorsIndex, _CheckpointTensorTask, _copy_row, _sync_pending_cpu_copies
+from areno.engine.checkpoints.io import (
+    PolicyFlatPiece,
+    PolicyTensorLayout,
+    PolicyTensorStore,
+    SafetensorsIndex,
+    _CheckpointTensorTask,
+    _copy_row,
+    _sync_pending_cpu_copies,
+    policy_plan_scope,
+)
 from areno.engine.layers.linear import _shard_range
 from areno.engine.parallel.context import get_tp_context
 from areno.models.minicpmv46.model import (
@@ -111,6 +120,18 @@ def save_minicpmv46_weights(
     return saved_path
 
 
+def build_minicpmv46_policy_plan(model: MiniCPMV46ForCausalLM) -> PolicyTensorStore:
+    """Build live canonical tasks without checkpoint materialization."""
+
+    tensors = PolicyTensorStore()
+    with policy_plan_scope():
+        _save_embedding_norm_head(tensors, model)
+        prefix = model.config.checkpoint_prefix
+        for layer_idx, layer in enumerate(model.layers):
+            _save_layer(tensors, layer, f"{prefix}.layers.{layer_idx}")
+    return tensors
+
+
 def _load_embedding_norm_head(
     model: MiniCPMV46ForCausalLM, index: SafetensorsIndex, rank: int, world_size: int
 ) -> None:
@@ -120,7 +141,9 @@ def _load_embedding_norm_head(
 
 def _save_embedding_norm_head(tensors: dict[str, torch.Tensor | None], model: MiniCPMV46ForCausalLM) -> None:
     save_embedding_norm_head(tensors, model, TOP_LEVEL_SPEC)
-    tensors[TOP_LEVEL_SPEC.norm_key] = rank0_tensor(model.norm.weight - 1.0)
+    tensors[TOP_LEVEL_SPEC.norm_key] = rank0_tensor(
+        model.norm.weight if isinstance(tensors, PolicyTensorStore) else model.norm.weight - 1.0
+    )
 
 
 def _load_layer(index: SafetensorsIndex, layer: MiniCPMDecoderLayer, prefix: str, rank: int, world_size: int) -> None:
@@ -156,7 +179,10 @@ def _load_layer(index: SafetensorsIndex, layer: MiniCPMDecoderLayer, prefix: str
 
 def _save_layer(tensors: dict[str, torch.Tensor | None], layer: MiniCPMDecoderLayer, prefix: str) -> None:
     for spec in LAYER_NORM_SPECS:
-        tensors[spec.key.format(prefix=prefix)] = rank0_tensor(_attr_path(layer, spec.attr) - 1.0)
+        value = _attr_path(layer, spec.attr)
+        tensors[spec.key.format(prefix=prefix)] = rank0_tensor(
+            value if isinstance(tensors, PolicyTensorStore) else value - 1.0
+        )
     gate_weight, up_weight = gather_tensor_parallel_column_tensors(
         list(_attr_path(layer, GATE_UP_WEIGHT_SPEC.dst_attr).split(layer.mlp.gate_up_proj.local_out_features, dim=0))
     )
@@ -257,16 +283,46 @@ def _save_full_attention(tensors: dict[str, torch.Tensor | None], attn: MiniCPMF
     gate = attn.qkv_proj.weight[q_size : q_size + gate_size]
     k = attn.qkv_proj.weight[q_size + gate_size : q_size + gate_size + k_size]
     v = attn.qkv_proj.weight[q_size + gate_size + k_size : q_size + gate_size + k_size + v_size]
-    q_weight, gate_weight = gather_tensor_parallel_column_tensors([q, gate])
-    tensors[f"{prefix}.self_attn.q_proj.weight"] = _merge_q_gate_by_head(
-        q_weight, gate_weight, attn.num_heads, attn.head_dim
-    )
+    q_key = f"{prefix}.self_attn.q_proj.weight"
+    if isinstance(tensors, PolicyTensorStore):
+        ctx = get_tp_context()
+        local_heads = q.shape[0] // attn.head_dim
+        head_numel = attn.head_dim * q.shape[1]
+        pieces = []
+        q_heads = q.reshape(local_heads, attn.head_dim, q.shape[1])
+        gate_heads = gate.reshape(local_heads, attn.head_dim, gate.shape[1])
+        for local_head in range(local_heads):
+            global_head = ctx.rank * local_heads + local_head
+            base = global_head * 2 * head_numel
+            pieces.extend(
+                (
+                    PolicyFlatPiece(q_heads[local_head], base),
+                    PolicyFlatPiece(gate_heads[local_head], base + head_numel),
+                )
+            )
+        tensors.add_layout(
+            q_key,
+            PolicyTensorLayout(
+                shape=(attn.num_heads * 2 * attn.head_dim, q.shape[1]),
+                dtype=q.dtype,
+                pieces=(),
+                flat_pieces=tuple(pieces),
+            ),
+        )
+    else:
+        q_weight, gate_weight = gather_tensor_parallel_column_tensors([q, gate])
+        tensors[q_key] = _merge_q_gate_by_head(q_weight, gate_weight, attn.num_heads, attn.head_dim)
     k_weight, v_weight = gather_tensor_parallel_column_tensors([k, v])
     tensors[f"{prefix}.self_attn.k_proj.weight"] = k_weight
     tensors[f"{prefix}.self_attn.v_proj.weight"] = v_weight
     tensors[f"{prefix}.self_attn.o_proj.weight"] = gather_tensor_parallel_tensor(attn.o_proj.weight, dim=1)
-    tensors[f"{prefix}.self_attn.q_norm.weight"] = rank0_tensor(attn.q_norm.weight - 1.0)
-    tensors[f"{prefix}.self_attn.k_norm.weight"] = rank0_tensor(attn.k_norm.weight - 1.0)
+    policy = isinstance(tensors, PolicyTensorStore)
+    tensors[f"{prefix}.self_attn.q_norm.weight"] = rank0_tensor(
+        attn.q_norm.weight if policy else attn.q_norm.weight - 1.0
+    )
+    tensors[f"{prefix}.self_attn.k_norm.weight"] = rank0_tensor(
+        attn.k_norm.weight if policy else attn.k_norm.weight - 1.0
+    )
 
 
 def _save_gated_delta_net(tensors: dict[str, torch.Tensor | None], attn: MiniCPMGatedDeltaNet, prefix: str) -> None:

--- a/areno/models/minicpmv46/model.py
+++ b/areno/models/minicpmv46/model.py
@@ -715,3 +715,8 @@ class MiniCPMV46Adapter(ModelAdapter):
         from areno.models.minicpmv46.checkpoint import save_minicpmv46_weights
 
         return save_minicpmv46_weights(model, output_path, source_path)
+
+    def build_policy_plan(self, model: nn.Module):
+        from areno.models.minicpmv46.checkpoint import build_minicpmv46_policy_plan
+
+        return build_minicpmv46_policy_plan(model)

--- a/areno/models/olmo2/model.py
+++ b/areno/models/olmo2/model.py
@@ -14,7 +14,11 @@ import torch
 import torch.distributed.nn.functional as dist_nn
 from torch import nn
 
-from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
+from areno.engine.checkpoints.common import (
+    build_checkpoint_policy_plan,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
 from areno.engine.config import ModelConfig
 from areno.engine.layers.attention import CausalSelfAttention
 from areno.engine.layers.linear import mark_tensor_parallel_parameter
@@ -141,3 +145,6 @@ class Olmo2Adapter(ModelAdapter):
         if not isinstance(model, Olmo2ForCausalLM):
             raise TypeError(f"Olmo2Adapter cannot save weights from {type(model)!r}")
         return save_checkpoint_weights(model, output_path, source_path, CHECKPOINT_SPEC)
+
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, CHECKPOINT_SPEC)

--- a/areno/models/qwen3/model.py
+++ b/areno/models/qwen3/model.py
@@ -109,7 +109,16 @@ class Qwen3MoeExperts(nn.Module):
             self.local_num_experts,
         )
         if x.shape[0] == 0:
-            return all_reduce(flat.new_zeros(flat.shape))
+            # Every TP rank must produce gradients for the same parameter set.
+            # Keep a zero-valued graph edge to the local experts and router
+            # even when this rank receives no routes; otherwise its later TP
+            # gradient all-reduces diverge from ranks that did receive tokens.
+            zero = (
+                self.gate_up_weight.reshape(-1)[0] * 0
+                + self.down_weight.reshape(-1)[0] * 0
+                + topk_weight.sum().to(dtype=self.gate_up_weight.dtype) * 0
+            )
+            return all_reduce(flat.new_zeros(flat.shape) + zero)
         hidden = _areno_grouped_linear_no_compile(x.contiguous(), self.gate_up_weight, tokens_per_expert)
         log_once("qwen3_moe_silu_and_mul", "using ARENO fused silu_and_mul kernel for Qwen3-MoE experts")
         hidden = (

--- a/areno/models/qwen3/model.py
+++ b/areno/models/qwen3/model.py
@@ -30,7 +30,11 @@ from areno.accel import (
     areno_topk_softmax,
 )
 from areno.accel.ops import FusedMoeConfig, areno_fused_experts, areno_silu_and_mul, log_once
-from areno.engine.checkpoints.common import load_checkpoint_weights, save_checkpoint_weights
+from areno.engine.checkpoints.common import (
+    build_checkpoint_policy_plan,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention import CausalSelfAttention
 from areno.engine.layers.linear import mark_tensor_parallel_parameter
@@ -439,6 +443,9 @@ class Qwen3Adapter(ModelAdapter):
             raise TypeError(f"Qwen3Adapter cannot save weights from {type(model)!r}")
         return save_checkpoint_weights(model, output_path, source_path, CHECKPOINT_SPEC)
 
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, CHECKPOINT_SPEC)
+
 
 class Qwen3MoeAdapter(ModelAdapter):
     """Adapter for Qwen3 MoE checkpoints (for example Qwen3-30B-A3B)."""
@@ -489,6 +496,9 @@ class Qwen3MoeAdapter(ModelAdapter):
         if not isinstance(model, Qwen3MoeForCausalLM):
             raise TypeError(f"Qwen3MoeAdapter cannot save weights from {type(model)!r}")
         return save_checkpoint_weights(model, output_path, source_path, QWEN3_MOE_CHECKPOINT_SPEC)
+
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, QWEN3_MOE_CHECKPOINT_SPEC)
 
 
 @torch._dynamo.disable

--- a/areno/models/qwen3/model.py
+++ b/areno/models/qwen3/model.py
@@ -44,7 +44,7 @@ from areno.engine.layers.vocab import VocabParallelEmbedding, VocabParallelLMHea
 from areno.engine.parallel.collectives import all_reduce, scatter_to_sequence_parallel_region, sequence_parallel_region
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
-from areno.engine.runtime.recompute import checkpoint_layer
+from areno.engine.runtime.recompute import checkpoint_layer, checkpoint_routed_moe_layer
 from areno.models.base import CausalLMOutput, ModelAdapter
 from areno.models.qwen3.checkpoint import CHECKPOINT_SPEC, QWEN3_MOE_CHECKPOINT_SPEC
 
@@ -172,17 +172,33 @@ class Qwen3MoeMLP(nn.Module):
             routed_scaling_factor=config.routed_scaling_factor,
         )
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        batch, seqlen, hidden = hidden_states.shape
-        flat = hidden_states.reshape(-1, hidden)
+    def route(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute routing once so activation recompute can reuse the decision."""
+
+        flat = hidden_states.reshape(-1, hidden_states.shape[-1])
         logits = _areno_linear_no_compile(flat.to(dtype=self.gate.dtype), self.gate)
         log_once("qwen3_moe_topk_softmax", "using ARENO fused topk_softmax router for Qwen3-MoE")
-        topk_idx, topk_weight = _areno_topk_softmax_no_compile(logits, self.top_k, self.norm_topk_prob)
+        return _areno_topk_softmax_no_compile(logits, self.top_k, self.norm_topk_prob)
+
+    def forward_with_routes(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run experts with a fixed routing decision."""
+
+        batch, seqlen, hidden = hidden_states.shape
+        flat = hidden_states.reshape(-1, hidden)
         if self.training:
             out = self.experts(flat, topk_idx.to(torch.long), topk_weight)
         else:
             out = self._forward_fused_moe(flat, topk_idx, topk_weight)
         return out.view(batch, seqlen, hidden)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        topk_idx, topk_weight = self.route(hidden_states)
+        return self.forward_with_routes(hidden_states, topk_idx, topk_weight)
 
     @torch.no_grad()
     def prepare_infer_weights(self) -> None:
@@ -230,9 +246,45 @@ class Qwen3MoeMLP(nn.Module):
 class Qwen3MoeDecoderLayer(QwenDecoderLayer):
     """Qwen3 block with routed MoE MLP."""
 
+    checkpoint_internally = True
+
     def __init__(self, config: ModelConfig, layer_idx: int):
         super().__init__(config, layer_idx)
         self.mlp = Qwen3MoeMLP(config)
+
+    def _attention_block(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        normalized = self.input_layernorm(hidden_states)
+        return residual + self.self_attn(normalized, position_ids, train_meta, infer_meta)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> torch.Tensor:
+        # Router top-k can change after a numerically non-bitwise-identical
+        # attention recompute. Keep routing outside the checkpoint boundary,
+        # then checkpoint the expensive expert MLP with fixed route tensors.
+        return checkpoint_routed_moe_layer(
+            self._attention_block,
+            self.post_attention_layernorm,
+            self.mlp.route,
+            self.mlp.forward_with_routes,
+            hidden_states,
+            position_ids,
+            train_meta,
+            infer_meta,
+            train_meta=train_meta,
+            infer_meta=infer_meta,
+        )
 
 
 class Qwen3ForCausalLM(nn.Module):
@@ -266,15 +318,18 @@ class Qwen3ForCausalLM(nn.Module):
             hidden_states = scatter_to_sequence_parallel_region(hidden_states)
         with sequence_parallel_region(use_sequence_parallel):
             for layer in self.layers:
-                hidden_states = checkpoint_layer(
-                    layer,
-                    hidden_states,
-                    position_ids,
-                    train_meta,
-                    infer_meta,
-                    train_meta=train_meta,
-                    infer_meta=infer_meta,
-                )
+                if getattr(layer, "checkpoint_internally", False):
+                    hidden_states = layer(hidden_states, position_ids, train_meta, infer_meta)
+                else:
+                    hidden_states = checkpoint_layer(
+                        layer,
+                        hidden_states,
+                        position_ids,
+                        train_meta,
+                        infer_meta,
+                        train_meta=train_meta,
+                        infer_meta=infer_meta,
+                    )
             hidden_states = self.norm(hidden_states)
             logits_shard = self.lm_head(hidden_states)
         return CausalLMOutput(logits_shard=logits_shard, hidden_states=hidden_states)

--- a/areno/models/qwen3_5/checkpoint.py
+++ b/areno/models/qwen3_5/checkpoint.py
@@ -25,11 +25,16 @@ from areno.engine.checkpoints.common import (
     write_hf_safetensors_checkpoint,
 )
 from areno.engine.checkpoints.io import (
+    PolicyFlatPiece,
+    PolicyTensorLayout,
+    PolicyTensorStore,
     SafetensorsIndex,
     _all_gather_tensor_parallel,
     _copy_row,
     _owns_checkpoint_tensor,
     _tensor_to_cpu,
+    gather_tensor_parallel_ranged_tensor,
+    policy_plan_scope,
 )
 from areno.engine.layers.linear import _shard_range
 from areno.engine.parallel.context import get_tp_context
@@ -98,6 +103,18 @@ def save_qwen35_weights(
     return saved_path
 
 
+def build_qwen35_policy_plan(model: Qwen35ForCausalLM) -> PolicyTensorStore:
+    """Build a live canonical layout for direct train-to-rollout sync."""
+
+    tensors = PolicyTensorStore()
+    prefix = model.config.checkpoint_prefix
+    with policy_plan_scope():
+        _save_embedding_norm_head(tensors, model, prefix)
+        for layer_idx, layer in enumerate(model.layers):
+            _save_layer(tensors, layer, f"{prefix}.layers.{layer_idx}")
+    return tensors
+
+
 def _top_level_spec(prefix: str, lm_head_key: str = "lm_head.weight") -> TopLevelSpec:
     return TopLevelSpec(
         embedding_key=f"{prefix}.embed_tokens.weight",
@@ -138,7 +155,9 @@ def _save_embedding_norm_head(tensors: dict[str, torch.Tensor | None], model: Qw
     spec = _top_level_spec(prefix, model.config.checkpoint_lm_head_key)
     _require_lm_head_shape(model, spec.lm_head_key)
     save_embedding_norm_head(tensors, model, spec)
-    tensors[spec.norm_key] = rank0_tensor(model.norm.weight - 1.0)
+    tensors[spec.norm_key] = rank0_tensor(
+        model.norm.weight if isinstance(tensors, PolicyTensorStore) else model.norm.weight - 1.0
+    )
 
 
 def _require_lm_head_shape(model: Qwen35ForCausalLM, lm_head_key: str) -> None:
@@ -180,7 +199,10 @@ def _load_layer(index: SafetensorsIndex, layer: Qwen35DecoderLayer, prefix: str,
 
 def _save_layer(tensors: dict[str, torch.Tensor | None], layer: Qwen35DecoderLayer, prefix: str) -> None:
     for spec in LAYER_NORM_SPECS:
-        tensors[spec.key.format(prefix=prefix)] = rank0_tensor(_attr_path(layer, spec.attr) - 1.0)
+        value = _attr_path(layer, spec.attr)
+        tensors[spec.key.format(prefix=prefix)] = rank0_tensor(
+            value if isinstance(tensors, PolicyTensorStore) else value - 1.0
+        )
     _save_mlp(tensors, layer, prefix)
 
     if isinstance(layer.attention, Qwen35FullAttention):
@@ -219,7 +241,11 @@ def _save_moe_mlp(tensors: dict[str, torch.Tensor | None], mlp: nn.Module, prefi
 def _save_packed_routed_experts(tensors: dict[str, torch.Tensor | None], mlp: nn.Module, prefix: str) -> None:
     gate_up_key = f"{prefix}.experts.gate_up_proj"
     down_key = f"{prefix}.experts.down_proj"
-    full_weights = gather_moe_expert_weights(getattr(mlp, "experts"))
+    experts = getattr(mlp, "experts")
+    if isinstance(tensors, PolicyTensorStore):
+        _stage_packed_policy_experts(tensors, experts, gate_up_key, down_key)
+        return
+    full_weights = gather_moe_expert_weights(experts)
     if full_weights is None:
         tensors[gate_up_key] = None
         tensors[down_key] = None
@@ -228,6 +254,59 @@ def _save_packed_routed_experts(tensors: dict[str, torch.Tensor | None], mlp: nn
     gate_up = torch.cat((gate_weights, up_weights), dim=1).contiguous()
     tensors[gate_up_key] = _tensor_to_cpu(gate_up) if _owns_checkpoint_tensor(gate_up_key) else None
     tensors[down_key] = _tensor_to_cpu(down_weights.contiguous()) if _owns_checkpoint_tensor(down_key) else None
+
+
+def _stage_packed_policy_experts(
+    tensors: PolicyTensorStore,
+    experts: nn.Module,
+    gate_up_key: str,
+    down_key: str,
+) -> None:
+    gate_weights, up_weights, down_weights = experts.expert_weights()
+    local_start = int(experts.local_expert_start)
+    num_experts = int(experts.local_num_experts) * get_tp_context().world_size
+    gate_shape = tuple(gate_weights[0].shape)
+    up_shape = tuple(up_weights[0].shape)
+    down_shape = tuple(down_weights[0].shape)
+    trailing = _shape_numel(gate_shape[1:])
+    combined_rows = gate_shape[0] + up_shape[0]
+    gate_up_pieces = []
+    down_pieces = []
+    for local_index, (gate, up, down) in enumerate(zip(gate_weights, up_weights, down_weights, strict=True)):
+        expert_id = local_start + local_index
+        base = expert_id * combined_rows * trailing
+        gate_up_pieces.extend(
+            (
+                PolicyFlatPiece(gate.detach(), base),
+                PolicyFlatPiece(up.detach(), base + gate.numel()),
+            )
+        )
+        down_pieces.append(PolicyFlatPiece(down.detach(), expert_id * down.numel()))
+    tensors.add_layout(
+        gate_up_key,
+        PolicyTensorLayout(
+            shape=(num_experts, combined_rows, *gate_shape[1:]),
+            dtype=gate_weights[0].dtype,
+            pieces=(),
+            flat_pieces=tuple(gate_up_pieces),
+        ),
+    )
+    tensors.add_layout(
+        down_key,
+        PolicyTensorLayout(
+            shape=(num_experts, *down_shape),
+            dtype=down_weights[0].dtype,
+            pieces=(),
+            flat_pieces=tuple(down_pieces),
+        ),
+    )
+
+
+def _shape_numel(shape: tuple[int, ...]) -> int:
+    result = 1
+    for size in shape:
+        result *= size
+    return result
 
 
 def _save_shared_expert_gate(tensors: dict[str, torch.Tensor | None], mlp: nn.Module, prefix: str) -> None:
@@ -598,8 +677,13 @@ def _save_full_attention(tensors: dict[str, torch.Tensor | None], attn: Qwen35Fu
     tensors[f"{prefix}.self_attn.k_proj.weight"] = k_weight
     tensors[f"{prefix}.self_attn.v_proj.weight"] = v_weight
     tensors[f"{prefix}.self_attn.o_proj.weight"] = gather_tensor_parallel_tensor(attn.o_proj.weight, dim=1)
-    tensors[f"{prefix}.self_attn.q_norm.weight"] = rank0_tensor(attn.q_norm.weight - 1.0)
-    tensors[f"{prefix}.self_attn.k_norm.weight"] = rank0_tensor(attn.k_norm.weight - 1.0)
+    policy = isinstance(tensors, PolicyTensorStore)
+    tensors[f"{prefix}.self_attn.q_norm.weight"] = rank0_tensor(
+        attn.q_norm.weight if policy else attn.q_norm.weight - 1.0
+    )
+    tensors[f"{prefix}.self_attn.k_norm.weight"] = rank0_tensor(
+        attn.k_norm.weight if policy else attn.k_norm.weight - 1.0
+    )
 
 
 def _save_full_attention_replicated_kv(
@@ -613,13 +697,28 @@ def _save_full_attention_replicated_kv(
     tensors[f"{prefix}.self_attn.q_proj.weight"] = q_weight
     k_key = f"{prefix}.self_attn.k_proj.weight"
     v_key = f"{prefix}.self_attn.v_proj.weight"
-    k_full = _gather_replicated_kv_heads(k, attn.num_kv_heads)
-    v_full = _gather_replicated_kv_heads(v, attn.num_kv_heads)
-    tensors[k_key] = _tensor_to_cpu(k_full) if _owns_checkpoint_tensor(k_key) else None
-    tensors[v_key] = _tensor_to_cpu(v_full) if _owns_checkpoint_tensor(v_key) else None
+    if isinstance(tensors, PolicyTensorStore):
+        _, k_range, v_range = attn.qkv_proj.shard_ranges
+        global_kv_rows = attn.num_kv_heads * attn.head_dim
+        tensors[k_key] = gather_tensor_parallel_ranged_tensor(
+            k, start=k_range[0], end=k_range[1], global_size=global_kv_rows
+        )
+        tensors[v_key] = gather_tensor_parallel_ranged_tensor(
+            v, start=v_range[0], end=v_range[1], global_size=global_kv_rows
+        )
+    else:
+        k_full = _gather_replicated_kv_heads(k, attn.num_kv_heads)
+        v_full = _gather_replicated_kv_heads(v, attn.num_kv_heads)
+        tensors[k_key] = _tensor_to_cpu(k_full) if _owns_checkpoint_tensor(k_key) else None
+        tensors[v_key] = _tensor_to_cpu(v_full) if _owns_checkpoint_tensor(v_key) else None
     tensors[f"{prefix}.self_attn.o_proj.weight"] = gather_tensor_parallel_tensor(attn.o_proj.weight, dim=1)
-    tensors[f"{prefix}.self_attn.q_norm.weight"] = rank0_tensor(attn.q_norm.weight - 1.0)
-    tensors[f"{prefix}.self_attn.k_norm.weight"] = rank0_tensor(attn.k_norm.weight - 1.0)
+    policy = isinstance(tensors, PolicyTensorStore)
+    tensors[f"{prefix}.self_attn.q_norm.weight"] = rank0_tensor(
+        attn.q_norm.weight if policy else attn.q_norm.weight - 1.0
+    )
+    tensors[f"{prefix}.self_attn.k_norm.weight"] = rank0_tensor(
+        attn.k_norm.weight if policy else attn.k_norm.weight - 1.0
+    )
 
 
 def _gather_replicated_kv_heads(local: torch.Tensor, num_kv_heads: int) -> torch.Tensor:

--- a/areno/models/qwen3_5/model.py
+++ b/areno/models/qwen3_5/model.py
@@ -876,6 +876,11 @@ class Qwen35Adapter(ModelAdapter):
 
         return save_qwen35_weights(model, output_path, source_path)
 
+    def build_policy_plan(self, model: nn.Module):
+        from areno.models.qwen3_5.checkpoint import build_qwen35_policy_plan
+
+        return build_qwen35_policy_plan(model)
+
 
 class Qwen35MoeAdapter(ModelAdapter):
     name = "qwen3_5_moe"
@@ -955,6 +960,11 @@ class Qwen35MoeAdapter(ModelAdapter):
         from areno.models.qwen3_5.checkpoint import save_qwen35_weights
 
         return save_qwen35_weights(model, output_path, source_path)
+
+    def build_policy_plan(self, model: nn.Module):
+        from areno.models.qwen3_5.checkpoint import build_qwen35_policy_plan
+
+        return build_qwen35_policy_plan(model)
 
 
 def _layer_types_from_interval(num_layers: int, full_attention_interval: int) -> list[str]:

--- a/areno/models/registry.py
+++ b/areno/models/registry.py
@@ -99,6 +99,12 @@ def save_model_weights(
     return _adapter(config.model_type).save_weights(_unwrap_compiled_model(model), output_path, source_path)
 
 
+def build_policy_weight_plan(model, config: ModelConfig):
+    """Build an adapter-owned canonical layout over the live model tensors."""
+
+    return _adapter(config.model_type).build_policy_plan(_unwrap_compiled_model(model))
+
+
 def _unwrap_compiled_model(model):
     """Strip any number of ``torch.compile`` wrappers to reveal the raw module."""
 

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -88,8 +88,9 @@ Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
 ``world-size`` must be divisible by ``tp-size``.
 
 ``--train-devices TEXT``
-   Comma-separated logical CUDA device indices used by training. The count
-   must equal ``world-size``. When omitted, AReno uses ``0`` through
+   Comma-separated logical CUDA device indices or inclusive ranges used by
+   training. For example, ``0..8,11..29`` includes both endpoints. The expanded
+   count must equal ``world-size``. When omitted, AReno uses ``0`` through
    ``world-size - 1``.
 
 Rollout
@@ -100,10 +101,10 @@ limits, sampling, decode runtime, the agentic-rollout hooks, and the reward
 signal.
 
 ``--rollout-devices TEXT``
-   Comma-separated logical CUDA device indices for an independent rollout
-   engine. They may overlap ``--train-devices`` when the GPU has enough memory
-   for both worker processes. This option is valid only for online algorithms
-   that generate rollouts.
+   Comma-separated logical CUDA device indices or inclusive ranges for an
+   independent rollout engine. They may overlap ``--train-devices`` when the
+   GPU has enough memory for both worker processes. This option is valid only
+   for online algorithms that generate rollouts.
 
 ``--rollout-tp-size INTEGER``
    Tensor parallel size of the independent rollout engine. It defaults to the

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -80,18 +80,20 @@ Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
    indices have completed, even if the current epoch still has more batches.
 
 ``--world-size INTEGER``
-   Total device count for the backend. Default: ``8``.
+   Total training device count. Default: ``8``. When ``--train-devices`` is
+   provided, AReno infers this value from the expanded device list.
 
-``--tp-size INTEGER``
-   Tensor parallel size for the backend. Default: ``4``.
+``--tp-size INTEGER``, ``--train-tp-size INTEGER``
+   Tensor parallel size for training. The two option names are aliases.
+   Default: ``4``.
 
 ``world-size`` must be divisible by ``tp-size``.
 
 ``--train-devices TEXT``
    Comma-separated logical CUDA device indices or inclusive ranges used by
-   training. For example, ``0..8,11..29`` includes both endpoints. The expanded
-   count must equal ``world-size``. When omitted, AReno uses ``0`` through
-   ``world-size - 1``.
+   training. For example, ``0..8,11..29`` includes both endpoints. AReno
+   derives ``world-size`` from the expanded count. When omitted, AReno uses
+   ``0`` through ``world-size - 1``.
 
 Rollout
 ~~~~~~~

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -101,8 +101,9 @@ signal.
 
 ``--rollout-devices TEXT``
    Comma-separated logical CUDA device indices for an independent rollout
-   engine. They must not overlap ``--train-devices``. This option is valid only
-   for online algorithms that generate rollouts.
+   engine. They may overlap ``--train-devices`` when the GPU has enough memory
+   for both worker processes. This option is valid only for online algorithms
+   that generate rollouts.
 
 ``--rollout-tp-size INTEGER``
    Tensor parallel size of the independent rollout engine. It defaults to the

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -87,12 +87,47 @@ Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
 
 ``world-size`` must be divisible by ``tp-size``.
 
+``--train-devices TEXT``
+   Comma-separated logical CUDA device indices used by training. The count
+   must equal ``world-size``. When omitted, AReno uses ``0`` through
+   ``world-size - 1``.
+
 Rollout
 ~~~~~~~
 
 Everything that generates and scores completions: batch volume, sequence
 limits, sampling, decode runtime, the agentic-rollout hooks, and the reward
 signal.
+
+``--rollout-devices TEXT``
+   Comma-separated logical CUDA device indices for an independent rollout
+   engine. They must not overlap ``--train-devices``. This option is valid only
+   for online algorithms that generate rollouts.
+
+``--rollout-tp-size INTEGER``
+   Tensor parallel size of the independent rollout engine. It defaults to the
+   training ``tp-size``. The rollout device count must be divisible by this
+   value.
+
+``--policy-sync-bucket-mb INTEGER``
+   Maximum reusable GPU buffer used while streaming policy weights from the
+   training engine to the rollout engine. Default: ``64`` MiB.
+
+For example, the following uses four visible GPUs for training and two
+different visible GPUs for rollout:
+
+.. code-block:: bash
+
+   areno train \
+     --algo gspo \
+     --ckpt Qwen/Qwen3-8B \
+     --dataset-path ... \
+     --reward-fn-path ... \
+     --world-size 4 \
+     --tp-size 4 \
+     --train-devices 0,1,2,3 \
+     --rollout-devices 4,5 \
+     --rollout-tp-size 2
 
 ``--batch-size INTEGER``
    Prompt or pair batch size. Default: ``32``.

--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -20,15 +20,28 @@ training to that backend.
 training loop. ``ArenoBackend`` is the registered AReno implementation in
 ``areno/api/backend/areno/backend.py``.
 
-One colocated engine
---------------------
+Colocated and partitioned engines
+---------------------------------
 
-``ArenoBackend.initialize`` creates one ``ArenoEngine`` and stores it in
-``self._engine``. The same engine handles both sides of the loop:
+By default, ``ArenoBackend.initialize`` creates one ``ArenoEngine``. The same
+engine handles both sides of the loop:
 
 * ``ArenoBackend.rollout_batch`` calls ``ArenoEngine.generate_rollout``.
 * ``ArenoBackend.train`` calls ``ArenoEngine.step``.
 
 ``ArenoEngine`` is implemented in ``areno/engine/api.py``. It coordinates the
-worker cluster used by both rollout and training, so the current backend does
-not split those calls across separate engines or external runtimes.
+worker cluster used by both rollout and training.
+
+Online RL runs may instead assign non-overlapping CUDA devices to an
+independent rollout engine. Training and rollout workers then join one
+distributed world but use separate TP and DP process groups. This permits, for
+example, training with TP 8 while generating rollouts with TP 2.
+
+After an optimizer step, the rollout engine keeps its current policy until the
+next rollout begins. AReno then streams the new policy directly between GPUs
+with NCCL. Tensors are distributed over training DP rows by byte size, moved
+through a bounded bucket, and written into the rollout TP shards without a CPU
+or filesystem staging copy.
+
+Both device lists use logical indices within the parent process'
+``CUDA_VISIBLE_DEVICES``. The two lists must not overlap.

--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -46,4 +46,13 @@ or filesystem staging copy.
 Both device lists use logical indices within the parent process'
 ``CUDA_VISIBLE_DEVICES``. They may overlap; overlapping devices hold both a
 training worker and a rollout worker, so the combined model, optimizer, cache,
-and CUDA-context memory must fit on those GPUs.
+and CUDA-context memory must fit on those GPUs. For an overlapping topology,
+AReno selects train and rollout relay ranks on different physical GPUs, then
+fans each received bucket through rollout-only TP/DP groups. This keeps
+duplicate physical GPUs out of an NCCL communicator.
+
+Every completed synchronization logs its total time, collective transfer time,
+bytes, tensor count, and effective throughput. The same values are emitted
+with the next training metrics as ``policy_sync_time_s``,
+``policy_sync_transfer_time_s``, ``policy_sync_bytes``,
+``policy_sync_tensors``, and ``policy_sync_throughput_gbps``.

--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -32,8 +32,8 @@ engine handles both sides of the loop:
 ``ArenoEngine`` is implemented in ``areno/engine/api.py``. It coordinates the
 worker cluster used by both rollout and training.
 
-Online RL runs may instead assign non-overlapping CUDA devices to an
-independent rollout engine. Training and rollout workers then join one
+Online RL runs may instead assign CUDA devices to an independent rollout
+engine. Training and rollout workers then join one
 distributed world but use separate TP and DP process groups. This permits, for
 example, training with TP 8 while generating rollouts with TP 2.
 
@@ -44,4 +44,6 @@ through a bounded bucket, and written into the rollout TP shards without a CPU
 or filesystem staging copy.
 
 Both device lists use logical indices within the parent process'
-``CUDA_VISIBLE_DEVICES``. The two lists must not overlap.
+``CUDA_VISIBLE_DEVICES``. They may overlap; overlapping devices hold both a
+training worker and a rollout worker, so the combined model, optimizer, cache,
+and CUDA-context memory must fit on those GPUs.

--- a/tests/test_dual_engine_backend_cpu.py
+++ b/tests/test_dual_engine_backend_cpu.py
@@ -107,6 +107,11 @@ def test_policy_sync_runs_once_for_each_new_train_version() -> None:
     assert backend._rollout_policy_version == 2
     assert [op for op, _ in train.cluster.calls] == [Op.POLICY_SYNC_PLAN, Op.POLICY_SYNC_PUBLISH]
     assert [op for op, _ in rollout.cluster.calls] == [Op.POLICY_SYNC_PLAN, Op.POLICY_SYNC_RECEIVE]
+    assert backend._pending_policy_sync_metrics["policy_sync_transfer_time_s"] == pytest.approx(0.01)
+    assert backend._pending_policy_sync_metrics["policy_sync_bytes"] == 16.0
+    assert backend._pending_policy_sync_metrics["policy_sync_tensors"] == 1.0
+    assert backend._pending_policy_sync_metrics["policy_sync_throughput_gbps"] == pytest.approx(0.0000128)
+    assert backend._pending_policy_sync_metrics["policy_sync_time_s"] > 0.0
 
 
 def test_policy_sync_failure_does_not_advance_rollout_version() -> None:

--- a/tests/test_dual_engine_backend_cpu.py
+++ b/tests/test_dual_engine_backend_cpu.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from areno.api.backend.areno.backend import ArenoBackend
+from areno.engine.policy_sync import PolicyTensorMeta
+from areno.engine.protocol import Op
+
+
+class _Handle:
+    def __init__(self, result=None, error: Exception | None = None):
+        self._result = result
+        self._error = error
+
+    def result(self):
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class _Cluster:
+    def __init__(self, plan, *, sync_error: Exception | None = None):
+        self.plan = plan
+        self.sync_error = sync_error
+        self.calls = []
+
+    def call(self, op, payload=None):
+        self.calls.append((op, payload))
+        assert op is Op.POLICY_SYNC_PLAN
+        return [self.plan]
+
+    def submit(self, op, payload=None):
+        self.calls.append((op, payload))
+        if self.sync_error is not None:
+            return _Handle(error=self.sync_error)
+        return _Handle(
+            [
+                {
+                    "version": payload.version,
+                    "bytes": 16,
+                    "tensors": 1,
+                    "elapsed_s": 0.01,
+                }
+            ]
+        )
+
+
+class _Engine:
+    def __init__(self, name, plan, *, sync_error: Exception | None = None):
+        self.name = name
+        self.cluster = _Cluster(plan, sync_error=sync_error)
+        self.config = SimpleNamespace(dp_size=1, model=SimpleNamespace(max_position_embeddings=128))
+        self.events = []
+
+    def begin_rollout_session(self):
+        self.events.append("begin")
+
+    async def begin_rollout_session_async(self):
+        self.events.append("begin_async")
+
+    def end_rollout_session(self):
+        self.events.append("end")
+
+    async def end_rollout_session_async(self):
+        self.events.append("end_async")
+
+    def save_checkpoint(self, path):
+        self.events.append(("save", path))
+        return path
+
+    def close(self):
+        self.events.append("close")
+
+
+def _backend(*, rollout_error: Exception | None = None) -> tuple[ArenoBackend, _Engine, _Engine]:
+    plan = (PolicyTensorMeta("weight", (4,), "float32", 16),)
+    train = _Engine("train", plan)
+    rollout = _Engine("rollout", plan, sync_error=rollout_error)
+    backend = ArenoBackend()
+    backend._train_engine = train
+    backend._rollout_engine = rollout
+    backend._separate_rollout = True
+    backend._policy_sync_bucket_bytes = 1024
+    return backend, train, rollout
+
+
+def test_dual_backend_routes_rollout_lifecycle_and_checkpoint() -> None:
+    backend, train, rollout = _backend()
+
+    backend.begin_rollout_session(None)
+    backend.end_rollout_session(None)
+    assert backend.save_checkpoint(None, "checkpoint") == "checkpoint"
+
+    assert rollout.events == ["begin", "end"]
+    assert train.events == [("save", "checkpoint")]
+
+
+def test_policy_sync_runs_once_for_each_new_train_version() -> None:
+    backend, train, rollout = _backend()
+    backend._train_policy_version = 2
+
+    backend._sync_policy_if_needed()
+    backend._sync_policy_if_needed()
+
+    assert backend._rollout_policy_version == 2
+    assert [op for op, _ in train.cluster.calls] == [Op.POLICY_SYNC_PLAN, Op.POLICY_SYNC_PUBLISH]
+    assert [op for op, _ in rollout.cluster.calls] == [Op.POLICY_SYNC_PLAN, Op.POLICY_SYNC_RECEIVE]
+
+
+def test_policy_sync_failure_does_not_advance_rollout_version() -> None:
+    backend, _, _ = _backend(rollout_error=RuntimeError("receive failed"))
+    backend._train_policy_version = 1
+
+    with pytest.raises(RuntimeError, match="receive failed"):
+        backend._sync_policy_if_needed()
+
+    assert backend._rollout_policy_version == 0
+
+
+def test_policy_plan_mismatch_fails_before_collectives() -> None:
+    backend, train, rollout = _backend()
+    rollout.cluster.plan = (PolicyTensorMeta("other", (4,), "float32", 16),)
+    backend._train_policy_version = 1
+
+    with pytest.raises(RuntimeError, match="layouts do not match"):
+        backend._sync_policy_if_needed()
+
+    assert [op for op, _ in train.cluster.calls] == [Op.POLICY_SYNC_PLAN]
+    assert [op for op, _ in rollout.cluster.calls] == [Op.POLICY_SYNC_PLAN]
+
+
+def test_close_releases_both_engines() -> None:
+    backend, train, rollout = _backend()
+
+    backend.close()
+
+    assert rollout.events == ["close"]
+    assert train.events == ["close"]

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -525,7 +525,14 @@ def test_worker_refill_queue_is_drained_by_tp_rank0_decision():
 
     worker = object.__new__(worker_mod.ArenoWorker)
     worker._cmd_queue = _QueueDouble([])
-    ctx = SimpleNamespace(is_rank0=True, world_size=2, dp_rank=0, device=torch.device("cpu"), group=object())
+    ctx = SimpleNamespace(
+        is_rank0=True,
+        world_size=2,
+        dp_rank=0,
+        device=torch.device("cpu"),
+        group=object(),
+        tp_global_rank=lambda rank: rank,
+    )
 
     with PatchedContext(
         worker_mod,
@@ -551,7 +558,14 @@ def test_worker_non_rank0_consumes_refill_only_after_tp_broadcast():
     command = _rollout_command(2, [[2]], target=2)
     worker = object.__new__(worker_mod.ArenoWorker)
     worker._cmd_queue = _QueueDouble([command])
-    ctx = SimpleNamespace(is_rank0=False, world_size=2, dp_rank=0, device=torch.device("cpu"), group=object())
+    ctx = SimpleNamespace(
+        is_rank0=False,
+        world_size=2,
+        dp_rank=0,
+        device=torch.device("cpu"),
+        group=object(),
+        tp_global_rank=lambda rank: rank,
+    )
 
     with PatchedContext(
         worker_mod,
@@ -573,7 +587,14 @@ def test_worker_non_rank0_defers_unmatched_refill_commands():
     worker = object.__new__(worker_mod.ArenoWorker)
     worker._cmd_queue = _QueueDouble([stale, selected])
     worker._deferred_commands = []
-    ctx = SimpleNamespace(is_rank0=False, world_size=2, dp_rank=0, device=torch.device("cpu"), group=object())
+    ctx = SimpleNamespace(
+        is_rank0=False,
+        world_size=2,
+        dp_rank=0,
+        device=torch.device("cpu"),
+        group=object(),
+        tp_global_rank=lambda rank: rank,
+    )
 
     with PatchedContext(
         worker_mod,

--- a/tests/test_parallel_partition_cpu.py
+++ b/tests/test_parallel_partition_cpu.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import torch
+
+from areno.engine.parallel import context
+
+
+def _mock_distributed(monkeypatch):
+    calls = []
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(context.dist, "init_process_group", lambda **kwargs: calls.append(("init", kwargs)))
+
+    def new_group(*, ranks):
+        group = tuple(ranks)
+        calls.append(("group", group))
+        return group
+
+    monkeypatch.setattr(context.dist, "new_group", new_group)
+    return calls
+
+
+def _init_partition(*, local_rank: int, global_rank: int, role: str):
+    return context.init_process_group(
+        rank=local_rank,
+        world_size=4 if role == "train" else 2,
+        master_addr="127.0.0.1",
+        master_port=12345,
+        device_id=local_rank,
+        tp_size=2 if role == "train" else 1,
+        global_rank=global_rank,
+        global_world_size=6,
+        train_world_size=4,
+        train_tp_size=2,
+        rollout_world_size=2,
+        rollout_tp_size=1,
+        role=role,
+    )
+
+
+def test_partitioned_group_construction_order_is_identical(monkeypatch) -> None:
+    train_calls = _mock_distributed(monkeypatch)
+    train_ctx = _init_partition(local_rank=1, global_rank=1, role="train")
+    train_groups = [value for kind, value in train_calls if kind == "group"]
+
+    rollout_calls = _mock_distributed(monkeypatch)
+    rollout_ctx = _init_partition(local_rank=1, global_rank=5, role="rollout")
+    rollout_groups = [value for kind, value in rollout_calls if kind == "group"]
+
+    assert (
+        train_groups
+        == rollout_groups
+        == [
+            (0, 1),
+            (2, 3),
+            (0, 2),
+            (1, 3),
+            (4,),
+            (5,),
+            (4, 5),
+            (0, 1, 4, 5),
+            (2, 3, 4, 5),
+        ]
+    )
+    assert train_ctx.rank == 1
+    assert train_ctx.dp_rank == 0
+    assert train_ctx.group == (0, 1)
+    assert train_ctx.dp_group == (1, 3)
+    assert train_ctx.policy_publisher_groups == ((0, 1, 4, 5), None)
+    assert rollout_ctx.rank == 0
+    assert rollout_ctx.dp_rank == 1
+    assert rollout_ctx.group == (5,)
+    assert rollout_ctx.dp_group == (4, 5)
+    assert rollout_ctx.policy_publisher_groups == ((0, 1, 4, 5), (2, 3, 4, 5))
+
+
+def test_single_engine_context_creates_no_policy_publisher_group(monkeypatch) -> None:
+    calls = _mock_distributed(monkeypatch)
+    ctx = context.init_process_group(
+        rank=0,
+        world_size=2,
+        master_addr="127.0.0.1",
+        master_port=12345,
+        device_id=0,
+        tp_size=2,
+    )
+
+    assert ctx.role == "train"
+    assert ctx.policy_publisher_groups == ()
+    assert [value for kind, value in calls if kind == "group"] == [(0, 1), (0,), (1,)]

--- a/tests/test_parallel_partition_cpu.py
+++ b/tests/test_parallel_partition_cpu.py
@@ -1,8 +1,37 @@
 from __future__ import annotations
 
+import multiprocessing as mp
+
 import torch
 
 from areno.engine.parallel import context
+from areno.engine.parallel.collectives import broadcast_object
+from areno.engine.protocol import find_free_port
+
+
+def _run_offset_tp_broadcast(global_rank: int, port: int, output_queue) -> None:
+    role = "train" if global_rank < 2 else "rollout"
+    local_rank = global_rank if role == "train" else global_rank - 2
+    context.init_process_group(
+        rank=local_rank,
+        world_size=2,
+        master_addr="127.0.0.1",
+        master_port=port,
+        device_id=local_rank,
+        tp_size=2,
+        global_rank=global_rank,
+        global_world_size=4,
+        train_world_size=2,
+        train_tp_size=2,
+        rollout_world_size=2,
+        rollout_tp_size=2,
+        role=role,
+    )
+    try:
+        value = f"{role}-root" if local_rank == 0 else None
+        output_queue.put((global_rank, broadcast_object(value, src=0)))
+    finally:
+        context.destroy_process_group()
 
 
 def _mock_distributed(monkeypatch):
@@ -71,6 +100,9 @@ def test_partitioned_group_construction_order_is_identical(monkeypatch) -> None:
     assert rollout_ctx.group == (5,)
     assert rollout_ctx.dp_group == (4, 5)
     assert rollout_ctx.policy_publisher_groups == ((0, 1, 4, 5), (2, 3, 4, 5))
+    assert train_ctx.tp_global_rank(0) == 0
+    assert train_ctx.tp_global_rank(1) == 1
+    assert rollout_ctx.tp_global_rank(0) == 5
 
 
 def test_single_engine_context_creates_no_policy_publisher_group(monkeypatch) -> None:
@@ -87,3 +119,26 @@ def test_single_engine_context_creates_no_policy_publisher_group(monkeypatch) ->
     assert ctx.role == "train"
     assert ctx.policy_publisher_groups == ()
     assert [value for kind, value in calls if kind == "group"] == [(0, 1), (0,), (1,)]
+
+
+def test_real_gloo_tp_broadcast_uses_partition_global_root() -> None:
+    spawn = mp.get_context("spawn")
+    output_queue = spawn.Queue()
+    port = find_free_port()
+    processes = [
+        spawn.Process(target=_run_offset_tp_broadcast, args=(global_rank, port, output_queue))
+        for global_rank in range(4)
+    ]
+    for process in processes:
+        process.start()
+    results = dict(output_queue.get(timeout=30) for _ in processes)
+    for process in processes:
+        process.join(timeout=30)
+        assert process.exitcode == 0
+
+    assert results == {
+        0: "train-root",
+        1: "train-root",
+        2: "rollout-root",
+        3: "rollout-root",
+    }

--- a/tests/test_parallel_partition_cpu.py
+++ b/tests/test_parallel_partition_cpu.py
@@ -86,20 +86,23 @@ def test_partitioned_group_construction_order_is_identical(monkeypatch) -> None:
             (4,),
             (5,),
             (4, 5),
-            (0, 1, 4, 5),
-            (2, 3, 4, 5),
+            (0, 5),
+            (2, 4),
         ]
     )
     assert train_ctx.rank == 1
     assert train_ctx.dp_rank == 0
     assert train_ctx.group == (0, 1)
     assert train_ctx.dp_group == (1, 3)
-    assert train_ctx.policy_publisher_groups == ((0, 1, 4, 5), None)
+    assert train_ctx.policy_publisher_groups == (None, None)
     assert rollout_ctx.rank == 0
     assert rollout_ctx.dp_rank == 1
     assert rollout_ctx.group == (5,)
     assert rollout_ctx.dp_group == (4, 5)
-    assert rollout_ctx.policy_publisher_groups == ((0, 1, 4, 5), (2, 3, 4, 5))
+    assert rollout_ctx.policy_publisher_groups == ((0, 5), None)
+    assert rollout_ctx.policy_source_ranks == (0, 2)
+    assert rollout_ctx.policy_bridge_ranks == (5, 4)
+    assert rollout_ctx.policy_bridge_dp_ranks == (1, 0)
     assert train_ctx.tp_global_rank(0) == 0
     assert train_ctx.tp_global_rank(1) == 1
     assert rollout_ctx.tp_global_rank(0) == 5

--- a/tests/test_policy_tensor_sync_cpu.py
+++ b/tests/test_policy_tensor_sync_cpu.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from areno.engine.checkpoints.io import (
+    PolicyFlatPiece,
+    PolicyTensorLayout,
+    _RangedTensorParallelGatherTask,
+    _ReplicatedTensorTask,
+    _SplitColumnGatherTask,
+    _TensorParallelGatherTask,
+)
+from areno.engine.parallel.context import TPContext, destroy_process_group, init_process_group, set_tp_context
+from areno.engine.policy_sync import PolicyTensorMeta, assign_policy_owners, transfer_policy_weights
+from areno.engine.protocol import PolicySyncPayload, find_free_port
+
+
+def _set_rank(rank: int, world_size: int) -> None:
+    set_tp_context(
+        TPContext(
+            rank=rank,
+            world_size=world_size,
+            device=torch.device("cpu"),
+            group=None,
+        )
+    )
+
+
+def _canonical(layouts: list[PolicyTensorLayout], *, chunk_size: int = 5) -> torch.Tensor:
+    output = torch.empty(layouts[0].numel, dtype=layouts[0].dtype)
+    for offset in range(0, output.numel(), chunk_size):
+        chunk = torch.zeros(min(chunk_size, output.numel() - offset), dtype=output.dtype)
+        for layout in layouts:
+            contribution = torch.empty_like(chunk)
+            layout.read_chunk(offset, contribution)
+            chunk.add_(contribution)
+        output[offset : offset + chunk.numel()].copy_(chunk)
+    return output.reshape(layouts[0].shape)
+
+
+def _write(layouts: list[PolicyTensorLayout], canonical: torch.Tensor, *, chunk_size: int = 7) -> None:
+    flat = canonical.reshape(-1)
+    for offset in range(0, flat.numel(), chunk_size):
+        chunk = flat[offset : offset + chunk_size]
+        for layout in layouts:
+            layout.write_chunk(offset, chunk)
+
+
+def test_column_parallel_layout_reshards_tp2_to_tp1() -> None:
+    full = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+    train_layouts = []
+    for rank, local in enumerate(full.chunk(2, dim=0)):
+        _set_rank(rank, 2)
+        train_layouts.append(_TensorParallelGatherTask(local.clone(), dim=0).policy_layout())
+    canonical = _canonical(train_layouts)
+
+    target = torch.zeros_like(full)
+    _set_rank(0, 1)
+    rollout_layout = _TensorParallelGatherTask(target, dim=0).policy_layout()
+    _write([rollout_layout], canonical)
+
+    torch.testing.assert_close(canonical, full)
+    torch.testing.assert_close(target, full)
+
+
+def test_row_parallel_layout_reshards_tp1_to_tp2() -> None:
+    full = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+    _set_rank(0, 1)
+    canonical = _canonical([_TensorParallelGatherTask(full.clone(), dim=1).policy_layout()])
+
+    targets = [torch.zeros(4, 3), torch.zeros(4, 3)]
+    layouts = []
+    for rank, target in enumerate(targets):
+        _set_rank(rank, 2)
+        layouts.append(_TensorParallelGatherTask(target, dim=1).policy_layout())
+    _write(layouts, canonical)
+
+    torch.testing.assert_close(torch.cat(targets, dim=1), full)
+
+
+def test_split_column_layout_preserves_fused_qkv_order() -> None:
+    q = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    k = torch.arange(8, 16, dtype=torch.float32).reshape(2, 4)
+    v = torch.arange(16, 24, dtype=torch.float32).reshape(2, 4)
+    layouts = []
+    for rank in range(2):
+        _set_rank(rank, 2)
+        parts = [part.chunk(2, dim=0)[rank].clone() for part in (q, k, v)]
+        layouts.append(_SplitColumnGatherTask(parts).policy_layout())
+
+    torch.testing.assert_close(_canonical(layouts), torch.cat((q, k, v), dim=0))
+
+
+def test_ranged_layout_publishes_replicated_kv_once_and_writes_all_replicas() -> None:
+    head0 = torch.tensor([[1.0, 2.0]])
+    head1 = torch.tensor([[3.0, 4.0]])
+    train_layouts = []
+    for rank, local in enumerate((head0, head0, head1, head1)):
+        _set_rank(rank, 4)
+        start = 0 if rank < 2 else 1
+        train_layouts.append(_RangedTensorParallelGatherTask(local.clone(), start, start + 1, 2).policy_layout())
+    canonical = _canonical(train_layouts)
+    torch.testing.assert_close(canonical, torch.cat((head0, head1), dim=0))
+
+    targets = [torch.zeros_like(head0) for _ in range(4)]
+    rollout_layouts = []
+    for rank, target in enumerate(targets):
+        _set_rank(rank, 4)
+        start = 0 if rank < 2 else 1
+        rollout_layouts.append(_RangedTensorParallelGatherTask(target, start, start + 1, 2).policy_layout())
+    _write(rollout_layouts, canonical)
+    torch.testing.assert_close(targets[0], head0)
+    torch.testing.assert_close(targets[1], head0)
+    torch.testing.assert_close(targets[2], head1)
+    torch.testing.assert_close(targets[3], head1)
+
+
+def test_replicated_and_flat_piece_layouts_write_live_tensors() -> None:
+    replicated = torch.zeros(5)
+    layout = _ReplicatedTensorTask(replicated).policy_layout()
+    _write([layout], torch.arange(5, dtype=torch.float32), chunk_size=2)
+    torch.testing.assert_close(replicated, torch.arange(5, dtype=torch.float32))
+
+    first = torch.zeros(2)
+    second = torch.zeros(2)
+    packed = PolicyTensorLayout(
+        shape=(6,),
+        dtype=torch.float32,
+        pieces=(),
+        flat_pieces=(PolicyFlatPiece(first, 1), PolicyFlatPiece(second, 4)),
+    )
+    _write([packed], torch.arange(6, dtype=torch.float32), chunk_size=3)
+    torch.testing.assert_close(first, torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(second, torch.tensor([4.0, 5.0]))
+
+
+def test_policy_owner_assignment_is_deterministic_and_byte_balanced() -> None:
+    metadata = tuple(
+        PolicyTensorMeta(f"tensor.{index}", (size,), "float32", size * 4)
+        for index, size in enumerate((100, 80, 60, 40, 20, 10))
+    )
+    owners = assign_policy_owners(metadata, 2)
+    assert owners == assign_policy_owners(metadata, 2)
+    loads = [sum(meta.nbytes for meta, owner in zip(metadata, owners, strict=True) if owner == dp) for dp in range(2)]
+    assert max(loads) - min(loads) <= max(meta.nbytes for meta in metadata)
+
+
+def _gloo_policy_sync_worker(global_rank: int, port: int, output_queue) -> None:
+    role = "train" if global_rank < 2 else "rollout"
+    local_rank = global_rank if role == "train" else 0
+    init_process_group(
+        rank=local_rank,
+        world_size=2 if role == "train" else 1,
+        master_addr="127.0.0.1",
+        master_port=port,
+        device_id=0,
+        tp_size=2 if role == "train" else 1,
+        global_rank=global_rank,
+        global_world_size=3,
+        train_world_size=2,
+        train_tp_size=2,
+        rollout_world_size=1,
+        rollout_tp_size=1,
+        role=role,
+    )
+    try:
+        if role == "train":
+            full = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+            local = full.chunk(2, dim=0)[local_rank].clone()
+        else:
+            local = torch.zeros(4, 2)
+        task = _TensorParallelGatherTask(local, dim=0)
+        layout = task.policy_layout()
+        meta = PolicyTensorMeta("weight", layout.shape, "float32", layout.nbytes)
+        worker = type("Worker", (), {})()
+        worker._policy_sync_plan = {"weight": task}
+        worker._policy_sync_metadata = (meta,)
+        worker._policy_sync_buffer = None
+        transfer_policy_weights(worker, PolicySyncPayload(version=1, bucket_bytes=16))
+        dist.barrier()
+        if role == "rollout":
+            output_queue.put(local.tolist())
+    finally:
+        destroy_process_group()
+
+
+def test_real_gloo_collectives_reshard_train_tp2_to_rollout_tp1() -> None:
+    ctx = mp.get_context("spawn")
+    output_queue = ctx.Queue()
+    port = find_free_port()
+    processes = [ctx.Process(target=_gloo_policy_sync_worker, args=(rank, port, output_queue)) for rank in range(3)]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    assert [process.exitcode for process in processes] == [0, 0, 0]
+    assert output_queue.get(timeout=5) == torch.arange(8, dtype=torch.float32).reshape(4, 2).tolist()
+
+
+def _gloo_policy_sync_reverse_worker(global_rank: int, port: int, output_queue) -> None:
+    role = "train" if global_rank == 0 else "rollout"
+    local_rank = 0 if role == "train" else global_rank - 1
+    init_process_group(
+        rank=local_rank,
+        world_size=1 if role == "train" else 2,
+        master_addr="127.0.0.1",
+        master_port=port,
+        device_id=0,
+        tp_size=1 if role == "train" else 2,
+        global_rank=global_rank,
+        global_world_size=3,
+        train_world_size=1,
+        train_tp_size=1,
+        rollout_world_size=2,
+        rollout_tp_size=2,
+        role=role,
+    )
+    try:
+        full = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+        local = full.clone() if role == "train" else torch.zeros(2, 2)
+        task = _TensorParallelGatherTask(local, dim=0)
+        layout = task.policy_layout()
+        meta = PolicyTensorMeta("weight", layout.shape, "float32", layout.nbytes)
+        worker = type("Worker", (), {})()
+        worker._policy_sync_plan = {"weight": task}
+        worker._policy_sync_metadata = (meta,)
+        worker._policy_sync_buffer = None
+        transfer_policy_weights(worker, PolicySyncPayload(version=1, bucket_bytes=16))
+        dist.barrier()
+        if role == "rollout":
+            output_queue.put((local_rank, local.tolist()))
+    finally:
+        destroy_process_group()
+
+
+def test_real_gloo_collectives_reshard_train_tp1_to_rollout_tp2() -> None:
+    ctx = mp.get_context("spawn")
+    output_queue = ctx.Queue()
+    port = find_free_port()
+    processes = [
+        ctx.Process(target=_gloo_policy_sync_reverse_worker, args=(rank, port, output_queue)) for rank in range(3)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+    assert [process.exitcode for process in processes] == [0, 0, 0]
+    shards = sorted((output_queue.get(timeout=5) for _ in range(2)), key=lambda item: item[0])
+    combined = torch.cat([torch.tensor(rows) for _, rows in shards], dim=0)
+    torch.testing.assert_close(combined, torch.arange(8, dtype=torch.float32).reshape(4, 2))

--- a/tests/test_recompute_cpu.py
+++ b/tests/test_recompute_cpu.py
@@ -5,7 +5,7 @@ import unittest
 import torch
 
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
-from areno.engine.runtime.recompute import checkpoint_layer, should_checkpoint_layer
+from areno.engine.runtime.recompute import checkpoint_layer, checkpoint_routed_moe_layer, should_checkpoint_layer
 
 
 class RecomputeTest(unittest.TestCase):
@@ -58,6 +58,43 @@ class RecomputeTest(unittest.TestCase):
 
         self.assertEqual(out.tolist(), [2.0])
         self.assertEqual(calls["count"], 1)
+
+    def test_routed_moe_checkpoint_reuses_one_route_and_preserves_gradients(self):
+        """Dynamic routing stays outside recompute while all gradients survive."""
+        route_calls = 0
+        router_scale = torch.nn.Parameter(torch.tensor(0.5))
+        expert_scale = torch.nn.Parameter(torch.tensor(2.0))
+        states = torch.ones((1, 3, 4), requires_grad=True)
+
+        def attention_fn(x):
+            return x * 3
+
+        def route_fn(x):
+            nonlocal route_calls
+            route_calls += 1
+            tokens = x.numel() // x.shape[-1]
+            indices = torch.zeros((tokens, 1), dtype=torch.long)
+            weights = x.mean(dim=-1).reshape(tokens, 1) * router_scale
+            return indices, weights
+
+        def expert_fn(x, indices, weights):
+            del indices
+            return x * weights.view(*x.shape[:-1], 1) * expert_scale
+
+        output = checkpoint_routed_moe_layer(
+            attention_fn,
+            torch.nn.Identity(),
+            route_fn,
+            expert_fn,
+            states,
+            train_meta=TrainMeta(activation_checkpointing=True),
+        )
+        output.sum().backward()
+
+        self.assertEqual(route_calls, 1)
+        self.assertIsNotNone(states.grad)
+        self.assertIsNotNone(router_scale.grad)
+        self.assertIsNotNone(expert_scale.grad)
 
 
 if __name__ == "__main__":

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -436,7 +436,6 @@ def test_independent_rollout_topology_parses_distinct_cuda_devices() -> None:
         ({"train_devices": "0..2,2", "world_size": 4}, "--train-devices must not contain duplicate"),
         ({"train_devices": "0,-1", "world_size": 2}, "--train-devices must not contain negative"),
         ({"train_devices": "0,0", "world_size": 2}, "--train-devices must not contain duplicate"),
-        ({"train_devices": "0", "world_size": 2}, "--train-devices count must equal --world-size"),
         (
             {"world_size": 2, "rollout_devices": "2,3,4", "rollout_tp_size": 2},
             "--rollout-devices count must be divisible",
@@ -472,6 +471,47 @@ def test_cuda_device_ranges_are_inclusive_and_composable() -> None:
         *range(11, 14),
         20,
     ]
+
+
+def test_train_devices_infer_world_size() -> None:
+    cfg = _trainer_config_from_options(
+        **_options(
+            reward_ckpt="reward",
+            train_devices="0..3",
+            world_size=99,
+            tp_size=2,
+        )
+    )
+
+    assert cfg.world_size == 4
+    assert cfg.train_devices == [0, 1, 2, 3]
+
+
+def test_train_tp_size_alias_is_accepted(monkeypatch) -> None:
+    captured = []
+    monkeypatch.setattr(train_cli, "run", lambda config: captured.append(config))
+
+    result = CliRunner().invoke(
+        train_cli.train_command,
+        [
+            "--algo",
+            "sft",
+            "--ckpt",
+            "actor",
+            "--dataset-path",
+            "dataset",
+            "--dataset-loader-fn",
+            "examples/sft/alpaca/dataset_loader.py",
+            "--train-devices",
+            "0..3",
+            "--train-tp-size",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured[0].world_size == 4
+    assert captured[0].tp_size == 2
 
 
 def test_offline_algorithm_rejects_independent_rollout_devices() -> None:

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -402,6 +402,87 @@ def test_training_config_summary_section_handles_empty_rows():
     assert _format_summary_section("Empty", [], color=False) == ["", "Empty", "-----"]
 
 
+def test_independent_rollout_topology_parses_distinct_cuda_devices() -> None:
+    cfg = _trainer_config_from_options(
+        **_options(
+            train_devices="0, 2",
+            world_size=2,
+            tp_size=2,
+            rollout_devices="1,3",
+            rollout_tp_size=1,
+            policy_sync_bucket_mb=32,
+            reward_ckpt="reward",
+        )
+    )
+
+    assert cfg.train_devices == [0, 2]
+    assert cfg.rollout_devices == [1, 3]
+    assert cfg.rollout_tp_size == 1
+    assert cfg.policy_sync_bucket_mb == 32
+    backend = cfg.areno_config()
+    assert backend.devices == [0, 2]
+    assert backend.rollout_devices == [1, 3]
+    assert backend.resolved_rollout_tp_size() == 1
+    assert backend.uses_separate_rollout_engine()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"train_devices": "0,,1", "world_size": 2}, "--train-devices must be a comma-separated"),
+        ({"train_devices": "0,a", "world_size": 2}, "--train-devices must contain only integer"),
+        ({"train_devices": "0,-1", "world_size": 2}, "--train-devices must not contain negative"),
+        ({"train_devices": "0,0", "world_size": 2}, "--train-devices must not contain duplicate"),
+        ({"train_devices": "0", "world_size": 2}, "--train-devices count must equal --world-size"),
+        (
+            {"train_devices": "0,1", "world_size": 2, "rollout_devices": "1,2"},
+            "train and rollout devices must not overlap",
+        ),
+        (
+            {"world_size": 2, "rollout_devices": "2,3,4", "rollout_tp_size": 2},
+            "--rollout-devices count must be divisible",
+        ),
+        ({"rollout_tp_size": 2}, "--rollout-tp-size requires --rollout-devices"),
+        ({"policy_sync_bucket_mb": 0}, "--policy-sync-bucket-mb must be positive"),
+    ],
+)
+def test_independent_rollout_topology_rejects_invalid_values(overrides, message) -> None:
+    with pytest.raises(UsageError, match=message):
+        _trainer_config_from_options(**_options(reward_ckpt="reward", **overrides))
+
+
+def test_offline_algorithm_rejects_independent_rollout_devices() -> None:
+    with pytest.raises(UsageError, match="only valid for rollout-based algorithms"):
+        _trainer_config_from_options(
+            **_options(
+                algo="sft",
+                dataset_loader_fn="examples/sft/alpaca/dataset_loader.py",
+                reward_fn_path=None,
+                reward_ckpt=None,
+                rollout_devices="2",
+            )
+        )
+
+
+def test_training_summary_shows_independent_rollout_topology() -> None:
+    cfg = _trainer_config_from_options(
+        **_options(
+            world_size=2,
+            tp_size=2,
+            train_devices="0,1",
+            rollout_devices="2,3",
+            rollout_tp_size=1,
+            reward_ckpt="reward",
+        )
+    )
+
+    summary = _format_training_config_summary(cfg)
+
+    assert "devices       0,1" in summary
+    assert "topology             world=2, tp=1, dp=2, devices=2,3" in summary
+    assert "policy_sync          NCCL direct, lazy, bucket=64 MiB" in summary
+
+
 def test_training_config_summary_callable_name_handles_callable_objects():
     class CallableLoss:
         def __call__(self):

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -435,10 +435,6 @@ def test_independent_rollout_topology_parses_distinct_cuda_devices() -> None:
         ({"train_devices": "0,0", "world_size": 2}, "--train-devices must not contain duplicate"),
         ({"train_devices": "0", "world_size": 2}, "--train-devices count must equal --world-size"),
         (
-            {"train_devices": "0,1", "world_size": 2, "rollout_devices": "1,2"},
-            "train and rollout devices must not overlap",
-        ),
-        (
             {"world_size": 2, "rollout_devices": "2,3,4", "rollout_tp_size": 2},
             "--rollout-devices count must be divisible",
         ),
@@ -449,6 +445,22 @@ def test_independent_rollout_topology_parses_distinct_cuda_devices() -> None:
 def test_independent_rollout_topology_rejects_invalid_values(overrides, message) -> None:
     with pytest.raises(UsageError, match=message):
         _trainer_config_from_options(**_options(reward_ckpt="reward", **overrides))
+
+
+def test_train_and_rollout_devices_may_overlap() -> None:
+    cfg = _trainer_config_from_options(
+        **_options(
+            reward_ckpt="reward",
+            train_devices="0,1",
+            world_size=2,
+            tp_size=2,
+            rollout_devices="0,1",
+            rollout_tp_size=1,
+        )
+    )
+
+    assert cfg.train_devices == [0, 1]
+    assert cfg.rollout_devices == [0, 1]
 
 
 def test_offline_algorithm_rejects_independent_rollout_devices() -> None:

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -431,6 +431,9 @@ def test_independent_rollout_topology_parses_distinct_cuda_devices() -> None:
     [
         ({"train_devices": "0,,1", "world_size": 2}, "--train-devices must be a comma-separated"),
         ({"train_devices": "0,a", "world_size": 2}, "--train-devices must contain only integer"),
+        ({"train_devices": "0..", "world_size": 2}, "--train-devices must contain only integer"),
+        ({"train_devices": "3..1", "world_size": 2}, "--train-devices range start must not exceed"),
+        ({"train_devices": "0..2,2", "world_size": 4}, "--train-devices must not contain duplicate"),
         ({"train_devices": "0,-1", "world_size": 2}, "--train-devices must not contain negative"),
         ({"train_devices": "0,0", "world_size": 2}, "--train-devices must not contain duplicate"),
         ({"train_devices": "0", "world_size": 2}, "--train-devices count must equal --world-size"),
@@ -461,6 +464,14 @@ def test_train_and_rollout_devices_may_overlap() -> None:
 
     assert cfg.train_devices == [0, 1]
     assert cfg.rollout_devices == [0, 1]
+
+
+def test_cuda_device_ranges_are_inclusive_and_composable() -> None:
+    assert train_cli._parse_cuda_devices("0..8,11..13,20", "--train-devices") == [
+        *range(0, 9),
+        *range(11, 14),
+        20,
+    ]
 
 
 def test_offline_algorithm_rejects_independent_rollout_devices() -> None:


### PR DESCRIPTION
## What does this PR do?

Adds independent train and rollout topologies with direct, GPU-resident policy weight synchronization.

- Adds separate train and rollout device selection, independent rollout TP, bounded synchronization buckets, and inclusive CUDA device ranges.
- Infers training world size from `--train-devices` and accepts `--train-tp-size` as an alias for `--tp-size`.
- Starts train and rollout workers in one distributed world while preserving independent TP/DP groups and the existing colocated default path.
- Reuses checkpoint layout specifications to build live canonical policy plans instead of introducing a second model traversal or relying on `state_dict()` shape inference.
- Supports replicated, row/column TP, fused QKV, explicit ranged shards, replicated KV, and packed/flat expert layouts across the current model adapters.
- Balances canonical tensor bytes across train DP publishers and streams fixed-size buckets directly between GPUs.
- Supports different train/rollout TP sizes and overlapping device sets without creating NCCL communicators that contain duplicate physical GPUs.
- Synchronizes lazily before the next rollout policy version, invalidates stale rollout state, and rebuilds inference-derived weights after receipt.
- Adds synchronization logs and metrics for total time, transfer time, bytes, tensors, and throughput.
- Stabilizes Qwen3-MoE and Gemma4-MoE activation recompute by keeping dynamic routing outside recompute and preserving identical gradient collective ordering on zero-route TP ranks.
- Documents the topology, CLI behavior, overlap behavior, and observability fields.

## Related issue

Fixes #433

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

Local static and CPU validation:

- `ruff format --check areno tests`
- `ruff check areno tests`
- `git diff --check`
- `python -m compileall -q areno`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` — 401 passed.

Distributed CPU/Gloo coverage includes:

- shared-world train and rollout partition construction;
- TP-local to global rank mapping for nonzero partition offsets;
- real TP 2→1 and TP 1→2 policy resharding;
- overlapping-device relay selection without duplicate-device cross-partition groups;
- dual-engine lifecycle and policy-version routing;
- policy-plan mismatch and synchronization failure propagation;
- CLI device parsing, inclusive range notation, overlap, and topology validation;
- routed-MoE recompute gradient preservation.

GPU validation performed during development exercised Qwen3/Qwen3-MoE startup, rollout, training, overlapping train/rollout devices, and NCCL synchronization. Those runs identified and drove fixes for nonzero TP roots, duplicate-GPU NCCL groups, dynamic MoE recompute routing, and zero-route collective divergence.

Hardware limitation: the final commit was not re-run on an NVIDIA GPU in the local development environment; the final GPU confirmation should run in CI or on the reported multi-GPU environment.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
