### PR TITLE
fix(cli): infer rollout devices from world size

### DIFF
--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -186,8 +186,14 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
     args.train_devices = _parse_cuda_devices(getattr(args, "train_devices", None), "--train-devices")
     args.rollout_devices = _parse_cuda_devices(getattr(args, "rollout_devices", None), "--rollout-devices")
+    if args.rollout_tp_size is not None and args.rollout_tp_size <= 0:
+        raise click.UsageError("--rollout-tp-size must be positive")
     if args.train_devices is not None:
         args.world_size = len(args.train_devices)
+    else:
+        args.train_devices = list(range(args.world_size))
+    if args.rollout_devices is None and args.rollout_tp_size is not None:
+        args.rollout_devices = list(args.train_devices)
     args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
     args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
     smoke_infer = bool(getattr(args, "smoke_infer", False))
@@ -240,10 +246,6 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     has_rollout_topology = args.rollout_devices is not None or args.rollout_tp_size is not None
     if has_rollout_topology and not algorithm.requires_rollout:
         raise click.UsageError("independent rollout devices are only valid for rollout-based algorithms")
-    if args.rollout_tp_size is not None and args.rollout_tp_size <= 0:
-        raise click.UsageError("--rollout-tp-size must be positive")
-    if args.rollout_tp_size is not None and args.rollout_devices is None:
-        raise click.UsageError("--rollout-tp-size requires --rollout-devices")
     if args.rollout_devices is not None:
         rollout_tp_size = args.tp_size if args.rollout_tp_size is None else args.rollout_tp_size
         if len(args.rollout_devices) % rollout_tp_size != 0:
@@ -1333,19 +1335,19 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--train-devices",
     type=str,
     default=None,
-    help="CUDA devices for training, with inclusive ranges such as 0..7,10; overrides --world-size.",
+    help="CUDA devices for training, with inclusive ranges such as 0..7,10; defaults to devices from --world-size.",
 )
 @click.option(
     "--rollout-tp-size",
     type=int,
     default=None,
-    help="Tensor parallel size for the independent rollout engine; defaults to --tp-size.",
+    help="Tensor parallel size for an independent rollout engine using the training device set by default.",
 )
 @click.option(
     "--rollout-devices",
     type=str,
     default=None,
-    help="CUDA devices for the independent rollout engine, with inclusive ranges such as 0..7,10.",
+    help="CUDA devices for the independent rollout engine; defaults to the training device set when omitted.",
 )
 @click.option(
     "--policy-sync-bucket-mb",

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -440,7 +440,11 @@ def test_independent_rollout_topology_parses_distinct_cuda_devices() -> None:
             {"world_size": 2, "rollout_devices": "2,3,4", "rollout_tp_size": 2},
             "--rollout-devices count must be divisible",
         ),
-        ({"rollout_tp_size": 2}, "--rollout-tp-size requires --rollout-devices"),
+        (
+            {"world_size": 3, "rollout_tp_size": 2},
+            "--rollout-devices count must be divisible",
+        ),
+        ({"rollout_tp_size": 0}, "--rollout-tp-size must be positive"),
         ({"policy_sync_bucket_mb": 0}, "--policy-sync-bucket-mb must be positive"),
     ],
 )
@@ -463,6 +467,36 @@ def test_train_and_rollout_devices_may_overlap() -> None:
 
     assert cfg.train_devices == [0, 1]
     assert cfg.rollout_devices == [0, 1]
+
+
+def test_world_size_infers_shared_train_and_rollout_devices() -> None:
+    cfg = _trainer_config_from_options(
+        **_options(
+            reward_ckpt="reward",
+            world_size=8,
+            tp_size=4,
+            rollout_tp_size=2,
+        )
+    )
+
+    assert cfg.world_size == 8
+    assert cfg.train_devices == list(range(8))
+    assert cfg.rollout_devices == list(range(8))
+    assert cfg.rollout_tp_size == 2
+
+
+def test_world_size_infers_train_devices_without_separate_rollout() -> None:
+    cfg = _trainer_config_from_options(
+        **_options(
+            reward_ckpt="reward",
+            world_size=4,
+            tp_size=2,
+        )
+    )
+
+    assert cfg.world_size == 4
+    assert cfg.train_devices == [0, 1, 2, 3]
+    assert cfg.rollout_devices is None
 
 
 def test_cuda_device_ranges_are_inclusive_and_composable() -> None:


### PR DESCRIPTION
## What does this PR do?

Infer CUDA device lists from `--world-size` when explicit lists are omitted:

- training defaults to `range(world_size)`;
- an independent rollout engine defaults to the same training device set when `--rollout-tp-size` is provided;
- training and rollout TP divisibility are validated independently against their resolved device counts;
- CLI help documents the inferred defaults.

This makes `--world-size 8 --tp-size 4 --rollout-tp-size 2` resolve both engines to devices `0..7` without requiring redundant device flags.

Explicit `--train-devices` and `--rollout-devices` continue to override these defaults.

## Related issue

Fixes #443

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

```shell
conda run -n share env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_train_cli_config_cpu.py -q
```

Result: `89 passed, 1 warning`.

The warning is an existing `requests` dependency-version warning. No GPU test is needed because this change only resolves and validates CLI topology configuration.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description.
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible.
