### PR TITLE
feat: add Ling Tiny V3 support

### DIFF
--- a/.agents/skills/areno-model-adaptation/references/kernel-policy.md
+++ b/.agents/skills/areno-model-adaptation/references/kernel-policy.md
@@ -2,9 +2,13 @@
 
 - Prefer existing `areno/engine/layers` and `areno/accel` operators.
 - Required hot paths do not silently fall back to Python reference code.
+- Plain PyTorch reference implementations are short-lived correctness scaffolding. Convert rollout, prefill, decode, scoring, and training hot paths to an AReno-owned fused primitive before treating a model as production-ready.
 - Training use requires a verified backward path.
 - Kernel APIs describe mathematical operations, not one model brand.
+- Runtime-critical paths use AReno-owned model code and kernels by default. When the project already declares a kernel dependency such as FLA and the user explicitly accepts it, expose it through a small `areno/accel` wrapper rather than importing it from model code or vendoring it.
+- Treat SGLang as a semantic reference for recurrent linear attention. An explicitly accepted FLA dependency may implement gated-delta through `areno/accel`, but model code must call the AReno wrapper.
 - Prefill and decode may differ but must preserve normalization, rotary, scale, masking/window, and cache semantics.
 - Warm compiled callables before CUDA graph capture. Decode validation must exercise graph replay.
 - Avoid `.item()`, `.tolist()`, and CPU synchronization in model hot paths.
+- Any NaN in loss, logprobs, ratios, or grad norm is a correctness blocker. Reproduce on the smallest failing batch, locate the first non-finite tensor, and check reduction dtype, gate/beta domain, accumulators, masks, packed lengths, checkpoint transforms, and train/decode agreement.
 - If `areno/accel` changes, rebuild editable installation with `pip install -e . --no-deps --no-build-isolation`.

--- a/.agents/skills/areno-model-adaptation/references/remote-validation.md
+++ b/.agents/skills/areno-model-adaptation/references/remote-validation.md
@@ -9,7 +9,7 @@
 5. Before each GPU command, inspect GPUs and record the remote commit.
 6. Run bounded load, inference, train backward, save, and reload gates in order.
 7. Run the adapted model through at least two consecutive successful end-to-end training steps. Confirm that both steps complete with finite loss, metrics, and gradients; a one-step smoke train does not satisfy this gate.
-8. If a run appears stalled, inspect it with `py-spy` or GPU tools before changing implementation.
+8. If a run appears stalled or emits no logs for a long time, inspect it with `py-spy dump -p <pid>` and GPU tools before changing implementation. Use the stack to distinguish Triton/Inductor compilation, Python data processing, distributed waits, and a real kernel hang.
 
 Do not copy uncommitted local files to the remote as an implicit deployment mechanism.
 Do not patch, format, or commit source code in the remote checkout. Apply every

--- a/areno/accel/kda.py
+++ b/areno/accel/kda.py
@@ -1,0 +1,86 @@
+"""Bailing/Kimi Delta Attention accel entry points."""
+
+from __future__ import annotations
+
+import torch
+
+from areno.accel.kernels.kda_fla.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_update,
+)
+from areno.accel.kernels.kda_fla.kda import chunk_kda
+
+
+@torch._dynamo.disable
+def areno_kda_chunk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    scale: float,
+    cu_seqlens: torch.Tensor | None,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float | None,
+    use_qk_l2norm_in_kernel: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    return chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=raw_gate,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=state_indices,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+    )
+
+
+@torch._dynamo.disable
+def areno_kda_recurrent_update(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float | None,
+    use_qk_l2norm_in_kernel: bool = True,
+) -> torch.Tensor:
+    return fused_sigmoid_gating_delta_rule_update(
+        A_log=a_log,
+        a=raw_gate,
+        dt_bias=dt_bias,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        q=q,
+        k=k,
+        v=v,
+        b=beta,
+        initial_state_source=state,
+        initial_state_indices=state_indices,
+        scale=scale,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+        is_kda=True,
+        lower_bound=lower_bound,
+    )
+
+
+__all__ = ["areno_kda_chunk", "areno_kda_recurrent_update"]

--- a/areno/accel/kernels/kda_fla/__init__.py
+++ b/areno/accel/kernels/kda_fla/__init__.py
@@ -1,0 +1,1 @@
+"""Small AReno adapters around flash-linear-attention KDA ops."""

