### PR TITLE
docs: expand dataset formats into a full reference guide

### DIFF
--- a/docs/concepts/backend-topology.rst
+++ b/docs/concepts/backend-topology.rst
@@ -56,3 +56,32 @@ bytes, tensor count, and effective throughput. The same values are emitted
 with the next training metrics as ``policy_sync_time_s``,
 ``policy_sync_transfer_time_s``, ``policy_sync_bytes``,
 ``policy_sync_tensors``, and ``policy_sync_throughput_gbps``.
+
+Runtime scope
+-------------
+
+The current backend runtime is entirely AReno-owned CUDA/NVIDIA code.
+``ArenoEngine`` (``areno/engine/api.py``) manages a local worker cluster on a
+single node. Both rollout and training use custom CUDA kernels shipped in
+``areno/accel/`` for attention, activation, normalization, embedding, linear,
+MoE, and routing operations. All inter-GPU communication goes through NCCL
+collectives managed by AReno's cluster protocol (``areno/engine/protocol/``).
+
+The colocated path runs one ``ArenoEngine`` that handles both
+``generate_rollout`` and ``step``. The partitioned path starts two independent
+``ArenoEngine`` instances — one for training, one for rollout — within the
+same distributed world.
+
+Out of scope
+------------
+
+This backend topology document describes the current implementation only. The
+following are explicitly **not** promised or implied by this document:
+
+* MLX, TPU, or non-NVIDIA accelerator backends.
+* vLLM, SGLang, Megatron-LM, or Ray integration.
+* Multi-node distributed training (the cluster protocol is single-node).
+* A pluggable backend interface that third-party engines can implement without
+  modifying AReno source.
+
+Future architecture changes will be documented in the PR that introduces them.

--- a/docs/concepts/dataset-formats.rst
+++ b/docs/concepts/dataset-formats.rst
@@ -1,43 +1,258 @@
 Dataset formats
 ===============
 
-AReno loaders normalize external datasets into small dictionaries consumed by
-the selected algorithm. Keep tokenization out of the dataset layer; trainers
-own tokenizer rendering, sequence limits, and chat-template behavior.
+This guide answers one question: **"What columns must my dataset have for each
+AReno algorithm?"**
 
-SFT rows
---------
-
-SFT rows provide a supervised prompt and target response:
-
-.. code-block:: python
-
-   {"prompt": "Instruction: ...", "response": "..."}
-
-DPO rows
---------
-
-DPO rows provide one shared prompt and two ranked answers:
-
-.. code-block:: python
-
-   {"prompt": "...", "chosen": "...", "rejected": "..."}
-
-Prompt-based RL rows
---------------------
-
-GSPO, GRPO, and PPO prompt datasets provide ``prompt``. They can also preserve
-task metadata such as ``solutions`` for reward functions.
-
-Agentic rows
+Mental model
 ------------
 
