### PR TITLE
refactor(trainers): share auxiliary-role lifecycle

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -40,6 +40,7 @@ backend-only view.
 
 - Algorithms: `AlgorithmSpec` and `register_algorithm` in
   `areno/api/algorithms.py`; concrete loops in `areno/api/trainers/`;
+  shared auxiliary-role lifecycle in `areno/api/trainers/role_aware.py`;
   construction in `areno/api/trainer_factory.py`.
 - Losses: `sft_loss_fn`, `dpo_loss_fn`, `gspo_loss_fn`, `grpo_loss_fn`, and
   `ppo_loss_fn` under `areno/api/loss_fns/`.

--- a/areno/api/roles.py
+++ b/areno/api/roles.py
@@ -1,10 +1,11 @@
-"""PPO role declarations used by the trainer/backend boundary.
+"""Model-role declarations used by the trainer/backend boundary.
 
-Algorithms like PPO need several model instances at once (actor/ref/reward/
-critic). The trainer names these roles and supplies checkpoint paths; the
-backend is responsible for actually loading them, deciding how to colocate or
-offload weights, and exposing the score/train operations. Keeping the role
-description as a small dataclass keeps the contract minimal.
+Role-aware algorithms may need several model instances at once, such as an
+actor, reference policy, teacher, reward model, or critic. The trainer names
+these roles and supplies checkpoint paths; the backend is responsible for
+actually loading them, deciding how to colocate or offload weights, and
+exposing the score/train operations. Keeping the role description as a small
+dataclass keeps the contract minimal.
 """
 
 from __future__ import annotations
@@ -14,10 +15,10 @@ from dataclasses import dataclass
 
 @dataclass(slots=True)
 class ModelRole:
-    """A PPO model role owned by the backend.
+    """A named model role owned by the backend.
 
     The public trainer names roles and checkpoints, but never calls
-    onload/offload. Backends decide how actor/ref/reward/critic are colocated
+    onload/offload. Backends decide how actor/ref/teacher/reward/critic are colocated
     and how memory is moved between role operations. `optimizer_lr` is only
     meaningful when `trainable=True`.
     """

--- a/areno/api/trainers/__init__.py
+++ b/areno/api/trainers/__init__.py
@@ -17,4 +17,11 @@ from areno.api.trainers.role_aware import (
 )
 from areno.api.trainers.sft import SFTTrainer
 
-__all__ = ["DPOTrainer", "PolicyOnlyTrainer", "PPOTrainer", "SFTTrainer",  "RoleAwarePolicyTrainer", "RoleAwareTrainerMixin",]
+__all__ = [
+    "DPOTrainer",
+    "PolicyOnlyTrainer",
+    "PPOTrainer",
+    "SFTTrainer",
+    "RoleAwarePolicyTrainer",
+    "RoleAwareTrainerMixin",
+]

--- a/areno/api/trainers/__init__.py
+++ b/areno/api/trainers/__init__.py
@@ -11,6 +11,10 @@ roles and GAE.
 from areno.api.trainers.dpo import DPOTrainer
 from areno.api.trainers.policy_only import PolicyOnlyTrainer
 from areno.api.trainers.ppo import PPOTrainer
+from areno.api.trainers.role_aware import (
+    RoleAwarePolicyTrainer,
+    RoleAwareTrainerMixin,
+)
 from areno.api.trainers.sft import SFTTrainer
 
-__all__ = ["DPOTrainer", "PolicyOnlyTrainer", "PPOTrainer", "SFTTrainer"]
+__all__ = ["DPOTrainer", "PolicyOnlyTrainer", "PPOTrainer", "SFTTrainer",  "RoleAwarePolicyTrainer", "RoleAwareTrainerMixin",]

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -22,8 +22,9 @@ import areno.api
 from areno.api.dashboard import record_dashboard_state
 from areno.api.data_utils import apply_chat_template, encode_prompt_value, response_to_tokens_and_mask
 from areno.api.roles import ModelRole