--- a/areno/accel/kernels/kda_fla/chunk_intra.py
+++ b/areno/accel/kernels/kda_fla/chunk_intra.py
@@ -1,0 +1,840 @@
+# ruff: noqa
+# Adapted from flash-linear-attention project.
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+import torch
+import triton
+import triton.language as tl
+
+from areno.accel.kernels.kda_fla.chunk_intra_token_parallel import (
+    chunk_kda_fwd_intra_token_parallel,
+)
+from fla.ops.utils.index import prepare_chunk_indices
+from fla.ops.utils.op import exp, exp2, gather
+from fla.utils import (
+    IS_GATHER_SUPPORTED,
+    IS_TF32_SUPPORTED,
+    autotune_cache_kwargs,
+)
+
+if IS_TF32_SUPPORTED:
+    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
+else:
+    SOLVE_TRIL_DOT_PRECISION = tl.constexpr("ieee")
+
+
+################################################################################
+# Fused inter + solve_tril kernel: compute off-diagonal Akk and solve in one pass
+################################################################################
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({"BK": BK, "BV": 64}, num_warps=num_warps) for BK in [32, 64] for num_warps in [1, 2, 4]],
+    key=["H", "K", "BC", "V", "FUSE_RECOMPUTE", "FUSE_DIAGONAL"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_kda_fwd_kernel_inter_solve_fused(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akkd,
+    Akk,
+    scale,
+    v_in,
+    w_out,
+    u_out,
+    kg_out,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_SAFE_GATE: tl.constexpr,
+    FUSE_RECOMPUTE: tl.constexpr,
+    FUSE_DIAGONAL: tl.constexpr,
+):
+    """
+    Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
+    Prerequisite: token_parallel has already computed diagonal Akk blocks in Akkd.
+
+    This kernel:
+    1. Computes off-diagonal Aqk blocks -> writes to global
+    2. Computes off-diagonal Akk blocks -> keeps in registers
+    3. Loads diagonal Akk blocks from Akkd (fp32)
+    4. Does forward substitution on diagonals
+    5. Computes merged Akk_inv
+    6. Writes Akk_inv to Akk
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    Aqk += (bos * H + i_h) * BT
+    Akk += (bos * H + i_h) * BT
+    Akkd += (bos * H + i_h) * BC
+
+    o_i = tl.arange(0, BC)
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    if FUSE_DIAGONAL:
+        b_Aqk_d0 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d0 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Aqk_d1 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d1 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Aqk_d2 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d2 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Aqk_d3 = tl.zeros([BC, BC], dtype=tl.float32)
+        b_Akk_d3 = tl.zeros([BC, BC], dtype=tl.float32)
+        m_tc0 = (i_tc0 + o_i) < T
+
+    ################################################################################
+    # off-diagonal blocks (+ optional diagonal blocks)
+    ################################################################################
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k0 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+        p_g0 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
+        b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+
+        if FUSE_DIAGONAL:
+            p_q0 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            b_q0 = tl.load(p_q0, boundary_check=(0, 1)).to(tl.float32)
+            b_gn0 = tl.load(g + i_tc0 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+            b_gm0 = tl.clamp(b_g0 - b_gn0[None, :], -126.0, 126.0)
+            b_gq0 = tl.where(m_tc0[:, None], exp2(b_gm0), 0.0)
+            b_gk0 = tl.where(m_tc0[:, None], exp2(-b_gm0), 0.0)
+            b_kgt_d0 = tl.trans(b_k0 * b_gk0)
+            b_Aqk_d0 += tl.dot(b_q0 * b_gq0, b_kgt_d0)
+            b_Akk_d0 += tl.dot(b_k0 * b_gq0, b_kgt_d0)
+
+        if i_tc1 < T:
+            p_q1 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_k1 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_g1 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            # [BC, BK]
+            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
+            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            # [BK]
+            b_gn1 = tl.load(g + i_tc1 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+            # [BC, BK]
+            b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
+            # [BK, BC]
+            b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0)).to(tl.bfloat16)
+            # [BC, BC]
+            b_qg1 = (b_q1 * b_gqn).to(tl.bfloat16)
+            b_kg1 = (b_k1 * b_gqn).to(tl.bfloat16)
+            b_Aqk10 += tl.dot(b_qg1, b_kgt)
+            b_Akk10 += tl.dot(b_kg1, b_kgt)
+
+            if FUSE_DIAGONAL:
+                b_gm1_d = tl.clamp(b_gn1[None, :] - b_g1, -126.0, 126.0)
+                b_gk1_d = tl.where(m_tc1[:, None], exp2(b_gm1_d), 0.0)
+                b_kgt_d1 = tl.trans(b_k1 * b_gk1_d)
+                b_Aqk_d1 += tl.dot(b_q1 * b_gqn, b_kgt_d1)
+                b_Akk_d1 += tl.dot(b_k1 * b_gqn, b_kgt_d1)
+
+            if i_tc2 < T:
+                p_q2 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                p_k2 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                p_g2 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+                # [BC, BK]
+                b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
+                b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
+                b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+                # [BK]
+                b_gn2 = tl.load(g + i_tc2 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+                # [BC, BK]
+                b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
+                b_qg2 = (b_q2 * b_gqn2).to(tl.bfloat16)
+                b_kg2 = (b_k2 * b_gqn2).to(tl.bfloat16)
+                # [BK, BC]
+                b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0)).to(tl.bfloat16)
+                b_Aqk20 += tl.dot(b_qg2, b_kgt)
+                b_Akk20 += tl.dot(b_kg2, b_kgt)
+                # [BC, BC]
+                b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1)).to(tl.bfloat16)
+                # [BC, BC]
+                b_Aqk21 += tl.dot(b_qg2, b_kgt)
+                b_Akk21 += tl.dot(b_kg2, b_kgt)
+
+                if FUSE_DIAGONAL:
+                    b_gm2_d = tl.clamp(b_gn2[None, :] - b_g2, -126.0, 126.0)
+                    b_gk2_d = tl.where(m_tc2[:, None], exp2(b_gm2_d), 0.0)
+                    b_kgt_d2 = tl.trans(b_k2 * b_gk2_d)
+                    b_Aqk_d2 += tl.dot(b_q2 * b_gqn2, b_kgt_d2)
+                    b_Akk_d2 += tl.dot(b_k2 * b_gqn2, b_kgt_d2)
+
+                if i_tc3 < T:
+                    p_q3 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                    p_k3 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                    p_g3 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                    # [BC, BK]
+                    b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
+                    b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
+                    b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+                    # [BK]
+                    b_gn3 = tl.load(g + i_tc3 * H * K + o_k, mask=m_k, other=0).to(tl.float32)
+                    # [BC, BK]
+                    b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
+                    b_qg3 = (b_q3 * b_gqn3).to(tl.bfloat16)
+                    b_kg3 = (b_k3 * b_gqn3).to(tl.bfloat16)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0)).to(tl.bfloat16)
+                    # [BC, BC]
+                    b_Aqk30 += tl.dot(b_qg3, b_kgt)
+                    b_Akk30 += tl.dot(b_kg3, b_kgt)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1)).to(tl.bfloat16)
+                    # [BC, BC]
+                    b_Aqk31 += tl.dot(b_qg3, b_kgt)
+                    b_Akk31 += tl.dot(b_kg3, b_kgt)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2)).to(tl.bfloat16)
+                    # [BC, BC]
+                    b_Aqk32 += tl.dot(b_qg3, b_kgt)
+                    b_Akk32 += tl.dot(b_kg3, b_kgt)
+
+                    if FUSE_DIAGONAL:
+                        b_gm3_d = tl.clamp(b_gn3[None, :] - b_g3, -126.0, 126.0)
+                        b_gk3_d = tl.where(m_tc3[:, None], exp2(b_gm3_d), 0.0)
+                        b_kgt_d3 = tl.trans(b_k3 * b_gk3_d)
+                        b_Aqk_d3 += tl.dot(b_q3 * b_gqn3, b_kgt_d3)
+                        b_Akk_d3 += tl.dot(b_k3 * b_gqn3, b_kgt_d3)
+
+    ################################################################################
+    # save off-diagonal Aqk blocks and prepare Akk
+    ################################################################################
+    if i_tc1 < T:
+        p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+        b_Akk10 = b_Akk10 * b_b1[:, None]
+    if i_tc2 < T:
+        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        b_Akk20 = b_Akk20 * b_b2[:, None]
+        b_Akk21 = b_Akk21 * b_b2[:, None]
+    if i_tc3 < T:
+        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        b_Akk30 = b_Akk30 * b_b3[:, None]
+        b_Akk31 = b_Akk31 * b_b3[:, None]
+        b_Akk32 = b_Akk32 * b_b3[:, None]
+
+    if FUSE_DIAGONAL:
+        m_Aqk_diag = o_i[:, None] >= o_i[None, :]
+        m_Akk_diag = o_i[:, None] > o_i[None, :]
+
+        b_Aqk_d0 = tl.where(m_Aqk_diag, b_Aqk_d0, 0.0)
+        b_Akk_d0 = tl.where(m_Akk_diag, b_Akk_d0, 0.0)
+        b_Aqk_d1 = tl.where(m_Aqk_diag, b_Aqk_d1, 0.0)
+        b_Akk_d1 = tl.where(m_Akk_diag, b_Akk_d1, 0.0)
+        b_Aqk_d2 = tl.where(m_Aqk_diag, b_Aqk_d2, 0.0)
+        b_Akk_d2 = tl.where(m_Akk_diag, b_Akk_d2, 0.0)
+        b_Aqk_d3 = tl.where(m_Aqk_diag, b_Aqk_d3, 0.0)
+        b_Akk_d3 = tl.where(m_Akk_diag, b_Akk_d3, 0.0)
+
+        p_Aqk_d0 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+        p_Aqk_d1 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+        p_Aqk_d2 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0))
+        p_Aqk_d3 = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk_d0, (b_Aqk_d0 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk_d1, (b_Aqk_d1 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk_d2, (b_Aqk_d2 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk_d3, (b_Aqk_d3 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_bd0 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,))
+        p_bd1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        p_bd2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        p_bd3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+        b_bd0 = tl.load(p_bd0, boundary_check=(0,)).to(tl.float32)
+        b_bd1 = tl.load(p_bd1, boundary_check=(0,)).to(tl.float32)
+        b_bd2 = tl.load(p_bd2, boundary_check=(0,)).to(tl.float32)
+        b_bd3 = tl.load(p_bd3, boundary_check=(0,)).to(tl.float32)
+        b_Akk_d0 = b_Akk_d0 * b_bd0[:, None]
+        b_Akk_d1 = b_Akk_d1 * b_bd1[:, None]
+        b_Akk_d2 = b_Akk_d2 * b_bd2[:, None]
+        b_Akk_d3 = b_Akk_d3 * b_bd3[:, None]
+
+        p_Akkd00 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
+        p_Akkd11 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        p_Akkd22 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akkd33 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        tl.store(p_Akkd00, b_Akk_d0.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akkd11, b_Akk_d1.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akkd22, b_Akk_d2.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akkd33, b_Akk_d3.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+
+        b_Ai00 = b_Akk_d0
+        b_Ai11 = b_Akk_d1
+        b_Ai22 = b_Akk_d2
+        b_Ai33 = b_Akk_d3
+    else:
+        p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
+        p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (H * BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+
+    ################################################################################
+    # forward substitution on diagonals
+    # Diagonal blocks are RAW (need substitution) when:
+    #   - FUSE_DIAGONAL=True: blocks were computed fresh above as gated k·k.
+    #   - FUSE_DIAGONAL=False with USE_SAFE_GATE=False: token_parallel wrote raw.
+    # They are pre-inverted only by the safe_gate diagonal kernel
+    # (USE_SAFE_GATE=True, FUSE_DIAGONAL=False).
+    ################################################################################
+
+    if FUSE_DIAGONAL or not USE_SAFE_GATE:
+        m_A = o_i[:, None] > o_i[None, :]
+        m_I = o_i[:, None] == o_i[None, :]
+
+        b_Ai00 = -tl.where(m_A, b_Ai00, 0)
+        b_Ai11 = -tl.where(m_A, b_Ai11, 0)
+        b_Ai22 = -tl.where(m_A, b_Ai22, 0)
+        b_Ai33 = -tl.where(m_A, b_Ai33, 0)
+
+        for i in range(2, min(BC, T - i_tc0)):
+            b_a00 = -tl.load(Akkd + (i_tc0 + i) * H * BC + o_i)
+            b_a00 = tl.where(o_i < i, b_a00, 0.0)
+            b_a00 += tl.sum(b_a00[:, None] * b_Ai00, 0)
+            b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+        for i in range(BC + 2, min(2 * BC, T - i_tc0)):
+            b_a11 = -tl.load(Akkd + (i_tc0 + i) * H * BC + o_i)
+            b_a11 = tl.where(o_i < i - BC, b_a11, 0.0)
+            b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
+            b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
+        for i in range(2 * BC + 2, min(3 * BC, T - i_tc0)):
+            b_a22 = -tl.load(Akkd + (i_tc0 + i) * H * BC + o_i)
+            b_a22 = tl.where(o_i < i - 2 * BC, b_a22, 0.0)
+            b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
+            b_Ai22 = tl.where((o_i == i - 2 * BC)[:, None], b_a22, b_Ai22)
+        for i in range(3 * BC + 2, min(4 * BC, T - i_tc0)):
+            b_a33 = -tl.load(Akkd + (i_tc0 + i) * H * BC + o_i)
+            b_a33 = tl.where(o_i < i - 3 * BC, b_a33, 0.0)
+            b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
+            b_Ai33 = tl.where((o_i == i - 3 * BC)[:, None], b_a33, b_Ai33)
+
+        b_Ai00 += m_I
+        b_Ai11 += m_I
+        b_Ai22 += m_I
+        b_Ai33 += m_I
+
+    ################################################################################
+    # compute merged inverse using off-diagonals
+    ################################################################################
+
+    # we used tf32 to maintain matrix inverse's precision whenever possible.
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_Akk10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    ################################################################################
+    # Output: store Akk_inv OR compute w, u, kg from registers
+    ################################################################################
+
+    if FUSE_RECOMPUTE:
+        # Cast A-inverse sub-blocks to input dtype for dot products
+        b_Ai00_h = b_Ai00.to(k.dtype.element_ty)
+        b_Ai10_h = b_Ai10.to(k.dtype.element_ty)
+        b_Ai11_h = b_Ai11.to(k.dtype.element_ty)
+        b_Ai20_h = b_Ai20.to(k.dtype.element_ty)
+        b_Ai21_h = b_Ai21.to(k.dtype.element_ty)
+        b_Ai22_h = b_Ai22.to(k.dtype.element_ty)
+        b_Ai30_h = b_Ai30.to(k.dtype.element_ty)
+        b_Ai31_h = b_Ai31.to(k.dtype.element_ty)
+        b_Ai32_h = b_Ai32.to(k.dtype.element_ty)
+        b_Ai33_h = b_Ai33.to(k.dtype.element_ty)
+
+        # Load beta for all 4 sub-chunks
+        p_b0 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,))
+        b_b0 = tl.load(p_b0, boundary_check=(0,)).to(tl.float32)
+        p_b1r = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        b_b1r = tl.load(p_b1r, boundary_check=(0,)).to(tl.float32)
+        p_b2r = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        b_b2r = tl.load(p_b2r, boundary_check=(0,)).to(tl.float32)
+        p_b3r = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+        b_b3r = tl.load(p_b3r, boundary_check=(0,)).to(tl.float32)
+
+        # ---- u = A_inv @ (v * beta) ----
+        v_base = v_in + (bos * H + i_h) * V
+        u_base = u_out + (bos * H + i_h) * V
+        for i_v in range(tl.cdiv(V, BV)):
+            p_v0 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
+            p_v1 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
+            p_v2 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
+            p_v3 = tl.make_block_ptr(v_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+
+            b_v0 = tl.load(p_v0, boundary_check=(0, 1))
+            b_v1 = tl.load(p_v1, boundary_check=(0, 1))
+            b_v2 = tl.load(p_v2, boundary_check=(0, 1))
+            b_v3 = tl.load(p_v3, boundary_check=(0, 1))
+
+            b_vb0 = (b_v0 * b_b0[:, None]).to(b_v0.dtype)
+            b_vb1 = (b_v1 * b_b1r[:, None]).to(b_v1.dtype)
+            b_vb2 = (b_v2 * b_b2r[:, None]).to(b_v2.dtype)
+            b_vb3 = (b_v3 * b_b3r[:, None]).to(b_v3.dtype)
+
+            b_u0 = tl.dot(b_Ai00_h, b_vb0)
+            b_u1 = tl.dot(b_Ai10_h, b_vb0) + tl.dot(b_Ai11_h, b_vb1)
+            b_u2 = tl.dot(b_Ai20_h, b_vb0) + tl.dot(b_Ai21_h, b_vb1) + tl.dot(b_Ai22_h, b_vb2)
+            b_u3 = tl.dot(b_Ai30_h, b_vb0) + tl.dot(b_Ai31_h, b_vb1) + tl.dot(b_Ai32_h, b_vb2) + tl.dot(b_Ai33_h, b_vb3)
+
+            p_u0 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc0, i_v * BV), (BC, BV), (1, 0))
+            p_u1 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc1, i_v * BV), (BC, BV), (1, 0))
+            p_u2 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc2, i_v * BV), (BC, BV), (1, 0))
+            p_u3 = tl.make_block_ptr(u_base, (T, V), (H * V, 1), (i_tc3, i_v * BV), (BC, BV), (1, 0))
+            tl.store(p_u0, b_u0.to(p_u0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u1, b_u1.to(p_u1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u2, b_u2.to(p_u2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_u3, b_u3.to(p_u3.dtype.element_ty), boundary_check=(0, 1))
+
+        # ---- w = A_inv @ (k * beta * exp(gk)), kg = k * exp(gn - gk) ----
+        w_base = w_out + (bos * H + i_h) * K
+        kg_base = kg_out + (bos * H + i_h) * K
+        last_idx = min(i_t * BT + BT, T) - 1
+
+        for i_k in range(tl.cdiv(K, BK)):
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            b_gn = tl.load(g + last_idx * H * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+
+            p_k0 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_k1 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_k2 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_k3 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+
+            p_gk0 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_gk1 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_gk2 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_gk3 = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+
+            b_k0r = tl.load(p_k0, boundary_check=(0, 1))
+            b_k1r = tl.load(p_k1, boundary_check=(0, 1))
+            b_k2r = tl.load(p_k2, boundary_check=(0, 1))
+            b_k3r = tl.load(p_k3, boundary_check=(0, 1))
+
+            b_gk0r = tl.load(p_gk0, boundary_check=(0, 1)).to(tl.float32)
+            b_gk1r = tl.load(p_gk1, boundary_check=(0, 1)).to(tl.float32)
+            b_gk2r = tl.load(p_gk2, boundary_check=(0, 1)).to(tl.float32)
+            b_gk3r = tl.load(p_gk3, boundary_check=(0, 1)).to(tl.float32)
+
+            b_kb0 = (b_k0r * b_b0[:, None] * exp(b_gk0r)).to(b_k0r.dtype)
+            b_kb1 = (b_k1r * b_b1r[:, None] * exp(b_gk1r)).to(b_k1r.dtype)
+            b_kb2 = (b_k2r * b_b2r[:, None] * exp(b_gk2r)).to(b_k2r.dtype)
+            b_kb3 = (b_k3r * b_b3r[:, None] * exp(b_gk3r)).to(b_k3r.dtype)
+
+            b_w0 = tl.dot(b_Ai00_h, b_kb0)
+            b_w1 = tl.dot(b_Ai10_h, b_kb0) + tl.dot(b_Ai11_h, b_kb1)
+            b_w2 = tl.dot(b_Ai20_h, b_kb0) + tl.dot(b_Ai21_h, b_kb1) + tl.dot(b_Ai22_h, b_kb2)
+            b_w3 = tl.dot(b_Ai30_h, b_kb0) + tl.dot(b_Ai31_h, b_kb1) + tl.dot(b_Ai32_h, b_kb2) + tl.dot(b_Ai33_h, b_kb3)
+
+            p_w0 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_w1 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_w2 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_w3 = tl.make_block_ptr(w_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_w0, b_w0.to(p_w0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w1, b_w1.to(p_w1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w2, b_w2.to(p_w2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_w3, b_w3.to(p_w3.dtype.element_ty), boundary_check=(0, 1))
+
+            b_kg0 = b_k0r * exp(b_gn[None, :] - b_gk0r)
+            b_kg1 = b_k1r * exp(b_gn[None, :] - b_gk1r)
+            b_kg2 = b_k2r * exp(b_gn[None, :] - b_gk2r)
+            b_kg3 = b_k3r * exp(b_gn[None, :] - b_gk3r)
+
+            p_kg0 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+            p_kg1 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+            p_kg2 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_kg3 = tl.make_block_ptr(kg_base, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+            tl.store(p_kg0, b_kg0.to(p_kg0.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg1, b_kg1.to(p_kg1.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg2, b_kg2.to(p_kg2.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(p_kg3, b_kg3.to(p_kg3.dtype.element_ty), boundary_check=(0, 1))
+    else:
+        p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+        p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+        p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+        p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0))
+        p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0))
+        p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0))
+
+        tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_kda_fwd_kernel_intra_sub_chunk(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_GATHER: tl.constexpr,
+):
+    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_c = i_ti + tl.arange(0, BC)
+    m_c = o_c < T
+
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    g = g + (bos * H + i_h) * K
+    beta = beta + bos * H + i_h
+    Aqk = Aqk + (bos * H + i_h) * BT
+    Akk = Akk + (bos * H + i_h) * BC
+
+    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+
+    p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_ti,), (BC,), (0,))
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+
+    if USE_GATHER:
+        b_gn = gather(b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0)
+    else:
+        # calculate offset
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * H * K + tl.arange(0, BK)
+        b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+        b_gn = b_gn[None, :]
+
+    # current block, keep numerical stability by subtracting the left boundary
+    # less than 85 to avoid overflow in exp2
+    b_gm = (b_g - b_gn).to(tl.float32)
+
+    b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.0)
+    b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.0)
+
+    b_kgt = tl.trans(b_k * b_gk)
+
+    b_Aqk = tl.dot(b_q * b_gq, b_kgt) * scale
+    b_Akk = tl.dot(b_k * b_gq, b_kgt) * b_beta[:, None]
+
+    o_i = tl.arange(0, BC)
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (H * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+    p_Akk = tl.make_block_ptr(Akk, (T, BC), (H * BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.debug_barrier()
+
+    ################################################################################
+    # forward substitution
+    ################################################################################
+
+    b_Ai = -b_Akk
+    for i in range(2, min(BC, T - i_ti)):
+        b_a = -tl.load(Akk + (i_ti + i) * H * BC + o_i)
+        b_a = tl.where(o_i < i, b_a, 0.0)
+        b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+    b_Ai += m_I
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_kda_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    safe_gate: bool = False,
+    disable_recompute: bool = False,
+    fuse_recompute: bool = False,
+    fuse_diagonal: bool = False,
+):
+    B, T, H, K = k.shape
+    V = v.shape[-1]
+    BT = chunk_size
+    BC = 16
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+
+    if fuse_diagonal:
+        Aqk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    else:
+        Aqk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)
+    Akkd = torch.empty(B, T, H, BC, device=k.device, dtype=torch.float32)
+
+    # Step 1: compute diagonal blocks into Akkd (fp32)
+    # When fuse_diagonal=True, diagonal blocks are computed inside inter_solve
+    if not fuse_diagonal:
+        if safe_gate:
+            grid = (NT, NC, B * H)
+            BK = triton.next_power_of_2(K)
+            chunk_kda_fwd_kernel_intra_sub_chunk[grid](
+                q=q,
+                k=k,
+                g=gk,
+                beta=beta,
+                Aqk=Aqk,
+                Akk=Akkd,
+                scale=scale,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                T=T,
+                H=H,
+                K=K,
+                BT=BT,
+                BC=BC,
+                BK=BK,
+                USE_GATHER=IS_GATHER_SUPPORTED,
+            )
+        else:
+            Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
+                q=q,
+                k=k,
+                gk=gk,
+                beta=beta,
+                Aqk=Aqk,
+                Akk=Akkd,
+                scale=scale,
+                cu_seqlens=cu_seqlens,
+                chunk_size=BT,
+                sub_chunk_size=BC,
+            )
+
+    # Step 2: inter_solve (+ optional fused recompute)
+    grid = (NT, B * H)
+
+    if fuse_recompute:
+        w = torch.empty_like(k)
+        u = torch.empty_like(v)
+        kg = torch.empty_like(k)
+        chunk_kda_fwd_kernel_inter_solve_fused[grid](
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akkd=Akkd,
+            Akk=k,  # unused placeholder when FUSE_RECOMPUTE=True (dead branch)
+            scale=scale,
+            v_in=v,
+            w_out=w,
+            u_out=u,
+            kg_out=kg,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            K=K,
+            V=V,
+            BT=BT,
+            BC=BC,
+            USE_SAFE_GATE=safe_gate,
+            FUSE_RECOMPUTE=True,
+            FUSE_DIAGONAL=fuse_diagonal,
+        )
+        return w, u, None, kg, Aqk, None
+
+    # Non-fused path: inter_solve stores Akk, then separate recompute
+    Akk = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    chunk_kda_fwd_kernel_inter_solve_fused[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akkd=Akkd,
+        Akk=Akk,
+        scale=scale,
+        # v_in/w_out/u_out/kg_out unused when FUSE_RECOMPUTE=False (dead branch)
+        v_in=k,
+        w_out=k,
+        u_out=k,
+        kg_out=k,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=0,
+        BT=BT,
+        BC=BC,
+        USE_SAFE_GATE=safe_gate,
+        FUSE_RECOMPUTE=False,
+        FUSE_DIAGONAL=fuse_diagonal,
+    )
+
+    from fla.ops.kda.wy_fast import recompute_w_u_fwd as kda_recompute_w_u_fwd
+
+    w, u, qg, kg = kda_recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=Akk,
+        q=q if disable_recompute else None,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, qg, kg, Aqk, Akk

--- a/areno/accel/kernels/kda_fla/chunk_intra_token_parallel.py
+++ b/areno/accel/kernels/kda_fla/chunk_intra_token_parallel.py
@@ -1,0 +1,182 @@
+# ruff: noqa
+# Adapted from flash-linear-attention project.
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# Token-parallel implementation of KDA intra chunk kernel
+
+import torch
+import triton
+import triton.language as tl
+
+from fla.ops.utils.op import exp2
+from fla.utils import autotune_cache_kwargs
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({"BH": BH}, num_warps=num_warps) for BH in [1, 2, 4, 8] for num_warps in [1, 2, 4, 8]],
+    key=["K", "H"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "N"])
+def chunk_kda_fwd_kernel_intra_token_parallel(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    N,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    BH: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_tg, i_hg = tl.program_id(0), tl.program_id(1)
+
+    if IS_VARLEN:
+        i_n = 0
+        left, right = 0, N
+
+        # Unrolled binary search (max B=2^32)
+        # We can limit iterations based on expected max batch size if needed
+        # 20 iterations covers B=1M, usually enough
+        for _ in range(20):
+            if left < right:
+                mid = (left + right) // 2
+                if i_tg < tl.load(cu_seqlens + mid + 1).to(tl.int32):
+                    right = mid
+                else:
+                    left = mid + 1
+        i_n = left
+
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        i_t = i_tg - bos
+    else:
+        bos = (i_tg // T) * T
+        i_t = i_tg % T
+
+    if i_t >= T:
+        return
+
+    i_c = i_t // BT
+    i_s = (i_t % BT) // BC
+    i_tc = i_c * BT
+    i_ts = i_tc + i_s * BC
+
+    q += bos * H * K
+    k += bos * H * K
+    g += bos * H * K
+    Aqk += bos * H * BT
+    Akk += bos * H * BC
+    beta += bos * H
+
+    o_h = tl.arange(0, BH)
+    o_k = tl.arange(0, BK)
+    m_h = (i_hg * BH + o_h) < H
+    m_k = o_k < K
+
+    p_q = tl.make_block_ptr(q + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_k = tl.make_block_ptr(k + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_g = tl.make_block_ptr(g + i_t * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_beta = tl.make_block_ptr(beta + i_t * H, (H,), (1,), (i_hg * BH,), (BH,), (0,))
+    # [BH, BK]
+    b_q = tl.load(p_q, boundary_check=(0, 1)).to(tl.float32)
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_k = b_k * tl.load(p_beta, boundary_check=(0,)).to(tl.float32)[:, None]
+
+    for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
+        p_kj = tl.make_block_ptr(k + j * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+        p_gj = tl.make_block_ptr(g + j * H * K, (H, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+        # [BH, BK]
+        b_kj = tl.load(p_kj, boundary_check=(0, 1)).to(tl.float32)
+        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+
+        b_kgj = b_kj * exp2(b_g - b_gj)
+
+        b_kgj = tl.where(m_k[None, :], b_kgj, 0.0)
+        # [BH]
+        b_Aqk = tl.sum(b_q * b_kgj, axis=1) * scale
+        b_Akk = tl.sum(b_k * b_kgj, axis=1) * tl.where(j < i_t, 1.0, 0.0)
+
+        tl.store(
+            Aqk + i_t * H * BT + (i_hg * BH + o_h) * BT + j % BT,
+            b_Aqk.to(Aqk.dtype.element_ty),
+            mask=m_h,
+        )
+        tl.store(
+            Akk + i_t * H * BC + (i_hg * BH + o_h) * BC + j - i_ts,
+            b_Akk.to(Akk.dtype.element_ty),
+            mask=m_h,
+        )
+
+
+def chunk_kda_fwd_intra_token_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    sub_chunk_size: int = 16,
+) -> None:
+    """
+    Token-parallel implementation: each token gets its own thread block.
+    Supports both fixed-length and variable-length sequences.
+    Reduces wasted computation on padding.
+
+    Writes directly to Aqk and Akk tensors (in-place).
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        gk: [B, T, H, K] cumsum of gates
+        beta: [B, T, H]
+        Aqk: [B, T, H, BT] output tensor to write to
+        Akk: [B, T, H, BC] output tensor for diagonal blocks (fp32)
+        scale: attention scale
+        chunk_size: BT (default 64)
+        sub_chunk_size: BC (default 16)
+    """
+    B, T, H, K = q.shape
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BT = chunk_size
+    BC = sub_chunk_size
+
+    def grid(meta):
+        return (B * T, triton.cdiv(H, meta["BH"]))
+
+    BK = triton.next_power_of_2(K)
+
+    chunk_kda_fwd_kernel_intra_token_parallel[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        N=N,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+    )
+    return Aqk, Akk

--- a/areno/accel/kernels/kda_fla/fused_sigmoid_gating_recurrent.py
+++ b/areno/accel/kernels/kda_fla/fused_sigmoid_gating_recurrent.py
@@ -1,0 +1,356 @@
+# ruff: noqa
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit(do_not_specialize=["T"])
+def fused_sigmoid_gating_delta_rule_update_kernel(
+    A_log,
+    a,
+    dt_bias,
+    softplus_beta,
+    softplus_threshold,
+    lower_bound,
+    q,
+    k,
+    v,
+    b,
+    o,
+    h0_source,
+    h0_indices,
+    cu_seqlens,
+    # Parameters for target_verify support (unused for decode)
+    intermediate_states_buffer,
+    intermediate_state_indices,
+    cache_steps,
+    retrieve_parent_token_ptr,
+    stride_retrieve_parent_token_seq: tl.constexpr,
+    stride_retrieve_parent_token_token: tl.constexpr,
+    # ================================================
+    scale,
+    T,
+    stride_a,
+    stride_q,
+    stride_k,
+    stride_v,
+    stride_b,
+    NP2_T: tl.constexpr,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    IS_KDA: tl.constexpr,
+    # Optional flags for target_verify support (default False for decode)
+    DISABLE_STATE_UPDATE: tl.constexpr = False,
+    CACHE_INTERMEDIATE_STATES: tl.constexpr = False,
+    HAS_EAGLE_TREE_CUSTOM_ATTN_MASK: tl.constexpr = False,
+    USE_LOWER_BOUND: tl.constexpr = False,
+):
+    """
+    Fused kernel that combines sigmoid gating computation with recurrent delta rule update.
+    """
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        all = B * T
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_q = q + bos * stride_q + i_h * K + o_k
+    p_k = k + bos * stride_k + i_h * K + o_k
+    p_v = v + bos * stride_v + i_hv * V + o_v
+    p_b = b + bos * stride_b + i_hv
+    p_o = o + ((i_k * all + bos) * HV + i_hv) * V + o_v
+
+    # Gating computation pointers
+    p_A_log = A_log + i_hv
+    if IS_KDA:
+        p_a = a + bos * stride_a + i_hv * K + o_k
+        p_dt_bias = dt_bias + i_hv * K + o_k
+    else:
+        p_a = a + bos * stride_a + i_hv
+        p_dt_bias = dt_bias + i_hv
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        idx = tl.load(h0_indices + i_n)
+        if idx >= 0:
+            p_h0 = h0_source + idx * HV * K * V + i_hv * K * V + o_v[None, :] * K + o_k[:, None]
+            b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    # Preload tree attention data if needed
+    if HAS_EAGLE_TREE_CUSTOM_ATTN_MASK:
+        token_indices = tl.arange(0, NP2_T)
+        mask_retrieve = token_indices < T
+        retrieve_parent_token_base = (
+            retrieve_parent_token_ptr
+            + (i_n * stride_retrieve_parent_token_seq)
+            + token_indices * stride_retrieve_parent_token_token
+        )
+        parent_idx_tokens = tl.load(retrieve_parent_token_base, mask=mask_retrieve, other=0)
+
+    # Prepare intermediate state cache index if enabled
+    cache_idx = -1
+    if CACHE_INTERMEDIATE_STATES:
+        cache_idx = tl.load(intermediate_state_indices + i_n)
+
+    step_idx = 0
+    for _ in range(0, T):
+        # Tree attention: load parent's cached state
+        if HAS_EAGLE_TREE_CUSTOM_ATTN_MASK:
+            # step_idx == 0 uses b_h from USE_INITIAL_STATE
+            if step_idx != 0 and cache_idx >= 0:
+                parent_step_idx = tl.sum(tl.where(token_indices == step_idx, parent_idx_tokens, 0))
+                step_offset = parent_step_idx * HV * K * V
+                cache_ptr = (
+                    intermediate_states_buffer
+                    + cache_idx * cache_steps * HV * K * V
+                    + step_offset
+                    + i_hv * K * V
+                    + o_v[None, :] * K
+                    + o_k[:, None]
+                )
+                b_h = tl.load(cache_ptr, mask=mask_h, other=0).to(tl.float32)
+
+        # Load inputs
+        b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
+        b_b = tl.load(p_b).to(tl.float32)
+
+        # Compute sigmoid gating
+        # Load gating parameters
+        b_A_log = tl.load(p_A_log).to(tl.float32)
+        if IS_KDA:
+            b_a = tl.load(p_a, mask=mask_k, other=0).to(tl.float32)
+            b_dt_bias = tl.load(p_dt_bias, mask=mask_k, other=0).to(tl.float32)
+        else:
+            b_a = tl.load(p_a).to(tl.float32)
+            b_dt_bias = tl.load(p_dt_bias).to(tl.float32)
+
+        # Compute gate
+        x = b_a + b_dt_bias
+        if USE_LOWER_BOUND:
+            # safe gate: g = lower_bound * sigmoid(exp(A_log) * x)
+            b_g = lower_bound * tl.sigmoid(tl.exp(b_A_log) * x)
+        else:
+            # normal: g = -exp(A_log) * softplus(x)
+            beta_x = softplus_beta * x
+            softplus_x = tl.where(
+                beta_x <= softplus_threshold,
+                (1.0 / softplus_beta) * tl.log(1.0 + tl.exp(beta_x)),
+                x,
+            )
+            b_g = -tl.exp(b_A_log) * softplus_x
+
+        # Compute beta = sigmoid(b)
+        b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+
+        # Apply L2 normalization if enabled
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / (tl.sqrt(tl.sum(b_q * b_q) + 1e-6))
+            b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k) + 1e-6))
+
+        b_q = b_q * scale
+
+        # Apply gating to hidden state: h *= exp(g)
+        if IS_KDA:
+            b_h *= tl.exp(b_g[:, None])
+        else:
+            b_h *= tl.exp(b_g)
+
+        # Delta rule: v -= sum(h * k, dim=0)
+        b_v -= tl.sum(b_h * b_k[:, None], 0)
+
+        # Apply beta gating: v *= beta
+        b_v *= b_beta
+
+        # Update hidden state: h += k[:, None] * v[None, :]
+        b_h += b_k[:, None] * b_v[None, :]
+
+        # Compute output: o = sum(h * q, dim=0)
+        b_o = tl.sum(b_h * b_q[:, None], 0)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+
+        # Cache intermediate states if enabled
+        if CACHE_INTERMEDIATE_STATES:
+            if cache_idx >= 0:
+                step_offset = step_idx * HV * K * V
+                cache_ptr = (
+                    intermediate_states_buffer
+                    + cache_idx * cache_steps * HV * K * V
+                    + step_offset
+                    + i_hv * K * V
+                    + o_v[None, :] * K
+                    + o_k[:, None]
+                )
+                tl.store(cache_ptr, b_h.to(cache_ptr.dtype.element_ty), mask=mask_h)
+
+        step_idx += 1
+
+        # Update pointers for next timestep
+        p_q += stride_q
+        p_k += stride_k
+        p_v += stride_v
+        p_b += stride_b
+        p_o += HV * V
+        p_a += stride_a
+
+    # Store final state back to h0_source with bounds checking
+    if not DISABLE_STATE_UPDATE:
+        if USE_INITIAL_STATE:
+            idx = tl.load(h0_indices + i_n)
+            if idx >= 0:
+                p_h0 = h0_source + idx * HV * K * V + i_hv * K * V + o_v[None, :] * K + o_k[:, None]
+                tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=mask_h)
+
+
+def fused_sigmoid_gating_delta_rule_update(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    softplus_beta: float,
+    softplus_threshold: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    b: torch.Tensor,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    scale: Optional[float] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    is_kda: bool = False,
+    # Optional parameters for target_verify support
+    disable_state_update: bool = False,
+    intermediate_states_buffer: Optional[torch.Tensor] = None,
+    intermediate_state_indices: Optional[torch.Tensor] = None,
+    cache_steps: Optional[
+        int
+    ] = None,  # kept for API compat; stride is derived from ``intermediate_states_buffer.shape[1]``
+    retrieve_parent_token: Optional[torch.Tensor] = None,
+    lower_bound: Optional[float] = None,
+):
+    """
+    Fused triton implementation of sigmoid gating delta rule update.
+    This function uses a single fused kernel that combines both sigmoid gating computation
+    and the recurrent delta rule update for better performance.
+
+    Supports both decode and target_verify modes:
+    - decode: standard single-step update with state write-back
+    - target_verify: multi-step with intermediate state caching, optional tree attention,
+                     and optional state update disable
+    """
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    stride_q = q.stride()[1]
+    stride_k = k.stride()[1]
+    stride_v = v.stride()[1]
+    stride_b = b.stride()[-2]
+    # Both paths (KDA/GDN) advance p_a once per token, so use the token-axis stride.
+    # For 2D a ([T, ...]) this is stride(0); for 3D a ([B, T, ...]) this is stride(1).
+    # Using stride()[-2] covers GDN [T, HV] and KDA layouts ([T, HV*K] / [B, T, HV*K]).
+    stride_a = a.stride()[-2]
+    HV = v.shape[2]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    else:
+        assert scale > 0, "scale must be positive"
+
+    o = q.new_empty(NK, *v.shape)
+
+    # Prepare retrieve_parent_token strides
+    if retrieve_parent_token is not None:
+        stride_retrieve_parent_token_seq = retrieve_parent_token.stride(0)
+        stride_retrieve_parent_token_token = retrieve_parent_token.stride(1)
+    else:
+        stride_retrieve_parent_token_seq = 0
+        stride_retrieve_parent_token_token = 0
+
+    NP2_T = triton.next_power_of_2(T)
+
+    grid = (NK, NV, N * HV)
+
+    # Per-req stride must match the buffer's allocated dim, not runtime steps
+    # (they can differ under --speculative-adaptive).
+    cache_stride_steps = intermediate_states_buffer.shape[1] if intermediate_states_buffer is not None else 0
+
+    fused_sigmoid_gating_delta_rule_update_kernel[grid](
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=softplus_beta,
+        softplus_threshold=softplus_threshold,
+        lower_bound=lower_bound,
+        q=q,
+        k=k,
+        v=v,
+        b=b,
+        o=o,
+        h0_source=initial_state_source,
+        h0_indices=initial_state_indices,
+        cu_seqlens=cu_seqlens,
+        intermediate_states_buffer=intermediate_states_buffer,
+        intermediate_state_indices=intermediate_state_indices,
+        cache_steps=cache_stride_steps,
+        retrieve_parent_token_ptr=retrieve_parent_token,
+        stride_retrieve_parent_token_seq=stride_retrieve_parent_token_seq,
+        stride_retrieve_parent_token_token=stride_retrieve_parent_token_token,
+        scale=scale,
+        T=T,
+        stride_a=stride_a,
+        stride_q=stride_q,
+        stride_k=stride_k,
+        stride_v=stride_v,
+        stride_b=stride_b,
+        NP2_T=NP2_T,
+        B=B,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_INITIAL_STATE=initial_state_source is not None,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_VARLEN=cu_seqlens is not None,
+        IS_KDA=is_kda,
+        DISABLE_STATE_UPDATE=disable_state_update,
+        CACHE_INTERMEDIATE_STATES=intermediate_states_buffer is not None,
+        HAS_EAGLE_TREE_CUSTOM_ATTN_MASK=retrieve_parent_token is not None,
+        USE_LOWER_BOUND=lower_bound is not None,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    o = o.squeeze(0)
+    return o

--- a/areno/accel/kernels/kda_fla/kda.py
+++ b/areno/accel/kernels/kda_fla/kda.py
@@ -1,0 +1,87 @@
+"""AReno KDA wrappers for flash-linear-attention.
+
+This module keeps the Bailing V3 call contract and only overrides the KDA
+pieces that need AReno-specific behavior.  Shared kernels stay imported from
+FLA so we do not vendor the full FLA operator stack.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def activate_kda_gate(
+    raw_gate: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float | None,
+) -> torch.Tensor:
+    """Apply SGLang/FLA KDA gate activation without the chunk cumulative sum."""
+
+    head_count, key_dim = raw_gate.shape[-2:]
+    if a_log.numel() != head_count or dt_bias.numel() != head_count * key_dim:
+        raise ValueError("KDA gate parameters do not match gate shape")
+    rate = a_log.float().exp().view(1, 1, head_count, 1)
+    gate_input = raw_gate.float() + dt_bias.float().view(1, 1, head_count, key_dim)
+    if lower_bound is not None:
+        decay = lower_bound * torch.sigmoid(rate * gate_input)
+    else:
+        decay = -rate * F.softplus(gate_input)
+    return decay.to(dtype=raw_gate.dtype)
+
+
+def chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    initial_state: torch.Tensor | None = None,
+    initial_state_indices: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    from fla.ops.kda import chunk_kda as fla_chunk_kda
+
+    if initial_state_indices is not None and initial_state is not None:
+        initial_state = initial_state.index_select(0, initial_state_indices)
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    if A_log is None or dt_bias is None:
+        raise ValueError("KDA prefill requires A_log and dt_bias")
+    decay = activate_kda_gate(g, A_log, dt_bias, lower_bound)
+
+    if use_qk_l2norm_in_kernel:
+        q_float = q.float()
+        k_float = k.float()
+        q = (q_float * torch.rsqrt((q_float * q_float).sum(dim=-1, keepdim=True) + 1e-6)).to(q.dtype)
+        k = (k_float * torch.rsqrt((k_float * k_float).sum(dim=-1, keepdim=True) + 1e-6)).to(k.dtype)
+
+    fla_initial_state = initial_state.transpose(-1, -2).contiguous() if initial_state is not None else None
+    out, final_state = fla_chunk_kda(
+        q=q.contiguous(),
+        k=k.contiguous(),
+        v=v.contiguous(),
+        g=decay.contiguous(),
+        beta=beta.contiguous(),
+        scale=scale,
+        initial_state=fla_initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=False,
+        cu_seqlens=cu_seqlens,
+    )
+    if final_state is not None:
+        final_state = final_state.transpose(-1, -2).contiguous()
+    return out, final_state
+
+
+__all__ = ["activate_kda_gate", "chunk_kda"]

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -127,6 +127,7 @@ class AgentTrajectoryTurn:
     item: AgentItem
     messages: list[dict[str, Any]]
     response: Any | None = None
+    input_tokens: list[int] = field(default_factory=list)
     response_tokens: list[int] = field(default_factory=list)
     response_logprobs: list[float] = field(default_factory=list)
     parsed_tool_calls: list[dict[str, Any]] = field(default_factory=list)
@@ -138,6 +139,7 @@ class AgentTrajectoryTurn:
         if self.response is None:
             return
         metadata = _chat_response_agentic_metadata(self.response)
+        self.input_tokens = list(metadata.get("input_tokens") or [])
         self.response_tokens = list(metadata["response_tokens"])
         self.response_logprobs = [float(value) for value in metadata["response_logprobs"]]
         self.parsed_tool_calls = _chat_response_message_tool_calls(self.response)
@@ -148,6 +150,7 @@ class AgentTrajectory:
     """Explicit trajectories returned by ``run_agent`` for one rollout batch."""
 
     turns: list[AgentTrajectoryTurn] = field(default_factory=list)
+    invalid_items: list[AgentItem] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -569,7 +572,10 @@ class RolloutSession:
             tool_choice=turn.tool_choice,
             created_at=time.monotonic(),
         )