-Agentic datasets provide ``prompt`` plus any task metadata consumed by the agent
-and reward files.
+AReno separates three concerns:
+
+1. **Raw datasets** — upstream files from Hugging Face, ModelScope, or local
+   storage. Columns like ``question``/``answer`` (GSM8K) or
+   ``instruction``/``output`` (Alpaca) belong here.
+2. **Loader functions** — a Python file you write (``--dataset-loader-fn``)
+   that normalizes raw columns into the AReno training schema.
+3. **Training schemas** — the dict shape each algorithm expects. These are the
+   target of your loader function and the contract described in this document.
+
+.. code-block:: text
+
+   Raw dataset          Loader function          Training schema
+   ───────────          ──────────────          ───────────────
+   {"question": "2+2?",  ──►  load_training_  ──►  {"prompt": "Problem: 2+2?",
+    "answer": "4"}              dataset()            "solutions": ["4"]}
+
+SFT schemas
+-----------
+
+SFT requires rows with ``prompt`` and ``response``. The trainer tokenizes both,
+masks the prompt prefix, and computes next-token loss only on response
+positions.
+
+.. code-block:: python
+
+   {"prompt": "Instruction: Translate to French\nHello\nResponse:", "response": "Bonjour"}
+
+Pre-tokenized rows
+~~~~~~~~~~~~~~~~~~
+
+When you need full control over tokenization, return ``tokens`` and
+``prompt_mask`` instead:
+
+.. code-block:: python
+
+   {
+       "tokens": [101, 2054, 2003, 102, 2043, 2051, 103],
+       "prompt_mask": [True, True, True, True, False, False, False],
+   }
+
+Rows with an optional ``loss_mask`` can further exclude tokens (e.g. padding
+regions within multi-turn chat sequences). ``eos_token_id`` and ``features``
+(multimodal side-input) are also recognized when present. See
+``areno/api/trainers/sft.py`` for the full ``_record_to_train_sequence`` logic.
+
+Example loader and CLI
+~~~~~~~~~~~~~~~~~~~~~~
+
+``examples/sft/alpaca/dataset_loader.py`` normalizes Alpaca
+``instruction``/``input``/``output`` rows:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path yahma/alpaca-cleaned \
+     --dataset-loader-fn examples/sft/alpaca/dataset_loader.py \
+     --algo sft \
+     --tp-size 1 \
+     --world-size 1
+
+Prompt-based RL schema
+----------------------
+
+GSPO, GRPO, and PPO require at least ``prompt``. Reward functions typically
+need a ``solutions`` field — this is **reward metadata, not an SFT target**.
+The trainer never feeds ``solutions`` to the model; it is passed to
+``reward_fn`` via ``record.answer``.
+
+.. code-block:: python
+
+   {
+       "prompt": "Solve the following math problem. Show your reasoning and put the final answer in \\boxed{}.\n\nProblem: Natalia sold 48 clips in May. She sold half as many in April. How many did she sell in April and May?\nSolution:",
+       "solutions": ["72"],
+   }
+
+GSM8K example
+~~~~~~~~~~~~~
+
+Raw GSM8K rows look like this:
+
+.. code-block:: python
+
+   {"question": "Natalia sold 48 clips...", "answer": "Natalia sold 48/2 = 24 clips in April... #### 72"}
+
+Raw GSM8K is **not RL-ready** (no ``prompt`` column, answer is a rationale
+string rather than a machine-comparable value) and **not SFT-ready** (the
+``answer`` field contains chain-of-thought reasoning mixed with the result,
+not a clean supervised response). The loader at
+``examples/math/dataset_loader.py`` converts it for RL:
+
+.. code-block:: python
+
+   # Loader extracts the final answer from "#### 72" and wraps the
+   # question in a chain-of-thought instruction.
+   {"prompt": "Problem: Natalia sold 48 clips...\nSolution:", "solutions": ["72"]}
+
+Working CLI:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 1
+
+DPO schema
+----------
+
+DPO pairs a preferred ("chosen") answer against a less-preferred ("rejected")
+answer. Two sub-formats are supported.
+
+Prompt/response pairs
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   {"prompt": "Explain gravity in one sentence.", "chosen": "Gravity is the force that attracts objects with mass toward each other.", "rejected": "Gravity is when things fall."}
+
+The ``prompt`` may be a plain string or a list of chat messages. See
+``areno/api/data_utils.py`` for the ``encode_prompt_value`` path.
+
+Chat message pairs
+~~~~~~~~~~~~~~~~~~
+
+When ``chosen`` and ``rejected`` are both lists of chat messages, the trainer
+automatically detects their common prefix as the shared prompt context. Only
+the divergent suffixes contribute to the DPO objective.
+
+.. code-block:: python
+
+   {
+       "chosen": [
+           {"role": "user", "content": "Explain gravity."},
+           {"role": "assistant", "content": "Gravity is the force that attracts objects with mass toward each other."}
+       ],
+       "rejected": [
+           {"role": "user", "content": "Explain gravity."},
+           {"role": "assistant", "content": "Gravity is when things fall."}
+       ]
+   }
+
+No separate ``prompt`` key is needed for this sub-format. See
+``areno/api/trainers/dpo.py`` for the full ``_record_to_train_pair`` logic.
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path ./my_dpo_data.jsonl \
+     --dataset-loader-fn ./my_dpo_loader.py \
+     --algo dpo \
+     --tp-size 1 \
+     --world-size 1
+
+Agentic schema
+--------------
+
+Agentic datasets provide ``prompt`` plus any task metadata consumed by the
+agent function (``--agent-fn``) and reward function (``--reward-fn-path``).
+
+.. code-block:: python
+
+   {
+       "id": "board-00001",
+       "prompt": "You are playing TicTacToe. Choose your next move.\n\n X | O |   \n---+---+---\n   | X |   \n---+---+---\n O |   |   \n",
+       "board": ["X", "O", "", "", "X", "", "O", "", ""],
+       "best_moves": [5, 3, 7],
+       "valid_moves": [3, 5, 6, 7, 8],
+   }
+
+See ``examples/agentic/tictactoe/dataset_loader.py`` for the full example.
+
+.. code-block:: bash
+
+   areno train \
+     --agent-fn examples/agentic/tictactoe/run_agent.py \
+     --reward-fn-path examples/agentic/tictactoe/reward.py \
+     --algo gspo
+
+Loader function contract
+------------------------
+
+When raw columns do not match a training schema, write a loader file with one
+function:
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object):
+       dataset = default_loader(dataset_path)
+       records = []
+       for row in dataset:
+           records.append({
+               "prompt": f"Problem: {row['question']}\nAnswer:",
+               "response": str(row["answer"]),
+           })
+       return records
+
+**Rules:**
+
+* Use ``default_loader`` — it handles JSONL, Parquet, CSV, HF datasets, and
+  more.
+* Return a list of dicts whose keys match one of the schemas above.
+* Keep tokenization in the loader only when using the pre-tokenized
+  ``tokens``/``prompt_mask`` format; otherwise trainers own tokenization.
+* Loaders execute on the main process before GPU workers start. Keep them fast
+  and deterministic.
+
+Schema summary
+--------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Algorithm
+     - Required keys
+     - Optional keys
+     - Example file
+   * - SFT
+     - ``prompt``, ``response``
+     - ``tokens``, ``prompt_mask``, ``loss_mask``, ``features``, ``eos_token_id``
+     - ``examples/sft/alpaca/dataset_loader.py``
+   * - GSPO / GRPO / PPO
+     - ``prompt``
+     - ``solutions``, task metadata
+     - ``examples/math/dataset_loader.py``
+   * - DPO
+     - | prompt/response: ``prompt``, ``chosen``, ``rejected``
+       | chat messages: ``chosen``, ``rejected``
+     - —
+     - —
+   * - Agentic RL
+     - ``prompt``
+     - task state for agent and reward
+     - ``examples/agentic/tictactoe/dataset_loader.py``
 
 Where to go next
 ----------------
 
 * :doc:`/cookbook/writing-loaders-and-rewards` — step-by-step tutorial.