-from areno.api.trainers.role_aware import RoleAwareTrainerMixin
 from areno.api.tokenizer import configure_chat_template_enable_thinking
+from areno.api.trainers.role_aware import RoleAwareTrainerMixin
+
 
 class DPOTrainer(RoleAwareTrainerMixin):
     """Offline preference trainer using one frozen reference policy."""

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -22,10 +22,10 @@ import areno.api
 from areno.api.dashboard import record_dashboard_state
 from areno.api.data_utils import apply_chat_template, encode_prompt_value, response_to_tokens_and_mask
 from areno.api.roles import ModelRole
+from areno.api.trainers.role_aware import RoleAwareTrainerMixin
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 
-
-class DPOTrainer:
+class DPOTrainer(RoleAwareTrainerMixin):
     """Offline preference trainer using one frozen reference policy."""
 
     def __init__(self, config, *, instance, dataset, reward_fn, loss_fn):
@@ -47,21 +47,6 @@ class DPOTrainer:
             "ref": ModelRole("ref", config.ref_ckpt or config.ckpt, trainable=False),
         }
 
-    def fit(self) -> None:
-        self.areno.init()
-        self._ensure_roles()
-        try:
-            self._fit_initialized()
-        finally:
-            self.areno.close()
-
-    def _ensure_roles(self) -> None:
-        for role in self.roles.values():
-            self.logger.info("role=%s stage=init_start trainable=%s path=%s", role.name, role.trainable, role.path)
-        self.areno.ensure_roles(self.roles)
-        for role in self.roles.values():
-            self.logger.info("role=%s stage=init_end trainable=%s", role.name, role.trainable)
-
     def _fit_initialized(self) -> None:
         tokenizer = self.areno.get_tokenizer()
         configure_chat_template_enable_thinking(tokenizer, getattr(self.config, "chat_template_enable_thinking", None))
@@ -80,8 +65,9 @@ class DPOTrainer:
                 ref_start = time.perf_counter()
                 # Score the exact chosen/rejected token rows under the frozen
                 # reference before the actor update.
