### PR TITLE
feat: add async policy trainer primitives

### DIFF
--- a/areno/experimental/async_policy/__init__.py
+++ b/areno/experimental/async_policy/__init__.py
@@ -1,0 +1,21 @@
+"""Experimental asynchronous policy trainer primitives.
+
+This namespace hosts the standalone building blocks for the async policy
+trainer — batch metadata, a bounded queue, and staleness control — without
+registering any experimental algorithms. Algorithm registration lands together
+with the async trainer itself.
+"""
+
+from __future__ import annotations
+
+from areno.experimental.async_policy.batch import AsyncTrainBatch
+from areno.experimental.async_policy.queue import AsyncTrainBatchQueue, QueueClosed
+from areno.experimental.async_policy.staleness import is_stale, staleness_delta
+
+__all__ = [
+    "AsyncTrainBatch",
+    "AsyncTrainBatchQueue",
+    "QueueClosed",
+    "is_stale",
+    "staleness_delta",
+]

--- a/areno/experimental/async_policy/batch.py
+++ b/areno/experimental/async_policy/batch.py
@@ -1,0 +1,32 @@
+"""Batch metadata for the experimental asynchronous policy trainer."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from areno.api.models import TrainSequence
+
+
+@dataclass(slots=True)
+class AsyncTrainBatch:
+    """A materialized prompt batch ready for a training step.
+
+    This is the unit that flows through the bounded queue between the rollout
+    worker and the train loop. It carries the policy version under which the
+    rollout was generated so the train loop can enforce a staleness bound, plus
+    the timing and size fields needed for metrics and debugging.
+    """
+
+    train_sequences: list[TrainSequence]
+    rollout_policy_version: int
+    epoch: int
+    prompt_batch_id: int
+    prompt_count: int
+    sequence_count: int
+    token_count: int
+    reward_mean: float | None
+    rollout_time_s: float
+    reward_time_s: float
+    materialize_time_s: float
+    created_at_s: float = field(default_factory=time.time)

--- a/areno/experimental/async_policy/queue.py
+++ b/areno/experimental/async_policy/queue.py
@@ -1,0 +1,99 @@
+"""Bounded queue decoupling rollout from training."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+from areno.experimental.async_policy.batch import AsyncTrainBatch
+
+
+class QueueClosed(RuntimeError):
+    """Raised when a producer or consumer touches a closed queue."""
+
+
+class AsyncTrainBatchQueue:
+    """Bounded FIFO queue between the rollout worker and the train loop.
+
+    Producers block on :meth:`put` while the queue is full (backpressure);
+    consumers block on :meth:`get` while it is empty. :meth:`close` unblocks all
+    waiters and makes later operations raise :class:`QueueClosed`. A rollout
+    worker failure is surfaced through :meth:`report_error`, which likewise
+    unblocks waiters and makes the error visible to the next operation.
+    """
+
+    def __init__(self, maxsize: int, *, timeout_s: float | None = None) -> None:
+        if maxsize <= 0:
+            raise ValueError("maxsize must be positive")
+        self._maxsize = maxsize
+        self._timeout_s = timeout_s
+        self._items: deque[AsyncTrainBatch] = deque()
+        self._cond = threading.Condition()
+        self._closed = False
+        self._error: Exception | None = None
+
+    def put(self, batch: AsyncTrainBatch, *, timeout_s: float | None = None) -> None:
+        """Append a batch, blocking while the queue is full."""
+
+        with self._cond:
+            self._wait_while(lambda: len(self._items) >= self._maxsize, timeout_s, "put")
+            self._raise_if_unusable()
+            self._items.append(batch)
+            self._cond.notify_all()
+
+    def get(self, *, timeout_s: float | None = None) -> AsyncTrainBatch:
+        """Remove and return the oldest batch, blocking while the queue is empty."""
+
+        with self._cond:
+            self._wait_while(lambda: not self._items, timeout_s, "get")
+            self._raise_if_unusable()
+            batch = self._items.popleft()
+            self._cond.notify_all()
+            return batch
+
+    def report_error(self, error: Exception) -> None:
+        """Record a worker failure, unblocking all waiters.
+
+        The first reported error is retained; subsequent operations raise it.
+        """
+
+        with self._cond:
+            if self._error is None:
+                self._error = error
+            self._cond.notify_all()
+
+    def close(self) -> None:
+        """Close the queue, unblocking all waiters."""
+
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+
+    def qsize(self) -> int:
+        """Return the number of batches currently queued."""
+
+        return len(self._items)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def error(self) -> Exception | None:
+        return self._error
+
+    def _wait_while(self, blocked, timeout_s: float | None, op: str) -> None:
+        timeout = self._timeout_s if timeout_s is None else timeout_s
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while blocked() and not self._closed and self._error is None:
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                raise TimeoutError(f"{op} timed out")
+            self._cond.wait(remaining)
+
+    def _raise_if_unusable(self) -> None:
+        if self._error is not None:
+            raise self._error
+        if self._closed:
+            raise QueueClosed("queue is closed")

