### PR TITLE
refactor(algorithms): separate rollout and reward requirements

### DIFF
--- a/.agents/skills/areno-add-algorithm/scripts/inspect_algorithms.py
+++ b/.agents/skills/areno-add-algorithm/scripts/inspect_algorithms.py
@@ -18,7 +18,7 @@ def main() -> int:
             rows.append(
                 {
                     "name": name,
-                    "requires_rollout": spec.requires_rollout, 
+                    "requires_rollout": spec.requires_rollout,
                     "requires_reward": spec.requires_reward,
                     "experimental": spec.experimental,
                     "trainer": f"{trainer.__module__}.{trainer.__name__}",

--- a/.agents/skills/areno-add-algorithm/scripts/inspect_algorithms.py
+++ b/.agents/skills/areno-add-algorithm/scripts/inspect_algorithms.py
@@ -18,7 +18,8 @@ def main() -> int:
             rows.append(
                 {
                     "name": name,
-                    "requires_rollout": spec.requires_rollout,
+                    "requires_rollout": spec.requires_rollout, 
+                    "requires_reward": spec.requires_reward,
                     "experimental": spec.experimental,
                     "trainer": f"{trainer.__module__}.{trainer.__name__}",
                     "loss": f"{spec.default_loss_fn.__module__}.{spec.default_loss_fn.__name__}",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ ______________________________________________________________________
 
 **Trainer** (`areno/api/trainer.py`): the high-level entry. A typical RL loop is `init()` -> `rollout_batch()` -> score -> `train()` -> repeat -> `close()`. The CLI builds the same `Trainer` under the hood (`areno/cli/train.py`).
 
-**Algorithm registry** (`areno/api/algorithms.py`): each algorithm is an `AlgorithmSpec` (trainer class, default loss, `requires_rollout`). `--algo` selects one; discover them with `from areno.api import list_algorithms`.
+**Algorithm registry** (`areno/api/algorithms.py`): each algorithm is an `AlgorithmSpec` (trainer class, default loss, `requires_rollout`, `requires_reward`). `--algo` selects one; discover them with `from areno.api import list_algorithms`.
 
 **Loss functions** (`areno/api/loss_fns/`): `sft`, `dpo`, `gspo`, `grpo`, `ppo`, passed into `Trainer.train`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ open an issue with a short description of the method, a link to the paper, and a
 link to a reference implementation if one exists. Then:
 
 - **Algorithms** are registered, not branched. Add an `AlgorithmSpec` via
-  `register_algorithm(...)` in `areno/api/algorithms.py`, with a loss function in
+  `register_algorithm(...)` in `areno/api/algorithms.py`, declare its rollout and
+  reward requirements explicitly, and provide a loss function in
   `areno/api/loss_fns/`. New or unstable algorithms should land in
   `areno/experimental/` first and graduate to `areno/api/` once they have proven
   out — this keeps the stable API surface protected while lowering the bar to

--- a/areno/api/algorithms.py
+++ b/areno/api/algorithms.py
@@ -178,7 +178,7 @@ def _register_builtin_algorithms() -> None:
             trainer_cls=_load_policy_trainer,
             default_loss_fn=gspo_loss_fn,
             requires_rollout=True,
-            requires_reward=True, 
+            requires_reward=True,
             loss_fn_factory=_bind_gspo_loss,
         )
     )

--- a/areno/api/algorithms.py
+++ b/areno/api/algorithms.py
@@ -30,6 +30,7 @@ class AlgorithmSpec:
     trainer_cls: type | TrainerFactory
     default_loss_fn: Callable
     requires_rollout: bool
+    requires_reward: bool = False
     loss_fn_factory: LossFnFactory | None = None
     experimental: bool = False
 
@@ -62,6 +63,8 @@ def register_algorithm(spec: AlgorithmSpec, *, replace: bool = False) -> None:
     name = spec.name.strip().lower()
     if not name:
         raise ValueError("algorithm name must be non-empty")
+    if spec.requires_reward and not spec.requires_rollout:
+        raise ValueError("algorithms that require reward must also require rollout")
     if name in _ALGORITHMS and not replace:
         raise ValueError(f"algorithm {name!r} is already registered")
     if name != spec.name:
@@ -70,6 +73,7 @@ def register_algorithm(spec: AlgorithmSpec, *, replace: bool = False) -> None:
             trainer_cls=spec.trainer_cls,
             default_loss_fn=spec.default_loss_fn,
             requires_rollout=spec.requires_rollout,
+            requires_reward=spec.requires_reward,
             loss_fn_factory=spec.loss_fn_factory,
             experimental=spec.experimental,
         )
@@ -174,6 +178,7 @@ def _register_builtin_algorithms() -> None:
             trainer_cls=_load_policy_trainer,
             default_loss_fn=gspo_loss_fn,
             requires_rollout=True,
+            requires_reward=True, 
             loss_fn_factory=_bind_gspo_loss,
         )
     )
