### PR TITLE
fix(api): keep tokenizer loaders lazy at the public API boundary

### DIFF
--- a/areno/api/tokenizer.py
+++ b/areno/api/tokenizer.py
@@ -12,10 +12,28 @@ import json
 from pathlib import Path
 from typing import Any
 
-from areno.engine.data.tokenizer import load_processor as load_processor  # noqa: F401
-from areno.engine.data.tokenizer import load_tokenizer as load_tokenizer  # noqa: F401
-
+# The tokenizer loaders live in ``areno.engine.data.tokenizer`` and pull in
+# HuggingFace ``transformers`` on first use. Re-exporting them eagerly here
+# would force an engine-module import whenever the public API (``areno.api``,
+# ``areno.api.trainer``) is imported. Wrap them lazily so importing this seam
+# module stays free of engine-heavy imports; callers pay the cost on first call.
 _CHAT_TEMPLATE_ENABLE_THINKING_ATTR = "_areno_chat_template_enable_thinking"
+
+
+def load_tokenizer(model_path: str | Path):
+    """Load a HF tokenizer, retrying once with safe special-token defaults."""
+
+    from areno.engine.data.tokenizer import load_tokenizer as _load_tokenizer
+
+    return _load_tokenizer(model_path)
+
+
+def load_processor(model_path: str | Path):
+    """Load a HF processor when the checkpoint provides one, else None."""
+
+    from areno.engine.data.tokenizer import load_processor as _load_processor
+
+    return _load_processor(model_path)
 
 
 def configure_chat_template_enable_thinking(tokenizer, enable_thinking: bool | None) -> None:

--- a/tests/test_import_boundaries_cpu.py
+++ b/tests/test_import_boundaries_cpu.py
@@ -6,7 +6,17 @@ import textwrap
 
 
 def test_public_api_imports_do_not_load_engine_heavy_modules():
-    """Public API imports stay on the lazy side of the engine/backend boundary."""
+    """Public API imports stay on the lazy side of the engine/backend boundary.
+
+    Importing the SDK surface -- ``areno``, ``areno.api``, ``areno.api.trainer``,
+    and the lazy seam modules (``areno.api.backend.base`` resolves concrete
+    backends via ``__import__``; ``areno.api.tokenizer`` wraps the engine
+    tokenizer loader) -- must not eagerly construct ``ArenoEngine`` or pull in a
+    concrete backend / engine implementation module.
+
+    Only the heavy modules that matter are asserted, so the test does not break
+    when an unrelated dependency adds a new transitive import.
+    """
 
     script = textwrap.dedent(
         """
@@ -19,6 +29,7 @@ def test_public_api_imports_do_not_load_engine_heavy_modules():
             "areno.api.trainer",
             "areno.api.backend",
             "areno.api.backend.base",
+            "areno.api.tokenizer",
         ]:
             importlib.import_module(module_name)
 
@@ -27,6 +38,7 @@ def test_public_api_imports_do_not_load_engine_heavy_modules():
             "areno.engine.api",
             "areno.engine.inference",
             "areno.engine.worker",
+            "areno.engine.data.tokenizer",
         ]
         for name in heavy_modules:
             assert name not in sys.modules, f"{name} was unexpectedly loaded"

--- a/tests/test_tokenizer_api_cpu.py
+++ b/tests/test_tokenizer_api_cpu.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from areno.api.config import ArenoConfig, coerce_backend_config, resolve_backend_type
 from areno.api.models import BackendType, SamplingParams, TrainSequence
@@ -14,6 +15,8 @@ from areno.api.tokenizer import (
     configure_chat_template_enable_thinking,
     encode_generation_prompt,
     eos_token_ids,
+    load_processor,
+    load_tokenizer,
     normalize_token_ids,
 )
 
@@ -97,6 +100,22 @@ class TokenizerApiTest(unittest.TestCase):
 
         self.assertEqual(normalize_token_ids(encoding), [1, 2, 3])
         self.assertEqual(normalize_token_ids(batch_encoding), [4, 5, 6])
+
+    def test_loader_wrappers_delegate_to_engine_implementations(self):
+        """The public loader seam stays lazy without changing call semantics."""
+        model_path = Path("model")
+        tokenizer = object()
+        processor = object()
+
+        with (
+            patch("areno.engine.data.tokenizer.load_tokenizer", return_value=tokenizer) as engine_tokenizer,
+            patch("areno.engine.data.tokenizer.load_processor", return_value=processor) as engine_processor,
+        ):
+            self.assertIs(load_tokenizer(model_path), tokenizer)
+            self.assertIs(load_processor(model_path), processor)
+
+        engine_tokenizer.assert_called_once_with(model_path)
+        engine_processor.assert_called_once_with(model_path)
 
     def test_sampling_params_defaults_are_backend_agnostic(self):
         """Public sampling defaults are part of the backend API contract."""


### PR DESCRIPTION
Wrap load_tokenizer/load_processor lazily so importing areno.api / areno.api.trainer no longer pulls areno.engine.data.tokenizer. Extend the import-boundary CPU test to cover the seam and the engine tokenizer leak.

Closes #65

<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?

<!-- A clear and concise description of the change and its motivation. -->

## Related issue

<!-- Link the issue this PR addresses so GitHub closes it on merge, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

<!-- Select ONE that best describes this PR. -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

<!-- Note the test commands you ran (e.g. `pytest tests/ -k cpu`) and any hardware limitations. New behavior must be covered by tests — no testing, no merge. -->

## Checklist

- [ ] The PR title summarizes the contribution.
- [ ] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [ ] New behavior is covered by tests.
- [ ] Described the test commands run and any hardware limitations.
- [ ] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Breaking change details

<!-- If this is a breaking change, describe what breaks and how users should migrate. Otherwise delete this section. -->
