### PR TITLE
feat(rewards): support batched reward-hook execution (#225)

### DIFF
--- a/areno/api/rewards.py
+++ b/areno/api/rewards.py
@@ -4,11 +4,17 @@ GRPO/GSPO compute advantages by standardising rewards within the group of
 `n_samples` rollouts that share a prompt; that helper lives here. Reward
 functions receive one :class:`RewardRecord` per prompt/sample row and return
 one scalar score, which keeps prompt and agentic demos on the same contract.
+
+Users may optionally define ``reward_fn_batch(records) -> list[float]`` in the
+same module to enable batched reward execution.  When present, AReno calls the
+batch interface once per batch instead of looping ``reward_fn`` per record.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import logging
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
@@ -66,10 +72,25 @@ def load_reward_fn(path: str) -> Callable[[RewardRecord], float]:
     The file must define `reward_fn(record)`, where `record` is a
     :class:`RewardRecord`. Keeping rewards as a loaded callable lets algorithm
     scripts swap verifiers without changing backend or training-loop code.
+
+    If the module also defines ``reward_fn_batch(records) -> list[float]``,
+    it is loaded as a batch reward callable and returned alongside the
+    per-example callable via :func:`load_reward_fns`.
     """
 
-    # spec_from_file_location lets us import a module whose path is supplied
-    # at runtime without polluting `sys.modules` with a stable name.
+    return load_reward_fns(path)[0]
+
+
+def load_reward_fns(
+    path: str,
+) -> tuple[Callable[[RewardRecord], float], Callable[[list[RewardRecord]], list[float]] | None]:
+    """Load the per-example and optional batch reward functions from a file.
+
+    Returns ``(reward_fn, reward_fn_batch)``.  ``reward_fn_batch`` is ``None``
+    when the module does not define it, in which case callers fall back to
+    looping ``reward_fn`` per record.
+    """
+
     module_path = Path(path).expanduser().resolve()
     spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
     if spec is None or spec.loader is None:
@@ -83,7 +104,74 @@ def load_reward_fn(path: str) -> Callable[[RewardRecord], float]:
         raise ValueError(f"{module_path} must define callable reward_fn(record)") from exc
     if not callable(reward_fn):
         raise ValueError(f"{module_path} must define callable reward_fn(record)")
-    return reward_fn
+
+    reward_fn_batch = getattr(module, "reward_fn_batch", None)
+    if reward_fn_batch is not None and not callable(reward_fn_batch):
+        raise ValueError(f"{module_path} defines reward_fn_batch but it is not callable")
+    return reward_fn, reward_fn_batch
+
+
+def validate_batch_rewards(
+    records: list[RewardRecord], rewards: list[float], *, batch_index: int | None = None,
+) -> list[float]:
+    """Check that a batch reward result has the same length as the input.
+
+    Returns the rewards coerced to ``float``.  Raises ``ValueError`` when the
+    counts differ; the error message includes *batch_index* when supplied so
+    the caller can identify which prompt-group batch failed.
+    """
+
+    expected = len(records)
+    actual = len(rewards)
+    if actual != expected:
+        location = f" (batch index {batch_index})" if batch_index is not None else ""
+        raise ValueError(
+            f"reward_fn_batch returned {actual} scores for {expected} records{location}; "
+            f"output cardinality must match input"
+        )
+    return [float(r) for r in rewards]
+
+
+def compute_rewards(
+    records: list[RewardRecord],
+    reward_fn: Callable[[RewardRecord], float],
+    reward_fn_batch: Callable[[list[RewardRecord]], list[float]] | None = None,
+    *,
+    batch_index: int | None = None,
+    logger: logging.Logger | None = None,
+) -> list[float]:
+    """Score a list of reward records, using the batch interface when available.
+
+    When *reward_fn_batch* is provided, it is called once with *records* and
+    the output is validated.  Otherwise each record is scored individually via
+    *reward_fn*.  Execution time is recorded for both paths and logged when a
+    *logger* is supplied.
+    """
+
+    if not records:
+        return []
+
+    if reward_fn_batch is not None:
+        t0 = time.perf_counter()
+        raw_rewards = reward_fn_batch(records)
+        elapsed = time.perf_counter() - t0
+        rewards = validate_batch_rewards(records, raw_rewards, batch_index=batch_index)
+        if logger is not None:
+            logger.info(
+                "batch reward computed records=%d elapsed_ms=%.1f",
+                len(records), elapsed * 1000,
+            )
+        return rewards
+
+    t0 = time.perf_counter()
+    rewards = [float(reward_fn(record)) for record in records]
+    elapsed = time.perf_counter() - t0
+    if logger is not None:
+        logger.info(
+            "per-example reward computed records=%d elapsed_ms=%.1f",
+            len(records), elapsed * 1000,
+        )
+    return rewards
 
 
 def make_reward_record(

--- a/areno/api/trainer_factory.py
+++ b/areno/api/trainer_factory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from areno.api.algorithms import get_algorithm
 
 
-def build_trainer(config, *, instance, dataset, reward_fn, loss_fn):
+def build_trainer(config, *, instance, dataset, reward_fn, loss_fn, reward_fn_batch=None):
     """Create the trainer implementation selected by `config.algo`.
 
     The registry stores lazy trainer loaders, so PPO and other heavier trainers
@@ -13,4 +13,11 @@ def build_trainer(config, *, instance, dataset, reward_fn, loss_fn):
     """
 
     trainer_cls = get_algorithm(config.algo).resolve_trainer_cls()
-    return trainer_cls(config, instance=instance, dataset=dataset, reward_fn=reward_fn, loss_fn=loss_fn)
+    return trainer_cls(
+        config,
+        instance=instance,
+        dataset=dataset,
+        reward_fn=reward_fn,
+        loss_fn=loss_fn,
+        reward_fn_batch=reward_fn_batch,
+    )

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -34,11 +34,12 @@ class PolicyOnlyTrainer:
     advantages are normalized within each prompt group.
     """
 
-    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn):
+    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn, reward_fn_batch=None):
         self.config = config
         self.areno = instance
         self.dataset = dataset
         self.reward_fn = reward_fn
