### PR TITLE
docs: fix reward function API contract drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ ______________________________________________________________________
 
 **Loss functions** (`areno/api/loss_fns/`): `sft`, `dpo`, `gspo`, `grpo`, `ppo`, passed into `Trainer.train`.
 
-**Rewards**: plain Python files exposing `reward_fn(example, completions) -> list[float]`, injected via `--reward-fn-path`.
+**Rewards**: plain Python files exposing `reward_fn(record) -> float` over a `RewardRecord`, injected via `--reward-fn-path`.
 
 **Models** (`areno/models/`): per-family adapters with HF-compatible config and weights; each `<family>/` defines the model and checkpoint logic, registered through `areno/models/registry.py` (`register_adapter`, with `load_model_weights` / `save_model_weights` for weight I/O).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ link to a reference implementation if one exists. Then:
 - **Model families** are adapters under `areno/models/<family>/`, registered
   through `areno/models/registry.py` — no core changes needed.
 - **Reward functions** are plain Python files exposing
-  `reward_fn(example, completions) -> list[float]`, injected via `--reward-fn-path`
+  `reward_fn(record) -> float` over a `RewardRecord`, injected via `--reward-fn-path`
   (see `examples/math/math_verify_reward.py`).
 
 ## Do you want to add documentation?

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ from areno.api import (
     ArenoConfig,
     SamplingParams,
     Trainer,
+    RewardRecord,
     TrainSequence,
     gspo_loss_fn,
 )
@@ -125,8 +126,19 @@ async def main():
             )[0]
 
         # 3. Score with the same reward function the CLI uses, then form advantages
-        completions = [trainer.get_tokenizer().decode(seq.resp_tokens) for seq in rollout.sequences]
-        rewards = reward_fn(row, completions)
+        raw_answer = str(row["answer"])
+        final = raw_answer.rsplit("####", 1)[-1].strip()
+        rewards = [
+            reward_fn(
+                RewardRecord(
+                    prompt=prompt,
+                    completion=trainer.get_tokenizer().decode(seq.resp_tokens),
+                    answer=[final],
+                    source_record=dict(row),
+                )
+            )
+            for seq in rollout.sequences
+        ]
         advantages = to_advantages(rewards)
 
         batch = []

--- a/docs/concepts/reward-functions.rst
+++ b/docs/concepts/reward-functions.rst
@@ -1,27 +1,75 @@
 Reward functions
 ================
 
-Reward functions turn generated completions or trajectories into numeric scores.
-They are task-specific Python files loaded by AReno's training path and should
-be deterministic while you are debugging a run.
+Reward functions turn generated completions or trajectories into numeric
+scores. They are task-specific Python files loaded by AReno's training path
+and should be deterministic while you are debugging a run.
 
 The public shape is:
 
 .. code-block:: python
 
-   def reward_fn(example, completions) -> list[float]:
+   def reward_fn(record) -> float:
        ...
 
-The function receives the original example plus generated completions, then
-returns one score per completion. For agentic workflows, keep enough task state
-in the dataset row for the reward function to explain why a trajectory passed or
-failed.
+``record`` is a :doc:`RewardRecord </reference/reward-function-api>` and the
+function returns one scalar score for that one prompt/sample record. AReno
+calls ``reward_fn`` once per rollout sample, so there is no batching inside
+the reward function itself.
+
+Prompt RL
+---------
+
+For rollout algorithms such as GSPO, GRPO, and PPO, each generated completion
+becomes one record:
+
+* ``record.prompt`` is the rendered prompt string.
+* ``record.completion`` is the decoded completion text.
+* ``record.answer`` carries the ground truth when the dataset row provides
+  ``solutions``.
+* ``record.source_record`` is the full dataset row returned by your dataset
+  loader.
+
+The math demo verifies each completion against the stored solution; see
+``examples/math/math_verify_reward.py``.
+
+Agentic RL
+----------
+
+For agentic rollouts, the record additionally carries the multi-turn
+trajectory:
+
+* ``record.messages`` is the OpenAI-style message list, including tool
+  results.
+* ``record.trace`` is the normalized event list (assistant text, tool calls,
+  tool results, finish, errors).
+* ``record.tool_calls`` and ``record.tool_results`` summarize what the agent
+  invoked and what the environment answered.
+* ``record.rendered_completion`` renders the whole trajectory for display and
+  ``record.final_answer`` is the last assistant text.
+
+Keep enough task state in the dataset row for the reward function to explain
+why a trajectory passed or failed; it arrives intact as
+``record.source_record``. The tic-tac-toe demo scores the chosen tool call
+against the board stored in the row; see
+``examples/agentic/tictactoe/reward.py``.
+
+How dataset metadata reaches the reward
+---------------------------------------
+
+The dataset loader returns one record dict per row. AReno keeps that row on
+the rollout item and copies it into ``record.source_record`` when it builds
+the reward record. A ``solutions`` field also arrives as ``record.answer``.
+If the reward needs extra metadata, add it in the dataset loader record
+rather than through global state. See :doc:`/cli/dataset_loaders` for the
+loader contract.
 
 Practical rules
 ---------------
 
 * Keep parsing and scoring explicit.
-* Return one score for each completion.
+* Return one scalar for each call; never return a list.
+* Score empty or malformed completions as ``0.0`` instead of raising.
 * Avoid network calls in the hot path unless the task requires them.
 * Log enough context to debug wrong scores.
 