-* :doc:`/cli/dataset_loaders` documents loader shapes and examples.
-* :doc:`reward-functions` explains how preserved metadata is used for scoring.
+* :doc:`/cli/dataset_loaders` — CLI flag reference and loader shapes.
+* :doc:`reward-functions` — how ``solutions`` and metadata are consumed.
+* :doc:`/reference/dataset-loader-api` — full API contract.

--- a/docs/concepts/dataset-formats.rst
+++ b/docs/concepts/dataset-formats.rst
@@ -38,5 +38,6 @@ and reward files.
 Where to go next
 ----------------
 
+* :doc:`/cookbook/writing-loaders-and-rewards` — step-by-step tutorial.
 * :doc:`/cli/dataset_loaders` documents loader shapes and examples.
 * :doc:`reward-functions` explains how preserved metadata is used for scoring.

--- a/docs/concepts/reward-functions.rst
+++ b/docs/concepts/reward-functions.rst
@@ -28,6 +28,7 @@ Practical rules
 Where to go next
 ----------------
 
+* :doc:`/cookbook/writing-loaders-and-rewards` — step-by-step tutorial.
 * :doc:`/cli/training` documents the training CLI flag.
 * :doc:`/troubleshooting/reward-function` covers debugging workflow.
 * :doc:`/reference/reward-function-api` documents the API contract.

