### PR TITLE
feat(experimental): add Dr. GRPO

### DIFF
--- a/areno/api/algorithms.py
+++ b/areno/api/algorithms.py
@@ -93,7 +93,7 @@ def list_algorithms(*, include_experimental: bool = True) -> dict[str, Algorithm
 
     if include_experimental:
         load_experimental_algorithms()
-    return dict(_ALGORITHMS)
+    return {name: spec for name, spec in _ALGORITHMS.items() if include_experimental or not spec.experimental}
 
 
 def load_experimental_algorithms() -> None:

--- a/areno/api/backend/areno/backend.py
+++ b/areno/api/backend/areno/backend.py
@@ -534,7 +534,9 @@ class ArenoBackend(Backend):
         # forward worker can call it without having to know about the loss API.
         packs = []
         is_sft = _is_sft_loss_fn(loss_fn)
+        is_fixed_sequence_mean = _is_fixed_sequence_mean_loss_fn(loss_fn)
         sft_target_counts = [] if is_sft else None
+        sequence_counts = [] if is_fixed_sequence_mean else None
         for start in range(0, len(batch_data), mini_bs):
             seqs = batch_data[start : start + mini_bs]
             pack = _make_train_pack(seqs)
@@ -542,11 +544,20 @@ class ArenoBackend(Backend):
             packs.append(pack)
             if is_sft:
                 sft_target_counts.append(_sft_target_token_count(seqs))
+            if is_fixed_sequence_mean:
+                sequence_counts.append(len(seqs))
         if is_sft:
             _annotate_sft_token_mean_packs(
                 packs,
                 sft_target_counts,
                 gradient_accumulation_steps=gradient_accumulation_steps,
+            )
+        if is_fixed_sequence_mean:
+            _annotate_fixed_sequence_mean_packs(
+                packs,
+                sequence_counts,
+                gradient_accumulation_steps=gradient_accumulation_steps,
+                dp_size=int(engine.config.dp_size),
             )
         stats_list = engine.step(packs, gradient_accumulation_steps=gradient_accumulation_steps)
         if self._separate_rollout and any(bool(stats.stepped) for stats in stats_list):
@@ -796,6 +807,41 @@ def _is_sft_loss_fn(loss_fn: Callable) -> bool:
     """Return true for the built-in SFT loss, including simple partial wrappers."""
 
     return loss_fn is sft_loss_fn or getattr(loss_fn, "func", None) is sft_loss_fn
+
+
+def _is_fixed_sequence_mean_loss_fn(loss_fn: Callable) -> bool:
+    """Return true for losses normalized by a fixed constant per sequence."""
+
+    return getattr(loss_fn, "_areno_loss_reduction", None) == "fixed_sequence_mean"
+
+
+def _annotate_fixed_sequence_mean_packs(
+    packs: list[dict],
+    sequence_counts: list[int],
+    *,
+    gradient_accumulation_steps: int | None,
+    dp_size: int,
+) -> None:
+    """Attach sequence normalizers for one optimizer-step accumulation group."""
+
+    if not packs:
+        return
+    accumulation_steps = len(packs) if gradient_accumulation_steps is None else max(int(gradient_accumulation_steps), 1)
+    dp_size = max(int(dp_size), 1)
+    for group_start in range(0, len(packs), accumulation_steps):
+        group_end = min(group_start + accumulation_steps, len(packs))
+        group_total = max(sum(sequence_counts[group_start:group_end]), 1)
+        group_size = group_end - group_start
+        for pack, sequence_count in zip(
+            packs[group_start:group_end],
+            sequence_counts[group_start:group_end],
+            strict=True,
+        ):
+            pack["_fixed_sequence_total"] = group_total
+            # DP averages gradients across ranks. Sharded packs need the
+            # matching multiplier; packs smaller than DP are replicated.
+            dp_grad_scale = dp_size if int(sequence_count) >= dp_size else 1
+            pack["_fixed_sequence_grad_scale"] = group_size * dp_grad_scale
 
 
 def _annotate_sft_token_mean_packs(

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -176,6 +176,13 @@ class PolicyOnlyTrainer:
         # reference forward-time, ...) before they reach the metric recorder.
         return result
 
+    def _compute_group_advantages(self, rewards: list[float]) -> list[float]:
+        """Return the algorithm's scalar advantages for one prompt group."""
+
+        from areno.api.rewards import compute_group_advantages
+
+        return compute_group_advantages(rewards)
+
     def _agentic_enabled(self) -> bool:
         return bool(getattr(self.config, "agent_fn", None))
 
@@ -431,7 +438,6 @@ class PolicyOnlyTrainer:
         """Assemble TrainSequence rows from an agentic rollout batch."""
 
         import areno.api
-        from areno.api.rewards import compute_group_advantages
 
         del prompt_batch
         if agent_batch.rewards is None:
@@ -446,7 +452,7 @@ class PolicyOnlyTrainer:
         advantages_by_row: dict[int, float] = {}
         for row_indices in grouped.values():
             group_rewards = [rewards_all[row_idx] for row_idx in row_indices]
-            for row_idx, advantage in zip(row_indices, compute_group_advantages(group_rewards), strict=True):
+            for row_idx, advantage in zip(row_indices, self._compute_group_advantages(group_rewards), strict=True):
                 advantages_by_row[row_idx] = float(advantage)
         row_features = getattr(agent_batch, "features", [None] * len(agent_batch.token_rows))
         for row_idx, (tokens, response_mask, loss_mask, logprobs, reward, features) in enumerate(
@@ -562,15 +568,15 @@ class PolicyOnlyTrainer:
 
         Steps:
             1. Decode each completion and score it with `reward_fn`.
-            2. Standardise rewards within each prompt group to get advantages
-               (`compute_group_advantages`); this is the GRPO/GSPO baseline.
+            2. Compute one group-relative advantage per completion. The
+               default hook standardises rewards for the GRPO/GSPO baseline.
             3. Stitch each prompt prefix with its response tokens and copy the
                group-level advantage onto every response position; prompt
                positions carry zero advantage and zero logprob.
         """
 
         import areno.api
-        from areno.api.rewards import compute_group_advantages, make_reward_record
+        from areno.api.rewards import make_reward_record
 
         train_batch = []
         rewards_all = []
@@ -596,9 +602,9 @@ class PolicyOnlyTrainer:
                 for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
             ]
             rewards_all += rewards
-            # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
-            # every response token of sample i.
-            advantages = compute_group_advantages(rewards)
+            # The group-relative scalar is shared by every response token of
+            # sample i.
+            advantages = self._compute_group_advantages(rewards)
             for seq, advantage, reward in zip(result.sequences, advantages, rewards, strict=True):
                 resp_len = len(seq.resp_tokens)
                 rollout_logprobs += seq.resp_logprobs

--- a/areno/experimental/drgrpo/__init__.py
+++ b/areno/experimental/drgrpo/__init__.py
@@ -1,0 +1,40 @@
+"""Experimental Dr. GRPO algorithm registration."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from areno.api.algorithms import AlgorithmSpec, register_algorithm
+from areno.api.trainer_config import TrainerConfig
+from areno.experimental.drgrpo.loss import drgrpo_loss_fn
+
+
+def _load_trainer() -> type:
+    from areno.experimental.drgrpo.trainer import DrGRPOTrainer
+
+    return DrGRPOTrainer
+
+
+def _bind_loss(config: TrainerConfig, loss_fn):
+    clip_eps = float(getattr(config, "grpo_clip_eps"))
+    if clip_eps <= 0:
+        raise ValueError("grpo_clip_eps must be positive")
+    bound_loss_fn = partial(
+        loss_fn,
+        clip_eps=clip_eps,
+        max_completion_length=config.max_new_tokens,
+    )
+    setattr(bound_loss_fn, "_areno_loss_reduction", "fixed_sequence_mean")
+    return bound_loss_fn
+
+
+register_algorithm(
+    AlgorithmSpec(
+        name="drgrpo",
+        trainer_cls=_load_trainer,
+        default_loss_fn=drgrpo_loss_fn,
+        requires_rollout=True,
+        loss_fn_factory=_bind_loss,
+        experimental=True,
+    )
+)

--- a/areno/experimental/drgrpo/loss.py
+++ b/areno/experimental/drgrpo/loss.py
@@ -1,0 +1,69 @@
+"""Dr. GRPO advantage and policy-loss mathematics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from areno.api.loss_fns.layout import masked_mean, response_layout
+
+
+def compute_drgrpo_advantages(rewards: list[float]) -> list[float]:
+    """Center rewards within one prompt group without variance scaling."""
+
+    rewards_arr = np.asarray(rewards, dtype=np.float32)
+    return (rewards_arr - rewards_arr.mean()).tolist()
+
+
+def drgrpo_loss_fn(data_pack, logprobs, *, clip_eps: float = 0.2, max_completion_length: int):
+    """Compute the fixed-normalizer token policy loss proposed by Dr. GRPO."""
+
+    import torch
+
+    clip_eps = float(clip_eps)
+    max_completion_length = int(max_completion_length)
+    if max_completion_length <= 0:
+        raise ValueError("max_completion_length must be positive")
+
+    layout = response_layout(
+        data_pack,
+        logprobs,
+        need_old_logprobs=True,
+        need_advantages=True,
+        need_sequences=True,
+    )
+    token_log_ratio = logprobs - logprobs.detach()
+    ratio = torch.exp(token_log_ratio)
+    clipped_ratio = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps)
+    per_token_loss = -torch.min(ratio * layout.advantages, clipped_ratio * layout.advantages)
+    masked_token_loss = per_token_loss * layout.response_mask
+
+    sequence_total = data_pack.get("_fixed_sequence_total")
+    if sequence_total is None:
+        if layout.packed:
+            sequence_total = int(layout.num_sequences or 0)
+        else:
+            sequence_total = int(layout.response_mask.shape[0])
+    sequence_total = max(int(sequence_total), 1)
+    grad_scale = float(data_pack.get("_fixed_sequence_grad_scale", 1))
+    policy_loss = masked_token_loss.sum() * grad_scale / (sequence_total * max_completion_length)
+
+    valid_ratio = ratio[layout.response_mask.bool()]
+    logp_diff = layout.old_logprobs - logprobs.detach()
+    stats = {
+        "policy_loss": policy_loss.detach(),
+        "total_loss": policy_loss.detach(),
+        "ratio_mean": valid_ratio.mean().detach() if valid_ratio.numel() else ratio.mean().detach(),
+        "ratio_std": (
+            valid_ratio.std().detach() if valid_ratio.numel() > 1 else torch.zeros((), device=logprobs.device)
+        ),
+        "advantage_mean": masked_mean(layout.advantages, layout).detach(),
+        "response_len": layout.response_len.mean().detach(),
+        "rollout_logprobs_mean": masked_mean(layout.old_logprobs, layout).detach(),
+        "train_logprobs_mean": masked_mean(logprobs.detach(), layout).detach(),
+        "logp_diff_mean": masked_mean(logp_diff, layout).detach(),
+        "logp_abs_diff_mean": masked_mean(logp_diff.abs(), layout).detach(),
+    }
+    return policy_loss, stats
+
+
+__all__ = ["compute_drgrpo_advantages", "drgrpo_loss_fn"]

--- a/areno/experimental/drgrpo/trainer.py
+++ b/areno/experimental/drgrpo/trainer.py
@@ -1,0 +1,27 @@
+"""Policy-only trainer specialization for Dr. GRPO."""
+
+from __future__ import annotations
+
+from areno.api.trainers.policy_only import PolicyOnlyTrainer
+from areno.experimental.drgrpo.loss import compute_drgrpo_advantages
+
+
+class DrGRPOTrainer(PolicyOnlyTrainer):
+    """Use centered rewards and the Dr. GRPO fixed-normalizer policy loss."""
+
+    def __init__(self, config, *, instance, dataset, reward_fn, loss_fn):
+        if getattr(config, "agent_fn", None):
+            raise ValueError("Dr. GRPO does not support agentic rollouts")
+        super().__init__(
+            config,
+            instance=instance,
+            dataset=dataset,
+            reward_fn=reward_fn,
+            loss_fn=loss_fn,
+        )
+
+    def _compute_group_advantages(self, rewards: list[float]) -> list[float]:
+        return compute_drgrpo_advantages(rewards)
+
+
+__all__ = ["DrGRPOTrainer"]

--- a/tests/test_drgrpo_cpu.py
+++ b/tests/test_drgrpo_cpu.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import functools
+import unittest
+
+import torch
+
+from areno.api.algorithms import get_algorithm, list_algorithms
+from areno.api.rewards import compute_group_advantages
+from areno.api.trainer_config import PolicyTrainerConfig
+from areno.api.trainer_factory import build_trainer
+from areno.api.trainers.policy_only import PolicyOnlyTrainer
+from areno.experimental.drgrpo.loss import compute_drgrpo_advantages, drgrpo_loss_fn
+
+
+class DrGRPOAdvantageTest(unittest.TestCase):
+    """Dr. GRPO advantages center group rewards without variance scaling."""
+
+    def test_advantages_match_hand_computed_group_centering(self):
+        advantages = compute_drgrpo_advantages([1.0, 2.0, 4.0])
+
+        expected = [-4.0 / 3.0, -1.0 / 3.0, 5.0 / 3.0]
+        torch.testing.assert_close(torch.tensor(advantages), torch.tensor(expected))
+
+    def test_advantages_are_zero_for_constant_rewards(self):
+        advantages = compute_drgrpo_advantages([3.0, 3.0, 3.0])
+
+        self.assertEqual(advantages, [0.0, 0.0, 0.0])
+
+    def test_advantages_are_translation_invariant(self):
+        baseline = compute_drgrpo_advantages([1.0, 2.0, 4.0])
+        translated = compute_drgrpo_advantages([11.0, 12.0, 14.0])
+
+        torch.testing.assert_close(torch.tensor(translated), torch.tensor(baseline))
+
+    def test_advantages_scale_with_reward_magnitude(self):
+        baseline = compute_drgrpo_advantages([1.0, 2.0, 4.0])
+        scaled = compute_drgrpo_advantages([2.0, 4.0, 8.0])
+
+        torch.testing.assert_close(torch.tensor(scaled), 2.0 * torch.tensor(baseline))
+        standardized = compute_group_advantages([2.0, 4.0, 8.0])
+        self.assertNotAlmostEqual(float(scaled[-1]), float(standardized[-1]), places=5)
+
+
+class DrGRPOLossTest(unittest.TestCase):
+    """Dr. GRPO sums token losses under a fixed completion-length normalizer."""
+
+    def test_padded_loss_uses_fixed_max_completion_normalizer(self):
+        data_pack = {
+            "prompt_mask": torch.tensor(
+                [
+                    [True, True, False, False, False],
+                    [True, True, True, False, False],
+                ]
+            ),
+            "advantages": torch.tensor(
+                [
+                    [0.0, 0.0, 2.0, 2.0, 2.0],
+                    [0.0, 0.0, 0.0, -1.0, -1.0],
+                ]
+            ),
+            "logprobs": torch.zeros((2, 5)),
+        }
+        logprobs = torch.zeros((2, 4), requires_grad=True)
+
+        loss, stats = drgrpo_loss_fn(data_pack, logprobs, max_completion_length=4)
+        loss.backward()
+
+        self.assertAlmostEqual(float(loss.detach()), -0.5, places=6)
+        torch.testing.assert_close(
+            logprobs.grad,
+            torch.tensor(
+                [
+                    [0.0, -0.25, -0.25, -0.25],
+                    [0.0, 0.0, 0.125, 0.125],
+                ]
+            ),
+        )
+        self.assertAlmostEqual(float(stats["response_len"]), 2.5, places=6)
+
+    def test_packed_and_padded_layouts_have_equal_loss_and_gradients(self):
+        padded_pack = {
+            "prompt_mask": torch.tensor(
+                [
+                    [True, False, False, False],
+                    [True, True, False, False],
+                ]
+            ),
+            "advantages": torch.tensor(
+                [
+                    [0.0, 2.0, 2.0, 2.0],
+                    [0.0, 0.0, -1.0, -1.0],
+                ]
+            ),
+            "logprobs": torch.zeros((2, 4)),
+        }
+        padded_logprobs = torch.zeros((2, 3), requires_grad=True)
+        packed_pack = {
+            "packed_response_mask": torch.tensor([True, True, True, True, True]),
+            "packed_seq_ids": torch.tensor([0, 0, 0, 1, 1]),
+            "packed_num_sequences": 2,
+            "packed_advantages": torch.tensor([2.0, 2.0, 2.0, -1.0, -1.0]),
+            "packed_logprobs": torch.zeros(5),
+        }
+        packed_logprobs = torch.zeros(5, requires_grad=True)
+
+        padded_loss, padded_stats = drgrpo_loss_fn(
+            padded_pack,
+            padded_logprobs,
+            max_completion_length=4,
+        )
+        packed_loss, packed_stats = drgrpo_loss_fn(
+            packed_pack,
+            packed_logprobs,
+            max_completion_length=4,
+        )
+        padded_loss.backward()
+        packed_loss.backward()
+
+        torch.testing.assert_close(packed_loss, padded_loss)
+        padded_response_grad = torch.cat((padded_logprobs.grad[0], padded_logprobs.grad[1, 1:]))
+        torch.testing.assert_close(packed_logprobs.grad, padded_response_grad)
+        for key in (
+            "policy_loss",
+            "total_loss",
+            "ratio_mean",
+            "ratio_std",
+            "advantage_mean",
+            "response_len",
+            "rollout_logprobs_mean",
+            "train_logprobs_mean",
+            "logp_diff_mean",
+            "logp_abs_diff_mean",
+        ):
+            torch.testing.assert_close(packed_stats[key], padded_stats[key])
+
+    def test_accumulation_preserves_global_fixed_sequence_normalizer(self):
+        full_pack = {
+            "prompt_mask": torch.tensor(
+                [
+                    [True, False],
+                    [True, False],
+                    [True, False],
+                ]
+            ),
+            "advantages": torch.tensor(
+                [
+                    [0.0, 2.0],
+                    [0.0, -1.0],
+                    [0.0, 3.0],
+                ]
+            ),
+            "logprobs": torch.zeros((3, 2)),
+        }
+        full_logprobs = torch.zeros((3, 1), requires_grad=True)
+        full_loss, _ = drgrpo_loss_fn(full_pack, full_logprobs, max_completion_length=4)
+        full_loss.backward()
+
+        first_pack = {
+            "prompt_mask": full_pack["prompt_mask"][:2],
+            "advantages": full_pack["advantages"][:2],
+            "logprobs": full_pack["logprobs"][:2],
+            "_fixed_sequence_total": 3,
+            "_fixed_sequence_grad_scale": 2,
+        }
+        second_pack = {
+            "prompt_mask": full_pack["prompt_mask"][2:],
+            "advantages": full_pack["advantages"][2:],
+            "logprobs": full_pack["logprobs"][2:],
+            "_fixed_sequence_total": 3,
+            "_fixed_sequence_grad_scale": 2,
+        }
+        first_logprobs = torch.zeros((2, 1), requires_grad=True)
+        second_logprobs = torch.zeros((1, 1), requires_grad=True)
+        first_loss, _ = drgrpo_loss_fn(first_pack, first_logprobs, max_completion_length=4)
+        second_loss, _ = drgrpo_loss_fn(second_pack, second_logprobs, max_completion_length=4)
+        accumulated_loss = (first_loss + second_loss) / 2
+        accumulated_loss.backward()
+
+        torch.testing.assert_close(accumulated_loss, full_loss)
+        torch.testing.assert_close(
+            torch.cat((first_logprobs.grad, second_logprobs.grad)),
+            full_logprobs.grad,
+        )
+
+    def test_loss_mask_keeps_fixed_denominator_and_blocks_gradients(self):
+        data_pack = {
+            "prompt_mask": torch.tensor([[True, False, False]]),
+            "loss_mask": torch.tensor([[False, True, False]]),
+            "advantages": torch.tensor([[0.0, 2.0, 100.0]]),
+            "logprobs": torch.zeros((1, 3)),
+        }
+        logprobs = torch.zeros((1, 2), requires_grad=True)
+
+        loss, stats = drgrpo_loss_fn(data_pack, logprobs, max_completion_length=4)
+        loss.backward()
+
+        self.assertAlmostEqual(float(loss.detach()), -0.5, places=6)
+        torch.testing.assert_close(logprobs.grad, torch.tensor([[-0.5, 0.0]]))
+        self.assertAlmostEqual(float(stats["response_len"]), 1.0, places=6)
+
+    def test_fully_masked_batch_returns_finite_zero_loss(self):
+        data_pack = {
+            "prompt_mask": torch.tensor([[True, False, False]]),
+            "loss_mask": torch.tensor([[False, False, False]]),
+            "advantages": torch.tensor([[0.0, 2.0, -1.0]]),
+            "logprobs": torch.zeros((1, 3)),
+        }
+        logprobs = torch.zeros((1, 2), requires_grad=True)
+
+        loss, stats = drgrpo_loss_fn(data_pack, logprobs, max_completion_length=4)
+        loss.backward()
+
+        self.assertTrue(torch.isfinite(loss))
+        self.assertEqual(float(loss.detach()), 0.0)
+        torch.testing.assert_close(logprobs.grad, torch.zeros_like(logprobs))
+        self.assertTrue(all(torch.isfinite(value) for value in stats.values()))
+
+    def test_stored_rollout_logprobs_do_not_change_surrogate_loss_or_gradient(self):
+        common = {
+            "prompt_mask": torch.tensor([[True, False, False]]),
+            "advantages": torch.tensor([[0.0, 2.0, -1.0]]),
+        }
+        close_pack = {**common, "logprobs": torch.tensor([[0.0, -0.1, -0.2]])}
+        far_pack = {**common, "logprobs": torch.tensor([[0.0, -9.0, -7.0]])}
+        close_logprobs = torch.tensor([[0.0, -0.1]], requires_grad=True)
+        far_logprobs = close_logprobs.detach().clone().requires_grad_(True)
+
+        close_loss, close_stats = drgrpo_loss_fn(close_pack, close_logprobs, max_completion_length=4)
+        far_loss, far_stats = drgrpo_loss_fn(far_pack, far_logprobs, max_completion_length=4)
+        close_loss.backward()
+        far_loss.backward()
+
+        torch.testing.assert_close(far_loss, close_loss)
+        torch.testing.assert_close(far_logprobs.grad, close_logprobs.grad)
+        self.assertEqual(float(close_stats["ratio_mean"]), 1.0)
+        self.assertEqual(float(close_stats["ratio_std"]), 0.0)
+        self.assertNotEqual(float(far_stats["logp_abs_diff_mean"]), float(close_stats["logp_abs_diff_mean"]))
+
+    def test_loss_rejects_non_positive_max_completion_length(self):
+        data_pack = {
+            "prompt_mask": torch.tensor([[True, False]]),
+            "advantages": torch.tensor([[0.0, 1.0]]),
+            "logprobs": torch.zeros((1, 2)),
+        }
+        logprobs = torch.zeros((1, 1))
+
+        with self.assertRaisesRegex(ValueError, "max_completion_length must be positive"):
+            drgrpo_loss_fn(data_pack, logprobs, max_completion_length=0)
+
+
+class DrGRPORegistryTest(unittest.TestCase):
+    """Experimental discovery should expose Dr. GRPO without built-in branches."""
+
+    def test_registry_discovers_experimental_algorithm(self):
+        algorithm = get_algorithm("drgrpo")
+
+        self.assertEqual(algorithm.name, "drgrpo")
+        self.assertTrue(algorithm.requires_rollout)
+        self.assertTrue(algorithm.experimental)
+        self.assertIs(algorithm.default_loss_fn, drgrpo_loss_fn)
+
+    def test_builtin_listing_excludes_loaded_experimental_algorithm(self):
+        get_algorithm("drgrpo")
+
+        self.assertNotIn("drgrpo", list_algorithms(include_experimental=False))
+
+    def test_binding_reuses_grpo_clip_and_max_new_tokens(self):
+        config = PolicyTrainerConfig(
+            algo="drgrpo",
+            ckpt="unused",
+            dataset_path="unused",
+            grpo_clip_eps=0.17,
+            max_new_tokens=321,
+        )
+
+        loss_fn = get_algorithm("drgrpo").make_loss_fn(config)
+
+        self.assertIsInstance(loss_fn, functools.partial)
+        self.assertIs(loss_fn.func, drgrpo_loss_fn)
+        self.assertEqual(
+            loss_fn.keywords,
+            {"clip_eps": 0.17, "max_completion_length": 321},
+        )
+        self.assertEqual(getattr(loss_fn, "_areno_loss_reduction"), "fixed_sequence_mean")
+
+    def test_binding_rejects_non_positive_clip_epsilon(self):
+        config = PolicyTrainerConfig(
+            algo="drgrpo",
+            ckpt="unused",
+            dataset_path="unused",
+            grpo_clip_eps=0.0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "grpo_clip_eps must be positive"):
+            get_algorithm("drgrpo").make_loss_fn(config)
+
+
+class DrGRPOBackendTest(unittest.TestCase):
+    """Backend annotations should preserve fixed-normalizer gradients."""
+
+    def test_backend_annotations_account_for_accumulation_and_dp_replication(self):
+        from areno.api.backend.areno.backend import _annotate_fixed_sequence_mean_packs
+
+        packs = [{}, {}]
+        _annotate_fixed_sequence_mean_packs(
+            packs,
+            [2, 1],
+            gradient_accumulation_steps=None,
+            dp_size=2,
+        )
+
+        self.assertEqual(packs[0]["_fixed_sequence_total"], 3)
+        self.assertEqual(packs[1]["_fixed_sequence_total"], 3)
+        self.assertEqual(packs[0]["_fixed_sequence_grad_scale"], 4)
+        self.assertEqual(packs[1]["_fixed_sequence_grad_scale"], 2)
+
+        replicated_packs = [{}, {}]
+        _annotate_fixed_sequence_mean_packs(
+            replicated_packs,
+            [2, 1],
+            gradient_accumulation_steps=None,
+            dp_size=4,
+        )
+
+        self.assertEqual(replicated_packs[0]["_fixed_sequence_grad_scale"], 2)
+        self.assertEqual(replicated_packs[1]["_fixed_sequence_grad_scale"], 2)
+
+    def test_uneven_dp_shards_match_unsplit_loss_and_gradients(self):
+        from areno.engine.runtime.common import split_data_pack_by_dp
+
+        data_pack = {
+            "input_ids": torch.ones((3, 2), dtype=torch.long),
+            "prompt_mask": torch.tensor(
+                [
+                    [True, False],
+                    [True, False],
+                    [True, False],
+                ]
+            ),
+            "advantages": torch.tensor(
+                [
+                    [0.0, 2.0],
+                    [0.0, -1.0],
+                    [0.0, 3.0],
+                ]
+            ),
+            "logprobs": torch.zeros((3, 2)),
+        }
+        full_logprobs = torch.zeros((3, 1), requires_grad=True)
+        full_loss, _ = drgrpo_loss_fn(data_pack, full_logprobs, max_completion_length=4)
+        full_loss.backward()
+
+        sharded_pack = {
+            **data_pack,
+            "_fixed_sequence_total": 3,
+            "_fixed_sequence_grad_scale": 2,
+        }
+        shards = split_data_pack_by_dp(sharded_pack, 2)
+        sharded_logprobs = torch.zeros((3, 1), requires_grad=True)
+        rank_losses = [
+            drgrpo_loss_fn(
+                shard,
+                sharded_logprobs[rank::2],
+                max_completion_length=4,
+            )[0]
+            for rank, shard in enumerate(shards)
+        ]
+        dp_averaged_loss = torch.stack(rank_losses).mean()
+        dp_averaged_loss.backward()
+
+        torch.testing.assert_close(dp_averaged_loss, full_loss)
+        torch.testing.assert_close(sharded_logprobs.grad, full_logprobs.grad)
+
+    def test_uneven_microbatches_and_dp_shards_match_unsplit_gradients(self):
+        from areno.api.backend.areno.backend import _annotate_fixed_sequence_mean_packs
+        from areno.engine.runtime.common import split_data_pack_by_dp
+
+        full_pack = {
+            "input_ids": torch.ones((3, 2), dtype=torch.long),
+            "prompt_mask": torch.tensor(
+                [
+                    [True, False],
+                    [True, False],
+                    [True, False],
+                ]
+            ),
+            "advantages": torch.tensor(
+                [
+                    [0.0, 2.0],
+                    [0.0, -1.0],
+                    [0.0, 3.0],
+                ]
+            ),
+            "logprobs": torch.zeros((3, 2)),
+        }
+        full_logprobs = torch.zeros((3, 1), requires_grad=True)
+        full_loss, _ = drgrpo_loss_fn(full_pack, full_logprobs, max_completion_length=4)
+        full_loss.backward()
+
+        packs = [
+            {key: value[:2] for key, value in full_pack.items()},
+            {key: value[2:] for key, value in full_pack.items()},
+        ]
+        _annotate_fixed_sequence_mean_packs(
+            packs,
+            [2, 1],
+            gradient_accumulation_steps=None,
+            dp_size=2,
+        )
+        shards_by_pack = [split_data_pack_by_dp(pack, 2) for pack in packs]
+        sharded_logprobs = torch.zeros((3, 1), requires_grad=True)
+        rank_objectives = []
+        for rank in range(2):
+            first_loss, _ = drgrpo_loss_fn(
+                shards_by_pack[0][rank],
+                sharded_logprobs[rank:2:2],
+                max_completion_length=4,
+            )
+            second_loss, _ = drgrpo_loss_fn(
+                shards_by_pack[1][rank],
+                sharded_logprobs[2:],
+                max_completion_length=4,
+            )
+            rank_objectives.append((first_loss + second_loss) / 2)
+        dp_averaged_objective = torch.stack(rank_objectives).mean()
+        dp_averaged_objective.backward()
+
+        torch.testing.assert_close(dp_averaged_objective, full_loss)
+        torch.testing.assert_close(sharded_logprobs.grad, full_logprobs.grad)
+
+
+class DrGRPOTrainerTest(unittest.TestCase):
+    """The experimental trainer should specialize only advantage handling."""
+
+    @staticmethod
+    def _config(*, agent_fn: str | None = None) -> PolicyTrainerConfig:
+        return PolicyTrainerConfig(
+            algo="drgrpo",
+            ckpt="unused",
+            dataset_path="unused",
+            agent_fn=agent_fn,
+        )
+
+    def test_trainer_dispatch_resolves_drgrpo_specialization(self):
+        from areno.experimental.drgrpo.trainer import DrGRPOTrainer
+
+        trainer = build_trainer(
+            self._config(),
+            instance="api",
+            dataset=["row"],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=drgrpo_loss_fn,
+        )
+
+        self.assertIsInstance(trainer, DrGRPOTrainer)
+        self.assertEqual(
+            trainer._compute_group_advantages([1.0, 2.0, 4.0]),
+            compute_drgrpo_advantages([1.0, 2.0, 4.0]),
+        )
+
+    def test_policy_trainer_default_advantage_remains_standardized(self):
+        trainer = object.__new__(PolicyOnlyTrainer)
+
+        advantages = trainer._compute_group_advantages([1.0, 2.0, 4.0])
+
+        torch.testing.assert_close(
+            torch.tensor(advantages),
+            torch.tensor(compute_group_advantages([1.0, 2.0, 4.0])),
+        )
+
+    def test_trainer_rejects_agentic_rollouts(self):
+        with self.assertRaisesRegex(ValueError, "Dr. GRPO does not support agentic rollouts"):
+            build_trainer(
+                self._config(agent_fn="examples/agent.py"),
+                instance="api",
+                dataset=["row"],
+                reward_fn=lambda _record: 0.0,
+                loss_fn=drgrpo_loss_fn,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds Dr. GRPO as an opt-in experimental policy-training algorithm, following [*Understanding R1-Zero-Like Training: A Critical Perspective*](https://arxiv.org/abs/2503.20783).

The implementation keeps AReno's existing rollout and policy-only training flow while applying the two Dr. GRPO objective changes:

- computes group advantages as `reward - group_mean`, without standard-deviation normalization;
- normalizes the token policy objective by `num_sequences * max_completion_length` instead of the number of sampled response tokens.

The change also:

- registers `drgrpo` lazily under `areno.experimental` and keeps it out of the stable algorithm listing;
- specializes only the group-advantage hook while reusing `PolicyOnlyTrainer`;
- binds `grpo_clip_eps` and `max_new_tokens` to the experimental loss;
- preserves the global fixed-sequence denominator across packed/padded layouts, uneven microbatches, gradient accumulation, and data-parallel sharding;
- rejects agentic rollouts explicitly because this implementation assumes fixed prompt groups;
- keeps AReno's current GRPO ratio semantics unchanged. Stored rollout logprobs remain diagnostic in this PR; changing the old-policy ratio behavior is intentionally out of scope.

Existing GRPO behavior and defaults are unchanged. Users opt in with `--algo drgrpo`.

## Related issue

Fixes #483

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

Local static and CPU validation on the final rebased commit:

```text
python -m pytest tests/ -k cpu -q
```

Result: `474 passed, 11 skipped`, with 12 existing FastAPI deprecation warnings.

```text
ruff check .
ruff format --check .
python -m compileall -q areno
git diff --check upstream/main...HEAD
```

Result: all checks passed; 267 files were already formatted.

The new CPU coverage includes:

- exact centered advantages and fixed-normalizer loss/gradient values;
- prompt and explicit loss-mask gradient blocking;
- finite zero loss/gradients for fully masked batches;
- packed/padded loss, statistic, and gradient equivalence;
- full-batch versus gradient-accumulation equivalence;
- uneven data-parallel shard equivalence;
- combined uneven microbatch, accumulation, and DP scaling equivalence;
- registry metadata, experimental visibility, loss binding, trainer dispatch, and agentic rejection.

Target-side validation used the final commit with Qwen3-0.6B, PyTorch 2.9.1+cu130, native attention, TP 1, world size 1, four samples per prompt, mini-batch size 2, gradient accumulation 2, and 64 generated tokens:

- `tests/test_drgrpo_cpu.py`: `21 passed`;
- Dr. GRPO: 5/5 training steps completed with finite statistics, reward variation in every group, and positive gradient norms in every step;
- Dr. GRPO gradient norms: `2.4697, 6.2598, 2.8107, 5.6674, 7.0344`;
- existing GRPO baseline: 2/2 training steps completed under the same configuration with finite statistics and positive gradients.

Hardware limitation: GPU validation was single-device only (one NVIDIA RTX 5090). Multi-GPU CUDA execution was not available; DP denominator/scaling behavior is covered by deterministic CPU tests, including uneven real pack sharding.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description.
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).