### PR TITLE
docs: add tiny training smoke tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,14 @@ The report includes AReno, Python, platform, PyTorch/CUDA, GPU, `nvcc`, dependen
 
 ### Training
 
-#### Tiny training smoke test
+#### Tiny training smoke tutorial
 
-Use this command when you only want to check that a machine can run one small official training task end to end:
+Use the tutorial when you want to run the smallest official training task end
+to end and verify the checkpoint and metrics outputs:
 
 ```bash
+mkdir -p outputs/tiny-smoke
+
 areno train \
   --ckpt Qwen/Qwen3-0.6B \
   --dataset-path gsm8k:main \
@@ -222,10 +225,21 @@ areno train \
   --algo gspo \
   --tp-size 1 \
   --world-size 1 \
-  --batch-size 1
+  --batch-size 1 \
+  --max-steps 1 \
+  --save-path outputs/tiny-smoke \
+  --save-interval 1 \
+  --metrics-log-dir outputs/tiny-smoke/metrics
 ```
 
-This is a smoke/sanity task for the CLI, dataset loader, reward function, rollout, and training-step wiring. It is not a quality benchmark. It requires a CUDA-capable NVIDIA GPU; CPU-only machines can install the package for docs and metadata checks, but cannot run the AReno training engine. A successful run should reach rollout logs and a `train_stats=...` line without raising an exception.
+This is a smoke/sanity task for the CLI, dataset loader, reward function,
+rollout, training-step wiring, checkpoint saving, and TensorBoard metrics. It
+is not a quality benchmark. It requires a CUDA-capable NVIDIA GPU; CPU-only
+machines can install the package for docs and metadata checks, but cannot run
+the AReno training engine. A successful run should reach rollout logs, a
+`train_stats=...` line, and `step_000001/` under `outputs/tiny-smoke`.
+
+See the full [tiny training smoke tutorial](docs/getting-started/tiny-training-smoke.rst) for the step-by-step walkthrough and expected logs.
 
 Run GSPO on a GSM8K-style dataset with a reward function:
 

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -408,26 +408,13 @@ Observability
 Examples
 --------
 
-Tiny training smoke test
-~~~~~~~~~~~~~~~~~~~~~~~~
+Tiny training smoke tutorial
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use this command when you only want to check that a machine can run one small
-official training task end to end:
-
-.. code-block:: bash
-
-   areno train \
-     --ckpt Qwen/Qwen3-0.6B \
-     --dataset-path gsm8k:main \
-     --dataset-loader-fn examples/math/dataset_loader.py \
-     --reward-fn-path examples/math/math_verify_reward.py \
-     --algo gspo \
-     --tp-size 1 \
-     --world-size 1 \
-     --batch-size 1
-
-This verifies the training wiring; it is not intended to measure final model
-quality.
+See :doc:`../getting-started/tiny-training-smoke` for the runnable tutorial
+version of the smallest official AReno training task. It covers the CLI,
+dataset loader, reward function, rollout path, checkpoint writing, and
+TensorBoard metrics export.
 
 GSPO math training
 ~~~~~~~~~~~~~~~~~~

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -4,23 +4,11 @@ Quickstart
 Use these commands after installation to validate the main AReno paths. Full
 training and agentic rollout require a CUDA-capable NVIDIA GPU.
 
-Training smoke test
--------------------
+Tiny training smoke tutorial
+----------------------------
 
-Run the smallest official training task to verify that the CLI can load a
-model, build batches, execute the training loop, and write outputs locally.
-
-.. code-block:: bash
-
-   areno train \
-     --ckpt Qwen/Qwen3-0.6B \
-     --dataset-path gsm8k:main \
-     --dataset-loader-fn examples/math/dataset_loader.py \
-     --reward-fn-path examples/math/math_verify_reward.py \
-     --algo gspo \
-     --tp-size 1 \
-     --world-size 1 \
-     --batch-size 1
+Follow :doc:`tiny-training-smoke` for the runnable step-by-step walkthrough of
+the smallest official AReno training task.
 
 RLVR path
 ---------