--- a/docs/cookbook/writing-loaders-and-rewards.rst
+++ b/docs/cookbook/writing-loaders-and-rewards.rst
@@ -1,0 +1,322 @@
+Writing dataset loaders and reward functions
+============================================
+
+This tutorial walks through writing a custom dataset loader and reward function
+for AReno. You will learn the function signatures, the record shapes each
+training mode expects, and how to wire everything together with the CLI.
+
+Prerequisites
+-------------
+
+You should be comfortable with Python and have read the concept guides:
+
+* :doc:`/concepts/dataset-formats` — record shapes per algorithm family.
+* :doc:`/concepts/reward-functions` — how scores flow into the trainer.
+
+The reference pages :doc:`/reference/dataset-loader-api` and
+:doc:`/reference/reward-function-api` provide the full API contract; keep them
+handy as you read.
+
+.. _tutorial-dataset-loader:
+
+Writing a dataset loader
+------------------------
+
+A dataset loader is a Python file that defines one function:
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object):
+       ...
+
+**Parameters**
+
+``dataset_path``
+   The value of ``--dataset-path`` from the CLI. It can be a local file, a
+   directory, or a Hugging Face / ModelScope dataset reference.
+
+``default_loader``
+   A callable provided by AReno that can load CSV, TSV, JSON/JSONL, Parquet,
+   Arrow, ``datasets.save_to_disk(...)`` directories, and Hugging Face dataset
+   references. Always use this instead of writing your own I/O.
+
+**Return value**
+
+A list of dicts. The required keys depend on the training mode:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Training mode
+     - Required keys
+     - Optional keys
+   * - SFT
+     - ``prompt``, ``response``
+     - —
+   * - DPO
+     - ``prompt``, ``chosen``, ``rejected``
+     - —
+   * - Prompt-based RL (GSPO/GRPO/PPO)
+     - ``prompt``
+     - ``solutions``, task metadata
+   * - Agentic RL
+     - ``prompt``
+     - task state for agent and reward
+
+Step-by-step example: a custom math loader
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Imagine you have a JSONL file where each row looks like this:
+
+.. code-block:: json
+
+   {"problem": "What is 2 + 2?", "ground_truth": "4"}
+
+You want to use it for GSPO training. Here is the loader, built up one piece at
+a time.
+
+**1. Load the raw data with default_loader**
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object):
+       dataset = default_loader(dataset_path)
+       # dataset is a list of dicts — one per JSONL line
+       return dataset
+
+At this point every row still has the original ``problem`` / ``ground_truth``
+keys. The trainer does not understand those.
+
+**2. Normalize rows to the expected schema**
+
+Prompt-based RL requires at least a ``prompt`` key. Reward functions often need
+a ``solutions`` key. Add both:
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object):
+       dataset = default_loader(dataset_path)
+       records = []
+       for row in dataset:
+           records.append({
+               "prompt": f"Problem: {row['problem']}\nAnswer:",
+               "solutions": [str(row["ground_truth"])],
+           })
+       return records
+
+**3. Make it robust**
+
+Real-world datasets are rarely clean. Add a sniffing step so the loader
+passes through rows that are already in the right shape:
+
+.. code-block:: python
+
+   def load_training_dataset(dataset_path: str, *, default_loader, **_: object):
+       dataset = default_loader(dataset_path)
+       if len(dataset) == 0:
+           return dataset
+       if "prompt" in dataset[0]:
+           return dataset  # already normalized — pass through
+       records = []
+       for row in dataset:
+           records.append({
+               "prompt": f"Problem: {row['problem']}\nAnswer:",
+               "solutions": [str(row["ground_truth"])],
+           })
+       return records
+
+That is a complete, production-style dataset loader. The full version is about
+20 lines and handles three input schemas; see ``examples/math/dataset_loader.py``
+for the final form.
+
+.. _tutorial-reward-function:
+
+Writing a reward function
+-------------------------
+
+A reward file must expose a callable named ``reward_fn``. The signature depends
+on the training mode.
+
+Prompt-based RL reward
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   def reward_fn(record) -> float:
+       ...
+
+The ``record`` object has these attributes:
+
+* ``record.prompt`` — the prompt string.
+* ``record.completion`` — the model-generated completion string.
+* ``record.answer`` — the ``solutions`` list from the dataset loader (or
+  ``None`` if you did not provide one).
+
+Return a ``float``. The trainer calls this once per (example, completion) pair.
+
+Agentic RL reward
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   def reward_fn(record) -> float:
+       ...
+
+The ``record`` object also carries:
+
+* ``record.source_record`` — the original dataset row dict.
+* ``record.tool_calls`` — the list of tool calls the model made during the
+  trajectory.
+
+Return a ``float``.
+
+Step-by-step example: a custom math reward
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Continuing the math example from the loader tutorial, you have rows with a
+``problem`` prompt and a ``solutions`` list containing the ground-truth answer.
+
+**1. Extract the ground truth**
+
+.. code-block:: python
+
+   def reward_fn(record) -> float:
+       solutions = record.answer
+       if solutions is None:
+           raise KeyError("reward expects record.answer; check your dataset loader")
+       ground_truth = solutions[0] if isinstance(solutions, list) else solutions
+       ...
+
+**2. Compare prediction to ground truth**
+
+The simplest approach is an exact-match check after normalizing whitespace:
+
+.. code-block:: python
+
+   def reward_fn(record) -> float:
+       solutions = record.answer
+       if solutions is None:
+           return 0.0
+       ground_truth = str(solutions[0]).strip()
+       prediction = record.completion.strip()
+       return 1.0 if prediction == ground_truth else 0.0
+
+**3. Add tolerance for real model output**
+
+Models rarely output just the answer. They produce reasoning chains. A robust
+reward function parses the final answer from the completion. For math tasks,
+extract the last boxed expression:
+
+.. code-block:: python
+
+   import re
+
+
+   def _extract_final_answer(text: str) -> str | None:
+       # Look for \boxed{...} patterns and return the last one.
+       matches = re.findall(r"\\boxed\{([^}]*)\}", text)
+       return matches[-1].strip() if matches else None
+
+
+   def reward_fn(record) -> float:
+       solutions = record.answer
+       if solutions is None:
+           return 0.0
+       ground_truth = str(solutions[0]).strip()
+       prediction = _extract_final_answer(record.completion)
+       if prediction is None:
+           return 0.0
+       return 1.0 if prediction == ground_truth else 0.0
+
+This is the pattern used by the built-in math verifier at
+``examples/math/math_verify_reward.py``, which additionally uses symbolic
+comparison so that ``1/2`` and ``0.5`` are treated as equal.
+
+Wiring them together
+--------------------
+
+Once both files are written, pass them to the CLI:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path ./my_dataset.jsonl \
+     --dataset-loader-fn ./my_loader.py \
+     --reward-fn-path ./my_reward.py \
+     --algo gspo \
+     --tp-size 1 \
+     --world-size 1
+
+The flags work independently: you can pair your loader with an existing reward
+function, or your reward function with an existing loader.
+
+Debugging tips
+--------------
+
+**Test the loader in isolation**
+
+.. code-block:: python
+
+   # test_loader.py
+   from my_loader import load_training_dataset
+
+   # default_loader is just datasets.load_dataset for HF paths,
+   # or a JSONL reader for local files — approximate it:
+   import json
+
+   def fake_default_loader(path):
+       with open(path) as f:
+           return [json.loads(line) for line in f if line.strip()]
+
+   records = load_training_dataset("./my_dataset.jsonl", default_loader=fake_default_loader)
+   print(records[0])
+   # Check that every record has the keys your training mode requires.
+
+**Test the reward function in isolation**
+
+.. code-block:: python
+
+   # test_reward.py
+   from types import SimpleNamespace
+
+   from my_reward import reward_fn
+
+   fake_record = SimpleNamespace(
+       prompt="Problem: 2+2\nAnswer:",
+       completion="The answer is \\boxed{4}",
+       answer=["4"],
+   )
+   score = reward_fn(fake_record)
+   print(f"Score: {score}")  # Should be 1.0
+
+   fake_wrong = SimpleNamespace(
+       prompt="Problem: 2+2\nAnswer:",
+       completion="The answer is \\boxed{5}",
+       answer=["4"],
+   )
+   score = reward_fn(fake_wrong)
+   print(f"Score: {score}")  # Should be 0.0
+
+**Common pitfalls**
+
+* **Loader not called**: Make sure ``--dataset-loader-fn`` points to the file,
+  not just the directory. The path must end in ``.py``.
+* **Wrong keys**: Print ``records[0].keys()`` from your loader to verify the
+  keys match what your training mode expects.
+* **Non-deterministic rewards**: Avoid random number generators, timestamps, or
+  network calls inside ``reward_fn``. Non-deterministic rewards make training
+  dynamics hard to reproduce.
+* **Reward always zero**: Check that your reward function handles the model's
+  actual output format. Models often add markdown, extra whitespace, or
+  unexpected tokens.
+
+Where to go next
+----------------
+
+* Browse the shipped examples under ``examples/`` for more patterns:
+  ``examples/math/``, ``examples/agentic/tictactoe/``, ``examples/sft/alpaca/``.
+* :doc:`/cookbook/math-rlvr` — runnable recipe for the math RLVR path.
+* :doc:`/cookbook/tictactoe-agentic-rl` — agentic recipe with tool calls.
+* :doc:`/troubleshooting/reward-function` — debugging reward functions.
+* :doc:`/troubleshooting/tool-call` — debugging tool-call extraction.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ AReno documentation
    :maxdepth: 1
    :caption: Cookbook
 
+   cookbook/writing-loaders-and-rewards
    cookbook/math-rlvr
    cookbook/tictactoe-agentic-rl
    cookbook/duelgrid-visual-agent


### PR DESCRIPTION
## What does this PR do?

  Rewrite the Dataset Formats concept page as a comprehensive reference guide covering the mental model (raw data →
  loader → schema), all training schemas with concrete examples and working CLI commands, GSM8K walkthrough, and a
  schema summary table.

  ## Related issue

  See #70

  ## Type of change

  - [x] 📝 Documentation update

  ## How was it tested?

  Built docs with `sphinx-build -b html -W . _build/html` — zero warnings.

  ## Checklist

  - [x] The PR title summarizes the contribution.
  - [x] Linked the related issue in the description (if any).
  - [x] Existing tests pass (`pytest tests/ -k cpu`). *(skipped — doc-only change)*
  - [x] New behavior is covered by tests. *(N/A — doc-only change)*
  - [x] Described the test commands run and any hardware limitations.
  - [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md). *(N/A)*