-                ref_logprob_rows = self.areno.score_logprobs(
-                    "ref", [seq.tokens for seq in train_batch], microbatch_size=self.config.score_micro_bs
+                ref_logprob_rows = self._score_logprobs(
+                    "ref",
+                    [seq.tokens for seq in train_batch],
                 )
                 ref_time_s = time.perf_counter() - ref_start
                 self.logger.info(
@@ -89,8 +75,6 @@ class DPOTrainer:
                 )
                 record_dashboard_state(self.areno, stage="logprob_score_end", epoch=epoch, step=step, role="ref")
                 for seq, ref_logprobs in zip(train_batch, ref_logprob_rows, strict=True):
-                    if len(ref_logprobs) != len(seq.tokens):
-                        raise ValueError("reference role returned misaligned logprobs")
                     # Reuse TrainSequence.ref_logprobs so the existing backend
                     # packer carries reference scores to dpo_loss_fn.
                     seq.ref_logprobs = [float(value) for value in ref_logprobs]

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -30,12 +30,11 @@ from areno.api.advantages import compute_gae
 from areno.api.dashboard import record_dashboard_state
 from areno.api.rewards import make_reward_record
 from areno.api.roles import MissingRoleCapability, ModelRole
-from areno.api.trainers.policy_only import PolicyOnlyTrainer
-
+from areno.api.trainers.role_aware import RoleAwarePolicyTrainer
 logger = logging.getLogger(__name__)
 
 
-class PPOTrainer(PolicyOnlyTrainer):
+class PPOTrainer(RoleAwarePolicyTrainer):
     """PPO trainer skeleton with role-owned memory choreography.
 
     PPO needs actor rollout, ref logprob scoring, reward scoring, critic value
@@ -413,34 +412,6 @@ class PPOTrainer(PolicyOnlyTrainer):
             self._last_ppo_stats.update(_summary_stats("normalized_advantage", normalized_advantages))
         self._record_ppo_state(stage="advantage_end", role="critic")
         return train_batch, rewards_all, rollout_logprobs
-
-    def _ensure_roles(self) -> None:
-        # Surfaces a structured log per role so initialisation order is easy
-        # to follow when something fails mid-load.
-        for role in self.roles.values():
-            self.logger.info(
-                "role=%s stage=init_start trainable=%s path=%s",
-                role.name,
-                role.trainable,
-                role.path,
-            )
-        self.areno.ensure_roles(self.roles)
-        for role in self.roles.values():
-            self.logger.info("role=%s stage=init_end trainable=%s", role.name, role.trainable)
-
-    def fit(self) -> None:
-        # Override the base `fit` so role initialisation happens after the
-        # backend is up but before the first rollout/train cycle.
-        self.areno.init()
-        self._ensure_roles()
-        try:
-            self._fit_initialized()
-        finally:
-            self.areno.close()
-
-    def _score_logprobs(self, role: str, token_rows: list[list[int]]) -> list[list[float]]:
-        return self.areno.score_logprobs(role, token_rows, microbatch_size=self.config.score_micro_bs)
-
     def _score_values(self, role: str, token_rows: list[list[int]]) -> list[list[float]]:
         return self.areno.score_values(role, token_rows)
 

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -31,6 +31,7 @@ from areno.api.dashboard import record_dashboard_state
 from areno.api.rewards import make_reward_record
 from areno.api.roles import MissingRoleCapability, ModelRole
 from areno.api.trainers.role_aware import RoleAwarePolicyTrainer
+
 logger = logging.getLogger(__name__)
 
 
@@ -412,6 +413,7 @@ class PPOTrainer(RoleAwarePolicyTrainer):
             self._last_ppo_stats.update(_summary_stats("normalized_advantage", normalized_advantages))
         self._record_ppo_state(stage="advantage_end", role="critic")
         return train_batch, rewards_all, rollout_logprobs
+
     def _score_values(self, role: str, token_rows: list[list[int]]) -> list[list[float]]:
         return self.areno.score_values(role, token_rows)
 

--- a/areno/api/trainers/role_aware.py
+++ b/areno/api/trainers/role_aware.py
@@ -1,0 +1,85 @@
+"""Shared lifecycle and scoring helpers for trainers with auxiliary model roles.
+
+Role-aware algorithms initialize backend-owned models before training, score
+exact token rows through those models, and leave placement/offload decisions to
+the backend. DPO uses this for its frozen reference policy; PPO uses it for its
+reference, critic, and optional reward roles. Online distillation algorithms can
+reuse the same boundary for a frozen teacher.
+"""
+
+from __future__ import annotations
+from areno.api.trainers.policy_only import PolicyOnlyTrainer
+class RoleAwareTrainerMixin:
+    """Provide role initialization and validated log-probability scoring.
+
+    Subclasses must define ``areno``, ``config``, ``logger``, ``roles``, and an
+    ``_fit_initialized()`` method. The mixin deliberately does not manage model
+    placement itself; ``ensure_roles`` and scoring stay behind the backend API.
+    """
+
+    def fit(self) -> None:
+        self.areno.init()
+        try:
+            self._ensure_roles()
+            self._fit_initialized()
+        finally:
+            self.areno.close()
+
+    def _ensure_roles(self) -> None:
+        for role in self.roles.values():
+            self.logger.info(
+                "role=%s stage=init_start trainable=%s path=%s",
+                role.name,
+                role.trainable,
+                role.path,
+            )
+
+        self.areno.ensure_roles(self.roles)
+
+        for role in self.roles.values():
+            self.logger.info(
+                "role=%s stage=init_end trainable=%s",
+                role.name,
+                role.trainable,
+            )
+
+    def _score_logprobs(
+        self,
+        role: str,
+        token_rows: list[list[int]],
+    ) -> list[list[float]]:
+        rows = self.areno.score_logprobs(
+            role,
+            token_rows,
+            microbatch_size=self.config.score_micro_bs,
+        )
+
+        if len(rows) != len(token_rows):
+            raise ValueError(
+                f"role {role!r} returned {len(rows)} logprob rows "
+                f"for {len(token_rows)} token rows"
+            )
+
+        for row_idx, (tokens, logprobs) in enumerate(
+            zip(token_rows, rows, strict=True)
+        ):
+            if len(logprobs) != len(tokens):
+                raise ValueError(
+                    f"role {role!r} returned {len(logprobs)} logprobs "
+                    f"for token row {row_idx} with {len(tokens)} tokens"
+                )
+
+        return rows
+
+
+class RoleAwarePolicyTrainer(
+    RoleAwareTrainerMixin,
+    PolicyOnlyTrainer,
+):
+    """Policy rollout loop with backend-owned auxiliary model roles."""
+
+
+__all__ = [
+    "RoleAwarePolicyTrainer",
+    "RoleAwareTrainerMixin",
+]

--- a/areno/api/trainers/role_aware.py
+++ b/areno/api/trainers/role_aware.py
@@ -8,7 +8,10 @@ reuse the same boundary for a frozen teacher.
 """
 
 from __future__ import annotations
+
 from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+
 class RoleAwareTrainerMixin:
     """Provide role initialization and validated log-probability scoring.
 
@@ -55,18 +58,12 @@ class RoleAwareTrainerMixin:
         )
 
         if len(rows) != len(token_rows):
-            raise ValueError(
-                f"role {role!r} returned {len(rows)} logprob rows "
-                f"for {len(token_rows)} token rows"
-            )
+            raise ValueError(f"role {role!r} returned {len(rows)} logprob rows for {len(token_rows)} token rows")
 
-        for row_idx, (tokens, logprobs) in enumerate(
-            zip(token_rows, rows, strict=True)
-        ):
+        for row_idx, (tokens, logprobs) in enumerate(zip(token_rows, rows, strict=True)):
             if len(logprobs) != len(tokens):
                 raise ValueError(
-                    f"role {role!r} returned {len(logprobs)} logprobs "
-                    f"for token row {row_idx} with {len(tokens)} tokens"
+                    f"role {role!r} returned {len(logprobs)} logprobs for token row {row_idx} with {len(tokens)} tokens"
                 )
 
         return rows

--- a/tests/test_role_aware_trainer_cpu.py
+++ b/tests/test_role_aware_trainer_cpu.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from areno.api.roles import ModelRole
+from areno.api.trainers.dpo import DPOTrainer
+from areno.api.trainers.ppo import PPOTrainer
+from areno.api.trainers.role_aware import (
+    RoleAwarePolicyTrainer,
+    RoleAwareTrainerMixin,
+)
+
+
+class _FakeAreno:
+    def __init__(
+        self,
+        *,
+        score_rows=None,
+        ensure_error: Exception | None = None,
+    ):
+        self.score_rows = [] if score_rows is None else score_rows
+        self.ensure_error = ensure_error
+        self.events = []
+        self.score_calls = []
+
+    def init(self):
+        self.events.append("init")
+
+    def ensure_roles(self, roles):
+        self.events.append(
+            ("ensure_roles", tuple(roles))
+        )
+
+        if self.ensure_error is not None:
+            raise self.ensure_error
+
+    def close(self):
+        self.events.append("close")
+
+    def score_logprobs(
+        self,
+        role,
+        token_rows,
+        *,
+        microbatch_size,
+    ):
+        self.score_calls.append(
+            (role, token_rows, microbatch_size)
+        )
+        return self.score_rows
+
+
+class _DummyRoleTrainer(RoleAwareTrainerMixin):
+    def __init__(self, areno):
+        self.areno = areno
+        self.config = SimpleNamespace(
+            score_micro_bs=3
+        )
+        self.logger = logging.getLogger(
+            "test.role_aware"
+        )
+        self.roles = {
+            "teacher": ModelRole(
+                "teacher",
+                "teacher-ckpt",
+                trainable=False,
+            )
+        }
+        self.initialized_fit_called = False
+
+    def _fit_initialized(self):
+        self.initialized_fit_called = True
+        self.areno.events.append(
+            "fit_initialized"
+        )
+
+
+def test_existing_role_trainers_use_shared_role_boundary():
+    assert issubclass(
+        DPOTrainer,
+        RoleAwareTrainerMixin,
+    )
+    assert issubclass(
+        PPOTrainer,
+        RoleAwarePolicyTrainer,
+    )
+
+
+def test_role_aware_fit_initializes_roles_before_training_and_closes():
+    areno = _FakeAreno()
+    trainer = _DummyRoleTrainer(areno)
+
+    trainer.fit()
+
+    assert trainer.initialized_fit_called
+    assert areno.events == [
+        "init",
+        ("ensure_roles", ("teacher",)),
+        "fit_initialized",
+        "close",
+    ]
+
+
+def test_role_aware_fit_closes_when_role_initialization_fails():
+    areno = _FakeAreno(
+        ensure_error=RuntimeError("load failed")
+    )
+    trainer = _DummyRoleTrainer(areno)
+
+    with pytest.raises(
+        RuntimeError,
+        match="load failed",
+    ):
+        trainer.fit()
+
+    assert areno.events == [
+        "init",
+        ("ensure_roles", ("teacher",)),
+        "close",
+    ]
+
+
+def test_role_logprob_scoring_forwards_microbatch_and_validates_alignment():
+    token_rows = [
+        [1, 2],
+        [3],
+    ]
+    areno = _FakeAreno(
+        score_rows=[
+            [-0.1, -0.2],
+            [-0.3],
+        ]
+    )
+    trainer = _DummyRoleTrainer(areno)
+
+    rows = trainer._score_logprobs(
+        "teacher",
+        token_rows,
+    )
+
+    assert rows == [
+        [-0.1, -0.2],
+        [-0.3],
+    ]
+    assert areno.score_calls == [
+        ("teacher", token_rows, 3)
+    ]
+
+
+def test_role_logprob_scoring_rejects_missing_rows():
+    trainer = _DummyRoleTrainer(
+        _FakeAreno(score_rows=[])
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "returned 0 logprob rows "
+            "for 1 token rows"
+        ),
+    ):
+        trainer._score_logprobs(
+            "teacher",
+            [[1]],
+        )
+
+
+def test_role_logprob_scoring_rejects_misaligned_token_scores():
+    trainer = _DummyRoleTrainer(
+        _FakeAreno(
+            score_rows=[[-0.1]]
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "returned 1 logprobs for token row 0 "
+            "with 2 tokens"
+        ),
+    ):
+        trainer._score_logprobs(
+            "teacher",
+            [[1, 2]],
+        )

--- a/tests/test_role_aware_trainer_cpu.py
+++ b/tests/test_role_aware_trainer_cpu.py
@@ -30,9 +30,7 @@ class _FakeAreno:
         self.events.append("init")
 
     def ensure_roles(self, roles):
-        self.events.append(
-            ("ensure_roles", tuple(roles))
-        )
+        self.events.append(("ensure_roles", tuple(roles)))
 
         if self.ensure_error is not None:
             raise self.ensure_error
@@ -47,21 +45,15 @@ class _FakeAreno:
         *,
         microbatch_size,
     ):
-        self.score_calls.append(
-            (role, token_rows, microbatch_size)
-        )
+        self.score_calls.append((role, token_rows, microbatch_size))
         return self.score_rows
 
 
 class _DummyRoleTrainer(RoleAwareTrainerMixin):
     def __init__(self, areno):
         self.areno = areno
-        self.config = SimpleNamespace(
-            score_micro_bs=3
-        )
-        self.logger = logging.getLogger(
-            "test.role_aware"
-        )
+        self.config = SimpleNamespace(score_micro_bs=3)
+        self.logger = logging.getLogger("test.role_aware")
         self.roles = {
             "teacher": ModelRole(
                 "teacher",
@@ -73,9 +65,7 @@ class _DummyRoleTrainer(RoleAwareTrainerMixin):
 
     def _fit_initialized(self):
         self.initialized_fit_called = True
-        self.areno.events.append(
-            "fit_initialized"
-        )
+        self.areno.events.append("fit_initialized")
 
 
 def test_existing_role_trainers_use_shared_role_boundary():
@@ -105,9 +95,7 @@ def test_role_aware_fit_initializes_roles_before_training_and_closes():
 
 
 def test_role_aware_fit_closes_when_role_initialization_fails():
-    areno = _FakeAreno(
-        ensure_error=RuntimeError("load failed")
-    )
+    areno = _FakeAreno(ensure_error=RuntimeError("load failed"))
     trainer = _DummyRoleTrainer(areno)
 
     with pytest.raises(
@@ -145,22 +133,15 @@ def test_role_logprob_scoring_forwards_microbatch_and_validates_alignment():
         [-0.1, -0.2],
         [-0.3],
     ]
-    assert areno.score_calls == [
-        ("teacher", token_rows, 3)
-    ]
+    assert areno.score_calls == [("teacher", token_rows, 3)]
 
 
 def test_role_logprob_scoring_rejects_missing_rows():
-    trainer = _DummyRoleTrainer(
-        _FakeAreno(score_rows=[])
-    )
+    trainer = _DummyRoleTrainer(_FakeAreno(score_rows=[]))
 
     with pytest.raises(
         ValueError,
-        match=(
-            "returned 0 logprob rows "
-            "for 1 token rows"
-        ),
+        match=("returned 0 logprob rows for 1 token rows"),
     ):
         trainer._score_logprobs(
             "teacher",
@@ -169,18 +150,11 @@ def test_role_logprob_scoring_rejects_missing_rows():
 
 
 def test_role_logprob_scoring_rejects_misaligned_token_scores():
-    trainer = _DummyRoleTrainer(
-        _FakeAreno(
-            score_rows=[[-0.1]]
-        )
-    )
+    trainer = _DummyRoleTrainer(_FakeAreno(score_rows=[[-0.1]]))
 
     with pytest.raises(
         ValueError,
-        match=(
-            "returned 1 logprobs for token row 0 "
-            "with 2 tokens"
-        ),
+        match=("returned 1 logprobs for token row 0 with 2 tokens"),
     ):
         trainer._score_logprobs(
             "teacher",


### PR DESCRIPTION
## Summary

This PR extracts the auxiliary model-role lifecycle shared by DPO and PPO into reusable role-aware trainer classes.

The new `RoleAwareTrainerMixin` centralizes:

* backend initialization and cleanup;
* model-role initialization through `ensure_roles`;
* role-based log-probability scoring;
* validation that returned log-probabilities align with the input token rows.

`RoleAwarePolicyTrainer` combines this shared role handling with `PolicyOnlyTrainer`, allowing rollout-based algorithms to reuse the same infrastructure.

DPO now inherits the generic role-aware mixin for its frozen reference model, while PPO inherits the role-aware policy trainer for its actor, reference, critic, and reward roles. Their existing training behavior is unchanged.

This refactor also provides a reusable foundation for future teacher-scored workflows such as OPD, where a trainable student performs rollouts and a frozen teacher scores the generated tokens.

## Testing

Added CPU tests covering:

* DPO and PPO inheritance from the shared role-aware classes;
* role initialization order;
* backend cleanup when role initialization fails;
* forwarding of scoring microbatch configuration;
* validation of missing or misaligned log-probability rows.