-        pending.input_tokens, pending.features = self._messages_to_tokens_and_features(pending)
+        if turn.input_tokens:
+            pending.input_tokens = list(turn.input_tokens)
+        else:
+            pending.input_tokens, pending.features = self._messages_to_tokens_and_features(pending)
         return self._sample_from_pending_chat(
             pending,
             _ResponseData(response_tokens=list(turn.response_tokens), response_logprobs=list(turn.response_logprobs)),

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -22,10 +22,27 @@ def normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # the tool_calls payload.
         if item.get("content") is None:
             item["content"] = ""
+        elif isinstance(item.get("content"), list):
+            text_content = _text_only_content(item["content"])
+            if text_content is not None:
+                item["content"] = text_content
         if isinstance(item.get("tool_calls"), list):
             item["tool_calls"] = [_normalize_message_tool_call(call) for call in item["tool_calls"]]
         normalized.append(item)
     return normalized
+
+
+def _text_only_content(content: list[Any]) -> str | None:
+    """Flatten OpenAI text parts while preserving multimodal content lists."""
+
+    parts: list[str] = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") not in {"text", "input_text"}:
+            return None
+        text = part.get("text")
+        if text is not None:
+            parts.append(str(text))
+    return "".join(parts)
 
 
 def _normalize_message_tool_call(call: Any) -> Any:

--- a/areno/api/tool_call_parser.py
+++ b/areno/api/tool_call_parser.py
@@ -67,7 +67,7 @@ def infer_tool_call_parser_name(trainer: Any) -> str:
         return "gemma4"
     if "minicpm" in haystack:
         return "minicpm"
-    if "<tool_call>" in template or "qwen" in haystack:
+    if "<tool_call>" in template or "qwen" in haystack or "ling" in haystack:
         return "qwen"
     return "json"
 
@@ -84,13 +84,7 @@ class JsonToolCallParser:
         calls = _parse_json_tool_calls(content, tools, chosen_name)
         if calls:
             return ToolCallParseResult(normal_text="", tool_calls=calls)
-
-        if chosen_name is None:
-            return ToolCallParseResult(normal_text=content)
-        args = _parse_explicit_arguments_text(content, tools, chosen_name)
-        if args is None:
-            return ToolCallParseResult(normal_text=content)
-        return ToolCallParseResult(normal_text="", tool_calls=[_openai_tool_call(chosen_name, args)])
+        return ToolCallParseResult(normal_text=content)
 
 
 class QwenToolCallParser(JsonToolCallParser):
@@ -104,9 +98,12 @@ class QwenToolCallParser(JsonToolCallParser):
         for block in self._block_re.findall(content):
             calls.extend(_parse_json_tool_calls(block, tools, _chosen_tool_name(tools, tool_choice)))
             calls.extend(_parse_angle_tool_calls(block, tools, tool_choice))
+            calls.extend(_parse_arg_key_value_tool_calls(block, tools, tool_choice))
         if calls:
             normal = content[: content.find("<tool_call>")].strip()
             return ToolCallParseResult(normal_text=normal, tool_calls=calls)
+        if _chosen_tool_name(tools, tool_choice) is None:
+            return ToolCallParseResult(normal_text=content)
         return super().parse(content, tools, tool_choice)
 
 
@@ -253,23 +250,12 @@ def _load_json_object(text: str) -> Any | None:
     return None
 
 
-def _parse_explicit_arguments_text(content: str, tools: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
-    enum_arg = _single_enum_argument(tools, name)
-    if enum_arg is None:
-        return None
-    key, values = enum_arg
-    parsed = _single_enum_value_from_text(content, key, values)
-    if parsed is None:
-        return None
-    return {key: parsed}
-
-
 def _chosen_tool_name(tools: list[dict[str, Any]], tool_choice: Any) -> str | None:
     if isinstance(tool_choice, dict):
         function = tool_choice.get("function")
         if isinstance(function, dict) and isinstance(function.get("name"), str):
             return function["name"]
-    if len(tools) == 1:
+    if tool_choice == "required" and len(tools) == 1:
         function = _tool_function(tools[0])
         if isinstance(function, dict) and isinstance(function.get("name"), str):
             return function["name"]
@@ -298,24 +284,6 @@ def _tool_names(tools: list[dict[str, Any]]) -> set[str]:
     return names
 
 
-def _single_enum_argument(tools: list[dict[str, Any]], name: str) -> tuple[str, list[Any]] | None:
-    for tool in tools:
-        function = _tool_function(tool)
-        if not isinstance(function, dict) or function.get("name") != name:
-            continue
-        parameters = function.get("parameters")
-        properties = parameters.get("properties") if isinstance(parameters, dict) else None
-        if not isinstance(properties, dict):
-            return None
-        enum_fields = []
-        for key, spec in properties.items():
-            enum = spec.get("enum") if isinstance(spec, dict) else None
-            if isinstance(enum, list) and enum:
-                enum_fields.append((key, enum))
-        return enum_fields[0] if len(enum_fields) == 1 else None
-    return None
-
-
 def _tool_function(tool: dict[str, Any]) -> dict[str, Any] | None:
     """Return an OpenAI function schema from chat or flat tool syntax."""
 
@@ -330,23 +298,6 @@ def _tool_function(tool: dict[str, Any]) -> dict[str, Any] | None:
             "description": tool.get("description"),
             "parameters": tool.get("parameters"),
         }
-    return None
-
-
-def _single_enum_value_from_text(text: str, key: str, values: list[Any]) -> Any | None:
-    value_by_lower = {str(value).lower(): value for value in values}
-    if not value_by_lower:
-        return None
-    alternatives = "|".join(re.escape(value) for value in value_by_lower)
-    patterns = [
-        rf'["\']?{re.escape(key)}["\']?\s*[:=]\s*["\']?\b({alternatives})\b',
-        rf"<(?:{re.escape(key)}|move|action)>\s*({alternatives})\s*</(?:{re.escape(key)}|move|action)>",
-        rf"\b(?:choose|select|play|move|slide|go|answer|direction)\s*(?:is|:|=|to)?\s*\b({alternatives})\b",
-    ]
-    for pattern in patterns:
-        matches = re.findall(pattern, text, flags=re.IGNORECASE)
-        if matches:
-            return value_by_lower[str(matches[-1]).lower()]
     return None
 
 
@@ -479,6 +430,10 @@ def _parse_minicpm_param_value(value: str) -> Any:
 _ANGLE_TOOL_BLOCK_RE = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTALL | re.IGNORECASE)
 _ANGLE_FUNCTION_RE = re.compile(r"<function=([^>\s]+)>\s*(.*?)</function>", re.DOTALL | re.IGNORECASE)
 _ANGLE_PARAM_RE = re.compile(r"<parameter=([^>\s]+)>\s*(.*?)</parameter>", re.DOTALL | re.IGNORECASE)
+_ARG_PAIR_RE = re.compile(
+    r"<arg_key>\s*(.*?)\s*</arg_key>\s*<arg_value>\s*(.*?)\s*</arg_value>",
+    re.DOTALL | re.IGNORECASE,
+)
 
 
 def _parse_angle_tool_call_blocks(content: str, tools: list[dict[str, Any]], tool_choice: Any) -> list[dict[str, Any]]:
@@ -496,6 +451,62 @@ def _parse_angle_tool_calls(content: str, tools: list[dict[str, Any]], tool_choi
         args = {key.strip(): _parse_minicpm_param_value(value.strip()) for key, value in _ANGLE_PARAM_RE.findall(body)}
         calls.append(_openai_tool_call(name.strip(), args))
     return calls
+
+
+def _parse_arg_key_value_tool_calls(
+    content: str, tools: list[dict[str, Any]], tool_choice: Any
+) -> list[dict[str, Any]]:
+    """Parse Ling-style ``tool_name + arg_key/arg_value`` blocks."""
+
+    first_arg = content.lower().find("<arg_key>")
+    if first_arg < 0:
+        return []
+    name = content[:first_arg].strip()
+    if not name or "<" in name or not _tool_name_allowed(name, tools, tool_choice):
+        return []
+    properties = _tool_parameter_properties(name, tools)
+    args = {
+        key.strip(): _parse_schema_parameter_value(value.strip(), properties.get(key.strip()))
+        for key, value in _ARG_PAIR_RE.findall(content)
+    }
+    return [_openai_tool_call(name, args)] if args else []
+
+
+def _tool_parameter_properties(name: str, tools: list[dict[str, Any]]) -> dict[str, Any]:
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool.get("function"), dict) else tool
+        if function.get("name") == name:
+            parameters = function.get("parameters") or {}
+            properties = parameters.get("properties") or {}
+            return properties if isinstance(properties, dict) else {}
+    return {}
+
+
+def _parse_schema_parameter_value(value: str, schema: Any) -> Any:
+    expected_type = schema.get("type") if isinstance(schema, dict) else None
+    if expected_type == "string":
+        return value
+    if expected_type == "integer":
+        try:
+            return int(value)
+        except ValueError:
+            return value
+    if expected_type == "number":
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    if expected_type == "boolean":
+        if value.lower() in {"true", "false"}:
+            return value.lower() == "true"
+        return value
+    if expected_type in {"array", "object"}:
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return value
+        return parsed
+    return _parse_minicpm_param_value(value)
 
 
 def _first_nonnegative(*values: int) -> int | None:

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -245,6 +245,8 @@ class Trainer:
 
         cursor = 0
         total_skipped_long = 0
+        shortest_skipped = None
+        longest_skipped = None
         while cursor < len(dataset):
             items = []
             scanned = 0
@@ -301,6 +303,12 @@ class Trainer:
                 if len(input_tokens) > max_prompt_tokens:
                     skipped_long += 1
                     total_skipped_long += 1
+                    shortest_skipped = (
+                        len(input_tokens) if shortest_skipped is None else min(shortest_skipped, len(input_tokens))
+                    )
+                    longest_skipped = (
+                        len(input_tokens) if longest_skipped is None else max(longest_skipped, len(input_tokens))
+                    )
                     continue
                 items.append(
                     PromptItem(
@@ -311,6 +319,13 @@ class Trainer:
                     )
                 )
             if not items:
+                if total_skipped_long == len(dataset) and total_skipped_long > 0:
+                    raise ValueError(
+                        f"all {total_skipped_long} dataset prompts exceed "
+                        f"--max-prompt-tokens={max_prompt_tokens} "
+                        f"(shortest={shortest_skipped}, longest={longest_skipped}); "
+                        "increase --max-prompt-tokens or shorten the dataset prompts"
+                    )
                 break
             yield PromptBatch(
                 items=items,

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -14,6 +14,7 @@ role-management hooks; this is why the helpers are designed to be small.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -230,6 +231,7 @@ class PolicyOnlyTrainer:
             trajectories = await maybe_await(self._get_agent_run_fn()(ctx, agent_batch))
             if trajectories is None:
                 raise RuntimeError("agent run function must return explicit trajectories")
+            agent_filtered_count = self._agent_trajectory_invalid_count(trajectories)
             samples = []
             for turn in self._agent_trajectory_turns(ctx, trajectories):
                 sample = ctx._sample_from_trajectory_turn(turn)
@@ -242,14 +244,22 @@ class PolicyOnlyTrainer:
                 ctx, samples, sampling_params
             )
             expected = len(agent_batch)