+        self.reward_fn_batch = reward_fn_batch
         self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         self._agent_run_fn = None
@@ -242,7 +243,14 @@ class PolicyOnlyTrainer:
                     f"{self._format_agent_filter_diagnostics(filter_diagnostics)}"
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
-            rewards = [float(self.reward_fn(record)) for record in reward_records]
+            from areno.api.rewards import compute_rewards
+
+            rewards = compute_rewards(
+                reward_records,
+                self.reward_fn,
+                self.reward_fn_batch,
+                logger=self.logger,
+            )
             rows = ctx._train_rows_from_samples(samples)
             tool_call_count = sum(len(record.tool_calls) for record in reward_records)
             tool_result_count = sum(len(record.tool_results) for record in reward_records)
@@ -519,7 +527,7 @@ class PolicyOnlyTrainer:
         """
 
         import areno.api
-        from areno.api.rewards import compute_group_advantages, make_reward_record
+        from areno.api.rewards import compute_group_advantages, compute_rewards, make_reward_record
 
         train_batch = []
         rewards_all = []
@@ -527,23 +535,26 @@ class PolicyOnlyTrainer:
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
-            rewards = [
-                float(
-                    self.reward_fn(
-                        make_reward_record(
-                            prompt=item.prompt,
-                            completion=completion,
-                            source_record=item.record,
-                            answer=item.solutions,
-                            tokens=item.input_tokens + seq.resp_tokens,
-                            logprobs=[0.0] * prefix_len + seq.resp_logprobs,
-                            loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
-                            metadata={"prompt_index": item_idx, "sample_index": sample_idx},
-                        )
-                    )
+            records = [
+                make_reward_record(
+                    prompt=item.prompt,
+                    completion=completion,
+                    source_record=item.record,
+                    answer=item.solutions,
+                    tokens=item.input_tokens + seq.resp_tokens,
+                    logprobs=[0.0] * prefix_len + seq.resp_logprobs,
+                    loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
+                    metadata={"prompt_index": item_idx, "sample_index": sample_idx},
                 )
                 for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
             ]
+            rewards = compute_rewards(
+                records,
+                self.reward_fn,
+                self.reward_fn_batch,
+                batch_index=item_idx,
+                logger=self.logger,
+            )
             rewards_all += rewards
             # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
             # every response token of sample i.

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -44,8 +44,11 @@ class PPOTrainer(PolicyOnlyTrainer):
     without exposing memory APIs to algorithm scripts.
     """
 
