### PR TITLE
chore(release): bump version to v0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use our official [AReno image](https://ghcr.io/inclusionai/areno) `inclusionai/a
 ```bash
 # Please make sure the host has an NVIDIA driver and NVIDIA Container Toolkit.
 docker run --gpus all --rm -it \
-  ghcr.io/inclusionai/areno:v0.0.6 \
+  ghcr.io/inclusionai/areno:v0.0.7 \
   areno check
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "areno"
-version = "0.0.6"
+version = "0.0.7"
 description = "An easy-to-use, fast toolkit to scale up RL post-training on a single node."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What does this PR do?

- Bumps the package version from `0.0.6` to `0.0.7`.
- Updates the README GHCR image example to `v0.0.7`.
- Prepares the source commit for the `v0.0.7` tag and release workflows.

## Related issue

N/A — release preparation.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

- `python -c 'import tomllib; ...'` confirmed the committed `pyproject.toml` version is `0.0.7`.
- `ARENO_BUILD_EXT=0 .venv/bin/python setup.py --version` returned `0.0.7`.
- `UV_CACHE_DIR=/private/tmp/uv-cache ARENO_BUILD_EXT=0 uv build --sdist --out-dir dist` built `areno-0.0.7.tar.gz` from an archive of the exact commit.
- `twine check dist/areno-0.0.7.tar.gz` passed.
- `git diff --check` passed.

GPU training was not run because this change only updates release metadata and documentation.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`) — not rerun for this metadata-only change.
- [ ] New behavior is covered by tests — no runtime behavior changed.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md) — no public API or CLI changes.