-            if len(samples) + filtered_count != expected:
+            if len(samples) + filtered_count + agent_filtered_count != expected:
                 raise RuntimeError(
-                    f"agent rollout produced {len(samples)} trajectories and filtered {filtered_count}, expected {expected}"
+                    f"agent rollout produced {len(samples)} trajectories, filtered {filtered_count} overlong and "
+                    f"{agent_filtered_count} invalid, expected {expected}"
                 )
             if not samples:
                 raise RuntimeError(
-                    f"all {filtered_count} agent trajectories exceeded the configured context length; "
+                    f"all agent trajectories were filtered ({filtered_count} overlong, "
+                    f"{agent_filtered_count} invalid); "
                     f"{self._format_agent_filter_diagnostics(filter_diagnostics)}"
+                )
+            if agent_filtered_count:
+                self.logger.warning(
+                    "agentic rollout filtered invalid samples=%d valid_samples=%d",
+                    agent_filtered_count,
+                    len(samples),
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
             rewards = [float(self.reward_fn(record)) for record in reward_records]
@@ -397,6 +407,17 @@ class PolicyOnlyTrainer:
             else:
                 yield from trajectory
 
+    def _agent_trajectory_invalid_count(self, trajectories):
+        from areno.api.agentic import AgentTrajectory
+
+        if isinstance(trajectories, AgentTrajectory):
+            return len(trajectories.invalid_items)
+        if isinstance(trajectories, (list, tuple)):
+            return sum(
+                len(trajectory.invalid_items) for trajectory in trajectories if isinstance(trajectory, AgentTrajectory)
+            )
+        return 0
+
     def _find_agent_sample(self, samples, item):
         if item.prompt_index < 0 or item.sample_index < 0:
             return None
@@ -472,13 +493,13 @@ class PolicyOnlyTrainer:
     def _record_sample_completions(self, tokenizer, epoch: int, step: int, prompt_batch, rollout_results) -> None:
         # Diagnostics knob: setting ARENO_LOG_COMPLETIONS=N records up to N
         # decoded completions per step in the metrics directory.
-        limit = int(os.getenv("ARENO_LOG_COMPLETIONS", "1"))
+        limit = int(os.getenv("ARENO_LOG_COMPLETIONS", "0"))
         if limit <= 0:
             return
         logged = 0
         for prompt_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             for sample_idx, seq in enumerate(result.sequences):
-                self.areno.record_rollout_sample(
+                self._emit_completion_sample(
                     {
                         "kind": "rollout",
                         "epoch": epoch,
@@ -499,7 +520,7 @@ class PolicyOnlyTrainer:
     def _log_agentic_sample_completions(self, epoch: int, step: int, agent_batch) -> None:
         # Match non-agentic rollout diagnostics so reward/debug workflows do
         # not depend on rollout mode.
-        limit = int(os.getenv("ARENO_LOG_COMPLETIONS", "1"))
+        limit = int(os.getenv("ARENO_LOG_COMPLETIONS", "0"))
         if limit <= 0:
             return
         for logged, record in enumerate(agent_batch.reward_records):
@@ -508,7 +529,7 @@ class PolicyOnlyTrainer:
             loss_mask = agent_batch.loss_masks[logged]
             token_row = agent_batch.token_rows[logged]
             first_loss_idx = next((idx for idx, enabled in enumerate(loss_mask) if enabled), -1)
-            self.areno.record_rollout_sample(
+            self._emit_completion_sample(
                 {
                     "kind": "agentic",
                     "epoch": epoch,
@@ -529,6 +550,12 @@ class PolicyOnlyTrainer:
             )
             if logged + 1 >= limit:
                 return
+
+    def _emit_completion_sample(self, sample: dict) -> None:
+        """Log an opted-in completion and persist it with rollout metrics."""
+
+        self.logger.info("rollout_completion=%s", json.dumps(sample, ensure_ascii=False, default=str))
+        self.areno.record_rollout_sample(sample)
 
     def _materialize_train_batch(self, tokenizer, prompt_batch, rollout_results):
         """Assemble TrainSequence rows for one rollout batch.

--- a/areno/engine/checkpoints/common.py
+++ b/areno/engine/checkpoints/common.py
@@ -30,6 +30,7 @@ from torch import nn
 
 from areno.engine.checkpoints.io import (
     CheckpointTensorStore,
+    IncrementalHFSafetensorsWriter,
     PolicyTensorLayout,
     PolicyTensorPiece,
     PolicyTensorStore,
@@ -42,9 +43,9 @@ from areno.engine.checkpoints.io import (
     gather_tensor_parallel_ranged_tensor,
     gather_tensor_parallel_split_column_tensor,
     gather_tensor_parallel_tensor,
+    pageable_checkpoint_staging,
     policy_plan_scope,
     rank0_tensor,
-    write_hf_safetensors_checkpoint,
 )
 from areno.engine.layers.linear import _shard_range
 from areno.engine.parallel.context import get_tp_context
@@ -200,6 +201,7 @@ class LayerSpec:
     save_ops: tuple[object, ...] = ()
     load_handlers: tuple[Callable[[nn.Module, SafetensorsIndex, str, int, int], None], ...] = ()
     save_handlers: tuple[Callable[[dict[str, torch.Tensor | None], str, nn.Module, object | None], None], ...] = ()
+    prefetch_layer: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -400,15 +402,26 @@ def save_checkpoint_weights(
 ) -> str | None:
     """Save a tensor-parallel model as a HF sharded safetensors checkpoint."""
 
-    tensors = CheckpointTensorStore()
-    save_embedding_norm_head(tensors, model, spec.top_level)
-    # Some column-parallel tensors are batched until all layers are visited so
-    # that a single fused all-gather can be reused across shapes.
-    delayed_column_tensors: list[tuple[str, torch.Tensor]] = []
-    save_layer_specs(tensors, model, spec.layer, context=delayed_column_tensors)
-    if delayed_column_tensors:
-        save_column_tensors(tensors, delayed_column_tensors)
-    saved_path = write_hf_safetensors_checkpoint(tensors, output_path, source_path)
+    writer = IncrementalHFSafetensorsWriter(output_path, source_path)
+    with pageable_checkpoint_staging():
+        tensors = CheckpointTensorStore()
+        save_embedding_norm_head(tensors, model, spec.top_level)
+        writer.write(tensors, "top-level")
+        tensors.clear()
+
+        for layer_idx, layer in enumerate(model.layers):
+            prefix = spec.layer.prefix.format(layer=layer_idx)
+            delayed_column_tensors: list[tuple[str, torch.Tensor]] = []
+            save_replicated_tensors(tensors, layer, prefix, spec.layer.replicated)
+            for op in spec.layer.save_ops:
+                save_layer_op(tensors, layer, prefix, op, delayed_column_tensors)
+            for handler in spec.layer.save_handlers:
+                handler(tensors, prefix, layer, delayed_column_tensors)
+            if delayed_column_tensors:
+                save_column_tensors(tensors, delayed_column_tensors)
+            writer.write(tensors, f"layer-{layer_idx:05d}")
+            tensors.clear()
+    saved_path = writer.finish()
     if saved_path is not None and source_path is not None:
         copy_source_passthrough_weights(
             source_path, saved_path, protected_prefix=_protected_prefix_from_top_level(spec.top_level)
@@ -496,11 +509,14 @@ def load_layer_specs(model: nn.Module, index: SafetensorsIndex, spec: LayerSpec,
 
     for layer_idx, layer in enumerate(model.layers):
         prefix = spec.prefix.format(layer=layer_idx)
-        # Prefetch only small replicated keys. TP-sharded matrices are loaded
-        # with safetensors slicing in `load_layer_op`.
         layer_keys = index.keys_for_prefix(f"{prefix}.")
-        replicated_keys = [key(rep.key, prefix) for rep in spec.replicated]
-        index.prefetch(replicated_keys)
+        if spec.prefetch_layer:
+            index.prefetch(layer_keys)
+        else:
+            # Prefetch only small replicated keys. TP-sharded matrices are
+            # loaded on demand to avoid keeping a whole layer in CPU memory.
+            replicated_keys = [key(rep.key, prefix) for rep in spec.replicated]
+            index.prefetch(replicated_keys)
         load_replicated_tensors(layer, index, prefix, spec.replicated)
         for op in spec.load_ops:
             load_layer_op(layer, index, prefix, op, rank, world_size)

--- a/areno/engine/checkpoints/io.py
+++ b/areno/engine/checkpoints/io.py
@@ -34,6 +34,7 @@ from areno.engine.parallel.context import get_tp_context
 _ASYNC_CPU_COPY_MAX_BYTES = 2 * 1024**3
 _PENDING_CPU_COPY_BUCKETS: list[tuple[torch.cuda.Stream, int, torch.Tensor]] = []
 _POLICY_PLAN_ACTIVE: ContextVar[bool] = ContextVar("areno_policy_plan_active", default=False)
+_PAGEABLE_CHECKPOINT_STAGING: ContextVar[bool] = ContextVar("areno_pageable_checkpoint_staging", default=False)
 
 try:
     from tqdm.auto import tqdm
@@ -845,6 +846,8 @@ def _tensor_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
 
     if not tensor.is_cuda:
         return tensor.cpu()
+    if _PAGEABLE_CHECKPOINT_STAGING.get():
+        return tensor.detach().to(device="cpu", non_blocking=False)
     source = tensor.detach()
     output = torch.empty(tuple(tensor.shape), dtype=tensor.dtype, device="cpu", pin_memory=True)
     copy_bytes = tensor.numel() * tensor.element_size()
@@ -860,6 +863,17 @@ def _tensor_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
     source.record_stream(stream)
     _PENDING_CPU_COPY_BUCKETS.append((stream, copy_bytes, source))
     return output
+
+
+@contextmanager
+def pageable_checkpoint_staging():
+    """Use bounded, pageable D2H buffers while incrementally writing a checkpoint."""
+
+    token = _PAGEABLE_CHECKPOINT_STAGING.set(True)
+    try:
+        yield
+    finally:
+        _PAGEABLE_CHECKPOINT_STAGING.reset(token)
 
 
 def _sync_pending_cpu_copies(max_pending_bytes: int = 0) -> None:
@@ -967,6 +981,93 @@ def write_hf_safetensors_checkpoint(
         )
         f.write("\n")
     return str(path)
+
+
+class IncrementalHFSafetensorsWriter:
+    """Write independently disposable safetensors groups and one HF index."""
+
+    def __init__(self, output_path: str | Path, source_path: str | Path | None):
+        self.ctx = get_tp_context()
+        self.path = Path(output_path)
+        self.local_total_size = 0
+        self.local_weight_map: dict[str, str] = {}
+        self.group_index = 0
+        if self.ctx.dp_rank != 0:
+            return
+        self.path.mkdir(parents=True, exist_ok=True)
+        if self.ctx.rank == 0 and source_path is not None:
+            _copy_hf_assets(Path(source_path), self.path)
+
+    def write(self, tensors: dict[str, torch.Tensor | None], label: str) -> None:
+        """Write one bounded tensor group and release its file cache afterwards."""
+
+        if self.ctx.dp_rank != 0:
+            return
+        _sync_pending_cpu_copies()
+        final_tensors = {key: tensor for key, tensor in tensors.items() if tensor is not None}
+        if not final_tensors:
+            return
+        self.group_index += 1
+        safe_label = "".join(char if char.isalnum() else "-" for char in label).strip("-") or "group"
+        filename = f"model-rank{self.ctx.rank:05d}-{self.group_index:05d}-{safe_label}.safetensors"
+        file_path = self.path / filename
+        save_file(final_tensors, file_path, metadata={"format": "pt"})
+        _flush_and_evict_file(file_path)
+        self.local_total_size += sum(tensor.numel() * tensor.element_size() for tensor in final_tensors.values())
+        self.local_weight_map.update({key: filename for key in final_tensors})
+
+    def finish(self) -> str | None:
+        """Collect rank-local manifests and emit the unified HF index."""
+
+        if self.ctx.dp_rank != 0:
+            return None
+        local_metadata = {"total_size": self.local_total_size, "weight_map": self.local_weight_map}
+        if self.ctx.world_size == 1:
+            all_metadata = [local_metadata]
+        else:
+            all_metadata = [None for _ in range(self.ctx.world_size)]
+            dist.all_gather_object(all_metadata, local_metadata, group=self.ctx.group)
+        if self.ctx.rank != 0:
+            return None
+        weight_map: dict[str, str] = {}
+        total_size = 0
+        for metadata in all_metadata:
+            total_size += int(metadata["total_size"])
+            weight_map.update(metadata["weight_map"])
+        index_path = self.path / "model.safetensors.index.json"
+        index_path.write_text(
+            json.dumps(
+                {
+                    "metadata": {
+                        "total_size": total_size,
+                        "areno_checkpoint_writer": "distributed_tp_incremental",
+                    },
+                    "weight_map": weight_map,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return str(self.path)
+
+
+def _flush_and_evict_file(path: Path) -> None:
+    """Flush a completed shard and ask Linux to discard its cached pages."""
+
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        try:
+            os.fsync(fd)
+            if hasattr(os, "posix_fadvise") and hasattr(os, "POSIX_FADV_DONTNEED"):
+                os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+        except OSError:
+            # Some network/overlay filesystems reject advisory cache control.
+            # The checkpoint is already complete, so this must remain best-effort.
+            pass
+    finally:
+        os.close(fd)
 
 
 def _copy_hf_assets(source: Path, target: Path) -> None:

--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -162,7 +162,11 @@ class ModelConfig:
     qk_nope_head_dim: int = 0
     qk_rope_head_dim: int = 0
     v_head_dim: int = 0
+    q_lora_rank: int | None = None
     kv_lora_rank: int | None = None
+    kda_safe_gate: bool = False
+    kda_lower_bound: float | None = None
+    no_kda_lora: bool = False
     linear_backend: str = "minimax"
     linear_scale: bool = True
     linear_silu: bool = False

--- a/areno/models/__init__.py
+++ b/areno/models/__init__.py
@@ -9,6 +9,7 @@ def register_models() -> None:
     """Register all bundled model adapters with the global registry."""
 
     from areno.models.bailing import BailingMoeLinearV2Adapter
+    from areno.models.bailing_v3 import BailingMoeV3Adapter
     from areno.models.gemma4 import Gemma4Adapter
     from areno.models.llama import LlamaAdapter
     from areno.models.minicpmv46 import MiniCPMV46Adapter
@@ -27,6 +28,7 @@ def register_models() -> None:
     register_adapter(Qwen35VLAdapter())
     register_adapter(Qwen35Adapter())
     register_adapter(BailingMoeLinearV2Adapter())
+    register_adapter(BailingMoeV3Adapter())
     register_adapter(Gemma4Adapter())
     register_adapter(MiniCPMV46Adapter())
     register_adapter(Olmo2Adapter())

--- a/areno/models/bailing_v3/__init__.py
+++ b/areno/models/bailing_v3/__init__.py
@@ -1,0 +1,13 @@
+"""Bailing MoE V3 plugin.
+
+Re-exports the adapter and causal LM module so they can be registered without
+forcing callers to know the submodule layout. See ``model.py`` for the
+architecture details (hybrid softmax + lightning linear attention, grouped
+top-k sigmoid router, optional shared experts).
+"""
+
+from __future__ import annotations
+
+from areno.models.bailing_v3.model import BailingMoeV3Adapter, BailingMoeV3ForCausalLM
+
+__all__ = ["BailingMoeV3Adapter", "BailingMoeV3ForCausalLM"]

--- a/areno/models/bailing_v3/checkpoint.py
+++ b/areno/models/bailing_v3/checkpoint.py
@@ -1,0 +1,176 @@
+"""Bailing-MoE V3 HF safetensors load/save specs.
+
+Bailing's HF checkpoint stores each routed expert as a standalone
+``experts.{i}.gate_proj`` / ``up_proj`` / ``down_proj`` triple plus a router
+``gate.weight`` and a (sigmoid-biased grouped) router expert-bias buffer.
+``DenseOrMoeSpec`` defers to ``MoeSpec`` for the MoE layers and falls back to a
+dense gate/up/down loader on the leading ``first_k_dense_replace`` layers.
+
+Sharding-wise the experts use expert-parallelism that piggy-backs on the TP
+process group: each rank owns ``num_experts / world_size`` consecutive experts
+and the loader copies only those expert tensors into ``BailingGroupedExperts``'
+fused 3D weight buffers. Both attention pathways (softmax MLA and linear
+attention) share the same ``self_attn``/``attention`` HF prefix alias and the
+same ``dense.weight`` row-parallel output projection, so a single
+``AttentionSpec`` covers both.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from areno.engine.checkpoints.common import (
+    CheckpointSpec,
+    DenseOrMoeSpec,
+    LayerSpec,
+    MoeSpec,
+    ReplicatedTensorSpec,
+    TopLevelSpec,
+)
+from areno.engine.checkpoints.io import (
+    _copy_column,
+    _copy_row,
+    gather_tensor_parallel_tensor,
+    rank0_tensor,
+)
+from areno.engine.layers.linear import _shard_range
+
+# Bailing wraps the embedding under ``model.word_embeddings`` (not the more
+# common ``model.embed_tokens``). V3 checkpoints can ship an untied
+# ``lm_head.weight``; ``load_embedding_norm_head`` copies it only when
+# ``tie_word_embeddings`` is false.
+TOP_LEVEL_SPEC = TopLevelSpec(
+    embedding_key="model.word_embeddings.weight",
+    embedding_attr="word_embeddings",
+    lm_head_key="lm_head.weight",
+)
+# Pre-attn and pre-MLP RMSNorm scales — replicated across TP ranks.
+LAYER_NORM_SPECS = (
+    ReplicatedTensorSpec("{prefix}.input_layernorm.weight", "input_layernorm.weight"),
+    ReplicatedTensorSpec("{prefix}.post_attention_layernorm.weight", "post_attention_layernorm.weight"),
+)
+# MoE block: a sigmoid-scored router with per-expert bias plus per-expert gate
+# / up / down projections. ``local_expert_bias`` is the rank-local copy used by
+# the biased grouped top-k kernel; ``num_experts_attr`` lets the loader build
+# the right number of expert keys (``experts.{expert}.*``) per layer.
+MOE_SPEC = MoeSpec(
+    gate_weight_key="{prefix}.gate.weight",
+    gate_weight_attr="gate.weight",
+    expert_bias_key="{prefix}.gate.expert_bias",
+    expert_bias_attr="gate.expert_bias",
+    local_expert_bias_attr="gate.local_expert_bias",
+    experts_attr="experts",
+    num_experts_attr="num_experts",
+    expert_gate_key="{prefix}.experts.{expert}.gate_proj.weight",
+    expert_up_key="{prefix}.experts.{expert}.up_proj.weight",
+    expert_down_key="{prefix}.experts.{expert}.down_proj.weight",
+    # Bailing also keeps a small dense "shared expert" MLP that runs on every
+    # token regardless of routing; it lives under the same layer prefix.
+    shared_experts_attr="shared_experts",
+    shared_experts_prefix="{prefix}.shared_experts",
+)
+# DenseOrMoeSpec picks ``moe`` for MoE layers and falls back to a dense MLP
+# for layers strictly below ``first_k_dense_replace`` (handled in the loader).
+MLP_SPEC = DenseOrMoeSpec(attr="mlp", moe=MOE_SPEC)
+
+
+@torch.no_grad()
+def load_bailing_v3_attention(module, index, prefix: str, rank: int, world_size: int) -> None:
+    attn = module.attention
+    attn_prefix = f"{prefix}.attention"
+    if hasattr(attn, "q_conv1d_weight"):
+        _load_kda_attention(attn, index, attn_prefix, rank, world_size)
+        return
+    _load_mla_attention(attn, index, attn_prefix, rank, world_size)
+
+
+@torch.no_grad()
+def _load_kda_attention(attn, index, prefix: str, rank: int, world_size: int) -> None:
+    for name in ("q_proj", "k_proj", "v_proj", "f_proj", "g_proj", "b_proj"):
+        _copy_column(getattr(attn, name).weight, index.get_tensor(f"{prefix}.{name}.weight"), rank, world_size)
+    for name in ("q", "k", "v"):
+        _copy_column(
+            getattr(attn, f"{name}_conv1d_weight"),
+            index.get_tensor(f"{prefix}.{name}_conv1d.weight"),
+            rank,
+            world_size,
+        )
+    start, end = _shard_range(attn.proj_dim, rank, world_size)
+    attn.dt_bias.copy_(index.get_tensor(f"{prefix}.dt_bias")[start:end].to(dtype=attn.dt_bias.dtype))
+    start, end = _shard_range(attn.num_heads, rank, world_size)
+    attn.A_log.copy_(index.get_tensor(f"{prefix}.A_log")[start:end].to(dtype=attn.A_log.dtype))
+    attn.o_norm_weight.copy_(index.get_tensor(f"{prefix}.o_norm.weight").to(dtype=attn.o_norm_weight.dtype))
+    _copy_row(attn.o_proj.weight, index.get_tensor(f"{prefix}.o_proj.weight"), rank, world_size)
+
+
+@torch.no_grad()
+def _load_mla_attention(attn, index, prefix: str, rank: int, world_size: int) -> None:
+    if getattr(attn, "q_lora_rank", None) is None:
+        _copy_column(attn.q_proj.weight, index.get_tensor(f"{prefix}.q_proj.weight"), rank, world_size)
+    else:
+        attn.q_a_proj.weight.copy_(index.get_tensor(f"{prefix}.q_a_proj.weight").to(dtype=attn.q_a_proj.weight.dtype))
+        attn.q_a_layernorm.weight.copy_(
+            index.get_tensor(f"{prefix}.q_a_layernorm.weight").to(dtype=attn.q_a_layernorm.weight.dtype)
+        )
+        _copy_column(attn.q_b_proj.weight, index.get_tensor(f"{prefix}.q_b_proj.weight"), rank, world_size)
+    attn.kv_a_proj_with_mqa.weight.copy_(
+        index.get_tensor(f"{prefix}.kv_a_proj_with_mqa.weight").to(dtype=attn.kv_a_proj_with_mqa.weight.dtype)
+    )
+    attn.kv_a_layernorm.weight.copy_(
+        index.get_tensor(f"{prefix}.kv_a_layernorm.weight").to(dtype=attn.kv_a_layernorm.weight.dtype)
+    )
+    _copy_column(attn.kv_b_proj.weight, index.get_tensor(f"{prefix}.kv_b_proj.weight"), rank, world_size)
+    if getattr(attn, "g_proj", None) is not None:
+        _copy_column(attn.g_proj.weight, index.get_tensor(f"{prefix}.g_proj.weight"), rank, world_size)
+    _copy_row(attn.dense.weight, index.get_tensor(f"{prefix}.dense.weight"), rank, world_size)
+
+
+@torch.no_grad()
+def save_bailing_v3_attention(tensors: dict[str, torch.Tensor | None], prefix: str, module, context) -> None:
+    del context
+    attn = module.attention
+    attn_prefix = f"{prefix}.attention"
+    if hasattr(attn, "q_conv1d_weight"):
+        _save_kda_attention(tensors, attn_prefix, attn)
+        return
+    _save_mla_attention(tensors, attn_prefix, attn)
+
+
+def _save_kda_attention(tensors: dict[str, torch.Tensor | None], prefix: str, attn) -> None:
+    for name in ("q_proj", "k_proj", "v_proj", "f_proj", "g_proj", "b_proj"):
+        tensors[f"{prefix}.{name}.weight"] = gather_tensor_parallel_tensor(getattr(attn, name).weight, dim=0)
+    for name in ("q", "k", "v"):
+        tensors[f"{prefix}.{name}_conv1d.weight"] = gather_tensor_parallel_tensor(
+            getattr(attn, f"{name}_conv1d_weight"), dim=0
+        )
+    tensors[f"{prefix}.dt_bias"] = gather_tensor_parallel_tensor(attn.dt_bias, dim=0)
+    tensors[f"{prefix}.A_log"] = gather_tensor_parallel_tensor(attn.A_log, dim=0)
+    tensors[f"{prefix}.o_norm.weight"] = rank0_tensor(attn.o_norm_weight)
+    tensors[f"{prefix}.o_proj.weight"] = gather_tensor_parallel_tensor(attn.o_proj.weight, dim=1)
+
+
+def _save_mla_attention(tensors: dict[str, torch.Tensor | None], prefix: str, attn) -> None:
+    if getattr(attn, "q_lora_rank", None) is None:
+        tensors[f"{prefix}.q_proj.weight"] = gather_tensor_parallel_tensor(attn.q_proj.weight, dim=0)
+    else:
+        tensors[f"{prefix}.q_a_proj.weight"] = rank0_tensor(attn.q_a_proj.weight)
+        tensors[f"{prefix}.q_a_layernorm.weight"] = rank0_tensor(attn.q_a_layernorm.weight)
+        tensors[f"{prefix}.q_b_proj.weight"] = gather_tensor_parallel_tensor(attn.q_b_proj.weight, dim=0)
+    tensors[f"{prefix}.kv_a_proj_with_mqa.weight"] = rank0_tensor(attn.kv_a_proj_with_mqa.weight)
+    tensors[f"{prefix}.kv_a_layernorm.weight"] = rank0_tensor(attn.kv_a_layernorm.weight)
+    tensors[f"{prefix}.kv_b_proj.weight"] = gather_tensor_parallel_tensor(attn.kv_b_proj.weight, dim=0)
+    if getattr(attn, "g_proj", None) is not None:
+        tensors[f"{prefix}.g_proj.weight"] = gather_tensor_parallel_tensor(attn.g_proj.weight, dim=0)
+    tensors[f"{prefix}.dense.weight"] = gather_tensor_parallel_tensor(attn.dense.weight, dim=1)
+
+
+BAILING_LAYER_SPEC = LayerSpec(
+    prefix="model.layers.{layer}",
+    replicated=LAYER_NORM_SPECS,
+    load_ops=(MLP_SPEC,),
+    save_ops=(MLP_SPEC,),
+    load_handlers=(load_bailing_v3_attention,),
+    save_handlers=(save_bailing_v3_attention,),
+    prefetch_layer=True,
+)
+CHECKPOINT_SPEC = CheckpointSpec(top_level=TOP_LEVEL_SPEC, layer=BAILING_LAYER_SPEC)

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -1,0 +1,1787 @@
+"""BailingMoE V3 causal-LM adapter.
+
+Targets the BailingMoeV3ForCausalLM HF family (``model_type ==
+"bailing_hybrid"``). The architecture interleaves two attention flavours
+and a sparse mixture-of-experts MLP:
+    * Attention layers alternate between ``BailingSoftmaxAttention`` (a
+      classic GQA / optional MLA-style low-rank KV pathway running on flash
+      attention) and ``BailingLinearAttention`` (a chunked lightning-attention
+      / seg_la recurrent linear attention with ALiBi-style slope biases). The
+      pattern is governed by ``layer_group_size``: every group_size-th layer
+      is softmax, all others are linear; the trailing layers always run
+      softmax to anchor positions.
+    * The MLP is either a dense SwiGLU (``BailingDenseMLP``) for the leading
+      ``first_k_dense_replace`` layers, or a sparse ``BailingSparseMoeBlock``
+      for the remainder.
+    * The MoE router (``BailingGate``) uses sigmoid scoring with a learnable
+      per-expert bias and SGLang-style biased grouped top-k routing: experts
+      are partitioned into ``n_group`` groups, top ``topk_group`` groups win,
+      then top ``num_experts_per_tok`` experts inside the winning groups
+      score the token. The bias is updated online during training to balance
+      load.
+    * Experts are stored in ``BailingGroupedExperts`` as fused 3D weights
+      (``[local_experts, out, in]``) for ``areno_grouped_linear`` /
+      ``areno_moe_topk_permute`` / fused-MoE inference kernels. Expert
+      parallelism is collapsed into the TP group (each rank owns
+      ``num_experts / world_size`` experts) and routing uses
+      ``all_reduce`` to sum back the per-rank contributions.
+    * An optional ``shared_experts`` dense MLP runs unconditionally on every
+      token and is added to the routed output.
+    * Inference uses a separate ``_forward_fused_moe`` path that stacks the
+      per-expert gate/up/down weights into contiguous w1/w2 buffers and runs
+      ``areno_fused_experts``; training keeps the permute/unpermute path
+      so autograd can flow through.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from fla.ops.lightning_attn import chunk_lightning_attn
+from torch import nn
+
+from areno.accel import (
+    areno_grouped_linear,
+    areno_grouped_topk_router,
+    areno_linear,
+    areno_moe_topk_permute,
+    areno_moe_unpermute,
+    areno_sigmoid,
+    areno_silu,
+)
+from areno.accel.kda import areno_kda_chunk, areno_kda_recurrent_update
+from areno.accel.ops import (
+    FusedMoeConfig,
+    SegLaMeta,
+    areno_fused_experts,
+    areno_silu_and_mul,
+    log_once,
+    seg_la_fwd,
+)
+from areno.engine.checkpoints.common import (
+    build_checkpoint_policy_plan,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
+from areno.engine.config import ModelConfig, _parse_dtype
+from areno.engine.layers.attention_backend.infer import FlashAttnInferBackend, build_infer_attention_backend
+from areno.engine.layers.attention_backend.train import build_train_attention_backend
+from areno.engine.layers.linear import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+    _shard_range,
+    mark_tensor_parallel_parameter,
+)
+from areno.engine.layers.norm import GroupRMSNormSigmoidGate, RMSNorm
+from areno.engine.layers.rotary import PartialRotaryEmbedding
+from areno.engine.layers.vocab import VocabParallelEmbedding, VocabParallelLMHead
+from areno.engine.parallel.collectives import (
+    all_reduce,
+    gather_from_sequence_parallel_region,
+    is_sequence_parallel_active,
+    reduce_scatter_to_sequence_parallel_region,
+    scatter_to_sequence_parallel_region,
+    sequence_parallel_region,
+)
+from areno.engine.parallel.context import get_tp_context
+from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.models._shared.dynamo_wrappers import (
+    _areno_depthwise_causal_conv1d_silu_decode_no_compile,
+    _areno_depthwise_causal_conv1d_silu_no_compile,
+    _areno_packed_depthwise_causal_conv1d_silu_no_compile,
+    _fla_causal_conv1d_no_compile,
+    _require_fla_gdn,
+)
+from areno.models.bailing_v3.checkpoint import CHECKPOINT_SPEC
+from areno.models.base import CausalLMOutput, ModelAdapter
+
+
+class BailingDenseMLP(nn.Module):
+    """Plain SwiGLU MLP used for shared experts and for the first
+    ``first_k_dense_replace`` decoder layers (before MoE kicks in)."""
+
+    def __init__(self, config: ModelConfig, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = ColumnParallelLinear(config.hidden_size, intermediate_size, bias=False)
+        self.up_proj = ColumnParallelLinear(config.hidden_size, intermediate_size, bias=False)
+        self.down_proj = RowParallelLinear(intermediate_size, config.hidden_size, bias=False)
+        _cast_linear_weights(self.gate_proj, config.dtype)
+        _cast_linear_weights(self.up_proj, config.dtype)
+        _cast_linear_weights(self.down_proj, config.dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        proj_input = x.to(dtype=self.gate_proj.weight.dtype)
+        gate = self.gate_proj(proj_input)
+        up = self.up_proj(proj_input)
+        # Fused SiLU(gate) * up kernel — same as areno_silu_and_mul but reused
+        # under torch._dynamo.disable so eager and compiled paths agree.
+        hidden = _areno_silu_pair_no_compile(gate, up)
+        return self.down_proj(hidden)
+
+
+class BailingGate(nn.Module):
+    """Sigmoid-scored biased grouped top-k MoE router.
+
+    Produces, for every token, ``top_k`` expert indices and renormalized
+    routing weights. The bias is added to the per-expert logit *before* the
+    group/top-k pruning step (the "noaux_tc" variant of grouped routing);
+    during training the bias is updated to push load back towards balance.
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        if config.score_function != "sigmoid":
+            raise ValueError(f"BailingGate only supports sigmoid scoring, got {config.score_function!r}")
+        if not config.moe_router_enable_expert_bias:
+            raise ValueError("BailingGate requires expert bias for biased grouped topk")
+        if not config.norm_topk_prob:
+            raise ValueError("BailingGate requires norm_topk_prob=True")
+        self.top_k = config.num_experts_per_tok
+        self.num_experts = int(config.num_experts or 0)
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.router_dtype = config.moe_router_dtype
+        # Router projection: hidden_size -> num_experts logits. Replicated
+        # across TP ranks (sequence-parallel on the input side) so every rank
+        # sees identical routing decisions and accumulates the gradient via
+        # all-reduce.
+        self.weight = nn.Parameter(torch.empty(self.num_experts, config.hidden_size, dtype=self.router_dtype))
+        mark_tensor_parallel_parameter(self.weight, False, sequence_parallel=True, tp_grad_allreduce=True)
+        self.bias_update_rate = config.moe_router_bias_update_rate
+        self.expert_parallel_size = 1
+        # Per-step token-per-expert counter used to drive bias updates at the
+        # end of an optimizer step. ``expert_bias`` is the slowly-updated
+        # canonical value, ``local_expert_bias`` is the snapshot used by the
+        # kernel each forward pass.
+        self.register_buffer(
+            "local_tokens_per_expert", torch.zeros(self.num_experts, dtype=torch.float32), persistent=False
+        )
+        self.register_buffer("expert_bias", torch.zeros(self.num_experts), persistent=False)
+        self.register_buffer("local_expert_bias", torch.zeros(self.num_experts), persistent=False)
+
+    @torch._dynamo.disable
+    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        x = hidden_states.view(-1, hidden_states.shape[-1])
+        # Promote to router_dtype (typically fp32) for numerical stability of
+        # the sigmoid/top-k selection.
+        logits = _areno_linear_no_compile(x.to(dtype=self.weight.dtype), self.weight)
+        topk_idx, topk_weight = self._forward_grouped_topk(logits)
+        if torch.is_grad_enabled():
+            # Only track load when training; eval calls keep counters cold.
+            _accumulate_tokens_per_expert(self.local_tokens_per_expert, topk_idx, self.num_experts)
+        return topk_idx, topk_weight.float(), logits
+
+    @torch._dynamo.disable
+    def _forward_grouped_topk(self, logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        log_once("areno_grouped_topk_router", "using ARENO grouped router topk kernel")
+        return _areno_grouped_topk_router_no_compile(
+            logits,
+            self.local_expert_bias.to(device=logits.device, dtype=torch.float32),
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+        )
+
+    @torch.no_grad()
+    def finalize_expert_bias(self, tp_group, dp_group) -> None:
+        """Apply the per-step bias update and reset the token counter.
+
+        Called once per training step from the trainer. The token counts are
+        summed across data-parallel replicas, then nudged towards balance
+        using a signed step (``sign(mean - tokens) * rate``); finally the
+        zero-mean projection keeps the bias from drifting unboundedly.
+        """
+        del tp_group
+        tokens_per_expert = self.local_tokens_per_expert
+        if dist.is_available() and dist.is_initialized():
+            if dp_group is not None:
+                dist.all_reduce(tokens_per_expert, op=dist.ReduceOp.SUM, group=dp_group)
+        if self.bias_update_rate != 0.0:
+            mean_tokens = tokens_per_expert.mean(dim=-1, keepdim=True)
+            offset = mean_tokens - tokens_per_expert
+            # Under-loaded experts get a positive nudge, over-loaded a negative
+            # one. Re-center to mean zero to avoid drift.
+            self.expert_bias.add_(torch.sign(offset) * self.bias_update_rate)
+            self.expert_bias.sub_(self.expert_bias.mean())
+        self.local_expert_bias.copy_(self.expert_bias)
+        tokens_per_expert.zero_()
+
+
+@torch._dynamo.disable
+def _accumulate_tokens_per_expert(tokens_per_expert: torch.Tensor, topk_idx: torch.Tensor, num_experts: int) -> None:
+    """Histogram top-k expert assignments into ``tokens_per_expert`` (in place)."""
+    with torch.no_grad():
+        tokens_per_expert.add_(
+            torch.bincount(topk_idx.reshape(-1), minlength=num_experts).to(
+                device=tokens_per_expert.device,
+                dtype=tokens_per_expert.dtype,
+            )
+        )
+
+
+class BailingSparseMoeBlock(nn.Module):
+    """Sparse MoE block: router -> permute -> grouped experts -> unpermute,
+    plus an optional dense shared-expert pathway.
+
+    Training and inference take different code paths: training keeps the
+    autograd-friendly permute/unpermute split, inference uses the fused
+    ``areno_fused_experts`` kernel over stacked w1/w2 weight tiles.
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.num_experts = int(config.num_experts or 0)
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.gate = BailingGate(config)
+        self.experts = BailingGroupedExperts(config)
+        # Shared experts always run (no routing decision) — their intermediate
+        # size scales with ``num_shared_experts``. Output is added to the
+        # routed result post-reduce.
+        self.shared_experts = (
+            BailingDenseMLP(config, config.moe_intermediate_size * config.num_shared_experts)
+            if config.num_shared_experts is not None
+            else None
+        )
+        # Inference-only fused weight buffers, populated by
+        # ``prepare_infer_weights``. w1 stacks the (gate, up) projections per
+        # expert; w2 holds the per-expert down projection.
+        self.register_buffer("_infer_gate_weight", torch.empty(0), persistent=False)
+        self.register_buffer("_infer_up_weight", torch.empty(0), persistent=False)
+        self.register_buffer("_infer_down_weight", torch.empty(0), persistent=False)
+        self.register_buffer("_infer_w1_weight", torch.empty(0), persistent=False)
+        self.register_buffer("_infer_w2_weight", torch.empty(0), persistent=False)
+        self._infer_weights_ready = False
+        self._fused_moe_config = FusedMoeConfig(
+            num_experts=self.experts.local_num_experts,
+            hidden_size=self.config.hidden_size,
+            intermediate_size=self.config.moe_intermediate_size,
+            top_k=self.num_experts_per_tok,
+            routed_scaling_factor=self.config.routed_scaling_factor,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # In SP mode we need the full (un-scattered) hidden states for routing
+        # since the router weight isn't sharded along the sequence dim.
+        moe_sequence_parallel = is_sequence_parallel_active()
+        if moe_sequence_parallel:
+            hidden_states = gather_from_sequence_parallel_region(hidden_states)
+        identity = hidden_states
+        bsz, seqlen, hidden = hidden_states.shape
+        expert_input = hidden_states.to(dtype=self.experts.linear_fc1.weight.dtype)
+        with sequence_parallel_region(False):
+            topk_idx, topk_weight, _ = self.gate(hidden_states)
+            flat = expert_input.view(-1, hidden)
+            if self.training:
+                # Permute/unpermute path is autograd-friendly.
+                out = self.experts(flat, topk_idx, topk_weight).view(bsz, seqlen, hidden)
+                if self.shared_experts is not None:
+                    out = out + self.shared_experts(identity)
+                return reduce_scatter_to_sequence_parallel_region(out) if moe_sequence_parallel else out
+            # Inference: fused-MoE kernel over the stacked w1/w2 weights.
+            out = self._forward_fused_moe(flat, topk_idx, topk_weight)
+        out = out.view(bsz, seqlen, hidden)
+        if self.shared_experts is not None:
+            out = out + self.shared_experts(identity)
+        return reduce_scatter_to_sequence_parallel_region(out) if moe_sequence_parallel else out
+
+    @torch.no_grad()
+    def prepare_infer_weights(self) -> None:
+        """Stack per-expert weights into contiguous fused tiles for inference.
+
+        ``_infer_w1_weight`` concatenates (gate, up) per expert so the fused
+        kernel does one matmul per expert. ``_infer_w2_weight`` mirrors the
+        down projection. Buffers are reused across calls if the shape/device
+        already match to avoid reallocating on every weight refresh.
+        """
+        gate_weights, up_weights, down_weights = self.experts.expert_weights()
+        self._infer_gate_weight = self._updated_infer_weight(
+            self._infer_gate_weight,
+            torch.stack(gate_weights, dim=0).to(dtype=self.config.dtype).contiguous(),
+        )
+        self._infer_up_weight = self._updated_infer_weight(
+            self._infer_up_weight,
+            torch.stack(up_weights, dim=0).to(dtype=self.config.dtype).contiguous(),
+        )
+        self._infer_down_weight = self._updated_infer_weight(
+            self._infer_down_weight,
+            torch.stack(down_weights, dim=0).to(dtype=self.config.dtype).contiguous(),
+        )
+        # w1 = [gate || up] along the intermediate dim so SiLU(gate) * up can
+        # be folded into a single fused kernel call.
+        self._infer_w1_weight = self._updated_infer_weight(
+            self._infer_w1_weight,
+            torch.cat((self._infer_gate_weight, self._infer_up_weight), dim=1).contiguous(),
+        )
+        self._infer_w2_weight = self._updated_infer_weight(self._infer_w2_weight, self._infer_down_weight.contiguous())
+        self._infer_weights_ready = True
+
+    @torch.no_grad()
+    def _updated_infer_weight(self, current: torch.Tensor, value: torch.Tensor) -> torch.Tensor:
+        # Reuse the existing storage when possible — important when the trainer
+        # keeps swapping weights in and out (e.g. for evaluation cycles).
+        if current.shape == value.shape and current.device == value.device and current.dtype == value.dtype:
+            current.copy_(value)
+            return current
+        return value
+
+    @torch.no_grad()
+    def clear_infer_weights(self) -> None:
+        """Drop the fused inference tiles and reclaim memory."""
+        device = self._infer_gate_weight.device
+        dtype = self._infer_gate_weight.dtype
+        self._infer_gate_weight = torch.empty(0, device=device, dtype=dtype)
+        self._infer_up_weight = torch.empty(0, device=device, dtype=dtype)
+        self._infer_down_weight = torch.empty(0, device=device, dtype=dtype)
+        self._infer_w1_weight = torch.empty(0, device=device, dtype=dtype)
+        self._infer_w2_weight = torch.empty(0, device=device, dtype=dtype)
+        self._infer_weights_ready = False
+
+    def _forward_fused_moe(self, flat: torch.Tensor, topk_idx: torch.Tensor, topk_weight: torch.Tensor) -> torch.Tensor:
+        if self._infer_w1_weight.numel() == 0:
+            raise RuntimeError("fused MoE inference weights are not prepared")
+        log_once("areno_fused_moe", "using areno fused MoE expert kernel")
+        # Drop routes pointing at experts owned by other ranks (their weight
+        # is zero, so they contribute nothing locally) and remap global expert
+        # ids into the local 0..local_num_experts-1 range.
+        local_idx, local_weight = self.experts.local_routes(topk_idx, topk_weight)
+        out = _areno_fused_experts_no_compile(
+            flat.contiguous(),
+            self._infer_w1_weight,
+            self._infer_w2_weight,
+            local_weight.float(),
+            local_idx.int(),
+            self._fused_moe_config,
+        )
+        # Sum each rank's owned-expert contribution back together.
+        return all_reduce(out)
+
+
+class BailingGroupedExperts(nn.Module):
+    """Bank of MoE expert FFNs stored as a single fused 3D weight tensor.
+
+    Expert parallelism is piggy-backed on the TP group: each rank owns
+    ``local_num_experts = num_experts / world_size`` consecutive experts.
+    The grouped-linear kernel takes ``tokens_per_expert`` and runs one fused
+    GEMM per expert without materialising per-expert slices.
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        ctx = get_tp_context()
+        self.config = config
+        self.num_experts = int(config.num_experts or 0)
+        if self.num_experts % ctx.world_size != 0:
+            raise ValueError(f"num_experts={self.num_experts} must be divisible by TP/EP size={ctx.world_size}")
+        # Contiguous slab of experts owned by this rank.
+        self.local_num_experts = self.num_experts // ctx.world_size
+        self.local_expert_start = ctx.rank * self.local_num_experts
+        self.local_expert_end = self.local_expert_start + self.local_num_experts
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.moe_intermediate_size
+        # fc1 = [gate || up] fused into ``2 * intermediate_size`` rows so
+        # SiLU(gate) * up can collapse into a single kernel; fc2 is the down
+        # projection back to hidden size.
+        self.linear_fc1 = _build_grouped_linear(
+            self.local_num_experts,
+            self.hidden_size,
+            2 * self.intermediate_size,
+            dtype=config.dtype,
+        )
+        self.linear_fc2 = _build_grouped_linear(
+            self.local_num_experts,
+            self.intermediate_size,
+            self.hidden_size,
+            dtype=config.dtype,
+        )
+        # Expert weights are sharded by EP (collapsed into TP); flag them as
+        # not-TP/not-SP so the standard TP collectives leave them alone.
+        for param in self.parameters():
+            mark_tensor_parallel_parameter(param, False, sequence_parallel=False)
+
+    def forward(self, flat: torch.Tensor, topk_idx: torch.Tensor, topk_weight: torch.Tensor) -> torch.Tensor:
+        return self._forward_fused_permute(flat, topk_idx, topk_weight)
+
+    def _forward_fused_permute(
+        self, flat: torch.Tensor, topk_idx: torch.Tensor, topk_weight: torch.Tensor
+    ) -> torch.Tensor:
+        log_once("areno_moe_permute", "using fused MoE permute/unpermute kernels")
+        # Permute: group tokens by destination expert, keeping only routes for
+        # locally-owned experts. ``tokens_per_expert`` is a 1D count used to
+        # offset the grouped GEMM.
+        x, sorted_route_weight, sorted_token_idx, tokens_per_expert = _areno_moe_topk_permute_no_compile(
+            flat,
+            topk_idx,
+            topk_weight.float(),
+            self.local_expert_start,
+            self.local_num_experts,
+        )
+        if x.shape[0] == 0:
+            # No tokens routed to this rank — still need to all_reduce to keep
+            # collective sync with peers.
+            return all_reduce(flat.new_zeros(flat.shape))
+        hidden, _ = _grouped_linear_forward(self.linear_fc1, x.contiguous(), tokens_per_expert)
+        # Apply routing weight before fc2 so it stays inside the fp32 reduction.
+        hidden = (
+            _areno_silu_and_mul_no_compile(hidden) * sorted_route_weight.unsqueeze(-1).to(dtype=hidden.dtype)
+        ).contiguous()
+        expert_out, _ = _grouped_linear_forward(self.linear_fc2, hidden, tokens_per_expert)
+        # Unpermute back to original (batch, seq) order, then scale and reduce.
+        out = _areno_moe_unpermute_no_compile(
+            expert_out, sorted_token_idx, merging_probs=None, restore_shape=flat.shape
+        )
+        return all_reduce(out * self.config.routed_scaling_factor)
+
+    def local_routes(self, topk_idx: torch.Tensor, topk_weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Mask routes that miss locally-owned experts and remap ids to 0-based local."""
+        local_mask = (topk_idx >= self.local_expert_start) & (topk_idx < self.local_expert_end)
+        local_idx = (topk_idx - self.local_expert_start).clamp(0, self.local_num_experts - 1)
+        return local_idx, topk_weight * local_mask.to(dtype=topk_weight.dtype)
+
+    @torch.no_grad()
+    def copy_expert(
+        self, expert_id: int, gate: torch.Tensor, up: torch.Tensor, down: torch.Tensor, rank: int, world_size: int
+    ) -> None:
+        """Copy one expert's HF weights into the appropriate local slot."""
+        del rank, world_size
+        if expert_id < self.local_expert_start or expert_id >= self.local_expert_end:
+            return
+        local_expert_id = expert_id - self.local_expert_start
+        fc1_weight = _grouped_weight(self.linear_fc1, local_expert_id)
+        # Concatenate gate+up along the output dim to match fc1's fused layout.
+        fc1_weight.copy_(torch.cat((gate, up), dim=0).to(dtype=fc1_weight.dtype))
+        fc2_weight = _grouped_weight(self.linear_fc2, local_expert_id)
+        fc2_weight.copy_(down.to(dtype=fc2_weight.dtype))
+
+    @torch.no_grad()
+    def expert_weights(self) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+        """Return per-local-expert (gate, up, down) views for fused-MoE prep."""
+        gate_weights = []
+        up_weights = []
+        down_weights = []
+        for expert_id in range(self.local_num_experts):
+            fc1_weight = _grouped_weight(self.linear_fc1, expert_id).detach()
+            # Split the fused gate||up tile back into the two halves.
+            gate, up = fc1_weight.chunk(2, dim=0)
+            gate_weights.append(gate)
+            up_weights.append(up)
+            down_weights.append(_grouped_weight(self.linear_fc2, expert_id).detach())
+        return gate_weights, up_weights, down_weights
+
+    @torch.no_grad()
+    def full_expert_weights(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        """Gather all experts onto DP rank 0 for checkpoint saving (None elsewhere)."""
+        gate_weights, up_weights, down_weights = self.expert_weights()
+        gate = _gather_expert_parallel_tensor(torch.stack(gate_weights, dim=0))
+        up = _gather_expert_parallel_tensor(torch.stack(up_weights, dim=0))
+        down = _gather_expert_parallel_tensor(torch.stack(down_weights, dim=0))
+        if gate is None or up is None or down is None:
+            return None
+        return gate, up, down
+
+    @torch.no_grad()
+    def offload_to_cpu(self) -> None:
+        """Move all expert params to CPU (used during inference-only phases)."""
+        for param in self.parameters():
+            param.data = param.data.to(device="cpu")
+
+    @torch.no_grad()
+    def onload_to_device(self, device: torch.device) -> None:
+        """Restore params to the target device for training."""
+        for param in self.parameters():
+            if param.device != device:
+                param.data = param.data.to(device=device)
+
+
+def _build_grouped_linear(num_gemms: int, in_features: int, out_features: int, *, dtype: torch.dtype) -> nn.Module:
+    return ArenoGroupedLinear(num_gemms, in_features, out_features, dtype=dtype)
+
+
+class ArenoGroupedLinear(nn.Module):
+    """Fused per-expert linear: ``(num_gemms, out, in)`` weight + per-expert
+    token counts driving ``areno_grouped_linear``."""
+
+    def __init__(self, num_gemms: int, in_features: int, out_features: int, *, dtype: torch.dtype):
+        super().__init__()
+        self.num_gemms = num_gemms
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(num_gemms, out_features, in_features, dtype=dtype))
+
+    def forward(self, x: torch.Tensor, tokens_per_expert: torch.Tensor | Sequence[int]) -> torch.Tensor:
+        if isinstance(tokens_per_expert, torch.Tensor):
+            if tokens_per_expert.numel() != self.num_gemms:
+                raise ValueError(f"expected {self.num_gemms} expert token counts, got {tokens_per_expert.numel()}")
+            if x.shape[0] == 0:
+                # Avoid invoking the kernel on an empty batch — return a fresh
+                # empty tensor with the right out feature dim.
+                return x.new_empty((0, self.out_features))
+            return areno_grouped_linear(x.contiguous(), self.weight, tokens_per_expert)
+        if len(tokens_per_expert) != self.num_gemms:
+            raise ValueError(f"expected {self.num_gemms} expert token counts, got {len(tokens_per_expert)}")
+        offset = sum(tokens_per_expert)
+        if offset != x.shape[0]:
+            raise ValueError(f"tokens_per_expert sums to {offset}, but input has {x.shape[0]} rows")
+        if offset == 0:
+            # Avoid invoking the kernel on an empty batch — return a fresh
+            # empty tensor with the right out feature dim.
+            return x.new_empty((0, self.out_features))
+        return areno_grouped_linear(x.contiguous(), self.weight, tokens_per_expert)
+
+
+def _grouped_linear_forward(
+    module: nn.Module, x: torch.Tensor, tokens_per_expert: torch.Tensor | Sequence[int]
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    out = module(x, tokens_per_expert)
+    if isinstance(out, tuple):
+        return out
+    return out, None
+
+
+@torch._dynamo.disable
+def _areno_silu_no_compile(x: torch.Tensor) -> torch.Tensor:
+    return areno_silu(x)
+
+
+@torch._dynamo.disable
+def _areno_sigmoid_no_compile(x: torch.Tensor) -> torch.Tensor:
+    return areno_sigmoid(x)
+
+
+@torch._dynamo.disable
+def _areno_grouped_topk_router_no_compile(
+    logits: torch.Tensor,
+    expert_bias: torch.Tensor,
+    top_k: int,
+    num_groups: int,
+    topk_group: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return areno_grouped_topk_router(logits, expert_bias, top_k, num_groups, topk_group)
+
+
+@torch._dynamo.disable
+def _areno_linear_no_compile(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return areno_linear(x, weight, None)
+
+
+def _cast_linear_weights(module: nn.Module, dtype: torch.dtype) -> None:
+    weight = getattr(module, "weight", None)
+    if isinstance(weight, nn.Parameter):
+        weight.data = weight.data.to(dtype=dtype)
+    bias = getattr(module, "bias", None)
+    if isinstance(bias, nn.Parameter):
+        bias.data = bias.data.to(dtype=dtype)
+
+
+@torch._dynamo.disable
+def _areno_silu_pair_no_compile(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    return areno_silu_and_mul(torch.cat((gate, up), dim=-1))
+
+
+@torch._dynamo.disable
+def _areno_silu_and_mul_no_compile(x: torch.Tensor) -> torch.Tensor:
+    return areno_silu_and_mul(x)
+
+
+@torch._dynamo.disable
+def _areno_moe_topk_permute_no_compile(
+    flat: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weight: torch.Tensor,
+    local_expert_start: int,
+    local_num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return areno_moe_topk_permute(flat, topk_idx, topk_weight, local_expert_start, local_num_experts)
+
+
+@torch._dynamo.disable
+def _areno_moe_unpermute_no_compile(
+    expert_out: torch.Tensor,
+    sorted_token_idx: torch.Tensor,
+    *,
+    merging_probs: None,
+    restore_shape: tuple[int, int],
+) -> torch.Tensor:
+    del merging_probs
+    return areno_moe_unpermute(expert_out, sorted_token_idx, restore_shape)
+
+
+def _gather_expert_parallel_tensor(tensor: torch.Tensor) -> torch.Tensor | None:
+    ctx = get_tp_context()
+    if ctx.dp_rank != 0:
+        return None
+    local = tensor.detach().contiguous()
+    if ctx.world_size == 1:
+        return local.cpu()
+    if ctx.rank == 0:
+        chunks = [torch.empty_like(local) for _ in range(ctx.world_size)]
+        dist.gather(local, gather_list=chunks, dst=ctx.dp_rank * ctx.world_size, group=ctx.group)
+        return torch.cat(chunks, dim=0).cpu()
+    dist.gather(local, dst=ctx.dp_rank * ctx.world_size, group=ctx.group)
+    return None
+
+
+def _grouped_weight(module: nn.Module, expert_id: int) -> torch.Tensor:
+    weight = getattr(module, f"weight{expert_id}", None)
+    if weight is not None:
+        return weight
+    weights = getattr(module, "weight", None)
+    if isinstance(weights, torch.Tensor) and weights.dim() == 3:
+        return weights[expert_id]
+    if isinstance(weights, list | tuple | nn.ParameterList):
+        return weights[expert_id]
+    raise AttributeError(f"cannot find grouped expert weight for expert {expert_id}")
+
+
+def _parse_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+class BailingSoftmaxAttention(nn.Module):
+    """Softmax attention layer with either GQA (fused QKV projection) or
+    MLA-style low-rank KV pathway.
+
+    When ``kv_lora_rank`` is set the layer follows the DeepSeek-V2-style MLA
+    factorisation: Q is computed normally, K/V come from a low-rank
+    compressed KV projection, RoPE is applied to a dedicated ``qk_rope_head_dim``
+    slice while the rest of QK uses non-rope ``qk_nope_head_dim`` channels.
+    """
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        ctx = get_tp_context()
+        self.layer_idx = layer_idx
+        # Head-dim split: rope vs non-rope channels on Q/K, plus separate V dim.
+        self.qk_nope_head_dim = config.qk_nope_head_dim or config.head_dim
+        self.qk_rope_head_dim = config.qk_rope_head_dim or int(config.head_dim * config.partial_rotary_factor)
+        self.v_head_dim = config.v_head_dim or config.head_dim
+        self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        # Per-rank head counts (TP sharded).
+        self.local_heads = self.num_heads // ctx.world_size
+        self.local_kv_heads = self.num_kv_heads // ctx.world_size
+        self.q_lora_rank = config.q_lora_rank
+        self.kv_lora_rank = config.kv_lora_rank
+        self.query_key_value = None
+        self.q_proj = None
+        self.q_a_proj = None
+        self.q_a_layernorm = None
+        self.q_b_proj = None
+        self.kv_a_proj_with_mqa = None
+        self.kv_a_layernorm = None
+        self.kv_b_proj = None
+        if self.kv_lora_rank is None:
+            # Standard GQA: one fused QKV projection.
+            self.num_qkv_heads = self.num_heads + 2 * self.num_kv_heads
+            self.local_qkv_heads = self.local_heads + 2 * self.local_kv_heads
+            self.query_key_value = ColumnParallelLinear(
+                config.hidden_size, self.num_qkv_heads * config.head_dim, bias=config.qkv_bias
+            )
+            _cast_linear_weights(self.query_key_value, config.dtype)
+            self.query_layernorm = RMSNorm(config.head_dim, config.rms_norm_eps) if config.qk_norm else None
+            self.key_layernorm = RMSNorm(config.head_dim, config.rms_norm_eps) if config.qk_norm else None
+        else:
+            # MLA: Q has full per-head projection, KV goes through a shared
+            # low-rank bottleneck (``kv_a_proj_with_mqa``) plus a per-head
+            # decompression (``kv_b_proj``). The ``kv_a`` output also carries
+            # the rope channels in its tail (``qk_rope_head_dim`` cols).
+            if self.q_lora_rank is None:
+                self.q_proj = ColumnParallelLinear(config.hidden_size, self.num_heads * self.head_dim, bias=False)
+                _cast_linear_weights(self.q_proj, config.dtype)
+            else:
+                self.q_a_proj = nn.Linear(config.hidden_size, self.q_lora_rank, bias=False)
+                _cast_linear_weights(self.q_a_proj, config.dtype)
+                mark_tensor_parallel_parameter(
+                    self.q_a_proj.weight, False, sequence_parallel=True, tp_grad_allreduce=True
+                )
+                self.q_a_layernorm = RMSNorm(self.q_lora_rank, config.rms_norm_eps)
+                self.q_b_proj = ColumnParallelLinear(self.q_lora_rank, self.num_heads * self.head_dim, bias=False)
+                _cast_linear_weights(self.q_b_proj, config.dtype)
+            self.kv_a_proj_with_mqa = nn.Linear(
+                config.hidden_size, self.kv_lora_rank + self.qk_rope_head_dim, bias=False
+            )
+            _cast_linear_weights(self.kv_a_proj_with_mqa, config.dtype)
+            mark_tensor_parallel_parameter(
+                self.kv_a_proj_with_mqa.weight, False, sequence_parallel=True, tp_grad_allreduce=True
+            )
+            self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, config.rms_norm_eps)
+            self.kv_b_proj = ColumnParallelLinear(
+                config.kv_lora_rank, self.num_heads * (self.qk_nope_head_dim + self.v_head_dim), bias=False
+            )
+            _cast_linear_weights(self.kv_b_proj, config.dtype)
+            self.query_layernorm = None
+            self.key_layernorm = None
+        self.g_proj = (
+            ColumnParallelLinear(config.hidden_size, self.num_heads, bias=False) if config.attn_output_gate else None
+        )
+        if self.g_proj is not None:
+            _cast_linear_weights(self.g_proj, config.dtype)
+        self.dense = RowParallelLinear(self.num_heads * self.v_head_dim, config.hidden_size, bias=config.use_bias)
+        _cast_linear_weights(self.dense, config.dtype)
+        # Rotary embedding applied only on the qk_rope_head_dim slice.
+        self.rope = PartialRotaryEmbedding(
+            self.qk_rope_head_dim,
+            config.max_position_embeddings,
+            config.rope_theta,
+            1.0,
+            is_neox_style=False,
+        )
+        self.attn_backend = config.attn_backend
+        self.train_backend = build_train_attention_backend(self.attn_backend)
+        self.infer_backend: FlashAttnInferBackend | None = None
+        # KV cache slots populated by the runtime at engine setup.
+        self.k_cache = torch.tensor([])
+        self.v_cache = torch.tensor([])
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states.to(dtype=self.dense.weight.dtype)
+        bsz, seqlen, _ = hidden_states.shape
+        q, k, v = self._project(hidden_states, position_ids)
+        if infer_meta is not None:
+            # Lazily build the inference backend so weight-only training paths
+            # don't pay the cost.
+            if self.infer_backend is None:
+                self.infer_backend = build_infer_attention_backend(self.attn_backend)
+            out = self.infer_backend(q, k, v, self.k_cache, self.v_cache, infer_meta)
+        else:
+            out = self.train_backend(q, k, v, train_meta)
+        if self.g_proj is not None:
+            gate = _areno_sigmoid_no_compile(self.g_proj(hidden_states)).view(bsz, seqlen, self.local_heads, 1)
+            out = out * gate
+        return self.dense(out.contiguous().view(bsz, seqlen, self.local_heads * self.v_head_dim))
+
+    def _project(
+        self, hidden_states: torch.Tensor, position_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        bsz, seqlen, _ = hidden_states.shape
+        if self.kv_lora_rank is None:
+            # Standard GQA path: split fused QKV, optional per-head norm, rope
+            # on the trailing qk_rope_head_dim channels only.
+            assert self.query_key_value is not None
+            qkv = self.query_key_value(hidden_states).view(
+                bsz, seqlen, self.local_heads + 2 * self.local_kv_heads, self.head_dim
+            )
+            q, k, v = qkv.split([self.local_heads, self.local_kv_heads, self.local_kv_heads], dim=-2)
+            if self.query_layernorm is not None:
+                q = self.query_layernorm(q)
+                k = self.key_layernorm(k)
+            q_rope, k_rope = self.rope(q[..., -self.qk_rope_head_dim :], k[..., -self.qk_rope_head_dim :], position_ids)
+            return (
+                torch.cat((q[..., : self.qk_nope_head_dim], q_rope), dim=-1),
+                torch.cat((k[..., : self.qk_nope_head_dim], k_rope), dim=-1),
+                v,
+            )
+
+        # MLA path: split Q into nope/rope chunks, decompress KV from the
+        # shared low-rank rep, then re-attach a broadcast rope channel.
+        assert self.kv_a_proj_with_mqa is not None and self.kv_a_layernorm is not None and self.kv_b_proj is not None
+        if self.q_lora_rank is None:
+            assert self.q_proj is not None
+            q = self.q_proj(hidden_states).view(bsz, seqlen, self.local_heads, self.head_dim)
+        else:
+            assert self.q_a_proj is not None and self.q_a_layernorm is not None and self.q_b_proj is not None
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states))).view(
+                bsz, seqlen, self.local_heads, self.head_dim
+            )
+        q_nope, q_rope = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        kv_a = self.kv_a_proj_with_mqa(hidden_states)
+        compressed_kv, k_rope = kv_a.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        kv = self.kv_b_proj(self.kv_a_layernorm(compressed_kv)).view(
+            bsz, seqlen, self.local_heads, self.qk_nope_head_dim + self.v_head_dim
+        )
+        k_nope, v = kv.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+        q_rope, k_rope = self.rope(q_rope, k_rope.unsqueeze(2), position_ids)
+        # Single rope channel is broadcast over all heads (MQA-style).
+        k_rope = k_rope.expand(-1, -1, self.local_heads, -1)
+        return torch.cat((q_nope, q_rope), dim=-1), torch.cat((k_nope, k_rope), dim=-1), v
+
+    def set_kv_cache(self, k_cache: torch.Tensor, v_cache: torch.Tensor) -> None:
+        self.k_cache = k_cache
+        self.v_cache = v_cache
+
+    def clear_kv_cache(self) -> None:
+        self.k_cache = torch.tensor([])
+        self.v_cache = torch.tensor([])
+        self.infer_backend = None
+
+    def reset_kv_cache(self) -> None:
+        return None
+
+
+class BailingLinearAttention(nn.Module):
+    """Linear-attention layer using chunked lightning-attn (training) or
+    ``seg_la`` recurrent kernels (inference).
+
+    Each layer carries a per-head ALiBi-style decay slope plus an optional
+    SiLU on QKV. A sigmoid-gated RMSNorm on the output (``g_norm`` /
+    ``g_proj``) acts as the layer-output gating mechanism, mirroring the
+    Lightning-Attention / Minimax linear attention paper recipe.
+    """
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        ctx = get_tp_context()
+        self.layer_idx = layer_idx
+        self.num_heads = config.num_attention_heads
+        self.local_heads = self.num_heads // ctx.world_size
+        # Linear attention treats Q/K/V symmetrically (same head count).
+        self.num_kv_heads = self.num_heads
+        self.num_qkv_heads = 3 * self.num_heads
+        self.local_qkv_heads = 3 * self.local_heads
+        self.head_dim = config.head_dim
+        self.num_layers = config.num_hidden_layers
+        self.scaling = self.head_dim**-0.5
+        self.linear_scale = config.linear_scale
+        self.linear_silu = config.linear_silu
+        # Fused QKV projection. ``g_proj`` produces the output gate.
+        self.query_key_value = ColumnParallelLinear(
+            config.hidden_size, self.num_qkv_heads * self.head_dim, bias=config.qkv_bias
+        )
+        self.dense = RowParallelLinear(self.num_heads * self.head_dim, config.hidden_size, bias=config.use_bias)
+        self.g_proj = ColumnParallelLinear(config.hidden_size, self.num_heads * self.head_dim, bias=False)
+        self.group_norm_size = config.group_norm_size
+        if self.group_norm_size > 1:
+            # Grouped RMSNorm + sigmoid gate fused into one kernel — used when
+            # the model exposes a coarser head-group granularity.
+            self.g_norm = GroupRMSNormSigmoidGate(
+                self.num_heads * self.head_dim,
+                self.group_norm_size,
+                ctx.world_size,
+                config.rms_norm_eps,
+            )
+        else:
+            # Plain per-rank RMSNorm; the sigmoid gate is applied outside.
+            self.g_norm = RMSNorm(
+                self.local_heads * self.head_dim,
+                config.rms_norm_eps,
+                tensor_model_parallel=True,
+                sequence_parallel=False,
+                tp_grad_allreduce=False,
+            )
+        self.query_layernorm = RMSNorm(self.head_dim, config.rms_norm_eps) if config.qk_norm else None
+        self.key_layernorm = RMSNorm(self.head_dim, config.rms_norm_eps) if config.qk_norm else None
+        self.rope = PartialRotaryEmbedding(
+            config.head_dim,
+            config.max_position_embeddings,
+            config.rope_theta,
+            config.partial_rotary_factor,
+            is_neox_style=True,
+        )
+        if config.linear_backend != "seg_la":
+            raise ValueError(
+                f"BailingMoeV2_5ForCausalLM expects linear_backend='seg_la', got {config.linear_backend!r}"
+            )
+        # Per-head decay slope (ALiBi-like, head- and layer-dependent) used as
+        # the gating factor in the recurrent state update.
+        self.register_buffer(
+            "slope",
+            _build_slope_tensor(
+                self.local_heads,
+                config.num_attention_heads,
+                layer_idx,
+                config.num_hidden_layers,
+                ctx.rank,
+                ctx.world_size,
+            ),
+            persistent=False,
+        )
+        # Recurrent state cache populated at engine setup; shape is
+        # ``[num_slots, local_heads, head_dim, head_dim]``.
+        self.state_cache = torch.tensor([])
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        bsz, seqlen, _ = hidden_states.shape
+        qkv = self.query_key_value(hidden_states)
+        if self.linear_silu:
+            qkv = _areno_silu_no_compile(qkv)
+        qkv = qkv.view(bsz, seqlen, 3 * self.local_heads, self.head_dim)
+        q, k, v = qkv.split([self.local_heads, self.local_heads, self.local_heads], dim=-2)
+        if self.query_layernorm is not None:
+            q = self.query_layernorm(q)
+            k = self.key_layernorm(k)
+        q, k = self.rope(q, k, position_ids)
+        if self.linear_scale:
+            q = q * self.scaling
+        if infer_meta is not None:
+            out = self._forward_infer(q, k, v, infer_meta)
+        else:
+            out = self._forward_train(q, k, v, train_meta)
+        out = out.to(hidden_states.dtype).reshape(bsz, seqlen, -1)
+        gate = self.g_proj(hidden_states)
+        if self.group_norm_size > 1:
+            # Fused norm+sigmoid-gate kernel.
+            out = self.g_norm(out, gate)
+        else:
+            out = self.g_norm(out) * _areno_sigmoid_no_compile(gate)
+        return self.dense(out.to(hidden_states.dtype))
+
+    def _forward_train(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, train_meta: TrainMeta | None
+    ) -> torch.Tensor:
+        # Packed sequences need ``cu_seqlens`` so the chunked kernel can
+        # respect document boundaries; otherwise fall back to dense path.
+        if train_meta is None or not train_meta.packed or train_meta.cu_seqlens is None:
+            return self._forward_full(q, k, v)
+        cu_seqlens = train_meta.cu_seqlens.to(device=q.device, dtype=torch.int32)
+        return self._forward_lightning(q, k, v, cu_seqlens=cu_seqlens)
+
+    def _forward_full(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return self._forward_lightning(q, k, v, cu_seqlens=None)
+
+    def _forward_lightning(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, cu_seqlens: torch.Tensor | None
+    ) -> torch.Tensor:
+        log_once("chunk_lightning_attn", "using chunk lightning attention training kernel")
+        k = k.to(dtype=q.dtype)
+        v = v.to(dtype=q.dtype)
+        # g_gamma = -slope feeds the gated decay; chunked impl runs an
+        # efficient block-recurrent pass without materialising the full
+        # attention matrix.
+        out, _ = chunk_lightning_attn(
+            q,
+            k,
+            v,
+            g_gamma=-self.slope,
+            layer_idx=self.layer_idx,
+            num_layers=self.num_layers,
+            initial_state=None,
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            head_first=False,
+        )
+        return out
+
+    def _forward_infer(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, infer_meta: InferMeta) -> torch.Tensor:
+        if infer_meta.block_table is None:
+            raise RuntimeError("linear attention inference requires block_table")
+        if self.state_cache.numel() == 0:
+            raise RuntimeError("linear attention inference requires recurrent state cache")
+        # Each request maps to one state-cache slot (first column of its block table).
+        slots = infer_meta.block_table[:, 0].long()
+        if infer_meta.mode == "decode":
+            return self._forward_decode(q, k, v, slots)
+        if infer_meta.mode == "prefill":
+            if infer_meta.cu_seqlens is None:
+                raise RuntimeError("linear attention prefill requires cu_seqlens")
+            return self._forward_prefill(q, k, v, slots, infer_meta.cu_seqlens)
+        raise ValueError(f"unsupported inference mode: {infer_meta.mode}")
+
+    def _forward_decode(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, slots: torch.Tensor) -> torch.Tensor:
+        log_once("seg_la_decode", "using seg_la linear attention decode kernel")
+        # Decode runs one token per request; flatten to (batch, heads, dim)
+        # and supply unit-stride offsets and "scale=1" gating per request.
+        q_flat = q.reshape(-1, self.local_heads, self.head_dim).contiguous()
+        k_flat = k.reshape(-1, self.local_heads, self.head_dim).contiguous()
+        v_flat = v.reshape(-1, self.local_heads, self.head_dim).contiguous()
+        batch = q_flat.shape[0]
+        q_offsets = torch.arange(batch + 1, device=q.device, dtype=torch.int32)
+        # s_scales=True -> apply the previously-stored state for decode.
+        s_scales = torch.ones(batch, device=q.device, dtype=torch.bool)
+        out = self._forward_seg_la(q_flat, k_flat, v_flat, self.state_cache, slots.to(torch.int32), q_offsets, s_scales)
+        return out.view_as(q)
+
+    def _forward_prefill(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, slots: torch.Tensor, cu_seqlens: torch.Tensor
+    ) -> torch.Tensor:
+        q_flat = q.reshape(-1, self.local_heads, self.head_dim)
+        k_flat = k.reshape(-1, self.local_heads, self.head_dim)
+        v_flat = v.reshape(-1, self.local_heads, self.head_dim)
+        log_once("seg_la_prefill", "using seg_la linear attention prefill kernel")
+        batch = slots.numel()
+        # Prefill starts from zero state, so s_scales=False (no prior state).
+        s_scales = torch.zeros(batch, device=q.device, dtype=torch.bool)
+        return self._forward_seg_la(
+            q_flat.contiguous(),
+            k_flat.contiguous(),
+            v_flat.contiguous(),
+            self.state_cache,
+            slots.to(torch.int32),
+            cu_seqlens.to(device=q.device, dtype=torch.int32),
+            s_scales,
+        ).view_as(q)
+
+    def _forward_seg_la(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        state: torch.Tensor,
+        slots: torch.Tensor,
+        q_offsets: torch.Tensor,
+        s_scales: torch.Tensor,
+    ) -> torch.Tensor:
+        q_lengths = q_offsets.diff()
+        meta = SegLaMeta(
+            batch_size=int(slots.numel()),
+            max_q_length=0,
+            q_offsets=q_offsets,
+            s_offsets=slots,
+            q_lengths=q_lengths,
+            s_scales=s_scales,
+            mask=None,
+        )
+        return _seg_la_fwd_no_compile(
+            q=q,
+            k=k,
+            v=v,
+            s=state,
+            decay_scales=self.slope.to(device=q.device, dtype=torch.float32),
+            meta=meta,
+        )
+
+    def set_state_cache(self, state_cache: torch.Tensor) -> None:
+        self.state_cache = state_cache
+
+    def clear_kv_cache(self) -> None:
+        self.state_cache = torch.tensor([])
+
+    @torch.no_grad()
+    def reset_kv_cache(self) -> None:
+        # Zero the recurrent state but keep the buffer (re-allocation is
+        # expensive on hot reload).
+        if self.state_cache.numel() > 0:
+            self.state_cache.zero_()
+
+
+@torch._dynamo.disable
+def _seg_la_fwd_no_compile(**kwargs) -> torch.Tensor:
+    return seg_la_fwd(**kwargs)
+
+
+@torch._dynamo.disable
+def _areno_fused_experts_no_compile(*args, **kwargs) -> torch.Tensor:
+    return areno_fused_experts(*args, **kwargs)
+
+
+class BailingKDAAttention(nn.Module):
+    """Bailing V3 Kimi Delta Attention layout.
+
+    The checkpoint stores separate Q/K/V, beta, forget-gate, output-gate, and
+    causal-conv tensors under ``attention.*``. Runtime execution reuses the
+    existing AReno/FLA gated-delta path used by other hybrid adapters.
+    """
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        ctx = get_tp_context()
+        self.layer_idx = layer_idx
+        self.num_heads = config.num_attention_heads
+        self.local_heads = self.num_heads // ctx.world_size
+        self.head_dim = config.head_dim
+        self.v_head_dim = config.v_head_dim or config.head_dim
+        self.proj_dim = self.num_heads * self.head_dim
+        self.local_proj_dim = self.local_heads * self.head_dim
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+        self.kda_safe_gate = config.kda_safe_gate
+        self.kda_lower_bound = config.kda_lower_bound
+
+        self.q_proj = ColumnParallelLinear(config.hidden_size, self.proj_dim, bias=False)
+        self.k_proj = ColumnParallelLinear(config.hidden_size, self.proj_dim, bias=False)
+        self.v_proj = ColumnParallelLinear(config.hidden_size, self.proj_dim, bias=False)
+        self.f_proj = ColumnParallelLinear(config.hidden_size, self.proj_dim, bias=False)
+        self.g_proj = ColumnParallelLinear(config.hidden_size, self.proj_dim, bias=False)
+        self.b_proj = ColumnParallelLinear(config.hidden_size, self.num_heads, bias=False)
+        for proj in (self.q_proj, self.k_proj, self.v_proj, self.f_proj, self.g_proj, self.b_proj):
+            _cast_linear_weights(proj, config.dtype)
+        self.q_conv1d_weight = nn.Parameter(torch.empty(self.local_proj_dim, 1, self.conv_kernel_size))
+        self.k_conv1d_weight = nn.Parameter(torch.empty(self.local_proj_dim, 1, self.conv_kernel_size))
+        self.v_conv1d_weight = nn.Parameter(torch.empty(self.local_proj_dim, 1, self.conv_kernel_size))
+        mark_tensor_parallel_parameter(self.q_conv1d_weight, True, sequence_parallel=True)
+        mark_tensor_parallel_parameter(self.k_conv1d_weight, True, sequence_parallel=True)
+        mark_tensor_parallel_parameter(self.v_conv1d_weight, True, sequence_parallel=True)
+        self.dt_bias = nn.Parameter(torch.empty(self.local_proj_dim, dtype=torch.float32))
+        self.A_log = nn.Parameter(torch.empty(self.local_heads, dtype=torch.float32))
+        mark_tensor_parallel_parameter(self.dt_bias, True, sequence_parallel=True)
+        mark_tensor_parallel_parameter(self.A_log, True, sequence_parallel=True)
+        self.o_norm_weight = nn.Parameter(torch.ones(self.head_dim))
+        self.o_proj = RowParallelLinear(self.proj_dim, config.hidden_size, bias=False)
+        _cast_linear_weights(self.o_proj, config.dtype)
+        self.scale = self.head_dim**-0.5
+        self.eps = config.rms_norm_eps
+        self.state_cache = torch.tensor([])
+        self.conv_cache = torch.tensor([])
+
+    @torch._dynamo.disable
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        del position_ids
+        hidden_states = hidden_states.to(dtype=self.q_proj.weight.dtype)
+        batch, seqlen, _ = hidden_states.shape
+        q = self._causal_conv(self.q_proj(hidden_states), self.q_conv1d_weight, 0, train_meta, infer_meta)
+        k = self._causal_conv(self.k_proj(hidden_states), self.k_conv1d_weight, 1, train_meta, infer_meta)
+        v = self._causal_conv(self.v_proj(hidden_states), self.v_conv1d_weight, 2, train_meta, infer_meta)
+        q = q.to(dtype=hidden_states.dtype)
+        k = k.to(dtype=hidden_states.dtype)
+        v = v.to(dtype=hidden_states.dtype)
+        f = self.f_proj(hidden_states).view(batch, seqlen, self.local_heads, self.head_dim)
+        gate = self.g_proj(hidden_states).view(batch, seqlen, self.local_heads, self.head_dim)
+        beta = self.b_proj(hidden_states).view(batch, seqlen, self.local_heads)
+        q = q.view(batch, seqlen, self.local_heads, self.head_dim)
+        k = k.view(batch, seqlen, self.local_heads, self.head_dim)
+        v = v.view(batch, seqlen, self.local_heads, self.v_head_dim)
+        if infer_meta is not None:
+            out = self._forward_infer(q, k, v, f, beta, infer_meta)
+        else:
+            out = self._forward_train(q, k, v, f, beta, train_meta)
+        out = _rmsnorm_sigmoid_gate(out, gate, self.o_norm_weight, self.eps)
+        return self.o_proj(out.reshape(batch, seqlen, self.local_proj_dim).to(dtype=hidden_states.dtype))
+
+    def _causal_conv(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cache_idx: int,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        if infer_meta is not None:
+            return self._causal_conv_infer(x, weight, cache_idx, infer_meta)
+        if train_meta is not None and train_meta.packed and train_meta.cu_seqlens is not None:
+            if x.shape[0] != 1:
+                raise ValueError("packed Bailing V3 KDA causal-conv expects flattened input with batch size 1")
+            return _areno_packed_depthwise_causal_conv1d_silu_no_compile(x, weight, train_meta.cu_seqlens)
+        _require_fla_gdn()
+        return _fla_causal_conv1d_no_compile(x, weight=weight.squeeze(1), activation="silu")
+
+    def _causal_conv_infer(
+        self, x: torch.Tensor, weight: torch.Tensor, cache_idx: int, infer_meta: InferMeta
+    ) -> torch.Tensor:
+        if infer_meta.block_table is None:
+            raise RuntimeError("Bailing V3 KDA inference requires block_table")
+        if self.conv_cache.numel() == 0:
+            raise RuntimeError("Bailing V3 KDA inference requires conv state cache")
+        slots = infer_meta.block_table[:, 0].long()
+        if infer_meta.mode == "decode":
+            current = x.reshape(-1, x.shape[-1])
+            history = self.conv_cache.index_select(0, slots)[:, cache_idx].to(dtype=current.dtype)
+            out = _areno_depthwise_causal_conv1d_silu_decode_no_compile(current, history, weight)
+            window = torch.cat((history, current.unsqueeze(-1)), dim=-1)
+            self.conv_cache[slots, cache_idx] = window[:, :, 1:].detach().to(dtype=self.conv_cache.dtype)
+            return out.view(x.shape)
+        if infer_meta.mode == "prefill":
+            if infer_meta.cu_seqlens is None:
+                raise RuntimeError("Bailing V3 KDA prefill requires cu_seqlens")
+            return self._causal_conv_infer_prefill(x, weight, cache_idx, infer_meta.cu_seqlens, slots)
+        raise ValueError(f"unsupported inference mode: {infer_meta.mode}")
+
+    @torch._dynamo.disable
+    def _causal_conv_infer_prefill(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cache_idx: int,
+        cu_seqlens: torch.Tensor,
+        slots: torch.Tensor,
+    ) -> torch.Tensor:
+        out = torch.empty_like(x)
+        cu = cu_seqlens.to(device=x.device, dtype=torch.long)
+        for idx, slot in enumerate(slots):
+            start, end = int(cu[idx].item()), int(cu[idx + 1].item())
+            segment = x[:, start:end]
+            out[:, start:end] = _areno_depthwise_causal_conv1d_silu_no_compile(segment, weight)
+            tail = segment.reshape(-1, x.shape[-1])[-(self.conv_kernel_size - 1) :]
+            cache = torch.zeros(x.shape[-1], self.conv_kernel_size - 1, device=x.device, dtype=self.conv_cache.dtype)
+            cache[:, -tail.shape[0] :] = tail.transpose(0, 1).to(dtype=self.conv_cache.dtype)
+            self.conv_cache[slot, cache_idx] = cache
+        return out
+
+    def _forward_train(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        train_meta: TrainMeta | None,
+    ) -> torch.Tensor:
+        cu = (
+            train_meta.cu_seqlens.to(device=q.device, dtype=torch.long)
+            if train_meta is not None and train_meta.packed and train_meta.cu_seqlens is not None
+            else None
+        )
+        return self._forward_prefill(q, k, v, g, beta, cu, None, None, output_final_state=False)[0]
+
+    def _forward_prefill(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        raw_gate: torch.Tensor,
+        raw_beta: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        initial_state: torch.Tensor | None,
+        state_indices: torch.Tensor | None,
+        *,
+        output_final_state: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        return areno_kda_chunk(
+            q,
+            k,
+            v,
+            raw_gate=raw_gate,
+            beta=_areno_sigmoid_no_compile(raw_beta).to(dtype=q.dtype),
+            initial_state=initial_state,
+            state_indices=state_indices,
+            output_final_state=output_final_state,
+            scale=self.scale,
+            cu_seqlens=cu_seqlens,
+            a_log=self.A_log.float(),
+            dt_bias=self.dt_bias.float(),
+            lower_bound=float(self.kda_lower_bound)
+            if self.kda_safe_gate and self.kda_lower_bound is not None
+            else None,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    def _forward_infer(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        f: torch.Tensor,
+        beta: torch.Tensor,
+        infer_meta: InferMeta,
+    ) -> torch.Tensor:
+        if infer_meta.block_table is None:
+            raise RuntimeError("Bailing V3 KDA inference requires block_table")
+        if self.state_cache.numel() == 0:
+            raise RuntimeError("Bailing V3 KDA inference requires recurrent state cache")
+        slots = infer_meta.block_table[:, 0].long()
+        initial_state = self.state_cache.index_select(0, slots).to(device=q.device)
+        cu = (
+            torch.arange(slots.numel() + 1, device=q.device, dtype=torch.long)
+            if infer_meta.mode == "decode"
+            else infer_meta.cu_seqlens.to(device=q.device, dtype=torch.long)
+            if infer_meta.cu_seqlens is not None
+            else None
+        )
+        if cu is None:
+            raise RuntimeError("Bailing V3 KDA inference requires cu_seqlens")
+        state_indices = torch.arange(slots.numel(), device=q.device, dtype=torch.long)
+        if infer_meta.mode == "prefill":
+            out, final_state = self._forward_prefill(
+                q,
+                k,
+                v,
+                f,
+                beta,
+                cu,
+                initial_state,
+                state_indices,
+                output_final_state=True,
+            )
+            if final_state is None:
+                raise RuntimeError("KDA prefill did not return final state")
+            self.state_cache[slots] = final_state.detach().to(dtype=self.state_cache.dtype)
+            return out
+        beta = beta.to(dtype=q.dtype)
+        out = areno_kda_recurrent_update(
+            q=q,
+            k=k,
+            v=v,
+            # SGLang's recurrent KDA kernel expects the raw gate as
+            # [batch, tokens, heads * head_dim]. Keeping it 4D makes the
+            # kernel interpret the head stride as the token stride, so every
+            # packed sequence after the first reads gates from the wrong row.
+            raw_gate=f.flatten(2),
+            beta=beta,
+            state=initial_state,
+            state_indices=state_indices,
+            scale=self.scale,
+            cu_seqlens=cu,
+            a_log=self.A_log.float(),
+            dt_bias=self.dt_bias.float(),
+            lower_bound=float(self.kda_lower_bound)
+            if self.kda_safe_gate and self.kda_lower_bound is not None
+            else None,
+            use_qk_l2norm_in_kernel=True,
+        )
+        self.state_cache[slots] = initial_state.detach().to(dtype=self.state_cache.dtype)
+        return out
+
+    def set_state_cache(self, state_cache: torch.Tensor, conv_cache: torch.Tensor) -> None:
+        self.state_cache = state_cache
+        self.conv_cache = conv_cache
+
+    def clear_kv_cache(self) -> None:
+        self.state_cache = torch.tensor([])
+        self.conv_cache = torch.tensor([])
+
+    @torch.no_grad()
+    def reset_kv_cache(self) -> None:
+        if self.state_cache.numel() > 0:
+            self.state_cache.zero_()
+        if self.conv_cache.numel() > 0:
+            self.conv_cache.zero_()
+
+
+class BailingDecoderLayer(nn.Module):
+    """One Bailing decoder layer: pre-norm attention (softmax or linear) +
+    pre-norm MLP (dense or MoE).
+
+    ``_is_softmax_layer`` decides which attention flavour this layer runs:
+    every ``layer_group_size``-th layer (and the trailing tail) is softmax,
+    the rest are linear. ``first_k_dense_replace`` controls how many leading
+    layers use the dense SwiGLU MLP before MoE kicks in.
+    """
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attention_layer_type = "attention" if _is_softmax_layer(config, layer_idx) else "linear_attention"
+        self.input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.attention = (
+            BailingSoftmaxAttention(config, layer_idx)
+            if self.attention_layer_type == "attention"
+            else BailingKDAAttention(config, layer_idx)
+        )
+        # Dense MLP for the warmup layers, sparse MoE for the rest.
+        self.mlp = (
+            BailingSparseMoeBlock(config)
+            if config.num_experts is not None and layer_idx >= config.first_k_dense_replace
+            else BailingDenseMLP(config, config.intermediate_size)
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        # Standard pre-norm residual: norm -> sublayer -> add.
+        residual = hidden_states
+        hidden_states = residual + self.attention(
+            self.input_layernorm(hidden_states), position_ids, train_meta, infer_meta
+        )
+        residual = hidden_states
+        return residual + self.mlp(self.post_attention_layernorm(hidden_states))
+
+
+class BailingMoeV3ForCausalLM(nn.Module):
+    """Top-level Bailing-MoE V3 causal LM."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.word_embeddings = VocabParallelEmbedding(config.vocab_size, config.hidden_size, dtype=config.dtype)
+        self.layers = nn.ModuleList([BailingDecoderLayer(config, i) for i in range(config.num_hidden_layers)])
+        self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        # Bailing V3 checkpoints use an untied fp32 LM head. Keep the logits
+        # projection in fp32 to match the reference implementation and avoid
+        # bf16 overflow in the vocab softmax path.
+        lm_head_dtype = torch.float32 if not config.tie_word_embeddings else config.dtype
+        self.lm_head = VocabParallelLMHead(config.hidden_size, config.vocab_size, dtype=lm_head_dtype)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> CausalLMOutput:
+        if position_ids is None:
+            position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0).expand_as(input_ids)
+        hidden_states = self.word_embeddings(input_ids)
+        use_sequence_parallel = bool(train_meta is not None and train_meta.sequence_parallel)
+        if use_sequence_parallel:
+            # SP shards the sequence dim before entering the layer stack.
+            hidden_states = scatter_to_sequence_parallel_region(hidden_states)
+        with sequence_parallel_region(use_sequence_parallel):
+            for layer in self.layers:
+                hidden_states = layer(hidden_states, position_ids, train_meta, infer_meta)
+            hidden_states = self.norm(hidden_states)
+            logits_input = hidden_states
+            if self.lm_head.weight.dtype == torch.float32:
+                logits_input = hidden_states.float()
+            return CausalLMOutput(logits_shard=self.lm_head(logits_input), hidden_states=hidden_states)
+
+    def set_kv_caches(self, kv_caches: list[tuple[torch.Tensor, torch.Tensor]]) -> None:
+        """Bind per-softmax-layer KV caches and pre-allocate per-linear-layer
+        recurrent state cache.
+
+        ``kv_caches`` lists KV pairs *only* for softmax layers (in order of
+        appearance); linear layers get a fresh zero state of shape
+        ``[num_slots, heads, head_dim, head_dim]`` sized from the first KV
+        cache.
+        """
+        softmax_idx = 0
+        for layer in self.layers:
+            if isinstance(layer.attention, BailingSoftmaxAttention):
+                layer.attention.set_kv_cache(*kv_caches[softmax_idx])
+                softmax_idx += 1
+            elif isinstance(layer.attention, BailingKDAAttention):
+                num_slots = kv_caches[0][0].shape[0] if kv_caches else 1
+                device = kv_caches[0][0].device if kv_caches else next(self.parameters()).device
+                state = torch.zeros(
+                    num_slots,
+                    layer.attention.local_heads,
+                    layer.attention.head_dim,
+                    layer.attention.v_head_dim,
+                    device=device,
+                    dtype=torch.float32,
+                )
+                conv_state = torch.zeros(
+                    num_slots,
+                    3,
+                    layer.attention.local_proj_dim,
+                    layer.attention.conv_kernel_size - 1,
+                    device=device,
+                    dtype=torch.float32,
+                )
+                layer.attention.set_state_cache(state, conv_state)
+
+    @torch.no_grad()
+    def prepare_infer_weights(self) -> None:
+        """Stack per-expert weights for fused-MoE inference on every MoE block."""
+        for layer in self.layers:
+            if isinstance(layer.mlp, BailingSparseMoeBlock):
+                layer.mlp.prepare_infer_weights()
+
+    @torch.no_grad()
+    def clear_infer_weights(self) -> None:
+        """Drop fused-MoE inference tiles to reclaim memory before training."""
+        for layer in self.layers:
+            if isinstance(layer.mlp, BailingSparseMoeBlock):
+                layer.mlp.clear_infer_weights()
+
+    @torch.no_grad()
+    def offload_train_weights(self) -> None:
+        for layer in self.layers:
+            if isinstance(layer.mlp, BailingSparseMoeBlock):
+                layer.mlp.experts.offload_to_cpu()
+
+    @torch.no_grad()
+    def onload_train_weights(self, device: torch.device) -> None:
+        for layer in self.layers:
+            if isinstance(layer.mlp, BailingSparseMoeBlock):
+                layer.mlp.experts.onload_to_device(device)
+
+    @torch.no_grad()
+    def finalize_router_expert_bias(self, tp_group, dp_group) -> None:
+        """Apply the per-step router-bias update on every MoE layer."""
+        for layer in self.layers:
+            if isinstance(layer.mlp, BailingSparseMoeBlock):
+                layer.mlp.gate.finalize_expert_bias(tp_group, dp_group)
+
+    def allocate_kv_caches(
+        self, num_blocks: int, block_size: int, device: torch.device
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Allocate paged KV caches — only for softmax-attention layers."""
+        caches = []
+        for layer in self.layers:
+            if not isinstance(layer.attention, BailingSoftmaxAttention):
+                continue
+            k_cache = torch.empty(
+                num_blocks,
+                block_size,
+                layer.attention.local_kv_heads,
+                layer.attention.head_dim,
+                device=device,
+                dtype=self.config.dtype,
+            )
+            v_cache = torch.empty(
+                num_blocks,
+                block_size,
+                layer.attention.local_kv_heads,
+                layer.attention.head_dim,
+                device=device,
+                dtype=self.config.dtype,
+            )
+            caches.append((k_cache, v_cache))
+        return caches
+
+    def clear_kv_caches(self) -> None:
+        for layer in self.layers:
+            layer.attention.clear_kv_cache()
+
+    @torch.no_grad()
+    def reset_kv_caches(self) -> None:
+        for layer in self.layers:
+            layer.attention.reset_kv_cache()
+
+    @torch.no_grad()
+    def offload_kv_caches(self) -> None:
+        for layer in self.layers:
+            attn = layer.attention
+            if isinstance(attn, BailingSoftmaxAttention):
+                if attn.k_cache.numel() > 0:
+                    attn.k_cache = attn.k_cache.to(device="cpu")
+                if attn.v_cache.numel() > 0:
+                    attn.v_cache = attn.v_cache.to(device="cpu")
+                attn.infer_backend = None
+            elif isinstance(attn, BailingKDAAttention):
+                if attn.state_cache.numel() > 0:
+                    attn.state_cache = attn.state_cache.to(device="cpu")
+                if attn.conv_cache.numel() > 0:
+                    attn.conv_cache = attn.conv_cache.to(device="cpu")
+
+    @torch.no_grad()
+    def onload_kv_caches(self, device: torch.device) -> bool:
+        found = False
+        for layer in self.layers:
+            attn = layer.attention
+            if isinstance(attn, BailingSoftmaxAttention):
+                if attn.k_cache.numel() > 0:
+                    found = True
+                    if attn.k_cache.device != device:
+                        attn.k_cache = attn.k_cache.to(device=device)
+                if attn.v_cache.numel() > 0:
+                    found = True
+                    if attn.v_cache.device != device:
+                        attn.v_cache = attn.v_cache.to(device=device)
+            elif isinstance(attn, BailingKDAAttention):
+                if attn.state_cache.numel() > 0:
+                    found = True
+                    if attn.state_cache.device != device:
+                        attn.state_cache = attn.state_cache.to(device=device)
+                if attn.conv_cache.numel() > 0:
+                    found = True
+                    if attn.conv_cache.device != device:
+                        attn.conv_cache = attn.conv_cache.to(device=device)
+        return found
+
+
+class BailingMoeV3Adapter(ModelAdapter):
+    """Model adapter binding HF Bailing-MoE V3 checkpoints to the areno runtime."""
+
+    name = "bailing_moe_v3"
+
+    def match_hf_config(self, hf_config: dict[str, Any]) -> bool:
+        architectures = hf_config.get("architectures") or []
+        model_type = str(hf_config.get("model_type", "")).lower()
+        return "BailingMoeV3ForCausalLM" in architectures or model_type == "bailing_hybrid"
+
+    def config_from_hf(self, hf_config: dict[str, Any]) -> ModelConfig:
+        """Build a ``ModelConfig`` from a Bailing HF config dict.
+
+        Bailing uses several alternate key spellings (SGLang lineage); we
+        accept either ``num_experts``/``n_routed_experts``, ``n_group``/
+        ``moe_router_num_groups``, ``score_function``/``scoring_func`` etc.
+        and validate that the routing setup matches what ``BailingGate``
+        actually implements (sigmoid scoring, expert bias enabled, top-k
+        renormalization on).
+        """
+        dtype = _parse_dtype(hf_config.get("torch_dtype") or hf_config.get("dtype"))
+        num_heads = int(hf_config["num_attention_heads"])
+        head_dim = int(hf_config.get("head_dim", hf_config["hidden_size"] // num_heads))
+        rotary_dim = int(hf_config.get("rotary_dim", hf_config.get("qk_rope_head_dim", head_dim)))
+        num_experts = hf_config.get("num_experts", hf_config.get("n_routed_experts"))
+        moe_intermediate_size = int(hf_config.get("moe_intermediate_size", hf_config.get("intermediate_size", 0)))
+        num_experts_per_tok = int(hf_config.get("num_experts_per_tok", hf_config.get("moe_router_topk", 1)))
+        n_group = int(hf_config.get("n_group", hf_config.get("moe_router_num_groups", 1)))
+        topk_group = int(hf_config.get("topk_group", hf_config.get("moe_router_group_topk", 1)))
+        routed_scaling_factor = float(
+            hf_config.get("routed_scaling_factor", hf_config.get("moe_router_topk_scaling_factor", 1.0))
+        )
+        shared_size = hf_config.get("moe_shared_expert_intermediate_size")
+        num_shared_experts = hf_config.get("num_shared_experts")
+        if shared_size is not None and num_shared_experts is None:
+            # Derive shared-expert count from total intermediate size when only
+            # the aggregate is given.
+            num_shared_experts = max(1, int(shared_size) // max(1, moe_intermediate_size))
+        linear_backend = str(hf_config.get("linear_backend", "seg_la")).lower()
+        score_function = str(
+            hf_config.get(
+                "score_function", hf_config.get("scoring_func", hf_config.get("moe_router_score_function", "sigmoid"))
+            )
+        ).lower()
+        topk_method = str(hf_config.get("topk_method", "noaux_tc")).lower()
+        moe_router_enable_expert_bias = _parse_bool(hf_config.get("moe_router_enable_expert_bias"), True)
+        norm_topk_prob = _parse_bool(hf_config.get("norm_topk_prob"), True)
+        moe_router_dtype = _parse_dtype(hf_config.get("moe_router_dtype") or "fp32")
+        if score_function != "sigmoid":
+            raise ValueError(f"BailingMoeV3 only supports score_function='sigmoid', got {score_function!r}")
+        if not moe_router_enable_expert_bias:
+            raise ValueError("BailingMoeV3 requires moe_router_enable_expert_bias=True to match biased grouped topk")
+        if not norm_topk_prob:
+            raise ValueError("BailingMoeV3 requires norm_topk_prob=True to match top-k renormalization")
+        if topk_method not in {"noaux_tc", "group_limited_greedy"}:
+            raise ValueError(f"unsupported BailingMoeV3 topk_method={topk_method!r}")
+        return ModelConfig(
+            model_type=self.name,
+            vocab_size=int(hf_config["vocab_size"]),
+            hidden_size=int(hf_config["hidden_size"]),
+            intermediate_size=int(hf_config["intermediate_size"]),
+            num_hidden_layers=int(hf_config["num_hidden_layers"]),
+            num_attention_heads=num_heads,
+            num_key_value_heads=int(hf_config.get("num_key_value_heads", num_heads)),
+            head_dim=head_dim,
+            rms_norm_eps=float(hf_config.get("rms_norm_eps", 1e-6)),
+            rope_theta=float(hf_config.get("rope_theta", hf_config.get("rotary_base", 10000.0))),
+            max_position_embeddings=int(hf_config.get("max_position_embeddings", 4096)),
+            tie_word_embeddings=_parse_bool(hf_config.get("tie_word_embeddings"), False),
+            qkv_bias=_parse_bool(hf_config.get("use_qkv_bias", hf_config.get("qkv_bias")), False),
+            qk_norm=_parse_bool(hf_config.get("use_qk_norm"), True),
+            dtype=dtype,
+            hidden_act=str(hf_config.get("hidden_act", "silu")),
+            use_bias=_parse_bool(hf_config.get("use_bias"), False),
+            layer_group_size=int(hf_config.get("layer_group_size", 1)),
+            partial_rotary_factor=float(hf_config.get("partial_rotary_factor", rotary_dim / head_dim)),
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            n_group=n_group,
+            topk_group=topk_group,
+            routed_scaling_factor=routed_scaling_factor,
+            first_k_dense_replace=int(hf_config.get("first_k_dense_replace", 0)),
+            moe_intermediate_size=moe_intermediate_size,
+            num_shared_experts=num_shared_experts,
+            moe_router_enable_expert_bias=moe_router_enable_expert_bias,
+            norm_topk_prob=norm_topk_prob,
+            moe_router_dtype=moe_router_dtype,
+            score_function=score_function,
+            topk_method=topk_method,
+            group_norm_size=int(
+                hf_config.get(
+                    "group_norm_size", hf_config.get("linear_attn_norm_group_size", hf_config.get("head_dim", 128))
+                )
+            ),
+            num_nextn_predict_layers=int(hf_config.get("num_nextn_predict_layers", 0)),
+            mtp_loss_scaling_factor=float(hf_config.get("mtp_loss_scaling_factor", 0.0)),
+            qk_nope_head_dim=int(hf_config.get("qk_nope_head_dim", head_dim)),
+            qk_rope_head_dim=int(hf_config.get("qk_rope_head_dim", rotary_dim)),
+            v_head_dim=int(hf_config.get("v_head_dim", head_dim)),
+            q_lora_rank=hf_config.get("q_lora_rank"),
+            kv_lora_rank=hf_config.get("kv_lora_rank"),
+            kda_safe_gate=_parse_bool(hf_config.get("kda_safe_gate"), False),
+            kda_lower_bound=(
+                float(hf_config["kda_lower_bound"]) if hf_config.get("kda_lower_bound") is not None else None
+            ),
+            no_kda_lora=_parse_bool(hf_config.get("no_kda_lora"), False),
+            linear_backend=linear_backend,
+            linear_scale=linear_backend == "minimax",
+            linear_silu=_parse_bool(hf_config.get("use_linear_silu", hf_config.get("linear_silu")), False),
+            attn_output_gate=str(hf_config.get("gated_attention_proj_granularity_type", "")).lower() == "head_wise",
+            linear_conv_kernel_dim=int(hf_config.get("short_conv_kernel_size", 4)),
+            linear_key_head_dim=head_dim,
+            linear_value_head_dim=int(hf_config.get("v_head_dim", head_dim)),
+            linear_num_key_heads=num_heads,
+            linear_num_value_heads=num_heads,
+            sequence_parallel=_parse_bool(hf_config.get("sequence_parallel"), True),
+            moe_router_bias_update_rate=float(hf_config.get("moe_router_bias_update_rate", 0.0)),
+        )
+
+    def build(self, config: ModelConfig) -> nn.Module:
+        return BailingMoeV3ForCausalLM(config)
+
+    @torch.no_grad()
+    def load_weights(self, model: nn.Module, model_path: str | Path) -> None:
+        if not isinstance(model, BailingMoeV3ForCausalLM):
+            raise TypeError(f"BailingMoeV3Adapter cannot load weights into {type(model)!r}")
+        load_checkpoint_weights(model, model_path, CHECKPOINT_SPEC)
+
+    @torch.no_grad()
+    def save_weights(self, model: nn.Module, output_path: str | Path, source_path: str | Path | None) -> str | None:
+        if not isinstance(model, BailingMoeV3ForCausalLM):
+            raise TypeError(f"BailingMoeV3Adapter cannot save weights from {type(model)!r}")
+        return save_checkpoint_weights(model, output_path, source_path, CHECKPOINT_SPEC)
+
+    def build_policy_plan(self, model: nn.Module):
+        return build_checkpoint_policy_plan(model, CHECKPOINT_SPEC)
+
+
+def _is_softmax_layer(config: ModelConfig, layer_idx: int) -> bool:
+    """Return True iff this layer should run softmax attention.
+
+    Bailing groups layers into chunks of ``layer_group_size``: the last layer
+    of each group is softmax, the rest are linear. Any trailing layers that
+    don't fit a full group (when num_hidden_layers isn't divisible by
+    layer_group_size) are also forced to softmax so attention always anchors
+    the sequence end.
+    """
+    return (
+        (layer_idx + 1) % config.layer_group_size == 0
+        or layer_idx >= config.num_hidden_layers // config.layer_group_size * config.layer_group_size
+    )
+
+
+@torch._dynamo.disable
+def _rmsnorm_sigmoid_gate(x: torch.Tensor, gate: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Apply per-head RMSNorm followed by a sigmoid output gate.
+
+    This matches SGLang's ``FusedRMSNormGated(head_dim, activation="sigmoid")``
+    for Bailing V3 KDA, where the same ``head_dim`` scale is shared by every
+    local attention head.
+    """
+
+    inv_rms = torch.rsqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + float(eps))
+    return (
+        (x * inv_rms.to(dtype=x.dtype))
+        * weight.to(device=x.device, dtype=x.dtype).view(1, 1, 1, -1)
+        * torch.sigmoid(gate.float()).to(dtype=x.dtype)
+    )
+
+
+def _build_slope_tensor(
+    local_heads: int,
+    total_heads: int,
+    layer_idx: int,
+    num_hidden_layers: int,
+    rank: int,
+    world_size: int,
+) -> torch.Tensor:
+    """Build the ALiBi-style decay slopes for one rank's local heads.
+
+    The slope table follows the standard ALiBi recipe (geometric sequence
+    starting at ``2^(-2^(-(log2(n)-3)))``), with a small per-layer linear
+    decay so deeper layers attenuate slightly more slowly. The slice for
+    this rank is the standard TP shard of the full per-head table.
+    """
+
+    def get_slopes(n: int) -> list[float]:
+        def get_slopes_power_of_2(m: int) -> list[float]:
+            start = 2 ** (-(2 ** -(math.log2(m) - 3)))
+            return [start * start**i for i in range(m)]
+
+        if math.log2(n).is_integer():
+            return get_slopes_power_of_2(n)
+        # Non-power-of-two head counts: take the next-smaller power-of-two
+        # slopes and interleave the doubled sequence to fill the rest.
+        closest_power_of_2 = 2 ** math.floor(math.log2(n))
+        return (
+            get_slopes_power_of_2(closest_power_of_2)
+            + get_slopes(2 * closest_power_of_2)[0::2][: n - closest_power_of_2]
+        )
+
+    if total_heads != local_heads * world_size:
+        raise ValueError(f"total_heads={total_heads} must equal local_heads * world_size={local_heads * world_size}")
+    start, end = _shard_range(total_heads, rank, world_size)
+    # Layer scaling: deeper layers get a slightly smaller multiplier; the
+    # +1e-5 floor keeps the zero-layer single-layer case finite.
+    layer_scale = 1 + 1e-5 if num_hidden_layers <= 1 else 1 - layer_idx / (num_hidden_layers - 1) + 1e-5
+    return torch.tensor(get_slopes(total_heads)[start:end], dtype=torch.float32) * layer_scale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
   "torch>=2.6",
-  "flash-linear-attention>=0.2",
+  "flash-linear-attention @ git+https://github.com/fla-org/flash-linear-attention.git@v0.5.2",
   "safetensors>=0.4",
   "transformers>=4.56",
   "huggingface-hub>=0.25",

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -1,16 +1,19 @@
 import asyncio
 import importlib.util
+import json
 import logging
 import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
 
+from areno.api.agentic import AgentTrajectory as RuntimeAgentTrajectory
 from areno.api.tool_call_parser import (
     Gemma4ToolCallParser,
     JsonToolCallParser,
     MiniCPMToolCallParser,
     QwenToolCallParser,
+    infer_tool_call_parser_name,
 )
 from areno.api.trainers.policy_only import PolicyOnlyTrainer
 
@@ -122,10 +125,17 @@ def test_agent_trajectory_turn_extracts_response_metadata():
     turn = AgentTrajectoryTurn(
         item=item,
         messages=[{"role": "user", "content": "same prompt"}],
-        response={"areno": {"response_tokens": [10, 11], "response_logprobs": [-0.1, -0.2]}},
+        response={
+            "areno": {
+                "input_tokens": [1, 2, 3],
+                "response_tokens": [10, 11],
+                "response_logprobs": [-0.1, -0.2],
+            }
+        },
     )
 
     assert turn.item.record == {"task": "same"}
+    assert turn.input_tokens == [1, 2, 3]
     assert turn.response_tokens == [10, 11]
     assert turn.response_logprobs == [-0.1, -0.2]
 
@@ -220,6 +230,39 @@ def test_normalize_messages_rewrites_null_tool_call_content_for_templates():
 
     assert tokens == [3]
     assert messages[1]["content"] == ""
+
+
+def test_normalize_messages_flattens_openai_text_parts_for_templates():
+    tokenizer = _StrictContentTokenizer()
+    messages = agentic._normalize_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect "},
+                    {"type": "text", "text": "the repository"},
+                ],
+            },
+            {"role": "tool", "content": [{"type": "text", "text": "README.md"}]},
+        ]
+    )
+
+    tokens = agentic._messages_to_prompt_tokens(tokenizer, messages, tools=[], fallback_prompt="fallback")
+
+    assert tokens == [2]
+    assert messages[0]["content"] == "inspect the repository"
+    assert messages[1]["content"] == "README.md"
+
+
+def test_normalize_messages_preserves_multimodal_content_parts():
+    content = [
+        {"type": "text", "text": "describe"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+    ]
+
+    messages = agentic._normalize_messages([{"role": "user", "content": content}])
+
+    assert messages[0]["content"] == content
 
 
 def test_messages_to_prompt_tokens_normalizes_tool_call_arguments_for_templates():
@@ -355,6 +398,28 @@ def test_explicit_trajectory_tokenization_normalizes_null_tool_call_content():
     sample = session._sample_from_trajectory_turn(turn)
 
     assert sample.token_row == [3, 1]
+
+
+def test_explicit_trajectory_uses_exact_input_tokens_from_response_metadata():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    trainer.tokenizer = _ExactInputTokenizer()
+    session = RolloutSession(trainer, sampling_params=_FakeSamplingParams(), loss_mask_policy=LossMaskPolicy())
+    item = next(AgentBatch(records=[{}], prompts=["p"], input_tokens=[[1]], n_samples=1).iter_samples())
+    turn = AgentTrajectoryTurn(
+        item=item,
+        messages=[{"role": "user", "content": [{"type": "text", "text": "Pi-owned prompt"}]}],
+        response={
+            "areno": {
+                "input_tokens": [7, 8, 9],
+                "response_tokens": [10],
+                "response_logprobs": [-0.1],
+            }
+        },
+    )
+
+    sample = session._sample_from_trajectory_turn(turn)
+
+    assert sample.token_row == [7, 8, 9, 10]
 
 
 def test_messages_to_prompt_tokens_falls_back_when_template_rejects_tools():
@@ -899,7 +964,7 @@ def test_agentic_tool_request_returns_tool_call_and_reward_record():
     assert record.loss_mask == [True, True]
 
 
-def test_json_tool_call_parser_prefers_explicit_final_direction():
+def test_json_tool_call_parser_rejects_explicit_direction_in_plain_text():
     tools = [
         {
             "type": "function",
@@ -919,8 +984,8 @@ def test_json_tool_call_parser_prefers_explicit_final_direction():
         {"type": "function", "function": {"name": "choose_move"}},
     )
 
-    assert len(parsed.tool_calls) == 1
-    assert '"direction":"left"' in parsed.tool_calls[0]["function"]["arguments"]
+    assert parsed.tool_calls == []
+    assert parsed.normal_text == "Valid moves are up, down, left, right. I choose left."
 
 
 def test_json_tool_call_parser_rejects_plain_reasoning_without_action():
@@ -1011,6 +1076,95 @@ def test_qwen_tool_call_parser_supports_angle_function_blocks():
     assert parsed.tool_calls[0]["function"]["name"] == "inspect_tree"
     assert '"path":"."' in parsed.tool_calls[0]["function"]["arguments"]
     assert '"max_depth":3' in parsed.tool_calls[0]["function"]["arguments"]
+
+
+def test_qwen_tool_call_parser_supports_ling_arg_key_value_blocks():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                        "timeout": {"type": "integer"},
+                    },
+                },
+            },
+        }
+    ]
+
+    parsed = QwenToolCallParser().parse(
+        "Inspecting the workspace.</think><tool_call>bash\n"
+        "<arg_key>command</arg_key>\n"
+        "<arg_value>ls -la /tmp/pi-rollout/</arg_value>\n"
+        "<arg_key>timeout</arg_key>\n"
+        "<arg_value>30</arg_value>\n"
+        "</tool_call>",
+        tools,
+        "required",
+    )
+
+    assert parsed.normal_text == "Inspecting the workspace.</think>"
+    assert len(parsed.tool_calls) == 1
+    assert parsed.tool_calls[0]["function"]["name"] == "bash"
+    assert json.loads(parsed.tool_calls[0]["function"]["arguments"]) == {
+        "command": "ls -la /tmp/pi-rollout/",
+        "timeout": 30,
+    }
+
+
+def test_qwen_tool_call_parser_does_not_infer_auto_call_from_truncated_reasoning():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "move",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"direction": {"type": "string", "enum": ["up", "down", "left", "right"]}},
+                },
+            },
+        }
+    ]
+    content = "I considered every move. The best move is up, but let me reconsider. <tool_call>move\n<arg_key>direction"
+
+    parsed = QwenToolCallParser().parse(content, tools, "auto")
+
+    assert parsed.tool_calls == []
+    assert parsed.normal_text == content
+
+
+def test_qwen_tool_call_parser_accepts_complete_ling_block_in_auto_mode():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "move",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"direction": {"type": "string", "enum": ["up", "down", "left", "right"]}},
+                },
+            },
+        }
+    ]
+    content = (
+        "The best move is up.</think><tool_call>move\n"
+        "<arg_key>direction</arg_key>\n<arg_value>up</arg_value>\n</tool_call>"
+    )
+
+    parsed = QwenToolCallParser().parse(content, tools, "auto")
+
+    assert len(parsed.tool_calls) == 1
+    assert json.loads(parsed.tool_calls[0]["function"]["arguments"]) == {"direction": "up"}
+
+
+def test_tool_call_parser_infers_qwen_protocol_for_ling_model():
+    tokenizer = SimpleNamespace(chat_template="", name_or_path="Ling-Tiny-v3")
+    trainer = SimpleNamespace(get_tokenizer=lambda: tokenizer, _model_path="/models/Ling-Tiny-v3")
+
+    assert infer_tool_call_parser_name(trainer) == "qwen"
 
 
 def test_gemma4_tool_call_parser_supports_chat_completions_tools():
@@ -1156,6 +1310,14 @@ def test_tool_call_parser_supports_flat_tool_schema():
     assert parsed.tool_calls[0]["function"]["name"] == "choose_move"
 
 
+def test_policy_trainer_counts_explicitly_invalid_agent_items():
+    trainer = PolicyOnlyTrainer.__new__(PolicyOnlyTrainer)
+    trajectory = RuntimeAgentTrajectory(invalid_items=[object(), object()])
+
+    assert trainer._agent_trajectory_invalid_count(trajectory) == 2
+    assert trainer._agent_trajectory_invalid_count([trajectory, RuntimeAgentTrajectory()]) == 2
+
+
 def test_json_tool_call_parser_rejects_tool_choice_mismatch():
     tools = [
         {
@@ -1298,6 +1460,13 @@ class _StrictContentTokenizer(_FakeTokenizer):
         for message in messages:
             assert isinstance(message.get("content"), str)
         return [len(messages)]
+
+
+class _ExactInputTokenizer(_FakeTokenizer):
+    chat_template = "template"
+
+    def apply_chat_template(self, *args, **kwargs):
+        raise AssertionError("exact Pi input tokens must bypass chat-template reconstruction")
 
 
 class _ToolCallArgumentsMappingTokenizer(_StrictContentTokenizer):

--- a/tests/test_trainer_api_cpu.py
+++ b/tests/test_trainer_api_cpu.py
@@ -18,6 +18,7 @@ def _encode_from_record_prompt(_tokenizer, prompt: str) -> list[int]:
     tokens_by_prompt = {
         "short": [1, 2],
         "long": [1, 2, 3, 4, 5],
+        "longer": [1, 2, 3, 4, 5, 6],
         "next": [3],
         "a": [10],
         "b": [11],
@@ -89,16 +90,18 @@ class TrainerPromptBatchTest(unittest.TestCase):
         self.assertEqual([batch.scanned for batch in batches], [2, 1])
         self.assertEqual([batch.skipped_long for batch in batches], [0, 0])
 
-    def test_load_prompt_batches_stops_when_only_long_prompts_remain(self):
-        """A tail containing only skipped rows should not emit an empty batch."""
+    def test_load_prompt_batches_errors_when_all_prompts_are_too_long(self):
+        """An all-overlong dataset should fail explicitly instead of training zero steps."""
         trainer = Trainer(world_size=1, model_path="unused")
         trainer._tokenizer = object()
-        dataset = [{"prompt": "long"}]
+        dataset = [{"prompt": "long"}, {"prompt": "longer"}]
 
         with PatchedContext(trainer_mod, encode_generation_prompt=_encode_from_record_prompt):
-            batches = list(trainer.load_prompt_batches(dataset, batch_size=1, max_prompt_tokens=3))
-
-        self.assertEqual(batches, [])
+            with self.assertRaisesRegex(
+                ValueError,
+                r"all 2 dataset prompts exceed --max-prompt-tokens=3 \(shortest=5, longest=6\)",
+            ):
+                list(trainer.load_prompt_batches(dataset, batch_size=1, max_prompt_tokens=3))
 
     def test_load_prompt_batches_requires_prompt_field(self):
         """Online RL datasets should expose canonical prompt rows."""


### PR DESCRIPTION
## What does this PR do?

Adds native Ling Tiny V3 / Bailing V3 support to AReno.

The change introduces the model and checkpoint adapter, KDA training/prefill kernels, recurrent continuous-batching decode, policy synchronization metadata, and bounded incremental checkpoint writing. Train and prefill use consistent KDA semantics while decode retains the dedicated recurrent operator chain. It also tightens structured tool-call parsing so truncated or free-form text cannot be inferred as a valid tool call.

`flash-linear-attention` is pinned to the GitHub v0.5.2 release used by this implementation.

## Related issue

Fixes #461

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

- Compared identical-request isolated and batched KDA execution:
  - prefill output max/relative error: `0.0` / `0.0`
  - prefill state max/relative error: `0.0` / `0.0`
  - decode output max/relative error: `0.0` / `0.0`
  - decode state max/relative error: `0.0` / `0.0`
- Exercised multi-rank agentic rollout and policy training with Ling Tiny V3 on CUDA hardware.
- Verified checkpoint load/save with a 25-stage checkpoint; incremental saving keeps post-save anonymous worker memory bounded instead of retaining a full-model staging copy.
- Ran Python compilation and `git diff --check` locally.
- CPU pytest could not be run in the local authoring environment because `torch` is not installed there.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