@@ -183,6 +188,7 @@ def _register_builtin_algorithms() -> None:
             trainer_cls=_load_policy_trainer,
             default_loss_fn=grpo_loss_fn,
             requires_rollout=True,
+            requires_reward=True,
             loss_fn_factory=_bind_grpo_loss,
         )
     )
@@ -192,6 +198,7 @@ def _register_builtin_algorithms() -> None:
             trainer_cls=_load_ppo_trainer,
             default_loss_fn=ppo_loss_fn,
             requires_rollout=True,
+            requires_reward=True,
         )
     )
 

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -219,7 +219,7 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if tune_max_samples <= 0:
         raise click.UsageError("--tune-max-samples must be positive")
     if (
-        algorithm.requires_rollout
+        algorithm.requires_reward
         and not (smoke_infer or smoke_train)
         and args.reward_fn_path is None
         and args.reward_ckpt is None
@@ -357,6 +357,7 @@ def _format_training_config_summary(
                 ("name", algorithm.name),
                 ("default_loss", _callable_name(algorithm.default_loss_fn)),
                 ("requires_rollout", _format_bool(algorithm.requires_rollout)),
+                ("requires_reward", _format_bool(algorithm.requires_reward)),
             ],
         ),
         (

--- a/tests/test_algorithms_cpu.py
+++ b/tests/test_algorithms_cpu.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import unittest
-
+import pytest
 from areno.api.algorithms import AlgorithmSpec, get_algorithm, list_algorithms, register_algorithm
 from areno.api.loss_fns.gspo import gspo_loss_fn
 from areno.api.loss_fns.ppo import ppo_loss_fn
@@ -20,7 +20,14 @@ class AlgorithmRegistryTest(unittest.TestCase):
         self.assertEqual(set(algorithms), {"dpo", "grpo", "gspo", "ppo", "sft"})
         self.assertFalse(algorithms["sft"].requires_rollout)
         self.assertTrue(algorithms["gspo"].requires_rollout)
+        self.assertTrue(algorithms["grpo"].requires_rollout)
+        self.assertTrue(algorithms["ppo"].requires_rollout)
         self.assertIs(algorithms["ppo"].default_loss_fn, ppo_loss_fn)
+        self.assertFalse(algorithms["sft"].requires_reward)
+        self.assertFalse(algorithms["dpo"].requires_reward)
+        self.assertTrue(algorithms["gspo"].requires_reward)
+        self.assertTrue(algorithms["grpo"].requires_reward)
+        self.assertTrue(algorithms["ppo"].requires_reward)
 
     def test_unknown_algorithm_error_lists_registered_names(self):
         """Unknown names should fail with a useful registry-backed message."""
@@ -70,6 +77,27 @@ class AlgorithmRegistryTest(unittest.TestCase):
         self.assertEqual(trainer.dataset, ["row"])
         self.assertIs(trainer.loss_fn, dummy_loss)
 
+
+def test_reward_requirement_implies_rollout():
+    """Reward-scored algorithms cannot be declared as offline trainers."""
+
+    def dummy_loss(data_pack, logprobs):
+        return data_pack, logprobs
+
+    with pytest.raises(
+        ValueError,
+        match = "require reward must also require rollout",
+    ):
+        register_algorithm(
+            AlgorithmSpec(
+                name="unit_invalid_reward_algo",
+                trainer_cls=object,
+                default_loss_fn=dummy_loss,
+                requires_rollout=False,
+                requires_reward=True,
+                experimental=True,
+            )
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_algorithms_cpu.py
+++ b/tests/test_algorithms_cpu.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import functools
 import unittest
+
 import pytest
+
 from areno.api.algorithms import AlgorithmSpec, get_algorithm, list_algorithms, register_algorithm
 from areno.api.loss_fns.gspo import gspo_loss_fn
 from areno.api.loss_fns.ppo import ppo_loss_fn
@@ -86,7 +88,7 @@ def test_reward_requirement_implies_rollout():
 
     with pytest.raises(
         ValueError,
-        match = "require reward must also require rollout",
+        match="require reward must also require rollout",
     ):
         register_algorithm(
             AlgorithmSpec(
@@ -98,6 +100,7 @@ def test_reward_requirement_implies_rollout():
                 experimental=True,
             )
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -16,7 +16,7 @@ from areno.cli.train import (
     _format_training_config_summary,
     _trainer_config_from_options,
 )
-
+from areno.api.algorithms import AlgorithmSpec, register_algorithm
 
 def test_train_config_requires_ckpt():
     with pytest.raises(UsageError, match="--ckpt is required"):
@@ -42,7 +42,6 @@ def test_train_config_requires_reward_source_for_rollout_algorithms():
     with pytest.raises(UsageError, match="--reward-fn-path or --reward-ckpt is required"):
         _trainer_config_from_options(**_options(algo="gspo", reward_fn_path=None, reward_ckpt=None))
 
-
 def test_train_config_unknown_algorithm_message_lists_registered_algorithms():
     with pytest.raises(UsageError, match=r"unknown algorithm 'bogus'; registered: .*dpo.*gspo.*ppo.*sft"):
         _trainer_config_from_options(**_options(algo="bogus"))
@@ -52,6 +51,35 @@ def test_train_config_requires_world_size_divisible_by_tp_size():
     with pytest.raises(UsageError, match="--world-size must be divisible by --tp-size"):
         _trainer_config_from_options(**_options(algo="sft", world_size=3, tp_size=2))
 
+def test_rollout_algorithm_can_omit_reward_when_registry_allows_it():
+    class DummyTrainer:
+        pass
+
+    def dummy_loss(data_pack, logprobs):
+        return data_pack, logprobs
+
+    register_algorithm(
+        AlgorithmSpec(
+            name="unit_rollout_without_reward",
+            trainer_cls=DummyTrainer,
+            default_loss_fn=dummy_loss,
+            requires_rollout=True,
+            requires_reward=False,
+            experimental=True,
+        ),
+        replace=True,
+    )
+
+    cfg = _trainer_config_from_options(
+        **_options(
+            algo="unit_rollout_without_reward",
+            reward_fn_path=None,
+            reward_ckpt=None,
+        )
+    )
+
+    assert isinstance(cfg, PolicyTrainerConfig)
+    assert cfg.reward_fn_path is None
 
 @pytest.mark.parametrize(
     ("field", "value", "message"),
@@ -329,7 +357,10 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "optimizer                    lr=2e-06, min_lr=0.0, decay=cosine/100" in summary
     assert "metrics_log_dir  /tmp/metrics" in summary
     assert "WARNING: no checkpoint output path configured (--save-path)" in summary
-
+    assert "name              gspo" in summary
+    assert "default_loss      gspo_loss_fn" in summary
+    assert "requires_rollout  yes" in summary
+    assert "requires_reward   yes" in summary
 
 def test_training_config_summary_warns_about_native_attention_fallback(monkeypatch):
     cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None, world_size=1))
@@ -387,7 +418,10 @@ def test_training_config_summary_marks_non_rollout_fields_not_applicable():
     assert "n_samples            n/a" in summary
     assert "max_running_prompts  n/a" in summary
     assert "sampling             n/a" in summary
-
+    assert "name              sft" in summary
+    assert "requires_rollout  no" in summary
+    assert "requires_reward   no" in summary
+    assert "reward_fn       n/a" in summary
 
 def test_training_config_summary_handles_invalid_tp_size_defensively():
     cfg = TrainerConfig(algo="sft", ckpt="actor", dataset_path="dataset", tp_size=0, world_size=8)

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -7,6 +7,7 @@ import pytest
 from click import UsageError, unstyle
 from click.testing import CliRunner
 
+from areno.api.algorithms import AlgorithmSpec, register_algorithm
 from areno.api.trainer_config import DPOTrainerConfig, PolicyTrainerConfig, PPOTrainerConfig, TrainerConfig
 from areno.cli import train as train_cli
 from areno.cli.train import (
@@ -16,7 +17,7 @@ from areno.cli.train import (
     _format_training_config_summary,
     _trainer_config_from_options,
 )
-from areno.api.algorithms import AlgorithmSpec, register_algorithm
+
 
 def test_train_config_requires_ckpt():
     with pytest.raises(UsageError, match="--ckpt is required"):
@@ -42,6 +43,7 @@ def test_train_config_requires_reward_source_for_rollout_algorithms():
     with pytest.raises(UsageError, match="--reward-fn-path or --reward-ckpt is required"):
         _trainer_config_from_options(**_options(algo="gspo", reward_fn_path=None, reward_ckpt=None))
 
+
 def test_train_config_unknown_algorithm_message_lists_registered_algorithms():
     with pytest.raises(UsageError, match=r"unknown algorithm 'bogus'; registered: .*dpo.*gspo.*ppo.*sft"):
         _trainer_config_from_options(**_options(algo="bogus"))
@@ -50,6 +52,7 @@ def test_train_config_unknown_algorithm_message_lists_registered_algorithms():
 def test_train_config_requires_world_size_divisible_by_tp_size():
     with pytest.raises(UsageError, match="--world-size must be divisible by --tp-size"):
         _trainer_config_from_options(**_options(algo="sft", world_size=3, tp_size=2))
+
 
 def test_rollout_algorithm_can_omit_reward_when_registry_allows_it():
     class DummyTrainer:
@@ -80,6 +83,7 @@ def test_rollout_algorithm_can_omit_reward_when_registry_allows_it():
 
     assert isinstance(cfg, PolicyTrainerConfig)
     assert cfg.reward_fn_path is None
+
 
 @pytest.mark.parametrize(
     ("field", "value", "message"),
@@ -362,6 +366,7 @@ def test_training_config_summary_shows_resolved_values_and_warning():
     assert "requires_rollout  yes" in summary
     assert "requires_reward   yes" in summary
 
+
 def test_training_config_summary_warns_about_native_attention_fallback(monkeypatch):
     cfg = _trainer_config_from_options(**_options(algo="sft", reward_fn_path=None, reward_ckpt=None, world_size=1))
     monkeypatch.setattr(
@@ -422,6 +427,7 @@ def test_training_config_summary_marks_non_rollout_fields_not_applicable():
     assert "requires_rollout  no" in summary
     assert "requires_reward   no" in summary
     assert "reward_fn       n/a" in summary
+
 
 def test_training_config_summary_handles_invalid_tp_size_defensively():
     cfg = TrainerConfig(algo="sft", ckpt="actor", dataset_path="dataset", tp_size=0, world_size=8)


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>This PR separates an algorithm’s rollout requirement from its reward requirement.</p><p>Previously, the training CLI assumed that every algorithm with <code inline="">requires_rollout=True</code> must also provide either <code inline="">--reward-fn-path</code> or <code inline="">--reward-ckpt</code>. This assumption is valid for the existing GSPO, GRPO, and PPO workflows, but it prevents rollout-based algorithms that use other forms of supervision, such as On-Policy Distillation.</p><p>This PR adds an explicit <code inline="">requires_reward</code> capability to <code inline="">AlgorithmSpec</code>.</p><h2>Motivation</h2><p>Rollout and reward are related but distinct algorithm requirements.</p><p>For example:</p>
Algorithm | Requires rollout | Requires reward
-- | -- | --
SFT | No | No
DPO | No | No
GSPO | Yes | Yes
GRPO | Yes | Yes
PPO | Yes | Yes
OPD | Yes | No

<p>In OPD, the student generates on-policy responses, but supervision comes from token-level teacher scores rather than a scalar reward function or reward model.</p><p>Separating these capabilities allows AReno to support this workflow without weakening validation for existing reinforcement-learning algorithms.</p><h2>Changes</h2><ul><li><p>Add <code inline="">requires_reward</code> to <code inline="">AlgorithmSpec</code>.</p></li><li><p>Validate that an algorithm cannot require reward without also requiring rollout.</p></li><li><p>Preserve <code inline="">requires_reward</code> when algorithm names are normalized.</p></li><li><p>Mark GSPO, GRPO, and PPO as requiring reward.</p></li><li><p>Update CLI reward-source validation to use <code inline="">requires_reward</code> instead of <code inline="">requires_rollout</code>.</p></li><li><p>Display <code inline="">requires_reward</code> in the resolved training configuration summary.</p></li><li><p>Include the new capability in the algorithm inspection script.</p></li><li><p>Update contributor and architecture documentation.</p></li><li><p>Add tests for:</p><ul><li><p>built-in algorithm reward metadata;</p></li><li><p>invalid reward-without-rollout registrations;</p></li><li><p>rollout algorithms that do not require reward;</p></li><li><p>training configuration summary output;</p></li><li><p>preservation of existing GSPO reward validation.</p></li></ul></li></ul><h2>Behavior after this change</h2><p>Existing reward-based algorithms continue to require:</p><pre><code class="language-bash">--reward-fn-path
</code></pre><p>or:</p><pre><code class="language-bash">--reward-ckpt
</code></pre><p>However, a future algorithm may now declare:</p><pre><code class="language-python">AlgorithmSpec(
    name="opd",
    trainer_cls=OPDTrainer,
    default_loss_fn=opd_loss_fn,
    requires_rollout=True,
    requires_reward=False,
)
</code></pre><p>and use rollout configuration without being forced to provide an unrelated reward source.</p><h2>Testing</h2><pre><code class="language-bash">python -m pytest \
  tests/test_algorithms_cpu.py \
  tests/test_train_cli_config_cpu.py \
  -q
</code></pre><p>Result:</p><pre><code class="language-text">92 passed
</code></pre><p>The algorithm inspection script was also checked with:</p><pre><code class="language-bash">PYTHONPATH=. python \
  .agents/skills/areno-add-algorithm/scripts/inspect_algorithms.py
</code></pre><h2>Scope</h2><p>This PR does not add the OPD algorithm itself. It introduces the registry and CLI capability separation needed for OPD and other rollout-based algorithms that use non-reward supervision.</p></body></html>