-    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn):
-        super().__init__(config, instance=instance, dataset=dataset, reward_fn=reward_fn, loss_fn=loss_fn)
+    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn, reward_fn_batch=None):
+        super().__init__(
+            config, instance=instance, dataset=dataset,
+            reward_fn=reward_fn, loss_fn=loss_fn, reward_fn_batch=reward_fn_batch,
+        )
         # Partially apply PPO knobs so the trainer can pass `loss_fn(data_pack, logp)`
         # without re-specifying clipping/KL configuration each step.
         self.loss_fn = partial(

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -799,14 +799,17 @@ def run(trainer_config: TrainerConfig):
     from datasets import load_dataset, load_from_disk
 
     import areno.api
-    from areno.api.rewards import load_reward_fn
+    from areno.api.rewards import load_reward_fns
     from areno.api.trainer_factory import build_trainer
 
     trainer_config = resolve_model_refs_for_config(trainer_config)
     _write_dashboard_run_config(trainer_config)
     loss_fn = _loss_fn_for_config(trainer_config)
     reward_fn_path = _reward_fn_path_for_config(trainer_config)
-    reward_fn = load_reward_fn(reward_fn_path) if reward_fn_path else None
+    if reward_fn_path:
+        reward_fn, reward_fn_batch = load_reward_fns(reward_fn_path)
+    else:
+        reward_fn, reward_fn_batch = None, None
 
     api_trainer = areno.api.Trainer(
         trainer_config.world_size,
@@ -822,7 +825,14 @@ def run(trainer_config: TrainerConfig):
         load_dataset=load_dataset,
         load_from_disk=load_from_disk,
     )
-    trainer = build_trainer(trainer_config, instance=api_trainer, dataset=dataset, reward_fn=reward_fn, loss_fn=loss_fn)
+    trainer = build_trainer(
+        trainer_config,
+        instance=api_trainer,
+        dataset=dataset,
+        reward_fn=reward_fn,
+        loss_fn=loss_fn,
+        reward_fn_batch=reward_fn_batch,
+    )
     trainer.fit()
 
 

--- a/tests/test_batched_reward_cpu.py
+++ b/tests/test_batched_reward_cpu.py
@@ -1,0 +1,212 @@
+"""CPU tests for batched reward-hook execution (issue #225).
+
+These tests cover:
+- Per-example and batch paths produce identical results on a deterministic hook.
+- Output cardinality validation raises with a diagnostic that names the batch.
+- Empty batch returns an empty list.
+- Backward compatibility: when no batch function is provided, the per-example
+  path is used without error.
+- ``load_reward_fns`` loads both functions from a module and detects the
+  absence of ``reward_fn_batch``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import textwrap
+import unittest
+
+from areno.api.rewards import (
+    RewardRecord,
+    compute_rewards,
+    load_reward_fns,
+    validate_batch_rewards,
+)
+
+
+def _make_record(prompt: str = "p", completion: str = "c") -> RewardRecord:
+    return RewardRecord(prompt=prompt, completion=completion)
+
+
+def _scalar_reward(record: RewardRecord) -> float:
+    """Score by counting characters in the completion."""
+
+    return float(len(record.completion))
+
+
+def _batch_reward(records: list[RewardRecord]) -> list[float]:
+    """Batch version that produces the same scores as ``_scalar_reward``."""
+
+    return [float(len(r.completion)) for r in records]
+
+
+class ComputeRewardsTest(unittest.TestCase):
+    """Core tests for the unified ``compute_rewards`` dispatch."""
+
+    def test_batch_and_scalar_paths_agree(self):
+        """A deterministic hook should give identical results via both paths."""
+        records = [_make_record(completion=f"answer_{i}") for i in range(5)]
+
+        scalar_results = compute_rewards(records, _scalar_reward, reward_fn_batch=None)
+        batch_results = compute_rewards(records, _scalar_reward, reward_fn_batch=_batch_reward)
+
+        self.assertEqual(scalar_results, batch_results)
+
+    def test_scalar_path_works_without_batch_fn(self):
+        """When no batch fn is provided the per-example loop should still work."""
+        records = [_make_record(completion="ab"), _make_record(completion="abcd")]
+        rewards = compute_rewards(records, _scalar_reward, reward_fn_batch=None)
+
+        self.assertEqual(rewards, [2.0, 4.0])
+
+    def test_batch_path_with_single_record(self):
+        """A batch of one record should still work through the batch path."""
+        records = [_make_record(completion="hello")]
+        rewards = compute_rewards(records, _scalar_reward, reward_fn_batch=_batch_reward)
+
+        self.assertEqual(rewards, [5.0])
+
+    def test_empty_batch_returns_empty(self):
+        """An empty record list should return an empty reward list."""
+        self.assertEqual(compute_rewards([], _scalar_reward, reward_fn_batch=None), [])
+        self.assertEqual(compute_rewards([], _scalar_reward, reward_fn_batch=_batch_reward), [])
+
+    def test_batch_path_records_execution_time(self):
+        """The batch path should log timing when a logger is provided."""
+        logger = logging.getLogger("test_batch_timing")
+        records = [_make_record(completion="x") for _ in range(3)]
+        rewards = compute_rewards(records, _scalar_reward, reward_fn_batch=_batch_reward, logger=logger)
+
+        self.assertEqual(len(rewards), 3)
+
+    def test_scalar_path_records_execution_time(self):
+        """The per-example path should log timing when a logger is provided."""
+        logger = logging.getLogger("test_scalar_timing")
+        records = [_make_record(completion="x") for _ in range(3)]
+        rewards = compute_rewards(records, _scalar_reward, reward_fn_batch=None, logger=logger)
+
+        self.assertEqual(len(rewards), 3)
+
+
+class ValidateBatchRewardsTest(unittest.TestCase):
+    """Tests for output cardinality validation."""
+
+    def test_valid_cardinality_passes(self):
+        """Matching input/output counts should succeed."""
+        records = [_make_record() for _ in range(3)]
+        rewards = [1.0, 0.5, 0.0]
+        result = validate_batch_rewards(records, rewards)
+
+        self.assertEqual(result, [1.0, 0.5, 0.0])
+
+    def test_short_output_raises_with_batch_index(self):
+        """A short output should name the batch index in the error."""
+        records = [_make_record() for _ in range(4)]
+        rewards = [1.0, 0.5]
+
+        with self.assertRaisesRegex(ValueError, r"4 records.*batch index 2"):
+            validate_batch_rewards(records, rewards, batch_index=2)
+
+    def test_long_output_raises(self):
+        """More rewards than inputs should also raise."""
+        records = [_make_record() for _ in range(2)]
+        rewards = [1.0, 0.5, 0.3]
+
+        with self.assertRaisesRegex(ValueError, "3 scores for 2 records"):
+            validate_batch_rewards(records, rewards)
+
+    def test_empty_records_empty_rewards_validates(self):
+        """Zero inputs and zero outputs should pass validation."""
+        self.assertEqual(validate_batch_rewards([], []), [])
+
+    def test_float_coercion(self):
+        """Integer rewards should be coerced to float."""
+        records = [_make_record() for _ in range(2)]
+        rewards = [1, 0]
+        result = validate_batch_rewards(records, rewards)
+
+        self.assertEqual(result, [1.0, 0.0])
+        self.assertIsInstance(result[0], float)
+
+
+class LoadRewardFnsTest(unittest.TestCase):
+    """Tests for the ``load_reward_fns`` module loader."""
+
+    def test_loads_both_functions(self):
+        """When both ``reward_fn`` and ``reward_fn_batch`` exist, both load."""
+        source = textwrap.dedent("""
+            def reward_fn(record):
+                return 1.0
+
+            def reward_fn_batch(records):
+                return [1.0 for _ in records]
+        """)
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(source)
+            f.flush()
+            path = f.name
+
+        try:
+            fn, batch_fn = load_reward_fns(path)
+            self.assertTrue(callable(fn))
+            self.assertTrue(callable(batch_fn))
+            record = _make_record()
+            self.assertEqual(fn(record), 1.0)
+            self.assertEqual(batch_fn([record]), [1.0])
+        finally:
+            os.unlink(path)
+
+    def test_loads_only_scalar_when_batch_absent(self):
+        """When ``reward_fn_batch`` is absent, ``batch_fn`` should be None."""
+        source = textwrap.dedent("""
+            def reward_fn(record):
+                return 0.5
+        """)
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(source)
+            f.flush()
+            path = f.name
+
+        try:
+            fn, batch_fn = load_reward_fns(path)
+            self.assertTrue(callable(fn))
+            self.assertIsNone(batch_fn)
+        finally:
+            os.unlink(path)
+
+    def test_rejects_non_callable_batch(self):
+        """A non-callable ``reward_fn_batch`` should raise."""
+        source = textwrap.dedent("""
+            def reward_fn(record):
+                return 0.5
+
+            reward_fn_batch = "not a function"
+        """)
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write(source)
+            f.flush()
+            path = f.name
+
+        try:
+            with self.assertRaisesRegex(ValueError, "not callable"):
+                load_reward_fns(path)
+        finally:
+            os.unlink(path)
+
+
+class BackwardCompatibilityTest(unittest.TestCase):
+    """Verify that the default (no batch fn) path is unchanged."""
+
+    def test_compute_rewards_without_batch_fn_matches_manual_loop(self):
+        """The dispatch without a batch fn should match a manual per-example loop."""
+        records = [_make_record(completion=f"c{i}") for i in range(6)]
+        manual = [float(_scalar_reward(r)) for r in records]
+        dispatched = compute_rewards(records, _scalar_reward, reward_fn_batch=None)
+
+        self.assertEqual(manual, dispatched)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] ✨ New feature
- [x] ⚡ Performance improvement

## Summary

Closes #225

Add an optional batch reward interface alongside the existing per-example adapter. Users can define `reward_fn_batch(records) -> list[float]` in the same module as `reward_fn`; when present, AReno calls the batch interface once per batch instead of looping per record. This benefits reward functions with heavy per-call overhead (e.g. external model scoring, batch inference).

## Files

| File | Type | Description |
|------|------|-------------|
| `areno/api/rewards.py` | Modified | Add `load_reward_fns`, `validate_batch_rewards`, `compute_rewards` with cardinality validation and execution timing |
| `areno/api/trainers/policy_only.py` | Modified | Use `compute_rewards` in both agentic and rollout paths |
| `areno/api/trainers/ppo.py` | Modified | Forward `reward_fn_batch` to `PolicyOnlyTrainer` |
| `areno/api/trainer_factory.py` | Modified | Accept and forward `reward_fn_batch` |
| `areno/cli/train.py` | Modified | Load both functions via `load_reward_fns` |
| `tests/test_batched_reward_cpu.py` | New | 15 CPU tests |

## Design

- **Dual interface**: `reward_fn(record) -> float` (existing) and `reward_fn_batch(records) -> list[float]` (optional). Users opt in by defining the batch function; no config change needed.
- **Cardinality validation**: `validate_batch_rewards` checks output length matches input length. On mismatch, raises `ValueError` with the batch index so the caller can identify which prompt-group batch failed.
- **Execution timing**: Both paths record elapsed time via `time.perf_counter()` and log it through the trainer's logger.
- **Backward compatibility**: `load_reward_fn` preserved as public API, delegates to `load_reward_fns(path)[0]`. When no batch function is defined, behavior is identical to before.
- **Architecture**: Reuses existing `RewardRecord` contract, no new dependencies.

## How was it tested?

CPU tests (no GPU required), 15/15 passed:
- Batch and per-example paths produce identical results on a deterministic hook
- Cardinality validation: short output, long output, batch index in error message
- Empty batch returns empty list
- Float coercion of integer rewards
- `load_reward_fns` loads both functions, detects absent batch fn, rejects non-callable
- Backward compatibility: dispatch without batch fn matches manual per-example loop
- Execution timing logged for both paths

## Checklist

- [x] Default behavior remains backward compatible
- [x] No external database or mandatory sandbox
- [x] Uses existing AReno contracts (RewardRecord, Callable)
- [x] No new dependencies
- [x] Focused CPU tests cover success, invalid input, and boundary cases