--- a/areno/experimental/async_policy/staleness.py
+++ b/areno/experimental/async_policy/staleness.py
@@ -1,0 +1,21 @@
+"""Policy-version staleness helpers for the asynchronous policy trainer."""
+
+from __future__ import annotations
+
+
+def staleness_delta(train_policy_version: int, rollout_policy_version: int) -> int:
+    """Return how far a batch's rollout policy lags the training policy."""
+
+    return train_policy_version - rollout_policy_version
+
+
+def is_stale(train_policy_version: int, rollout_policy_version: int, *, max_staleness: int) -> bool:
+    """Return whether a batch is older than the configured staleness bound.
+
+    A batch is stale when its rollout policy version lags the current training
+    policy version by more than ``max_staleness``.
+    """
+
+    if max_staleness < 0:
+        raise ValueError("max_staleness must be non-negative")
+    return staleness_delta(train_policy_version, rollout_policy_version) > max_staleness

--- a/tests/test_async_policy_cpu.py
+++ b/tests/test_async_policy_cpu.py
@@ -1,0 +1,196 @@
+"""CPU tests for the experimental async policy trainer primitives."""
+
+from __future__ import annotations
+
+import threading
+import unittest
+
+from areno.api.models import TrainSequence
+from areno.experimental.async_policy import (
+    AsyncTrainBatch,
+    AsyncTrainBatchQueue,
+    QueueClosed,
+    is_stale,
+    staleness_delta,
+)
+
+
+def _batch(*, version: int = 0, idx: int = 0) -> AsyncTrainBatch:
+    return AsyncTrainBatch(
+        train_sequences=[TrainSequence()],
+        rollout_policy_version=version,
+        epoch=0,
+        prompt_batch_id=idx,
+        prompt_count=1,
+        sequence_count=1,
+        token_count=0,
+        reward_mean=None,
+        rollout_time_s=0.0,
+        reward_time_s=0.0,
+        materialize_time_s=0.0,
+    )
+
+
+class StalenessTest(unittest.TestCase):
+    """Staleness helpers compare rollout and training policy versions."""
+
+    def test_delta_is_train_minus_rollout(self):
+        self.assertEqual(staleness_delta(5, 3), 2)
+
+    def test_below_bound_is_not_stale(self):
+        self.assertFalse(is_stale(2, 1, max_staleness=2))
+
+    def test_at_bound_is_not_stale(self):
+        self.assertFalse(is_stale(3, 1, max_staleness=2))
+
+    def test_above_bound_is_stale(self):
+        self.assertTrue(is_stale(4, 1, max_staleness=2))
+
+    def test_negative_max_staleness_rejected(self):
+        with self.assertRaises(ValueError):
+            is_stale(3, 2, max_staleness=-1)
+
+
+class AsyncTrainBatchTest(unittest.TestCase):
+    """AsyncTrainBatch carries the metadata the train loop needs."""
+
+    def test_fields_populate_and_created_at_defaults(self):
+        batch = _batch(version=2, idx=7)
+        self.assertEqual(batch.rollout_policy_version, 2)
+        self.assertEqual(batch.prompt_batch_id, 7)
+        self.assertEqual(len(batch.train_sequences), 1)
+        self.assertIsInstance(batch.created_at_s, float)
+        self.assertGreater(batch.created_at_s, 0.0)
+
+
+class AsyncTrainBatchQueueTest(unittest.TestCase):
+    """The bounded queue enforces backpressure, timeouts, and error flow."""
+
+    def test_fifo_order(self):
+        q = AsyncTrainBatchQueue(maxsize=2)
+        q.put(_batch(idx=0))
+        q.put(_batch(idx=1))
+        self.assertEqual(q.get().prompt_batch_id, 0)
+        self.assertEqual(q.get().prompt_batch_id, 1)
+
+    def test_rejects_nonpositive_maxsize(self):
+        with self.assertRaises(ValueError):
+            AsyncTrainBatchQueue(maxsize=0)
+
+    def test_qsize_tracks_pending_batches(self):
+        q = AsyncTrainBatchQueue(maxsize=2)
+        self.assertEqual(q.qsize(), 0)
+        q.put(_batch())
+        self.assertEqual(q.qsize(), 1)
+
+    def test_put_timeout_when_full(self):
+        q = AsyncTrainBatchQueue(maxsize=1, timeout_s=0.05)
+        q.put(_batch())
+        with self.assertRaises(TimeoutError):
+            q.put(_batch())
+
+    def test_get_timeout_when_empty(self):
+        q = AsyncTrainBatchQueue(maxsize=1, timeout_s=0.05)
+        with self.assertRaises(TimeoutError):
+            q.get()
+
+    def test_put_blocks_until_slot_frees(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        q.put(_batch(idx=0))
+        producer = threading.Thread(target=lambda: q.put(_batch(idx=1)))
+        producer.start()
+        producer.join(timeout=0.2)
+        self.assertTrue(producer.is_alive(), "producer should block on a full queue")
+        q.get()
+        producer.join(timeout=1.0)
+        self.assertFalse(producer.is_alive(), "producer should finish once a slot frees")
+
+    def test_get_blocks_until_item_arrives(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        result = []
+
+        def consume():
+            result.append(q.get())
+
+        consumer = threading.Thread(target=consume)
+        consumer.start()
+        consumer.join(timeout=0.2)
+        self.assertTrue(consumer.is_alive(), "consumer should block on an empty queue")
+        q.put(_batch(idx=3))
+        consumer.join(timeout=1.0)
+        self.assertFalse(consumer.is_alive(), "consumer should finish once an item arrives")
+        self.assertEqual(result[0].prompt_batch_id, 3)
+
+    def test_close_unblocks_blocked_put(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        q.put(_batch())
+        result = []
+
+        def produce():
+            try:
+                q.put(_batch(idx=1))
+            except Exception as e:
+                result.append(e)
+
+        producer = threading.Thread(target=produce)
+        producer.start()
+        producer.join(timeout=0.2)
+        self.assertTrue(producer.is_alive(), "producer should block on a full queue")
+        q.close()
+        producer.join(timeout=1.0)
+        self.assertFalse(producer.is_alive(), "producer should finish after close")
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], QueueClosed)
+
+    def test_put_after_close_raises(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        q.close()
+        with self.assertRaises(QueueClosed):
+            q.put(_batch())
+
+    def test_get_after_close_raises(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        q.close()
+        with self.assertRaises(QueueClosed):
+            q.get()
+
+    def test_report_error_surfaces_on_put(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        err = RuntimeError("rollout crashed")
+        q.report_error(err)
+        with self.assertRaises(RuntimeError) as ctx:
+            q.put(_batch())
+        self.assertIs(ctx.exception, err)
+
+    def test_report_error_surfaces_on_get(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        err = RuntimeError("rollout crashed")
+        q.report_error(err)
+        with self.assertRaises(RuntimeError) as ctx:
+            q.get()
+        self.assertIs(ctx.exception, err)
+
+    def test_report_error_unblocks_blocked_get(self):
+        q = AsyncTrainBatchQueue(maxsize=1)
+        result = []
+
+        def consume():
+            try:
+                q.get()
+            except Exception as e:
+                result.append(e)
+
+        consumer = threading.Thread(target=consume)
+        consumer.start()
+        consumer.join(timeout=0.2)
+        self.assertTrue(consumer.is_alive())
+        err = RuntimeError("boom")
+        q.report_error(err)
+        consumer.join(timeout=1.0)
+        self.assertFalse(consumer.is_alive())
+        self.assertEqual(len(result), 1)
+        self.assertIs(result[0], err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds the standalone building blocks for an experimental asynchronous policy trainer under `areno.experimental.async_policy`. The async trainer will overlaprollout/reward with training on single-node multi-GPU; these primitives — a bounded batch queue, batch metadata, and staleness control — are the first self-contained piece, landable and testable before any trainer integration. No algorithms are registered yet.

The change adds:

- `AsyncTrainBatch` (`batch.py`): a slotted dataclass holding the materialized `TrainSequence`s plus the rollout policy version and per-stage timing/size fields used for staleness control and metrics.
- `AsyncTrainBatchQueue` (`queue.py`): a bounded FIFO queue with backpressure, per-operation `put`/`get` timeouts, `close()` to unblock waiters, and `report_error()` to propagate a worker failure to the next operation. It uses `threading.Condition` rather than `queue.Queue` because the stdlib queue has no close/unblock or error-propagation semantics.
- `staleness_delta` / `is_stale` (`staleness.py`): helpers that compare a batch's rollout policy version against the current training policy version.
- `tests/test_async_policy_cpu.py`: 19 CPU tests covering FIFO ordering, backpressure, timeouts, close, error propagation, and staleness.

A runnable example and an async-vs-sync evaluation report will accompany the async trainer itself; this PR is intentionally limited to the queue, batch, and staleness primitives.

## Related issue
Fixes #487 
   - feature: add experimental async policy trainer. This PR is the first of the series and lands the queue, batch, and staleness primitives.

## Type of change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring
  - [ ] ⚡ Performance improvement
  - [ ] ✅ Test coverage improvement

## How was it tested?

Local CPU validation on the final commit:

```text
python -m pytest tests/test_async_policy_cpu.py -q
python -m pytest tests/test_algorithms_cpu.py tests/test_registry_discovery_cpu.py -q

Result: 19 passed and 5 passed respectively; existing algorithm/registry
discovery behavior is unaffected.

ruff check areno/experimental/async_policy tests/test_async_policy_cpu.py
ruff format --check areno/experimental/async_policy tests/test_async_policy_cpu.py

Result: all checks passed.

Hardware limitation: CPU-only validation (no GPU). This PR introduces no CUDA
execution path — the primitives are pure Python and gated behind
areno.experimental, so no GPU smoke test applies yet.
```

## Checklist

  - [x] The PR title summarizes the contribution.
  - [x] Linked the related issue in the description (if any).
  - [x] Existing tests pass (pytest tests/ -k cpu).
  - [x] New behavior is covered by tests.
  - [x] Described the test commands run and any hardware limitations.
  - [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

Breaking change details

None — purely additive code under areno.experimental/; no areno/api/, CLI, or stable-surface changes.