--- a/docs/getting-started/tiny-training-smoke.rst
+++ b/docs/getting-started/tiny-training-smoke.rst
@@ -1,0 +1,100 @@
+Tiny training smoke tutorial
+============================
+
+This walkthrough runs the smallest official AReno training task end to end.
+It checks the CLI, dataset loader, reward function, rollout path, training
+step, checkpoint writing, and TensorBoard metrics export. It is a wiring
+check, not a benchmark for final model quality.
+
+Prerequisites
+-------------
+
+* A CUDA-capable NVIDIA GPU with CUDA-enabled PyTorch 2.6+.
+* A working AReno install.
+* ``areno check`` should pass or at least report a usable GPU stack.
+
+CPU-only machines can still install AReno for documentation, packaging, and
+metadata checks, but they cannot run the training engine used in this
+tutorial.
+
+Step 1: Prepare an output directory
+-----------------------------------
+
+.. code-block:: bash
+
+   mkdir -p outputs/tiny-smoke
+
+Step 2: Run the smoke command
+-----------------------------
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 1 \
+     --max-steps 1 \
+     --save-path outputs/tiny-smoke \
+     --save-interval 1 \
+     --metrics-log-dir outputs/tiny-smoke/metrics
+
+The example dataset loader and reward function come from this repository, so
+the only external fetches are the model checkpoint and dataset.
+
+Step 3: Read the expected logs
+------------------------------
+
+Look for a short chain of lifecycle logs:
+
+.. code-block:: text
+
+   epoch=0 stage=epoch_start
+   role=policy stage=rollout_start
+   metric=reward_mean value=...
+   epoch=0 step=0 train_stats={...}
+   epoch=0 step=0 stage=save_checkpoint_start path=outputs/tiny-smoke/step_000001
+   epoch=0 step=0 stage=save_checkpoint_end path=...
+
+The exact numbers will vary. The important part is that the run reaches
+rollout, training, and checkpoint saving without raising an exception.
+
+Step 4: Inspect the artifacts
+-----------------------------
+
+After the run finishes, you should have:
+
+.. code-block:: text
+
+   outputs/tiny-smoke/step_000001/
+   outputs/tiny-smoke/metrics/
+
+``step_000001/`` is the checkpoint written by ``--save-interval 1``. The metrics
+directory contains TensorBoard event files and the same scalar series the
+dashboard reads.
+
+Step 5: Open TensorBoard
+------------------------
+
+.. code-block:: bash
+
+   tensorboard --logdir outputs/tiny-smoke/metrics
+
+Then confirm that the run exposes ``rollout/*``, ``train/*``, and ``time/*``
+scalar series.
+
+Troubleshooting
+---------------
+
+* If ``areno check`` reports no usable CUDA setup, stop here.
+* If the model or dataset download fails, retry once network access or hub
+  credentials are available.
+* If the command cannot import ``examples/math/dataset_loader.py`` or
+  ``examples/math/math_verify_reward.py``, check the paths relative to the
+  repository root.
+* If the run stops before ``train_stats=...``, use ``areno env --json`` and the
+  final log lines to narrow down the failure.

--- a/docs/getting-started/welcome.rst
+++ b/docs/getting-started/welcome.rst
@@ -75,7 +75,7 @@ Core workflows
    <div class="areno-command-grid areno-command-grid-wide">
      <div class="areno-command-card">
        <p class="areno-card-kicker">Training</p>
-       <h3>Run a small GSPO smoke task.</h3>
+       <h3>Run the tiny smoke tutorial.</h3>
       <pre><code>areno train \
      --ckpt Qwen/Qwen3-0.6B \
      --dataset-path gsm8k:main \
@@ -84,7 +84,12 @@ Core workflows
      --algo gspo \
      --tp-size 1 \
      --world-size 1 \
-     --batch-size 1</code></pre>
+     --batch-size 1 \
+     --max-steps 1 \
+     --save-path outputs/tiny-smoke \
+     --save-interval 1 \
+     --metrics-log-dir outputs/tiny-smoke/metrics</code></pre>
+       <p>Follow the smoke tutorial for the expected logs, checkpoint, and TensorBoard output.</p>
      </div>
      <div class="areno-command-card">
        <p class="areno-card-kicker">Serving</p>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ AReno documentation
    Welcome <getting-started/welcome>
    getting-started/installation
    getting-started/quickstart
+   getting-started/tiny-training-smoke
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
## Summary
- add a step-by-step tiny training smoke tutorial using the existing math dataset loader and reward function
- document GPU/CPU expectations, success logs, checkpoint output, and TensorBoard metrics
- link the tutorial from README, quickstart, CLI reference, and the docs landing page

Closes #41

## Test
- \\python -m sphinx -b html -D html_theme=alabaster docs docs/_build/html\\ (default shibuya theme package is not installed in this environment)