### PR TITLE
add IPO preference optimization

### DIFF
--- a/areno/api/__init__.py
+++ b/areno/api/__init__.py
@@ -18,7 +18,7 @@ from areno.api.agentic import (
 from areno.api.algorithms import AlgorithmSpec, get_algorithm, list_algorithms, register_algorithm
 from areno.api.config import ArenoConfig
 from areno.api.data import PromptBatch, PromptItem
-from areno.api.loss_fns import dpo_loss_fn, grpo_loss_fn, gspo_loss_fn, ppo_loss_fn, sft_loss_fn
+from areno.api.loss_fns import dpo_loss_fn, grpo_loss_fn, gspo_loss_fn, ipo_loss_fn, ppo_loss_fn, sft_loss_fn
 from areno.api.models import (
     BackendType,
     RolloutResult,
@@ -59,6 +59,7 @@ __all__ = [
     "list_algorithms",
     "register_algorithm",
     "dpo_loss_fn",
+    "ipo_loss_fn",
     "gspo_loss_fn",
     "grpo_loss_fn",
     "ppo_loss_fn",

--- a/areno/api/algorithms.py
+++ b/areno/api/algorithms.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
-from areno.api.loss_fns import dpo_loss_fn, grpo_loss_fn, gspo_loss_fn, ppo_loss_fn, sft_loss_fn
+from areno.api.loss_fns import dpo_loss_fn, grpo_loss_fn, gspo_loss_fn, ipo_loss_fn, ppo_loss_fn, sft_loss_fn
 from areno.api.trainer_config import TrainerConfig
 
 
@@ -139,6 +139,30 @@ def _load_ppo_trainer() -> type:
     return PPOTrainer
 
 
+def _bind_dpo_loss(
+    config: TrainerConfig,
+    loss_fn: Callable,
+) -> Callable:
+    from functools import partial
+
+    return partial(
+        loss_fn,
+        beta=getattr(config, "dpo_beta"),
+    )
+
+
+def _bind_ipo_loss(
+    config: TrainerConfig,
+    loss_fn: Callable,
+) -> Callable:
+    from functools import partial
+
+    return partial(
+        loss_fn,
+        beta=getattr(config, "ipo_beta"),
+    )
+
+
 def _bind_gspo_loss(config: TrainerConfig, loss_fn: Callable) -> Callable:
     from functools import partial
 
@@ -166,6 +190,16 @@ def _register_builtin_algorithms() -> None:
             trainer_cls=_load_dpo_trainer,
             default_loss_fn=dpo_loss_fn,
             requires_rollout=False,
+            loss_fn_factory=_bind_dpo_loss,
+        )
+    )
+    register_algorithm(
+        AlgorithmSpec(
+            name="ipo",
+            trainer_cls=_load_dpo_trainer,
+            default_loss_fn=ipo_loss_fn,
+            requires_rollout=False,
+            loss_fn_factory=_bind_ipo_loss,
         )
     )
     register_algorithm(

--- a/areno/api/loss_fns/__init__.py
+++ b/areno/api/loss_fns/__init__.py
@@ -1,7 +1,8 @@
 """Loss functions consumed by `Trainer.train`.
 
-Five flavours are bundled:
+Six flavours are bundled:
     dpo_loss_fn  - pairwise preference loss over chosen/rejected rows.
+    ipo_loss_fn  - squared preference-margin regression over chosen/rejected rows.
     grpo_loss_fn - PPO-style clipping applied per response token (GRPO).
     gspo_loss_fn - sequence-level clipping using a length-averaged log ratio.
     ppo_loss_fn  - clipped actor loss with optional KL penalty, matching the
@@ -14,7 +15,8 @@ swap algorithms without re-shaping its data path.
 from areno.api.loss_fns.dpo import dpo_loss_fn
 from areno.api.loss_fns.grpo import grpo_loss_fn
 from areno.api.loss_fns.gspo import gspo_loss_fn
+from areno.api.loss_fns.ipo import ipo_loss_fn
 from areno.api.loss_fns.ppo import ppo_loss_fn
 from areno.api.loss_fns.sft import sft_loss_fn
 
-__all__ = ["dpo_loss_fn", "grpo_loss_fn", "gspo_loss_fn", "ppo_loss_fn", "sft_loss_fn"]
+__all__ = ["dpo_loss_fn", "ipo_loss_fn", "grpo_loss_fn", "gspo_loss_fn", "ppo_loss_fn", "sft_loss_fn"]

--- a/areno/api/loss_fns/ipo.py
+++ b/areno/api/loss_fns/ipo.py
@@ -1,0 +1,98 @@
+"""Identity Preference Optimization loss over chosen/rejected pairs.
+
+IPO uses the same offline preference-pair layout as DPO: every chosen response
+is immediately followed by its rejected response. The backend computes
+current-policy next-token logprobs, while the trainer pre-fills `ref_logprobs`
+with scores from a frozen reference policy.
+
+This implementation follows the sampled sequence-level IPO objective from
+Eq. 17 of the IPO paper. Response-token logprobs are summed per sequence, and
+the policy-vs-reference preference margin is regressed toward 1 / (2 * beta).
+Here `beta` corresponds to the regularization parameter denoted by tau in the
+paper.
+"""
+
+from __future__ import annotations
+
+from areno.api.loss_fns.layout import response_layout, sequence_sum
+
+
+def ipo_loss_fn(data_pack, logprobs, *, beta: float = 0.1):
+    """IPO pairwise loss using sequence-summed log-probabilities.
+
+    Assumes row order is `[chosen_0, rejected_0, chosen_1, rejected_1, ...]`.
+    `mini_bs` must therefore be even so the backend never splits a pair across
+    microbatches.
+    """
+
+    beta = float(beta)
+    if beta <= 0:
+        raise ValueError("IPO beta must be positive")
+
+    layout = response_layout(
+        data_pack,
+        logprobs,
+        need_ref_logprobs=True,
+        need_sequences=True,
+    )
+
+    num_sequences = (
+        int(layout.num_sequences)
+        if layout.packed
+        else int(logprobs.shape[0])
+    )
+    if num_sequences % 2 != 0:
+        raise ValueError(
+            "IPO requires an even number of sequences per microbatch"
+        )
+
+    ref_logprobs = layout.ref_logprobs.to(dtype=logprobs.dtype)
+
+    # IPO Eq. 17 operates on sequence log-probabilities. We therefore sum
+    # response-token logprobs exactly as the existing DPO loss does.
+    policy_seq_logps = sequence_sum(logprobs, layout)
+    ref_seq_logps = sequence_sum(ref_logprobs, layout)
+
+    response_lens = layout.response_len.to(dtype=logprobs.dtype)
+
+    return _ipo_from_sequence_logps(
+        policy_seq_logps,
+        ref_seq_logps,
+        response_lens,
+        beta,
+    )
+
+
+def _ipo_from_sequence_logps(
+    policy_seq_logps,
+    ref_seq_logps,
+    response_lens,
+    beta: float,
+):
+    chosen_policy = policy_seq_logps[0::2]
+    rejected_policy = policy_seq_logps[1::2]
+    chosen_ref = ref_seq_logps[0::2]
+    rejected_ref = ref_seq_logps[1::2]
+
+    # Difference between the chosen-vs-rejected preference of the current
+    # policy and the same preference under the frozen reference policy.
+    policy_logratios = chosen_policy - rejected_policy
+    ref_logratios = chosen_ref - rejected_ref
+    delta = policy_logratios - ref_logratios
+
+    # Sampled IPO objective (Eq. 17). `beta` here is tau in the paper.
+    target = 1.0 / (2.0 * float(beta))
+    target_error = delta - target
+    losses = target_error.square()
+    loss = losses.mean()
+
+    return loss, {
+        "ipo_loss": loss.detach(),
+        "total_loss": loss.detach(),
+        "ipo_delta": delta.mean().detach(),
+        "ipo_target_error": target_error.abs().mean().detach(),
+        "ipo_response_len": response_lens.clamp(min=1).mean().detach(),
+    }
+
+
+__all__ = ["ipo_loss_fn"]

--- a/areno/api/loss_fns/ipo.py
+++ b/areno/api/loss_fns/ipo.py
@@ -36,15 +36,9 @@ def ipo_loss_fn(data_pack, logprobs, *, beta: float = 0.1):
         need_sequences=True,
     )
 
-    num_sequences = (
-        int(layout.num_sequences)
-        if layout.packed
-        else int(logprobs.shape[0])
-    )
+    num_sequences = int(layout.num_sequences) if layout.packed else int(logprobs.shape[0])
     if num_sequences % 2 != 0:
-        raise ValueError(
-            "IPO requires an even number of sequences per microbatch"
-        )
+        raise ValueError("IPO requires an even number of sequences per microbatch")
 
     ref_logprobs = layout.ref_logprobs.to(dtype=logprobs.dtype)
 

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -170,6 +170,19 @@ class DPOTrainerConfig(TrainerConfig):
 
 
 @dataclass(slots=True)
+class IPOTrainerConfig(TrainerConfig):
+    """IPO role configuration.
+
+    IPO uses offline chosen/rejected preference pairs plus one frozen reference
+    policy. `ipo_beta` is the regularization parameter denoted by tau in the
+    IPO paper and sets the sampled-loss target to 1 / (2 * ipo_beta).
+    """
+
+    ref_ckpt: str | None = None
+    ipo_beta: float = 0.1
+
+
+@dataclass(slots=True)
 class PPOTrainerConfig(PolicyTrainerConfig):
     """PPO role configuration.
 

--- a/areno/api/trainers/dpo.py
+++ b/areno/api/trainers/dpo.py
@@ -1,20 +1,19 @@
-"""Direct Preference Optimization trainer.
+"""Offline pairwise preference trainer used by DPO and IPO.
 
-DPO consumes offline preference pairs instead of sampling rollouts:
-    1. Convert each dataset row into a chosen/rejected token pair.
-    2. Score both rows with a frozen reference policy role.
-    3. Train the policy with `dpo_loss_fn`, which compares chosen-vs-rejected
-       sequence logprob margins against the reference margins.
+The trainer consumes offline preference pairs instead of sampling rollouts:
 
-Rows are handed to the backend as consecutive `[chosen, rejected]` pairs so the
-loss can stay backend-agnostic and recover pairs from row order.
+1. Convert each dataset row into a chosen/rejected token pair.
+2. Score both rows with a frozen reference policy role.
+3. Train the policy with the algorithm-selected pairwise preference loss.
+
+Rows are handed to the backend as consecutive `[chosen, rejected]` pairs so
+the selected loss can recover pairs from row order.
 """
 
 from __future__ import annotations
 
 import logging
 import time
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -33,13 +32,16 @@ class DPOTrainer:
         # Each DPO pair is represented as two adjacent rows. Keeping microbatch
         # size even prevents the backend from splitting chosen/rejected rows.
         if int(config.mini_bs) % 2 != 0:
-            raise ValueError("DPO requires --mini-bs to be even so chosen/rejected pairs stay together")
+            raise ValueError(
+                f"{str(config.algo).upper()} requires --mini-bs to be even so chosen/rejected pairs stay together"
+            )
         self.config = config
         self.areno = instance
         self.dataset = dataset
-        # DPO beta is an algorithm hyperparameter, so bind it once here and
-        # leave the backend-facing loss signature as loss_fn(data_pack, logprobs).
-        self.loss_fn = partial(loss_fn, beta=config.dpo_beta)
+        # Algorithm-specific loss parameters are bound by AlgorithmSpec before the
+        # trainer is constructed. The trainer only needs the common backend-facing
+        # loss signature: loss_fn(data_pack, logprobs).
+        self.loss_fn = loss_fn
         self.logger = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
         self.roles = {
             # DPO only needs a frozen reference policy; no rollout, reward, or
@@ -166,7 +168,7 @@ def _record_to_train_pair(record: Any, tokenizer, *, max_seq_len: int):
     record = dict(record)
     eos_token_id = tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 0
     if "chosen" not in record or "rejected" not in record:
-        raise ValueError("DPO dataset row must contain `chosen` and `rejected`")
+        raise ValueError("preference dataset row must contain `chosen` and `rejected`")
     chosen, rejected = record["chosen"], record["rejected"]
 
     if isinstance(chosen, list) and isinstance(rejected, list):
@@ -182,7 +184,7 @@ def _record_to_train_pair(record: Any, tokenizer, *, max_seq_len: int):
         # Prompt/response preference rows share one encoded prompt and differ
         # only in the chosen/rejected response suffix.
         if "prompt" not in record:
-            raise ValueError("DPO prompt/response rows must contain `prompt`")
+            raise ValueError("preference prompt/response rows must contain `prompt`")
         prompt = record["prompt"]
         prompt_ids = encode_prompt_value(tokenizer, prompt)
         chosen_tokens, chosen_mask = response_to_tokens_and_mask(prompt_ids, str(chosen), tokenizer, eos_token_id)

--- a/areno/cli/model_refs.py
+++ b/areno/cli/model_refs.py
@@ -48,7 +48,7 @@ def resolve_model_refs_for_config(config: ConfigT) -> ConfigT:
     model_hub = str(getattr(config, "model_hub", "modelscope"))
     config.ckpt = resolve_model_ref(config.ckpt, cache, model_hub=model_hub)
     algo = str(getattr(config, "algo", "")).lower()
-    if algo == "dpo" and getattr(config, "ref_ckpt", None) is not None:
+    if algo in {"dpo", "ipo"} and getattr(config, "ref_ckpt", None) is not None:
         config.ref_ckpt = resolve_model_ref(config.ref_ckpt, cache, model_hub=model_hub)
     if algo == "ppo":
         if getattr(config, "ref_ckpt", None) is not None:

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -27,6 +27,7 @@ from areno.api.algorithms import get_algorithm
 from areno.api.defaults import DEFAULT_METRICS_LOG_DIR
 from areno.api.trainer_config import (
     DPOTrainerConfig,
+    IPOTrainerConfig,
     PolicyTrainerConfig,
     PPOTrainerConfig,
     RolloutTrainerConfig,
@@ -121,6 +122,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "gspo_clip_eps",
             "grpo_clip_eps",
             "dpo_beta",
+            "ipo_beta",
             "use_kl_loss",
             "kl_loss_coef",
             "kl_loss_type",
@@ -291,6 +293,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         _require_positive_float(args.grpo_clip_eps, "--grpo-clip-eps")
     if algorithm.name == "dpo":
         _require_positive_float(args.dpo_beta, "--dpo-beta")
+    if algorithm.name == "ipo":
+        _require_positive_float(args.ipo_beta, "--ipo-beta")
     if algorithm.name == "ppo":
         _require_positive_float(args.critic_lr, "--critic-lr")
         _require_positive_float(args.kl_loss_coef, "--kl-loss-coef")
@@ -732,6 +736,48 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             ref_ckpt=args.ref_ckpt,
             dpo_beta=args.dpo_beta,
         )
+    if algorithm.name == "ipo":
+        return IPOTrainerConfig(
+            algo=algorithm.name,
+            ckpt=args.ckpt,
+            dataset_path=args.dataset_path,
+            model_hub=args.model_hub,
+            dataset_loader_fn=args.dataset_loader_fn,
+            save_path=args.save_path,
+            save_interval=args.save_interval,
+            epochs=args.epochs,
+            max_steps=args.max_steps,
+            tp_size=args.tp_size,
+            world_size=args.world_size,
+            train_devices=args.train_devices,
+            batch_size=args.batch_size,
+            mini_bs=args.mini_bs,
+            score_micro_bs=args.score_micro_bs,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            max_prompt_tokens=args.max_prompt_tokens,
+            max_new_tokens=args.max_new_tokens,
+            max_context_len=args.max_context_len,
+            optimizer_lr=args.lr,
+            optimizer_min_lr=args.min_lr,
+            lr_decay_steps=args.lr_decay_steps,
+            lr_decay_style=args.lr_decay_style,
+            optimizer_beta1=args.adam_beta1,
+            optimizer_beta2=args.adam_beta2,
+            weight_decay=args.weight_decay,
+            grad_clip_norm=args.grad_clip_norm,
+            adam_8bit=args.adam_8bit,
+            activation_checkpointing=args.activation_checkpointing,
+            keep_rollout_state=not args.drop_rollout_state,
+            eager_decode=args.eager_decode,
+            attn_backend=args.attn_backend,
+            metrics_log_dir=args.metrics_log_dir,
+            agent_fn=args.agent_fn,
+            agent_timeout_s=args.agent_timeout_s,
+            train_tool_results=args.train_tool_results,
+            chat_template_enable_thinking=chat_template_enable_thinking,
+            ref_ckpt=args.ref_ckpt,
+            ipo_beta=args.ipo_beta,
+        )
     if algorithm.name == "sft":
         return TrainerConfig(
             algo=algorithm.name,
@@ -1039,6 +1085,7 @@ def _training_config_settings(config: TrainerConfig) -> dict:
                 "gspo_clip_eps",
                 "grpo_clip_eps",
                 "dpo_beta",
+                "ipo_beta",
                 "kl_coef",
                 "use_kl_loss",
                 "kl_loss_coef",
@@ -1261,7 +1308,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     cls=GroupedOptionsCommand,
     option_groups=TRAIN_OPTION_GROUPS,
     context_settings={"help_option_names": ["-h", "--help"]},
-    help="Run SFT, DPO, GSPO, GRPO, or PPO training with the areno backend.",
+    help="Run SFT, DPO, IPO, GSPO, GRPO, or PPO training with the areno backend.",
 )
 @click.option("--algo", type=str, default="gspo", show_default=True, help="Training algorithm registered in areno.api.")
 @click.option("--ckpt", default=None, help="Actor model/tokenizer checkpoint path or remote model repo ID.")
@@ -1280,7 +1327,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option("--reward-fn-path", default=None, help="Python file defining reward_fn(record).")
 @click.option(
-    "--ref-ckpt", default=None, help="Optional PPO/DPO reference model checkpoint path or remote model repo ID."
+    "--ref-ckpt", default=None, help="Optional PPO/DPO/IPO reference model checkpoint path or remote model repo ID."
 )
 @click.option("--reward-ckpt", default=None, help="Optional PPO reward model checkpoint path or remote model repo ID.")
 @click.option("--critic-ckpt", default=None, help="Optional PPO critic model checkpoint path or remote model repo ID.")
@@ -1439,6 +1486,13 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
 )
 @click.option("--grpo-clip-eps", type=float, default=0.2, show_default=True, help="GRPO token-ratio clipping epsilon.")
 @click.option("--dpo-beta", type=float, default=0.1, show_default=True, help="DPO preference margin temperature.")
+@click.option(
+    "--ipo-beta",
+    type=float,
+    default=0.1,
+    show_default=True,
+    help="IPO regularization parameter (tau in the paper); target = 1 / (2 * beta).",
+)
 @click.option(
     "--critic-warmup-steps",
     type=int,

--- a/docs/cli/dataset_loaders.rst
+++ b/docs/cli/dataset_loaders.rst
@@ -43,10 +43,10 @@ SFT always requires ``--dataset-loader-fn``. The loader must return rows with
 For a concrete example, use ``--dataset-path yahma/alpaca-cleaned`` with
 ``examples/sft/alpaca/dataset_loader.py``.
 
-DPO
----
+DPO and IPO
+-----------
 
-DPO loaders should return ``prompt``, ``chosen``, and ``rejected``. ``prompt``
+DPO and IPO loaders should return ``prompt``, ``chosen``, and ``rejected``. ``prompt``
 is the shared context, ``chosen`` is the preferred answer, and ``rejected`` is
 the lower-ranked answer.
 

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -5,7 +5,7 @@ Training CLI reference
 
 ``areno train``
 
-Run SFT, DPO, GSPO, GRPO, or PPO training with the local Areno backend. The
+Run SFT, DPO, IPO, GSPO, GRPO, or PPO training with the local Areno backend. The
 command owns the full loop: dataset loading, optional normalization, rollout,
 reward scoring, loss computation, optimizer steps, metrics, and checkpoint
 saving.
@@ -70,7 +70,7 @@ per-algorithm loader contracts.
 ``--algo TEXT``
    Training algorithm registered in ``areno.api``. Default: ``gspo``.
 
-Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
+Built-in algorithms: ``sft``, ``dpo``, ``ipo``, ``gspo``, ``grpo``, ``ppo``.
 
 ``--epochs INTEGER``
    Number of dataset epochs to train. Default: ``10``.
@@ -341,7 +341,7 @@ in its description; flags for other algorithms are ignored.
    Policy gradient clipping norm. Default: ``1.0``.
 
 ``--ref-ckpt TEXT``
-   Optional PPO/DPO reference model checkpoint path or remote model repo ID.
+   Optional PPO/DPO/IPO reference model checkpoint path or remote model repo ID.
 
 ``--critic-ckpt TEXT``
    Optional PPO critic model checkpoint path or remote model repo ID.
@@ -360,6 +360,11 @@ in its description; flags for other algorithms are ignored.
 
 ``--dpo-beta FLOAT``
    DPO preference margin temperature. Default: ``0.1``.
+
+``--ipo-beta FLOAT``
+   IPO regularization parameter, corresponding to tau in the IPO paper.
+   The sampled sequence-level loss target is ``1 / (2 * beta)``.
+   Default: ``0.1``.
 
 ``--use-kl-loss / --no-use-kl-loss``
    Enable PPO actor KL loss. Default: enabled.
@@ -480,6 +485,21 @@ DPO preference training
 
 The DPO loader should normalize each row to ``prompt``, ``chosen``, and
 ``rejected``.
+
+IPO preference training
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt /path/to/policy \
+     --ref-ckpt /path/to/reference \
+     --dataset-path /path/to/preferences.jsonl \
+     --dataset-loader-fn /path/to/preference_dataset_loader.py \
+     --algo ipo \
+     --ipo-beta 0.1 \
+     --tp-size 1 \
+     --world-size 1
 
 PPO with reward and critic roles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_algorithms_cpu.py
+++ b/tests/test_algorithms_cpu.py
@@ -4,9 +4,10 @@ import functools
 import unittest
 
 from areno.api.algorithms import AlgorithmSpec, get_algorithm, list_algorithms, register_algorithm
+from areno.api.loss_fns import dpo_loss_fn, ipo_loss_fn
 from areno.api.loss_fns.gspo import gspo_loss_fn
 from areno.api.loss_fns.ppo import ppo_loss_fn
-from areno.api.trainer_config import PolicyTrainerConfig, TrainerConfig
+from areno.api.trainer_config import DPOTrainerConfig, IPOTrainerConfig, PolicyTrainerConfig, TrainerConfig
 from areno.api.trainer_factory import build_trainer
 
 
@@ -17,7 +18,9 @@ class AlgorithmRegistryTest(unittest.TestCase):
         """Built-ins should expose rollout and role requirements in one place."""
         algorithms = list_algorithms(include_experimental=False)
 
-        self.assertEqual(set(algorithms), {"dpo", "grpo", "gspo", "ppo", "sft"})
+        self.assertEqual(set(algorithms), {"dpo", "ipo", "grpo", "gspo", "ppo", "sft"})
+        self.assertFalse(algorithms["ipo"].requires_rollout)
+        self.assertIs(algorithms["ipo"].default_loss_fn, ipo_loss_fn)
         self.assertFalse(algorithms["sft"].requires_rollout)
         self.assertTrue(algorithms["gspo"].requires_rollout)
         self.assertIs(algorithms["ppo"].default_loss_fn, ppo_loss_fn)
@@ -26,6 +29,40 @@ class AlgorithmRegistryTest(unittest.TestCase):
         """Unknown names should fail with a useful registry-backed message."""
         with self.assertRaisesRegex(ValueError, "registered: .*gspo.*ppo"):
             get_algorithm("not_an_algorithm")
+
+    def test_registered_dpo_loss_binds_beta(self):
+        config = DPOTrainerConfig(
+            algo="dpo",
+            ckpt="unused",
+            dataset_path="unused",
+            dpo_beta=0.25,
+        )
+
+        loss_fn = get_algorithm("dpo").make_loss_fn(config)
+
+        self.assertIsInstance(loss_fn, functools.partial)
+        self.assertIs(loss_fn.func, dpo_loss_fn)
+        self.assertEqual(
+            loss_fn.keywords,
+            {"beta": 0.25},
+        )
+
+    def test_registered_ipo_loss_binds_beta(self):
+        config = IPOTrainerConfig(
+            algo="ipo",
+            ckpt="unused",
+            dataset_path="unused",
+            ipo_beta=0.2,
+        )
+
+        loss_fn = get_algorithm("ipo").make_loss_fn(config)
+
+        self.assertIsInstance(loss_fn, functools.partial)
+        self.assertIs(loss_fn.func, ipo_loss_fn)
+        self.assertEqual(
+            loss_fn.keywords,
+            {"beta": 0.2},
+        )
 
     def test_registered_gspo_loss_binds_config_clip_eps(self):
         """Algorithm specs can adapt the default loss with config parameters."""

--- a/tests/test_cli_model_refs_cpu.py
+++ b/tests/test_cli_model_refs_cpu.py
@@ -43,6 +43,27 @@ class CliModelReferenceTest(unittest.TestCase):
         self.assertEqual(resolved, "/cache/Qwen/Qwen3-4B")
         self.assertEqual(calls, ["Qwen/Qwen3-4B"])
 
+    def test_resolve_model_refs_for_ipo_config_resolves_reference(self):
+        """IPO should resolve both student and frozen-reference checkpoints."""
+
+        calls: list[str] = []
+
+        fake_modelscope = types.SimpleNamespace(snapshot_download=lambda repo: calls.append(repo) or f"/ms/{repo}")
+
+        config = SimpleNamespace(
+            algo="ipo",
+            model_hub="modelscope",
+            ckpt="org/student",
+            ref_ckpt="org/reference",
+        )
+
+        with patch.dict(sys.modules, {"modelscope": fake_modelscope}):
+            resolved = model_refs.resolve_model_refs_for_config(config)
+
+        self.assertEqual(resolved.ckpt, "/ms/org/student")
+        self.assertEqual(resolved.ref_ckpt, "/ms/org/reference")
+        self.assertEqual(calls, ["org/student", "org/reference"])
+
     def test_resolve_model_refs_for_ppo_config_reuses_duplicate_roles(self):
         """Train config resolution should not download the same repo once per role."""
         calls: list[str] = []

--- a/tests/test_ipo_loss_cpu.py
+++ b/tests/test_ipo_loss_cpu.py
@@ -8,6 +8,7 @@ from areno.api.loss_fns.ipo import (
     ipo_loss_fn,
 )
 
+
 def test_ipo_sequence_loss_matches_hand_calculation():
     # Policy:
     # chosen - rejected = -2 - (-4) = 2

--- a/tests/test_ipo_loss_cpu.py
+++ b/tests/test_ipo_loss_cpu.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from areno.api.loss_fns.ipo import (
+    _ipo_from_sequence_logps,
+    ipo_loss_fn,
+)
+
+def test_ipo_sequence_loss_matches_hand_calculation():
+    # Policy:
+    # chosen - rejected = -2 - (-4) = 2
+    #
+    # Reference:
+    # chosen - rejected = -3 - (-4) = 1
+    #
+    # delta = 2 - 1 = 1
+    #
+    # beta = 0.25 -> target = 1 / (2 * 0.25) = 2
+    #
+    # loss = (1 - 2)^2 = 1
+    policy_seq_logps = torch.tensor([-2.0, -4.0])
+    ref_seq_logps = torch.tensor([-3.0, -4.0])
+    response_lens = torch.tensor([2.0, 2.0])
+
+    loss, metrics = _ipo_from_sequence_logps(
+        policy_seq_logps,
+        ref_seq_logps,
+        response_lens,
+        beta=0.25,
+    )
+
+    torch.testing.assert_close(loss, torch.tensor(1.0))
+    torch.testing.assert_close(metrics["ipo_delta"], torch.tensor(1.0))
+    torch.testing.assert_close(
+        metrics["ipo_target_error"],
+        torch.tensor(1.0),
+    )
+
+
+def test_ipo_loss_is_zero_at_target():
+    # beta = 0.1 -> target = 5
+    #
+    # Policy margin = 5
+    # Reference margin = 0
+    # delta = 5
+    policy_seq_logps = torch.tensor([5.0, 0.0])
+    ref_seq_logps = torch.tensor([0.0, 0.0])
+    response_lens = torch.tensor([1.0, 1.0])
+
+    loss, metrics = _ipo_from_sequence_logps(
+        policy_seq_logps,
+        ref_seq_logps,
+        response_lens,
+        beta=0.1,
+    )
+
+    torch.testing.assert_close(loss, torch.tensor(0.0))
+    torch.testing.assert_close(metrics["ipo_delta"], torch.tensor(5.0))
+    torch.testing.assert_close(
+        metrics["ipo_target_error"],
+        torch.tensor(0.0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("delta", "expected_gradient_sign"),
+    [
+        (3.0, -1),
+        (5.0, 0),
+        (7.0, 1),
+    ],
+)
+def test_ipo_gradient_moves_delta_toward_target(
+    delta,
+    expected_gradient_sign,
+):
+    # beta = 0.1 -> target = 5.
+    #
+    # delta < 5 should be pushed upward.
+    # delta = 5 should have zero gradient.
+    # delta > 5 should be pushed downward.
+    policy_seq_logps = torch.tensor(
+        [delta, 0.0],
+        requires_grad=True,
+    )
+    ref_seq_logps = torch.zeros(2)
+    response_lens = torch.ones(2)
+
+    loss, _ = _ipo_from_sequence_logps(
+        policy_seq_logps,
+        ref_seq_logps,
+        response_lens,
+        beta=0.1,
+    )
+    loss.backward()
+
+    chosen_gradient = policy_seq_logps.grad[0].item()
+
+    if expected_gradient_sign < 0:
+        assert chosen_gradient < 0
+    elif expected_gradient_sign > 0:
+        assert chosen_gradient > 0
+    else:
+        assert abs(chosen_gradient) < 1.0e-6
+
+
+def test_ipo_loss_uses_sequence_sums_not_length_averages():
+    # Chosen has two response tokens:
+    #
+    # policy sum = -2
+    # ref sum = -3
+    # policy-vs-ref shift = 1
+    #
+    # Rejected has one response token:
+    #
+    # policy sum = -3
+    # ref sum = -3.5
+    # policy-vs-ref shift = 0.5
+    #
+    # delta = 1 - 0.5 = 0.5
+    #
+    # beta = 1 -> target = 0.5, so sequence-sum IPO has zero loss.
+    #
+    # A length-averaged implementation would produce a different delta.
+    logprobs = torch.tensor(
+        [
+            [0.0, -1.0, -1.0],
+            [0.0, -3.0, 100.0],
+        ]
+    )
+
+    data_pack = {
+        "prompt_mask": torch.tensor(
+            [
+                [True, True, False, False],
+                [True, True, False, True],
+            ]
+        ),
+        "ref_logprobs": torch.tensor(
+            [
+                [0.0, 0.0, -1.5, -1.5],
+                [0.0, 0.0, -3.5, 100.0],
+            ]
+        ),
+    }
+
+    loss, metrics = ipo_loss_fn(
+        data_pack,
+        logprobs,
+        beta=1.0,
+    )
+
+    torch.testing.assert_close(loss, torch.tensor(0.0))
+    torch.testing.assert_close(
+        metrics["ipo_delta"],
+        torch.tensor(0.5),
+    )
+
+
+def test_ipo_requires_even_number_of_sequences():
+    logprobs = torch.zeros((3, 2))
+
+    data_pack = {
+        "prompt_mask": torch.tensor(
+            [
+                [True, False, False],
+                [True, False, False],
+                [True, False, False],
+            ]
+        ),
+        "ref_logprobs": torch.zeros((3, 3)),
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="IPO requires an even number of sequences",
+    ):
+        ipo_loss_fn(
+            data_pack,
+            logprobs,
+            beta=0.1,
+        )
+
+
+@pytest.mark.parametrize("beta", [0.0, -0.1])
+def test_ipo_requires_positive_beta(beta):
+    with pytest.raises(
+        ValueError,
+        match="IPO beta must be positive",
+    ):
+        ipo_loss_fn(
+            {},
+            torch.zeros((2, 1)),
+            beta=beta,
+        )

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -7,7 +7,13 @@ import pytest
 from click import UsageError, unstyle
 from click.testing import CliRunner
 
-from areno.api.trainer_config import DPOTrainerConfig, PolicyTrainerConfig, PPOTrainerConfig, TrainerConfig
+from areno.api.trainer_config import (
+    DPOTrainerConfig,
+    IPOTrainerConfig,
+    PolicyTrainerConfig,
+    PPOTrainerConfig,
+    TrainerConfig,
+)
 from areno.cli import train as train_cli
 from areno.cli.train import (
     TRAIN_OPTION_GROUPS,
@@ -130,6 +136,17 @@ def test_train_config_validates_dpo_positive_fields(field, value, message):
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [
+        ("ipo_beta", 0.0, "--ipo-beta must be positive"),
+    ],
+)
+def test_train_config_validates_ipo_positive_fields(field, value, message):
+    with pytest.raises(UsageError, match=message):
+        _trainer_config_from_options(**_options(algo="ipo", **{field: value}))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
         ("critic_lr", 0.0, "--critic-lr must be positive"),
         ("kl_loss_coef", 0.0, "--kl-loss-coef must be positive"),
         ("clip_eps", 0.0, "--clip-eps must be positive"),
@@ -192,6 +209,25 @@ def test_train_config_builds_dpo_shape_and_ref_ckpt():
     assert cfg.algo == "dpo"
     assert cfg.ref_ckpt == "reference"
     assert cfg.dpo_beta == 0.25
+    assert not hasattr(cfg, "n_samples")
+    assert not hasattr(cfg, "reward_fn_path")
+
+
+def test_train_config_builds_ipo_shape_and_ref_ckpt():
+    cfg = _trainer_config_from_options(
+        **_options(
+            algo="ipo",
+            reward_fn_path=None,
+            reward_ckpt=None,
+            ref_ckpt="reference",
+            ipo_beta=0.25,
+        )
+    )
+
+    assert isinstance(cfg, IPOTrainerConfig)
+    assert cfg.algo == "ipo"
+    assert cfg.ref_ckpt == "reference"
+    assert cfg.ipo_beta == 0.25
     assert not hasattr(cfg, "n_samples")
     assert not hasattr(cfg, "reward_fn_path")
 
@@ -751,6 +787,7 @@ def test_train_command_smoke_resolves_model_ref_before_probe(monkeypatch):
     [
         ("sft", ["--dataset-loader-fn", "examples/sft/alpaca/dataset_loader.py"], TrainerConfig),
         ("dpo", [], DPOTrainerConfig),
+        ("ipo", [], IPOTrainerConfig),
     ],
 )
 def test_train_command_smoke_train_supports_offline_algorithms(monkeypatch, algo, extra_args, expected_type):
@@ -898,6 +935,7 @@ def _options(**overrides):
         grpo_clip_eps=0.2,
         ref_ckpt=None,
         dpo_beta=0.1,
+        ipo_beta=0.1,
         reward_ckpt="reward-model",
         critic_ckpt=None,
         critic_lr=1e-5,


### PR DESCRIPTION
## Summary

Adds Identity Preference Optimization (IPO) as a built-in offline preference-training algorithm.

## Changes

- Add a sequence-level IPO loss following Eq. 17 of the IPO paper using summed response log-probabilities.
- Reuse the existing DPO preference trainer and reference-model scoring workflow.
- Add `IPOTrainerConfig` and the `--ipo-beta` option.
- Register `ipo` in the algorithm registry.
- Add IPO reference-checkpoint resolution.
- Add CPU tests for the loss, configuration, registry integration, and model-reference resolution.
- Update CLI help and documentation.

The implementation currently uses sequence-summed log-probabilities rather than length-normalized averages.