--- a/docs/reference/reward-function-api.rst
+++ b/docs/reference/reward-function-api.rst
@@ -7,21 +7,71 @@ Reward files should expose a callable named ``reward_fn``:
 
 .. code-block:: python
 
-   def reward_fn(example, completions) -> list[float]:
+   def reward_fn(record) -> float:
        ...
 
 Parameters:
 
-``example``
-   The source record returned by the dataset loader.
-
-``completions``
-   The generated completions to score.
+``record``
+   A :class:`RewardRecord` describing one prompt/sample rollout. Prompt RL
+   and agentic RL share this input type.
 
 Return value:
 
-``list[float]``
-   One reward score per completion.
+``float``
+   One scalar reward for this record. AReno calls ``reward_fn`` once per
+   rollout sample and collects the scalars itself.
+
+RewardRecord fields
+-------------------
+
+``prompt`` / ``completion``
+   The rendered prompt string and the decoded completion text. Always set.
+
+``rendered_completion`` / ``final_answer``
+   Display-oriented views of the output. For prompt RL they equal
+   ``completion``; for agentic rollouts ``rendered_completion`` renders the
+   whole message list and ``final_answer`` is the last assistant text.
+
+``answer``
+   Ground truth copied from the dataset row's ``solutions`` field when
+   present, else ``None``.
+
+``messages``
+   The OpenAI-style message list for agentic rollouts, including tool
+   results and the final assistant message. Empty for prompt RL.
+
+``trace``
+   Normalized trajectory events for agentic rollouts. Each event has a
+   ``type`` (``request``, ``assistant_text``, ``assistant_tool_call``,
+   ``tool_result``, ``finish``, ``error``) plus optional ``text``, ``name``,
+   ``arguments``, ``content``, ``messages``, and ``metadata``.
+
+``tool_calls`` / ``tool_results``
+   Parsed assistant tool calls and environment tool results extracted from
+   the agentic trajectory. Empty for prompt RL.
+
+``tokens`` / ``logprobs`` / ``loss_mask``
+   Token ids, rollout logprobs, and per-token loss-mask bits for the full
+   row. Prompt positions are masked out of the loss.
+
+``source_record``
+   The dataset row dict returned by your dataset loader, unchanged. Use it
+   to read task metadata such as boards, expected outputs, or difficulty.
+
+``metadata``
+   Extra trainer metadata such as ``prompt_index`` and ``sample_index``.
+
+Loading
+-------
+
+``--reward-fn-path`` loads the file with ``areno.api.rewards.load_reward_fn``
+and expects a module-level ``reward_fn`` callable taking exactly one
+positional argument. Startup validation fails fast with
+``<path> must define callable reward_fn(record)`` when the symbol is missing
+or not callable.
 
 Keep this API stable for task code. If the reward needs extra metadata, add it
-through the dataset loader record rather than through global state.
+through the dataset loader record (it arrives as ``record.source_record``)
+rather than through global state. See ``examples/math/math_verify_reward.py``
+and ``examples/agentic/tictactoe/reward.py`` for working reward files.

--- a/docs/troubleshooting/reward-function.rst
+++ b/docs/troubleshooting/reward-function.rst
@@ -8,8 +8,8 @@ before changing algorithms.
 
 Check:
 
-* The file passed to ``--reward-fn-path`` exports ``reward_fn``.
-* The reward list length matches the completions list length.
+* The file passed to ``--reward-fn-path`` exports ``reward_fn(record)``.
+* ``reward_fn`` takes one ``RewardRecord`` and returns one scalar float.
 * Parsing handles empty, malformed, or unexpected completions.
 * Scores match a hand-checked example.
 * Logged examples include enough context to explain wrong scores.


### PR DESCRIPTION
## Summary

Fixes #141.

Some documentation still described the reward contract as `reward_fn(example, completions) -> list[float]`, while the implementation loads `reward_fn(record) -> float` over a `RewardRecord` (`areno/api/rewards.py`). This PR retires the old batch shape everywhere and documents the current contract.

## Changes

- `docs/concepts/reward-functions.rst`: rewritten around `reward_fn(record) -> float`. Explains the prompt-RL record fields, the agentic-RL trajectory fields (`messages`, `trace`, `tool_calls`, `tool_results`, `rendered_completion`, `final_answer`), and how dataset-loader rows reach rewards via `source_record` / `solutions` -> `answer`. Points at the existing example reward files.
- `docs/reference/reward-function-api.rst`: documents the full `RewardRecord` field table, the scalar return contract, and the `--reward-fn-path` loading/validation behavior (`must define callable reward_fn(record)`).
- `docs/troubleshooting/reward-function.rst`: drops the batch-shape check ("reward list length matches the completions list length") in favor of the per-record contract.
- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`: replace remaining `reward_fn(example, completions) -> list[float]` references. The README SDK quickstart additionally called the example reward file with the old shape, which no longer matches `examples/math/math_verify_reward.py`; it now builds one `RewardRecord` per rollout sample, mirroring what the CLI trainer does. These three files are outside `docs/` but still presented the old shape as the current contract, so they are included to satisfy the acceptance criterion.

## Verification

- `grep` across docs, README, AGENTS.md, CONTRIBUTING.md, CODEMAP.md, and examples: no `reward_fn(example, completions)` references remain.
- `sphinx-build -b html -E docs` builds with zero warnings and no broken internal links.
- The rewritten README quickstart snippet passes Python syntax compilation.
- Docs-only change; no code or public API changes.
