### PR TITLE
fix(cli): count prompt tokens once in serve usage accounting

### DIFF
--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -463,7 +463,7 @@ def _build_response_from(
     data = build_chat_completion_response(
         tokenizer=tokenizer,
         model=request.model or model_path,
-        prompt_tokens=len(prompt) * len(response_ids),
+        prompt_tokens=len(prompt),
         response_ids=response_ids,
         finish_reasons=finish_reasons,
         tools=request.tools,

--- a/tests/test_serve_cli_cpu.py
+++ b/tests/test_serve_cli_cpu.py
@@ -196,6 +196,31 @@ def test_serve_text_response_preserves_decoded_content():
     assert choice.message["content"] == "plan the answer</think>\n\nFinal answer"
 
 
+def test_serve_usage_counts_prompt_tokens_once_for_multiple_completions():
+    tokenizer = _TokenTokenizer({1: "a", 2: "b", 3: "c"})
+    request = serve_mod.ChatCompletionRequest(
+        model="areno",
+        messages=[serve_mod.ChatMessage(role="user", content="hi")],
+        n=2,
+    )
+    prompt = [10, 11]
+
+    response = serve_mod._build_response_from(
+        tokenizer,
+        "model",
+        QwenToolCallParser(),
+        request,
+        prompt,
+        [[1, 2], [2, 3]],
+        ["stop", "stop"],
+    )
+
+    assert len(response.choices) == 2
+    assert response.usage.prompt_tokens == len(prompt)
+    assert response.usage.completion_tokens == 4
+    assert response.usage.total_tokens == len(prompt) + 4
+
+
 def test_serve_tool_call_response_does_not_attach_reasoning_content():
     tokenizer = _TokenTokenizer(
         {


### PR DESCRIPTION
## Summary

Fixes token-usage accounting in the OpenAI-compatible `/v1/chat/completions` endpoint when a request asks for more than one completion (`n > 1`).

## Problem

`_build_response_from` in `areno/cli/serve.py` reported usage as:

```python
prompt_tokens=len(prompt) * len(response_ids),
```

`response_ids` holds one entry per requested completion, so for `n > 1` the same prompt was counted `n` times. This inflated `usage.prompt_tokens` and `usage.total_tokens` by a factor of `n`, misreporting token consumption to API callers (e.g. client-side cost tracking and token limits).

For the default `n == 1` the behaviour was already correct (`len(prompt) * 1`), so this is a targeted fix for the multi-completion path only.

## Fix

Count the prompt once, regardless of how many completions are generated:

```python
prompt_tokens=len(prompt),
```

## Tests

- Added `test_serve_usage_counts_prompt_tokens_once_for_multiple_completions` to `tests/test_serve_cli_cpu.py`. It calls `_build_response_from` with `n == 2` and asserts:
  - `usage.prompt_tokens == len(prompt)` (counted once),
  - `usage.completion_tokens` is the sum of all choices,
  - `usage.total_tokens` is consistent.
- The test reuses the existing `_TokenTokenizer` helper already in the file and runs without a GPU.

## Verification

I was unable to run the CPU suite on my local machine (Windows host without a GPU/PyTorch), so I have not claimed a local test run. The change is covered by the new CPU test; CI's `pytest tests/ -k cpu` suite covers this file (`tests/test_serve_cli_cpu.py`).