### PR TITLE
feat(experimental): add DAPO training support

### DIFF
--- a/areno/api/algorithms.py
+++ b/areno/api/algorithms.py
@@ -158,7 +158,8 @@ def list_algorithms(*, include_experimental: bool = True) -> dict[str, Algorithm
 
     if include_experimental:
         load_experimental_algorithms()
-    return dict(_ALGORITHMS)
+        return dict(_ALGORITHMS)
+    return {name: spec for name, spec in _ALGORITHMS.items() if not spec.experimental}
 
 
 def describe_loss_fn(loss_fn: Callable) -> BackendLossSpec:

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -34,8 +34,10 @@ from areno.api.backend.cuda.checkpoint import save_checkpoint
 from areno.api.backend.cuda.generation import rollout_options
 from areno.api.backend.cuda.losses import dispatch_loss
 from areno.api.backend.cuda.training import (
+    annotate_response_token_mean_packs,
     annotate_sft_token_mean_packs,
     is_sft_loss_fn,
+    loss_reduction,
     make_train_pack,
     pad_token_id,
     sft_target_token_count,
@@ -101,7 +103,7 @@ class CudaBackend(Backend):
     @classmethod
     def capabilities(cls) -> BackendCapabilities:
         return BackendCapabilities(
-            algorithms=frozenset({"sft", "dpo", "gspo", "grpo", "ppo"}),
+            algorithms=frozenset({"sft", "dpo", "gspo", "grpo", "ppo", "dapo"}),
             model_roles=frozenset({"actor", "ref", "reward", "critic"}),
             multimodal=True,
             distributed=True,
@@ -514,6 +516,8 @@ class CudaBackend(Backend):
         packs = []
         is_sft = is_sft_loss_fn(loss_fn)
         sft_target_counts = [] if is_sft else None
+        uses_response_token_mean = loss_reduction(loss_fn) == "response_token_mean"
+        response_token_counts = [] if uses_response_token_mean else None
         for start in range(0, len(batch_data), mini_bs):
             seqs = batch_data[start : start + mini_bs]
             pack = make_train_pack(seqs)
@@ -521,11 +525,20 @@ class CudaBackend(Backend):
             packs.append(pack)
             if is_sft:
                 sft_target_counts.append(sft_target_token_count(seqs))
+            if uses_response_token_mean:
+                response_token_counts.append(sft_target_token_count(seqs))
         if is_sft:
             annotate_sft_token_mean_packs(
                 packs,
                 sft_target_counts,
                 gradient_accumulation_steps=gradient_accumulation_steps,
+            )
+        if uses_response_token_mean:
+            annotate_response_token_mean_packs(
+                packs,
+                response_token_counts,
+                gradient_accumulation_steps=gradient_accumulation_steps,
+                data_parallel_size=max(int(getattr(engine.config, "dp_size", 1)), 1),
             )
         stats_list = engine.step(packs, gradient_accumulation_steps=gradient_accumulation_steps)
         if self._separate_rollout and any(bool(stats.stepped) for stats in stats_list):

--- a/areno/api/backend/cuda/training.py
+++ b/areno/api/backend/cuda/training.py
@@ -115,6 +115,41 @@ def annotate_sft_token_mean_packs(
             pack["_sft_grad_scale"] = end - start
 
 
+def annotate_response_token_mean_packs(
+    packs: list[dict],
+    response_token_counts: list[int],
+    *,
+    gradient_accumulation_steps: int | None,
+    data_parallel_size: int,
+) -> None:
+    """Attach global response-token normalizers to optimizer-step packs."""
+
+    if not packs:
+        return
+    if len(packs) != len(response_token_counts):
+        raise ValueError("packs and response_token_counts must have equal length")
+    data_parallel_size = max(int(data_parallel_size), 1)
+    accumulation = accumulation_steps(len(packs), gradient_accumulation_steps)
+    for start in range(0, len(packs), accumulation):
+        end = min(start + accumulation, len(packs))
+        total = max(sum(response_token_counts[start:end]), 1)
+        group_size = end - start
+        for pack in packs[start:end]:
+            batch_size = int(pack["input_ids"].shape[0])
+            dp_scale = data_parallel_size if batch_size >= data_parallel_size else 1
+            pack["_response_token_total"] = total
+            pack["_response_token_grad_scale"] = group_size * dp_scale
+
+
+def loss_reduction(loss_fn: Callable) -> str | None:
+    """Return an optional backend reduction marker from a function or partial."""
+
+    reduction = getattr(loss_fn, "_areno_loss_reduction", None)
+    if reduction is None:
+        reduction = getattr(getattr(loss_fn, "func", None), "_areno_loss_reduction", None)
+    return reduction
+
+
 def sft_target_token_count(seqs: list[TrainSequence]) -> int:
     """Count target tokens using the same shifted masks as training."""
 
@@ -197,8 +232,10 @@ def _sequence_prompt_len(seq: TrainSequence) -> int:
 
 
 __all__ = [
+    "annotate_response_token_mean_packs",
     "annotate_sft_token_mean_packs",
     "is_sft_loss_fn",
+    "loss_reduction",
     "make_routing_replay",
     "make_train_pack",
     "pad_token_id",

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -1,4 +1,4 @@
-"""Command-line entrypoint for SFT/DPO/GSPO/GRPO/PPO training.
+"""Command-line entrypoint for built-in and registered training algorithms.
 
 The flow is:
     1. `train_command` collects Click options and builds either a
@@ -123,6 +123,10 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "train_tool_results",
             "reward_fn_path",
             "reward_ckpt",
+            "dapo_gen_batch_size",
+            "dapo_max_num_gen_batches",
+            "dapo_overlong_buffer_len",
+            "dapo_overlong_penalty_factor",
         ),
     ),
     (
@@ -167,6 +171,8 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "critic_warmup_steps",
             "gspo_clip_eps",
             "grpo_clip_eps",
+            "dapo_clip_eps_low",
+            "dapo_clip_eps_high",
             "dpo_beta",
             "use_kl_loss",
             "kl_loss_coef",
@@ -290,6 +296,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     if args.model_hub not in {"hf", "modelscope"}:
         raise click.UsageError("--model-hub must be one of: hf, modelscope")
     algorithm = _algorithm_for_cli(args.algo)
+    if algorithm.name == "dapo" and args.backend != "cuda":
+        raise click.UsageError("DAPO currently supports only the CUDA backend")
     if algorithm.name == "sft" and args.dataset_loader_fn is None:
         raise click.UsageError("--dataset-loader-fn is required for --algo sft")
     tune_params = bool(getattr(args, "tune_params", False))
@@ -305,6 +313,8 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         raise click.UsageError("--mem-frac must be in (0, 1]")
     if tune_max_samples <= 0:
         raise click.UsageError("--tune-max-samples must be positive")
+    if algorithm.name == "dapo" and not (smoke_infer or smoke_train) and args.reward_fn_path is None:
+        raise click.UsageError("--reward-fn-path is required for DAPO")
     if (
         algorithm.requires_rollout
         and not (smoke_infer or smoke_train)
@@ -387,6 +397,27 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
         _require_positive_float(args.gspo_clip_eps, "--gspo-clip-eps")
     if algorithm.name == "grpo":
         _require_positive_float(args.grpo_clip_eps, "--grpo-clip-eps")
+    if algorithm.name == "dapo":
+        if args.n_samples < 2:
+            raise click.UsageError("--n-samples must be at least 2 for DAPO dynamic sampling")
+        if args.greedy:
+            raise click.UsageError("--greedy is not supported for DAPO dynamic sampling")
+        if args.agent_fn is not None:
+            raise click.UsageError("--agent-fn is not supported for DAPO")
+        if args.dapo_gen_batch_size is not None and args.dapo_gen_batch_size <= 0:
+            raise click.UsageError("--dapo-gen-batch-size must be positive")
+        if args.dapo_max_num_gen_batches <= 0:
+            raise click.UsageError("--dapo-max-num-gen-batches must be positive")
+        _require_positive_float(args.dapo_clip_eps_low, "--dapo-clip-eps-low")
+        _require_positive_float(args.dapo_clip_eps_high, "--dapo-clip-eps-high")
+        if args.dapo_clip_eps_high < args.dapo_clip_eps_low:
+            raise click.UsageError("--dapo-clip-eps-high must be greater than or equal to --dapo-clip-eps-low")
+        if args.dapo_overlong_buffer_len < 0:
+            raise click.UsageError("--dapo-overlong-buffer-len must be non-negative")
+        if args.dapo_overlong_buffer_len > args.max_new_tokens:
+            raise click.UsageError("--dapo-overlong-buffer-len must not exceed --max-new-tokens")
+        if args.dapo_overlong_penalty_factor < 0:
+            raise click.UsageError("--dapo-overlong-penalty-factor must be non-negative")
     if algorithm.name == "dpo":
         _require_positive_float(args.dpo_beta, "--dpo-beta")
     if algorithm.name == "ppo":
@@ -980,6 +1011,84 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             lora=lora,
             reference_mode=args.reference_mode,
         )
+    if algorithm.name == "dapo":
+        from areno.experimental.dapo.config import DAPOTrainerConfig
+
+        return DAPOTrainerConfig(
+            algo=algorithm.name,
+            ckpt=args.ckpt,
+            dataset_path=args.dataset_path,
+            backend=args.backend,
+            base_model_name_or_path=args.base_model_name_or_path,
+            model_hub=args.model_hub,
+            dataset_loader_fn=args.dataset_loader_fn,
+            reward_fn_path=args.reward_fn_path,
+            save_path=args.save_path,
+            save_interval=args.save_interval,
+            epochs=args.epochs,
+            max_steps=args.max_steps,
+            tp_size=args.tp_size,
+            sequence_parallel=args.sequence_parallel,
+            world_size=args.world_size,
+            train_devices=args.train_devices,
+            rollout_tp_size=args.rollout_tp_size,
+            rollout_devices=args.rollout_devices,
+            policy_sync_bucket_mb=args.policy_sync_bucket_mb,
+            batch_size=args.batch_size,
+            n_samples=args.n_samples,
+            mini_bs=args.mini_bs,
+            score_micro_bs=args.score_micro_bs,
+            gradient_accumulation_steps=(
+                1 if args.gradient_accumulation_steps is None else args.gradient_accumulation_steps
+            ),
+            max_prompt_tokens=args.max_prompt_tokens,
+            max_new_tokens=args.max_new_tokens,
+            max_context_len=args.max_context_len,
+            greedy=args.greedy,
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
+            max_running_prompts=args.max_running_prompts,
+            optimizer_lr=args.lr,
+            optimizer_min_lr=args.min_lr,
+            lr_decay_steps=args.lr_decay_steps,
+            lr_decay_style=args.lr_decay_style,
+            optimizer_beta1=args.adam_beta1,
+            optimizer_beta2=args.adam_beta2,
+            weight_decay=args.weight_decay,
+            grad_clip_norm=args.grad_clip_norm,
+            adam_8bit=args.adam_8bit,
+            adam_4bit=args.adam_4bit,
+            unfreeze_multimodal_tower=args.unfreeze_multimodal_tower,
+            unfreeze_multimodal_projector=args.unfreeze_multimodal_projector,
+            multimodal_tower_lr=args.multimodal_tower_lr,
+            multimodal_tower_min_lr=args.multimodal_tower_min_lr,
+            multimodal_tower_lr_decay_steps=args.multimodal_tower_lr_decay_steps,
+            multimodal_tower_lr_decay_style=args.multimodal_tower_lr_decay_style,
+            multimodal_projector_lr=args.multimodal_projector_lr,
+            multimodal_projector_min_lr=args.multimodal_projector_min_lr,
+            multimodal_projector_lr_decay_steps=args.multimodal_projector_lr_decay_steps,
+            multimodal_projector_lr_decay_style=args.multimodal_projector_lr_decay_style,
+            activation_checkpointing=args.activation_checkpointing,
+            keep_rollout_state=not args.drop_rollout_state,
+            optimizer_state_offload=args.optimizer_state_offload,
+            optimizer_state_offload_dir=args.optimizer_state_offload_dir,
+            optimizer_state_offload_batch_size=args.optimizer_state_offload_batch_size,
+            eager_decode=args.eager_decode,
+            attn_backend=args.attn_backend,
+            metrics_log_dir=args.metrics_log_dir,
+            agent_fn=args.agent_fn,
+            train_tool_results=args.train_tool_results,
+            chat_template_enable_thinking=chat_template_enable_thinking,
+            lora=lora,
+            reference_mode=args.reference_mode,
+            dapo_gen_batch_size=args.dapo_gen_batch_size,
+            dapo_max_num_gen_batches=args.dapo_max_num_gen_batches,
+            dapo_clip_eps_low=args.dapo_clip_eps_low,
+            dapo_clip_eps_high=args.dapo_clip_eps_high,
+            dapo_overlong_buffer_len=args.dapo_overlong_buffer_len,
+            dapo_overlong_penalty_factor=args.dapo_overlong_penalty_factor,
+        )
     if algorithm.name != "ppo":
         return PolicyTrainerConfig(
             algo=algorithm.name,
@@ -1513,7 +1622,7 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     cls=GroupedOptionsCommand,
     option_groups=TRAIN_OPTION_GROUPS,
     context_settings={"help_option_names": ["-h", "--help"]},
-    help="Run SFT, DPO, GSPO, GRPO, or PPO training with the areno backend.",
+    help="Run a registered training algorithm (SFT, DPO, GSPO, GRPO, PPO, or experimental DAPO).",
 )
 @click.option("--algo", type=str, default="gspo", show_default=True, help="Training algorithm registered in areno.api.")
 @click.option("--ckpt", default=None, help="Actor model/tokenizer checkpoint path or remote model repo ID.")
@@ -1629,7 +1738,10 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--gradient-accumulation-steps",
     type=int,
     default=None,
-    help="Optimizer step interval in microbatches; defaults to accumulating all mini-batches in one train call.",
+    help=(
+        "Optimizer step interval in microbatches; defaults to all mini-batches in one train call "
+        "(DAPO defaults to one)."
+    ),
 )
 @click.option("--max-prompt-tokens", type=int, default=1024, show_default=True, help="Maximum tokenized prompt length.")
 @click.option(
@@ -1795,6 +1907,47 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     "--gspo-clip-eps", type=float, default=3.0e-4, show_default=True, help="GSPO sequence-ratio clipping epsilon."
 )
 @click.option("--grpo-clip-eps", type=float, default=0.2, show_default=True, help="GRPO token-ratio clipping epsilon.")
+@click.option(
+    "--dapo-gen-batch-size",
+    type=int,
+    default=None,
+    help="Candidate prompts generated per DAPO dynamic-sampling attempt; defaults to --batch-size.",
+)
+@click.option(
+    "--dapo-max-num-gen-batches",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Maximum candidate batches used to fill one DAPO training batch.",
+)
+@click.option(
+    "--dapo-clip-eps-low",
+    type=float,
+    default=0.2,
+    show_default=True,
+    help="DAPO lower token-ratio clipping epsilon.",
+)
+@click.option(
+    "--dapo-clip-eps-high",
+    type=float,
+    default=0.28,
+    show_default=True,
+    help="DAPO upper token-ratio clipping epsilon (Clip-Higher).",
+)
+@click.option(
+    "--dapo-overlong-buffer-len",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Response-token buffer over which DAPO applies a linear overlong penalty; zero disables it.",
+)
+@click.option(
+    "--dapo-overlong-penalty-factor",
+    type=float,
+    default=1.0,
+    show_default=True,
+    help="Maximum magnitude of DAPO's soft overlong reward penalty.",
+)
 @click.option("--dpo-beta", type=float, default=0.1, show_default=True, help="DPO preference margin temperature.")
 @click.option(
     "--critic-warmup-steps",

--- a/areno/experimental/dapo/__init__.py
+++ b/areno/experimental/dapo/__init__.py
@@ -1,0 +1,41 @@
+"""Experimental DAPO algorithm registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+
+from areno.api.algorithms import AlgorithmSpec, register_algorithm
+from areno.api.trainer_config import TrainerConfig
+from areno.experimental.dapo.loss import dapo_loss_fn
+
+
+def _load_trainer() -> type:
+    from areno.experimental.dapo.trainer import DAPOTrainer
+
+    return DAPOTrainer
+
+
+def _bind_loss(config: TrainerConfig, loss_fn: Callable) -> Callable:
+    bound_loss = partial(
+        loss_fn,
+        clip_eps_low=getattr(config, "dapo_clip_eps_low"),
+        clip_eps_high=getattr(config, "dapo_clip_eps_high"),
+    )
+    setattr(bound_loss, "_areno_loss_reduction", "response_token_mean")
+    return bound_loss
+
+
+register_algorithm(
+    AlgorithmSpec(
+        name="dapo",
+        trainer_cls=_load_trainer,
+        default_loss_fn=dapo_loss_fn,
+        requires_rollout=True,
+        loss_fn_factory=_bind_loss,
+        experimental=True,
+    )
+)
+
+
+__all__ = ["dapo_loss_fn"]

--- a/areno/experimental/dapo/config.py
+++ b/areno/experimental/dapo/config.py
@@ -1,0 +1,57 @@
+"""Configuration for the experimental DAPO trainer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from areno.api.trainer_config import PolicyTrainerConfig
+
+
+@dataclass(slots=True)
+class DAPOTrainerConfig(PolicyTrainerConfig):
+    """DAPO-specific rollout, clipping, and reward-shaping settings."""
+
+    gradient_accumulation_steps: int | None = 1
+    dapo_gen_batch_size: int | None = None
+    dapo_max_num_gen_batches: int = 10
+    dapo_clip_eps_low: float = 0.2
+    dapo_clip_eps_high: float = 0.28
+    dapo_overlong_buffer_len: int = 0
+    dapo_overlong_penalty_factor: float = 1.0
+
+    def __post_init__(self) -> None:
+        PolicyTrainerConfig.__post_init__(self)
+        if self.n_samples < 2:
+            raise ValueError("DAPO requires n_samples >= 2")
+        if self.greedy:
+            raise ValueError("DAPO requires stochastic sampling")
+        if self.agent_fn is not None:
+            raise ValueError("DAPO does not support agent_fn")
+        if self.dapo_gen_batch_size is not None and self.dapo_gen_batch_size <= 0:
+            raise ValueError("dapo_gen_batch_size must be positive")
+        if self.dapo_max_num_gen_batches <= 0:
+            raise ValueError("dapo_max_num_gen_batches must be positive")
+        if self.dapo_clip_eps_low <= 0 or self.dapo_clip_eps_high <= 0:
+            raise ValueError("DAPO clip epsilons must be positive")
+        if self.dapo_clip_eps_high < self.dapo_clip_eps_low:
+            raise ValueError("dapo_clip_eps_high must be >= dapo_clip_eps_low")
+        if self.dapo_overlong_buffer_len < 0:
+            raise ValueError("dapo_overlong_buffer_len must be non-negative")
+        if self.dapo_overlong_buffer_len > self.max_new_tokens:
+            raise ValueError("dapo_overlong_buffer_len must not exceed max_new_tokens")
+        if self.dapo_overlong_penalty_factor < 0:
+            raise ValueError("dapo_overlong_penalty_factor must be non-negative")
+
+    def resolved_gen_batch_size(self) -> int:
+        """Return the candidate prompt count generated per dynamic-sampling attempt."""
+
+        if self.dapo_gen_batch_size is not None:
+            return self.dapo_gen_batch_size
+        return self.batch_size
+
+    def resolved_max_running_prompts(self) -> int:
+        """Default rollout concurrency follows the larger candidate batch."""
+
+        if self.max_running_prompts is not None:
+            return self.max_running_prompts
+        return max(self.resolved_gen_batch_size() * self.n_samples, 1)

--- a/areno/experimental/dapo/loss.py
+++ b/areno/experimental/dapo/loss.py
@@ -1,0 +1,77 @@
+"""DAPO token-level clipped policy-gradient loss."""
+
+from __future__ import annotations
+
+from areno.api.backend.common import LOGP_METRIC_WEIGHT, TrainMetric
+from areno.api.backend.cuda.losses import masked_mean, response_layout
+
+
+def dapo_loss_fn(
+    data_pack,
+    logprobs,
+    *,
+    clip_eps_low: float = 0.2,
+    clip_eps_high: float = 0.28,
+):
+    """Compute DAPO's asymmetric token-level policy objective.
+
+    Unlike the current GRPO surrogate, DAPO uses rollout logprobs as the old
+    policy so that the importance-sampling ratio can move away from one across
+    optimizer updates. The backend may attach response-token normalization
+    metadata when multiple packs contribute to one optimizer step.
+    """
+
+    import torch
+
+    clip_eps_low = float(clip_eps_low)
+    clip_eps_high = float(clip_eps_high)
+    layout = response_layout(
+        data_pack,
+        logprobs,
+        need_old_logprobs=True,
+        need_advantages=True,
+        need_sequences=True,
+    )
+
+    token_log_ratio = torch.clamp(logprobs - layout.old_logprobs, min=-20.0, max=20.0)
+    ratio = torch.exp(token_log_ratio)
+    clipped_ratio = torch.clamp(ratio, min=1.0 - clip_eps_low, max=1.0 + clip_eps_high)
+    unclipped_loss = -ratio * layout.advantages
+    clipped_loss = -clipped_ratio * layout.advantages
+    active_clip = clipped_loss > unclipped_loss
+    per_token_loss = torch.maximum(unclipped_loss, clipped_loss) * layout.response_mask
+
+    total_response_tokens = data_pack.get("_response_token_total")
+    grad_scale = data_pack.get("_response_token_grad_scale")
+    if total_response_tokens is not None and grad_scale is not None:
+        policy_loss = per_token_loss.sum() * float(grad_scale) / max(float(total_response_tokens), 1.0)
+    else:
+        policy_loss = per_token_loss.sum() / layout.valid_count
+
+    response_mask = layout.response_mask.bool()
+    valid_ratio = ratio[response_mask]
+    logp_diff = layout.old_logprobs - logprobs.detach()
+    lower_clip = active_clip & (ratio < 1.0 - clip_eps_low)
+    upper_clip = active_clip & (ratio > 1.0 + clip_eps_high)
+    stats = {
+        "policy_loss": policy_loss.detach(),
+        "total_loss": policy_loss.detach(),
+        TrainMetric.RATIO_MEAN: valid_ratio.mean().detach() if valid_ratio.numel() else ratio.mean().detach(),
+        TrainMetric.RATIO_STD: (
+            valid_ratio.std().detach() if valid_ratio.numel() > 1 else torch.zeros((), device=logprobs.device)
+        ),
+        "pg_clipfrac": masked_mean(active_clip.to(dtype=logprobs.dtype), layout).detach(),
+        "pg_clipfrac_lower": masked_mean(lower_clip.to(dtype=logprobs.dtype), layout).detach(),
+        "pg_clipfrac_upper": masked_mean(upper_clip.to(dtype=logprobs.dtype), layout).detach(),
+        "advantage_mean": masked_mean(layout.advantages, layout).detach(),
+        "response_len": layout.response_len.mean().detach(),
+        LOGP_METRIC_WEIGHT: layout.valid_count.detach(),
+        TrainMetric.ROLLOUT_LOGPROBS_MEAN: masked_mean(layout.old_logprobs, layout).detach(),
+        TrainMetric.TRAIN_LOGPROBS_MEAN: masked_mean(logprobs.detach(), layout).detach(),
+        TrainMetric.LOGP_DIFF_MEAN: masked_mean(logp_diff, layout).detach(),
+        TrainMetric.LOGP_ABS_DIFF_MEAN: masked_mean(logp_diff.abs(), layout).detach(),
+    }
+    return policy_loss, stats
+
+
+setattr(dapo_loss_fn, "_areno_loss_reduction", "response_token_mean")

--- a/areno/experimental/dapo/trainer.py
+++ b/areno/experimental/dapo/trainer.py
@@ -1,0 +1,375 @@
+"""Dynamic-sampling trainer for experimental DAPO."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from dataclasses import dataclass
+
+import numpy as np
+
+from areno.api.dashboard import record_dashboard_state
+from areno.api.data import PromptItem
+from areno.api.models import RolloutResult
+from areno.api.tokenizer import configure_chat_template_enable_thinking
+from areno.api.trainers.policy_only import PolicyOnlyTrainer
+
+
+@dataclass(slots=True)
+class _DAPOPromptGroup:
+    """One prompt's rollout samples and rewards before/after shaping."""
+
+    item: PromptItem
+    rollout_result: RolloutResult
+    raw_rewards: list[float]
+    shaped_rewards: list[float]
+
+    @property
+    def informative(self) -> bool:
+        """Return whether raw verifier rewards produce a non-zero advantage."""
+
+        return _has_reward_variance(self.raw_rewards)
+
+
+@dataclass(slots=True)
+class _DAPOCollection:
+    """Candidate-generation outcome for one intended optimizer batch."""
+
+    groups: list[_DAPOPromptGroup]
+    target_groups: int
+    gen_batches: int = 0
+    generated_groups: int = 0
+    filtered_groups: int = 0
+    discarded_qualified_groups: int = 0
+
+    @property
+    def complete(self) -> bool:
+        return len(self.groups) >= self.target_groups
+
+
+class DAPOTrainer(PolicyOnlyTrainer):
+    """Policy trainer implementing DAPO's dynamic sampling controller."""
+
+    def _fit_initialized(self) -> None:
+        import areno.api
+
+        if self._agentic_enabled():
+            raise ValueError("DAPO does not support agentic rollout")
+        if not callable(self.reward_fn):
+            raise ValueError("DAPO requires a callable reward_fn")
+        tokenizer = self.areno.get_tokenizer()
+        processor = self.areno.get_processor()
+        configure_chat_template_enable_thinking(tokenizer, self.config.chat_template_enable_thinking)
+        configure_chat_template_enable_thinking(processor, self.config.chat_template_enable_thinking)
+        sampling_params = areno.api.SamplingParams(
+            greedy=self.config.greedy,
+            temperature=self.config.temperature,
+            max_new_tokens=self.config.max_new_tokens,
+            max_context_len=self.config.max_context_len,
+            max_prompt_len=self.config.max_prompt_tokens,
+            top_k=self.config.top_k,
+            top_p=self.config.top_p,
+        )
+
+        step = 0
+        for epoch in range(self.config.epochs):
+            self.logger.info("epoch=%d stage=epoch_start", epoch)
+            record_dashboard_state(self.areno, stage="epoch_start", epoch=epoch, step=step, role="policy")
+            prompt_batches = iter(
+                self.areno.load_prompt_batches(
+                    self.dataset,
+                    batch_size=self.config.resolved_gen_batch_size(),
+                    max_prompt_tokens=self.config.max_prompt_tokens,
+                )
+            )
+            while True:
+                collection = self._collect_qualified_groups(
+                    tokenizer,
+                    sampling_params,
+                    prompt_batches,
+                    epoch=epoch,
+                    step=step,
+                )
+                if not collection.complete:
+                    if collection.gen_batches:
+                        self.logger.warning(
+                            "epoch=%d dropped incomplete DAPO batch qualified_groups=%d target_groups=%d",
+                            epoch,
+                            len(collection.groups),
+                            self.config.batch_size,
+                        )
+                        self.areno.finish_step()
+                    break
+
+                train_batch, raw_rewards, shaped_rewards, rollout_logprobs = self._materialize_scored_groups(
+                    tokenizer, collection.groups
+                )
+                train_stats = self._collection_metrics(collection, raw_rewards, shaped_rewards)
+                if rollout_logprobs:
+                    self.logger.info(
+                        "epoch=%d step=%d metric=rollout_logprob_mean value=%.6f",
+                        epoch,
+                        step,
+                        float(np.mean(rollout_logprobs)),
+                    )
+                accumulation_steps = self._resolved_gradient_accumulation_steps()
+                if (
+                    _optimizer_update_count(
+                        len(train_batch),
+                        mini_bs=self.config.mini_bs,
+                        gradient_accumulation_steps=accumulation_steps,
+                    )
+                    <= 1
+                ):
+                    self.logger.warning(
+                        "epoch=%d step=%d DAPO train batch has one optimizer update; "
+                        "importance ratios will remain near one",
+                        epoch,
+                        step,
+                    )
+
+                self.logger.info("epoch=%d step=%d role=policy stage=train_start", epoch, step)
+                record_dashboard_state(self.areno, stage="train_start", epoch=epoch, step=step, role="policy")
+                train_start = time.perf_counter()
+                result = self.areno.train(
+                    train_batch,
+                    self.loss_fn,
+                    mini_bs=self.config.mini_bs,
+                    gradient_accumulation_steps=accumulation_steps,
+                )
+                train_time_s = time.perf_counter() - train_start
+                if not isinstance(result, dict):
+                    result = {}
+                result.update(train_stats)
+                result["policy_train_wall_time_s"] = train_time_s
+                result = self._augment_train_stats(result)
+                self.logger.info("epoch=%d step=%d role=policy stage=train_end", epoch, step)
+                record_dashboard_state(self.areno, stage="train_end", epoch=epoch, step=step, role="policy")
+                self.logger.info("epoch=%d step=%d train_stats=%s", epoch, step, result)
+                self._maybe_save(epoch, step)
+
+                step += 1
+                if self.config.max_steps is not None and step >= self.config.max_steps:
+                    self.logger.info("epoch=%d step=%d stage=max_steps_reached", epoch, step)
+                    record_dashboard_state(
+                        self.areno,
+                        stage="max_steps_reached",
+                        epoch=epoch,
+                        step=step,
+                        role="policy",
+                    )
+                    return
+            self.logger.info("epoch=%d stage=epoch_end", epoch)
+            record_dashboard_state(self.areno, stage="epoch_end", epoch=epoch, step=step, role="policy")
+
+        if step == 0:
+            raise RuntimeError(
+                "DAPO dynamic sampling produced no complete training batch; "
+                "reduce --batch-size, increase the dataset, or inspect reward variance"
+            )
+
+    def _collect_qualified_groups(
+        self,
+        tokenizer,
+        sampling_params,
+        prompt_batches,
+        *,
+        epoch: int,
+        step: int,
+    ) -> _DAPOCollection:
+        collection = _DAPOCollection(groups=[], target_groups=self.config.batch_size)
+        while len(collection.groups) < self.config.batch_size:
+            try:
+                prompt_batch = next(prompt_batches)
+            except StopIteration:
+                return collection
+
+            collection.gen_batches += 1
+            groups = self._generate_candidate_groups(
+                tokenizer,
+                sampling_params,
+                prompt_batch,
+                epoch=epoch,
+                step=step,
+            )
+            collection.generated_groups += len(groups)
+            for group in groups:
+                if not group.informative:
+                    collection.filtered_groups += 1
+                    continue
+                if len(collection.groups) < self.config.batch_size:
+                    collection.groups.append(group)
+                else:
+                    collection.discarded_qualified_groups += 1
+
+            self.logger.info(
+                "epoch=%d step=%d stage=dynamic_sampling gen_batches=%d generated_groups=%d "
+                "qualified_groups=%d filtered_groups=%d",
+                epoch,
+                step,
+                collection.gen_batches,
+                collection.generated_groups,
+                len(collection.groups),
+                collection.filtered_groups,
+            )
+            if len(collection.groups) >= self.config.batch_size:
+                return collection
+            if collection.gen_batches >= self.config.dapo_max_num_gen_batches:
+                raise RuntimeError(
+                    "DAPO dynamic sampling reached dapo_max_num_gen_batches="
+                    f"{self.config.dapo_max_num_gen_batches}: generated_groups={collection.generated_groups} "
+                    f"qualified_groups={len(collection.groups)} filtered_groups={collection.filtered_groups}; "
+                    "increase --dapo-max-num-gen-batches or inspect reward variance"
+                )
+        return collection
+
+    def _generate_candidate_groups(self, tokenizer, sampling_params, prompt_batch, *, epoch: int, step: int):
+        self.logger.info("epoch=%d step=%d role=policy stage=rollout_start", epoch, step)
+        record_dashboard_state(self.areno, stage="rollout_start", epoch=epoch, step=step, role="policy")
+        rollout_results = asyncio.run(self._run_prompt_rollout(sampling_params, prompt_batch))
+        self.logger.info("epoch=%d step=%d role=policy stage=rollout_end", epoch, step)
+        record_dashboard_state(self.areno, stage="rollout_end", epoch=epoch, step=step, role="policy")
+        self._record_sample_completions(tokenizer, epoch, step, prompt_batch, rollout_results)
+        return [
+            self._score_prompt_group(tokenizer, item, result, prompt_index=prompt_index)
+            for prompt_index, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True))
+        ]
+
+    def _score_prompt_group(self, tokenizer, item, result, *, prompt_index: int) -> _DAPOPromptGroup:
+        from areno.api.rewards import make_reward_record
+
+        raw_rewards = []
+        shaped_rewards = []
+        prefix_len = len(item.input_tokens)
+        for sample_index, sequence in enumerate(result.sequences):
+            if len(sequence.resp_tokens) != len(sequence.resp_logprobs):
+                raise ValueError("DAPO rollout response tokens and logprobs must have equal length")
+            if any(not math.isfinite(logprob) for logprob in sequence.resp_logprobs):
+                raise ValueError("DAPO rollout must contain finite rollout logprobs")
+            completion = tokenizer.decode(sequence.resp_tokens)
+            reward = float(
+                self.reward_fn(
+                    make_reward_record(
+                        prompt=item.prompt,
+                        completion=completion,
+                        source_record=item.record,
+                        answer=item.solutions,
+                        tokens=item.input_tokens + sequence.resp_tokens,
+                        logprobs=[0.0] * prefix_len + sequence.resp_logprobs,
+                        loss_mask=[False] * prefix_len + [True] * len(sequence.resp_tokens),
+                        metadata={"prompt_index": prompt_index, "sample_index": sample_index},
+                    )
+                )
+            )
+            if not math.isfinite(reward):
+                raise ValueError("DAPO reward_fn must return finite rewards")
+            penalty = _overlong_penalty(
+                len(sequence.resp_tokens),
+                max_response_length=self.config.max_new_tokens,
+                buffer_length=self.config.dapo_overlong_buffer_len,
+                factor=self.config.dapo_overlong_penalty_factor,
+            )
+            raw_rewards.append(reward)
+            shaped_rewards.append(reward + penalty)
+        return _DAPOPromptGroup(
+            item=item,
+            rollout_result=result,
+            raw_rewards=raw_rewards,
+            shaped_rewards=shaped_rewards,
+        )
+
+    def _materialize_scored_groups(self, tokenizer, groups: list[_DAPOPromptGroup]):
+        import areno.api
+        from areno.api.rewards import compute_group_advantages
+
+        train_batch = []
+        raw_rewards_all = []
+        shaped_rewards_all = []
+        rollout_logprobs = []
+        for group in groups:
+            sequences = group.rollout_result.sequences
+            if len(sequences) != len(group.raw_rewards):
+                raise ValueError("DAPO rollout sequence and raw reward counts must match")
+            if len(sequences) != len(group.shaped_rewards):
+                raise ValueError("DAPO rollout sequence and reward counts must match")
+            advantages = compute_group_advantages(group.shaped_rewards)
+            prefix_len = len(group.item.input_tokens)
+            raw_rewards_all.extend(group.raw_rewards)
+            shaped_rewards_all.extend(group.shaped_rewards)
+            for sequence, advantage, reward in zip(
+                sequences,
+                advantages,
+                group.shaped_rewards,
+                strict=True,
+            ):
+                response_len = len(sequence.resp_tokens)
+                rollout_logprobs.extend(sequence.resp_logprobs)
+                train_batch.append(
+                    areno.api.TrainSequence(
+                        prompt_mask=[True] * prefix_len + [False] * response_len,
+                        tokens=group.item.input_tokens + sequence.resp_tokens,
+                        logprobs=[0.0] * prefix_len + sequence.resp_logprobs,
+                        advantages=[0.0] * prefix_len + [advantage] * response_len,
+                        features=group.item.record.get("features"),
+                        reward=reward,
+                        eos_token_id=tokenizer.eos_token_id,
+                    )
+                )
+        return train_batch, raw_rewards_all, shaped_rewards_all, rollout_logprobs
+
+    def _collection_metrics(self, collection, raw_rewards, shaped_rewards) -> dict[str, float]:
+        penalties = [shaped - raw for raw, shaped in zip(raw_rewards, shaped_rewards, strict=True)]
+        return {
+            "dapo_gen_batches": float(collection.gen_batches),
+            "dapo_generated_groups": float(collection.generated_groups),
+            "dapo_qualified_groups": float(len(collection.groups)),
+            "dapo_filtered_groups": float(collection.filtered_groups),
+            "dapo_discarded_qualified_groups": float(collection.discarded_qualified_groups),
+            "dapo_sampling_efficiency": float(len(collection.groups)) / max(collection.generated_groups, 1),
+            "dapo_raw_reward_mean": float(np.mean(raw_rewards)) if raw_rewards else 0.0,
+            "dapo_shaped_reward_mean": float(np.mean(shaped_rewards)) if shaped_rewards else 0.0,
+            "dapo_overlong_penalty_mean": float(np.mean(penalties)) if penalties else 0.0,
+        }
+
+    def _resolved_gradient_accumulation_steps(self) -> int:
+        """Default to per-pack updates so stored rollout ratios can evolve."""
+
+        if self.config.gradient_accumulation_steps is not None:
+            return max(int(self.config.gradient_accumulation_steps), 1)
+        return 1
+
+
+def _has_reward_variance(rewards: list[float]) -> bool:
+    """Return whether a prompt group yields a non-zero relative advantage."""
+
+    if len(rewards) < 2:
+        return False
+    rewards_array = np.asarray(rewards, dtype=np.float32)
+    return bool(rewards_array.max() > rewards_array.min())
+
+
+def _overlong_penalty(
+    response_length: int,
+    *,
+    max_response_length: int,
+    buffer_length: int,
+    factor: float,
+) -> float:
+    """Return DAPO's bounded linear penalty near the response-length limit."""
+
+    if buffer_length <= 0 or factor <= 0:
+        return 0.0
+    safe_length = max_response_length - buffer_length
+    excess = max(int(response_length) - safe_length, 0)
+    return -min(float(excess) / float(buffer_length), 1.0) * float(factor)
+
+
+def _optimizer_update_count(
+    sequence_count: int,
+    *,
+    mini_bs: int,
+    gradient_accumulation_steps: int,
+) -> int:
+    pack_count = math.ceil(sequence_count / max(int(mini_bs), 1))
+    return math.ceil(pack_count / max(int(gradient_accumulation_steps), 1))

--- a/areno/experimental/dapo/trainer.py
+++ b/areno/experimental/dapo/trainer.py
@@ -239,6 +239,9 @@ class DAPOTrainer(PolicyOnlyTrainer):
     def _score_prompt_group(self, tokenizer, item, result, *, prompt_index: int) -> _DAPOPromptGroup:
         from areno.api.rewards import make_reward_record
 
+        sequence_count = len(result.sequences)
+        if sequence_count != self.config.n_samples:
+            raise ValueError(f"DAPO rollout expected n_samples={self.config.n_samples}, got {sequence_count}")
         raw_rewards = []
         shaped_rewards = []
         prefix_len = len(item.input_tokens)

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -5,10 +5,10 @@ Training CLI reference
 
 ``areno train``
 
-Run SFT, DPO, GSPO, GRPO, or PPO training with the local Areno backend. The
-command owns the full loop: dataset loading, optional normalization, rollout,
-reward scoring, loss computation, optimizer steps, metrics, and checkpoint
-saving.
+Run SFT, DPO, GSPO, GRPO, PPO, or an experimental registered algorithm such
+as DAPO with the local Areno backend. The command owns the full loop: dataset
+loading, optional normalization, rollout, reward scoring, loss computation,
+optimizer steps, metrics, and checkpoint saving.
 
 The command selects CUDA on Linux and MLX on native Apple Silicon. It has no
 backend flag and does not fall back between runtimes. See
@@ -75,6 +75,8 @@ per-algorithm loader contracts.
    Training algorithm registered in ``areno.api``. Default: ``gspo``.
 
 Built-in algorithms: ``sft``, ``dpo``, ``gspo``, ``grpo``, ``ppo``.
+Experimental algorithms are discovered on demand. See
+:doc:`/reference/experimental` for their stability and usage constraints.
 
 ``--epochs INTEGER``
    Number of dataset epochs to train. Default: ``10``.
@@ -259,6 +261,26 @@ Reward files should expose:
 ``--reward-ckpt TEXT``
    Optional PPO reward model checkpoint path or remote model repo ID.
 
+``--dapo-gen-batch-size INTEGER``
+   Candidate prompt groups generated in each DAPO dynamic-sampling attempt.
+   Defaults to ``--batch-size``. It may be larger than the final training
+   batch when many prompt groups have constant raw rewards.
+
+``--dapo-max-num-gen-batches INTEGER``
+   Maximum candidate batches DAPO may generate while filling one complete
+   training batch. Default: ``10``. Reaching the limit raises an error with
+   generated, qualified, and filtered group counts instead of training an
+   undersized batch.
+
+``--dapo-overlong-buffer-len INTEGER``
+   Response-token buffer over which DAPO linearly increases its soft overlong
+   penalty. ``0`` disables reward shaping. Default: ``0``.
+
+``--dapo-overlong-penalty-factor FLOAT``
+   Maximum magnitude of DAPO's soft overlong penalty. Default: ``1.0``. The
+   penalty is applied after raw reward variance determines dynamic-sampling
+   eligibility.
+
 Parameter tuning
 ~~~~~~~~~~~~~~~~
 
@@ -333,7 +355,9 @@ in its description; flags for other algorithms are ignored.
 
 ``--gradient-accumulation-steps INTEGER``
    Optimizer step interval in microbatches. Defaults to accumulating all
-   mini-batches in one train call.
+   mini-batches in one train call. Experimental DAPO defaults to ``1`` so
+   later microbatches can observe a non-unit ratio against stored rollout
+   logprobs; an explicit value overrides this behavior.
 
 ``--activation-checkpointing / --no-activation-checkpointing``
    Enable decoder-layer activation recompute during training. Default:
@@ -441,6 +465,14 @@ in its description; flags for other algorithms are ignored.
 
 ``--grpo-clip-eps FLOAT``
    GRPO token-ratio clipping epsilon. Default: ``0.2``.
+
+``--dapo-clip-eps-low FLOAT``
+   DAPO lower token-ratio clipping epsilon. Default: ``0.2``.
+
+``--dapo-clip-eps-high FLOAT``
+   DAPO upper token-ratio clipping epsilon used by Clip-Higher. Default:
+   ``0.28``. It must be greater than or equal to
+   ``--dapo-clip-eps-low``.
 
 ``--dpo-beta FLOAT``
    DPO preference margin temperature. Default: ``0.1``.

--- a/docs/reference/experimental.rst
+++ b/docs/reference/experimental.rst
@@ -15,3 +15,65 @@ When documenting an experimental surface:
 
 Stable public surfaces should graduate into the relevant Reference page once
 the contract is ready.
+
+DAPO
+----
+
+``areno.experimental.dapo`` provides an experimental implementation of
+`DAPO: An Open-Source LLM Reinforcement Learning System at Scale
+<https://arxiv.org/abs/2503.14476>`_. It follows the four techniques described
+by the paper and the maintained `verl DAPO recipe
+<https://github.com/verl-project/verl-recipe/tree/main/dapo>`_:
+
+* **Clip-Higher** uses independent lower and upper token-ratio clip values.
+  The default interval is ``[1 - 0.2, 1 + 0.28]``.
+* **Dynamic sampling** removes prompt groups whose raw scalar rewards are all
+  equal, then samples candidate batches until ``batch-size`` qualified groups
+  are available.
+* **Token-level policy-gradient loss** divides by all response tokens in one
+  optimizer step. Backend metadata preserves this global mean across unequal
+  microbatches, gradient accumulation, and data-parallel gradient averaging.
+* **Soft overlong reward shaping** linearly subtracts up to the configured
+  penalty factor over the final response-length buffer.
+
+The dynamic-sampling test always uses the raw reward returned by
+``reward_fn``. Overlong shaping happens afterwards, so length penalties cannot
+turn an otherwise constant group into an eligible group. A partial qualified
+batch at dataset exhaustion is dropped, and reaching
+``dapo-max-num-gen-batches`` raises with sampling counters rather than silently
+changing the requested training batch size.
+
+Example
+~~~~~~~
+
+.. code-block:: bash
+
+   areno train \
+     --algo dapo \
+     --ckpt Qwen/Qwen3-0.6B \
+     --dataset-path gsm8k:main \
+     --dataset-loader-fn examples/math/dataset_loader.py \
+     --reward-fn-path examples/math/math_verify_reward.py \
+     --tp-size 1 \
+     --world-size 1 \
+     --batch-size 8 \
+     --dapo-gen-batch-size 16 \
+     --n-samples 8 \
+     --mini-bs 8 \
+     --dapo-overlong-buffer-len 512 \
+     --max-new-tokens 2048
+
+DAPO defaults ``gradient-accumulation-steps`` to ``1``. That gives later
+training microbatches a meaningful importance ratio against rollout
+logprobs. Increase it explicitly when a larger optimizer batch is required;
+the token-level denominator then covers the complete accumulation group.
+
+Current limitations
+~~~~~~~~~~~~~~~~~~~
+
+* The interface is experimental and may change before it becomes a stable
+  built-in algorithm.
+* Only direct prompt rollouts are supported; ``--agent-fn`` is rejected.
+* Dynamic sampling uses the scalar ``reward_fn`` output as its filter metric.
+* The CPU suite verifies formulas, gradients, filtering, and batching. It does
+  not claim reproduction of the paper's large-scale AIME result.

--- a/tests/test_dapo_cpu.py
+++ b/tests/test_dapo_cpu.py
@@ -1,0 +1,667 @@
+from __future__ import annotations
+
+import math
+import unittest
+from functools import partial
+from types import SimpleNamespace
+
+import torch
+
+from areno.api.algorithms import get_algorithm, list_algorithms
+from areno.api.data import PromptBatch, PromptItem
+from areno.api.models import RolloutResult, RolloutSequence
+from areno.experimental.dapo.config import DAPOTrainerConfig
+from areno.experimental.dapo.loss import dapo_loss_fn
+from areno.experimental.dapo.trainer import (
+    DAPOTrainer,
+    _DAPOPromptGroup,
+    _has_reward_variance,
+    _overlong_penalty,
+)
+
+
+class DAPOLossTest(unittest.TestCase):
+    """DAPO loss tests cover real ratios, Clip-Higher, and packed batches."""
+
+    @staticmethod
+    def _packed_pack(*, old_logprob: float, advantage: float) -> dict:
+        return {
+            "packed_response_mask": torch.tensor([True]),
+            "packed_logprobs": torch.tensor([old_logprob]),
+            "packed_advantages": torch.tensor([advantage]),
+            "packed_seq_ids": torch.tensor([0]),
+            "packed_num_sequences": 1,
+        }
+
+    def test_positive_advantage_uses_upper_clip(self):
+        """Clip-Higher caps an improving positive-advantage token at 1 + eps_high."""
+        logprobs = torch.tensor([math.log(1.5)], requires_grad=True)
+
+        loss, stats = dapo_loss_fn(
+            self._packed_pack(old_logprob=0.0, advantage=1.0),
+            logprobs,
+            clip_eps_low=0.2,
+            clip_eps_high=0.28,
+        )
+        loss.backward()
+
+        self.assertAlmostEqual(float(loss.detach()), -1.28, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac_upper"]), 1.0, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac_lower"]), 0.0, places=6)
+        self.assertAlmostEqual(float(logprobs.grad.item()), 0.0, places=6)
+
+    def test_negative_advantage_uses_lower_clip(self):
+        """The lower clip protects a negative-advantage token when its ratio falls."""
+        logprobs = torch.tensor([math.log(0.5)], requires_grad=True)
+
+        loss, stats = dapo_loss_fn(
+            self._packed_pack(old_logprob=0.0, advantage=-1.0),
+            logprobs,
+            clip_eps_low=0.2,
+            clip_eps_high=0.28,
+        )
+        loss.backward()
+
+        self.assertAlmostEqual(float(loss.detach()), 0.8, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac_lower"]), 1.0, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac_upper"]), 0.0, places=6)
+        self.assertAlmostEqual(float(logprobs.grad.item()), 0.0, places=6)
+
+    def test_rollout_logprobs_change_ratio_loss_and_gradient(self):
+        """DAPO must use stored rollout logprobs rather than a detached unit ratio."""
+        current_a = torch.tensor([-0.05], requires_grad=True)
+        current_b = torch.tensor([-0.05], requires_grad=True)
+
+        loss_a, stats_a = dapo_loss_fn(self._packed_pack(old_logprob=-0.10, advantage=1.0), current_a)
+        loss_b, stats_b = dapo_loss_fn(self._packed_pack(old_logprob=-0.20, advantage=1.0), current_b)
+        loss_a.backward()
+        loss_b.backward()
+
+        self.assertNotAlmostEqual(float(loss_a.detach()), float(loss_b.detach()), places=6)
+        self.assertNotAlmostEqual(float(current_a.grad.item()), float(current_b.grad.item()), places=6)
+        self.assertAlmostEqual(float(stats_a["ratio_mean"]), math.exp(0.05), places=6)
+        self.assertAlmostEqual(float(stats_b["ratio_mean"]), math.exp(0.15), places=6)
+
+    def test_unclipped_gradient_matches_finite_difference(self):
+        """A central finite difference should agree with the analytical DAPO gradient."""
+        data_pack = self._packed_pack(old_logprob=-0.2, advantage=0.7)
+        current = torch.tensor([-0.15], dtype=torch.float64, requires_grad=True)
+
+        loss, _ = dapo_loss_fn(data_pack, current)
+        loss.backward()
+
+        step = 1.0e-5
+        plus, _ = dapo_loss_fn(data_pack, torch.tensor([-0.15 + step], dtype=torch.float64))
+        minus, _ = dapo_loss_fn(data_pack, torch.tensor([-0.15 - step], dtype=torch.float64))
+        finite_difference = float((plus - minus) / (2 * step))
+        self.assertAlmostEqual(float(current.grad.item()), finite_difference, places=5)
+
+    def test_clip_higher_matches_hand_computed_mixed_token_reference(self):
+        """Every Clip-Higher branch should match an independent literal reference."""
+        data_pack = {
+            "packed_response_mask": torch.tensor([True, True, True, True]),
+            "packed_logprobs": torch.zeros(4),
+            "packed_advantages": torch.tensor([1.0, -1.0, 1.0, -1.0]),
+            "packed_seq_ids": torch.tensor([0, 0, 1, 1]),
+            "packed_num_sequences": 2,
+        }
+        current = torch.tensor(
+            [math.log(1.5), math.log(0.5), math.log(0.5), math.log(1.5)],
+            requires_grad=True,
+        )
+
+        loss, stats = dapo_loss_fn(data_pack, current, clip_eps_low=0.2, clip_eps_high=0.28)
+        loss.backward()
+
+        self.assertAlmostEqual(float(loss.detach()), 0.13, places=6)
+        self.assertTrue(torch.allclose(current.grad, torch.tensor([0.0, 0.0, -0.125, 0.375]), atol=1e-6))
+        self.assertAlmostEqual(float(stats["ratio_mean"]), 1.0, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac"]), 0.5, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac_lower"]), 0.25, places=6)
+        self.assertAlmostEqual(float(stats["pg_clipfrac_upper"]), 0.25, places=6)
+        self.assertAlmostEqual(float(stats["advantage_mean"]), 0.0, places=6)
+        self.assertAlmostEqual(float(stats["response_len"]), 2.0, places=6)
+
+    def test_packed_response_mask_excludes_inactive_tokens(self):
+        """Packed padding slots must not affect the DAPO objective or metrics."""
+        packed_pack = {
+            "packed_response_mask": torch.tensor([True, True, False, True]),
+            "packed_logprobs": torch.tensor([-0.2, -0.4, 9.0, -0.3]),
+            "packed_advantages": torch.tensor([1.0, 1.0, 9.0, -0.5]),
+            "packed_seq_ids": torch.tensor([0, 0, 0, 1]),
+            "packed_num_sequences": 2,
+        }
+        compact_pack = {
+            "packed_response_mask": torch.tensor([True, True, True]),
+            "packed_logprobs": torch.tensor([-0.2, -0.4, -0.3]),
+            "packed_advantages": torch.tensor([1.0, 1.0, -0.5]),
+            "packed_seq_ids": torch.tensor([0, 0, 1]),
+            "packed_num_sequences": 2,
+        }
+
+        masked_loss, masked_stats = dapo_loss_fn(packed_pack, torch.tensor([-0.1, -0.5, -9.0, -0.35]))
+        compact_loss, compact_stats = dapo_loss_fn(compact_pack, torch.tensor([-0.1, -0.5, -0.35]))
+
+        self.assertAlmostEqual(float(masked_loss), float(compact_loss), places=6)
+        for name in ("ratio_mean", "pg_clipfrac", "advantage_mean", "response_len"):
+            self.assertAlmostEqual(float(masked_stats[name]), float(compact_stats[name]), places=6)
+
+    def test_annotated_microbatches_use_global_response_token_mean(self):
+        """Unequal microbatches should contribute one global token-mean gradient."""
+        short_logprobs = torch.tensor([0.0], requires_grad=True)
+        long_logprobs = torch.tensor([0.0, 0.0, 0.0], requires_grad=True)
+        short_pack = {
+            "packed_response_mask": torch.tensor([True]),
+            "packed_logprobs": torch.tensor([0.0]),
+            "packed_advantages": torch.tensor([1.0]),
+            "packed_seq_ids": torch.tensor([0]),
+            "packed_num_sequences": 1,
+            "_response_token_total": 4,
+            "_response_token_grad_scale": 2,
+        }
+        long_pack = {
+            "packed_response_mask": torch.tensor([True, True, True]),
+            "packed_logprobs": torch.tensor([0.0, 0.0, 0.0]),
+            "packed_advantages": torch.tensor([3.0, 3.0, 3.0]),
+            "packed_seq_ids": torch.tensor([0, 0, 0]),
+            "packed_num_sequences": 1,
+            "_response_token_total": 4,
+            "_response_token_grad_scale": 2,
+        }
+
+        short_loss, _ = dapo_loss_fn(short_pack, short_logprobs)
+        long_loss, _ = dapo_loss_fn(long_pack, long_logprobs)
+        accumulated_loss = (short_loss + long_loss) / 2
+        accumulated_loss.backward()
+
+        self.assertAlmostEqual(float(accumulated_loss.detach()), -2.5, places=6)
+        self.assertAlmostEqual(float(short_logprobs.grad.item()), -0.25, places=6)
+        self.assertTrue(torch.allclose(long_logprobs.grad, torch.full((3,), -0.75)))
+
+
+class DAPOBackendNormalizationTest(unittest.TestCase):
+    """Backend metadata compensates for accumulation and DP gradient averaging."""
+
+    def test_annotations_cover_sharded_and_replicated_microbatches(self):
+        from areno.api.backend.cuda.training import annotate_response_token_mean_packs
+
+        packs = [
+            {"input_ids": torch.zeros((1, 2), dtype=torch.long)},
+            {"input_ids": torch.zeros((2, 3), dtype=torch.long)},
+        ]
+
+        annotate_response_token_mean_packs(
+            packs,
+            [1, 3],
+            gradient_accumulation_steps=None,
+            data_parallel_size=2,
+        )
+
+        self.assertEqual(packs[0]["_response_token_total"], 4)
+        self.assertEqual(packs[1]["_response_token_total"], 4)
+        self.assertEqual(packs[0]["_response_token_grad_scale"], 2)
+        self.assertEqual(packs[1]["_response_token_grad_scale"], 4)
+
+    def test_annotations_restart_at_optimizer_step_boundaries(self):
+        from areno.api.backend.cuda.training import annotate_response_token_mean_packs
+
+        packs = [{"input_ids": torch.zeros((2, 2), dtype=torch.long)} for _ in range(3)]
+
+        annotate_response_token_mean_packs(
+            packs,
+            [1, 3, 5],
+            gradient_accumulation_steps=2,
+            data_parallel_size=1,
+        )
+
+        self.assertEqual([pack["_response_token_total"] for pack in packs], [4, 4, 5])
+        self.assertEqual([pack["_response_token_grad_scale"] for pack in packs], [2, 2, 1])
+
+    def test_dp_averaging_reconstructs_global_response_token_gradient(self):
+        """DP rank averaging should equal one global token-mean objective."""
+        theta = torch.tensor(0.0, requires_grad=True)
+        rank_zero_pack = {
+            "packed_response_mask": torch.tensor([True, True]),
+            "packed_logprobs": torch.tensor([0.0, 0.0]),
+            "packed_advantages": torch.tensor([1.0, 1.0]),
+            "packed_seq_ids": torch.tensor([0, 0]),
+            "packed_num_sequences": 1,
+            "_response_token_total": 3,
+            "_response_token_grad_scale": 2,
+        }
+        rank_one_pack = {
+            "packed_response_mask": torch.tensor([True]),
+            "packed_logprobs": torch.tensor([0.0]),
+            "packed_advantages": torch.tensor([3.0]),
+            "packed_seq_ids": torch.tensor([0]),
+            "packed_num_sequences": 1,
+            "_response_token_total": 3,
+            "_response_token_grad_scale": 2,
+        }
+
+        rank_zero_loss, _ = dapo_loss_fn(rank_zero_pack, theta.expand(2))
+        rank_one_loss, _ = dapo_loss_fn(rank_one_pack, theta.expand(1))
+        dp_averaged_loss = (rank_zero_loss + rank_one_loss) / 2
+        dp_averaged_loss.backward()
+
+        self.assertAlmostEqual(float(dp_averaged_loss.detach()), -5.0 / 3.0, places=6)
+        self.assertAlmostEqual(float(theta.grad), -5.0 / 3.0, places=6)
+
+
+class DAPORegistrationTest(unittest.TestCase):
+    """DAPO is discoverable through the opt-in experimental registry path."""
+
+    def test_dapo_is_experimental_and_hidden_from_builtin_listing(self):
+        self.assertNotIn("dapo", list_algorithms(include_experimental=False))
+
+        spec = get_algorithm("dapo")
+
+        self.assertTrue(spec.experimental)
+        self.assertTrue(spec.requires_rollout)
+        self.assertIn("dapo", list_algorithms(include_experimental=True))
+
+    def test_dapo_loss_binds_asymmetric_clip_parameters(self):
+        config = DAPOTrainerConfig(
+            algo="dapo",
+            ckpt="unused",
+            dataset_path="unused",
+            dapo_clip_eps_low=0.11,
+            dapo_clip_eps_high=0.37,
+        )
+
+        loss_fn = get_algorithm("dapo").make_loss_fn(config)
+
+        self.assertIsInstance(loss_fn, partial)
+        self.assertIs(loss_fn.func, dapo_loss_fn)
+        self.assertEqual(loss_fn.keywords, {"clip_eps_low": 0.11, "clip_eps_high": 0.37})
+        self.assertEqual(getattr(loss_fn, "_areno_loss_reduction"), "response_token_mean")
+
+    def test_dapo_config_uses_generation_batch_for_default_concurrency(self):
+        config = DAPOTrainerConfig(
+            algo="dapo",
+            ckpt="unused",
+            dataset_path="unused",
+            batch_size=4,
+            n_samples=8,
+            dapo_gen_batch_size=12,
+        )
+
+        self.assertEqual(config.resolved_gen_batch_size(), 12)
+        self.assertEqual(config.resolved_max_running_prompts(), 96)
+
+
+class _TokenIdTokenizer:
+    eos_token_id = 99
+
+    def decode(self, tokens):
+        return str(tokens[0]) if tokens else ""
+
+
+def _prompt_batch(index: int) -> PromptBatch:
+    return PromptBatch(
+        items=[
+            PromptItem(
+                prompt=f"prompt-{index}",
+                solutions=None,
+                input_tokens=[index + 1],
+                record={},
+            )
+        ],
+        scanned=1,
+        skipped_long=0,
+        total_skipped_long=0,
+    )
+
+
+def _group(index: int, rewards: list[float]) -> _DAPOPromptGroup:
+    result = RolloutResult(
+        sequences=[
+            RolloutSequence(resp_tokens=[index * 10 + sample + 1], resp_logprobs=[-0.1])
+            for sample in range(len(rewards))
+        ]
+    )
+    return _DAPOPromptGroup(
+        item=_prompt_batch(index).items[0],
+        rollout_result=result,
+        raw_rewards=rewards,
+        shaped_rewards=list(rewards),
+    )
+
+
+class _DAPOFakeAreno:
+    def __init__(self, candidate_count: int):
+        self.candidate_count = candidate_count
+        self.train_calls = []
+        self.train_result = {}
+        self.finish_calls = 0
+
+    def get_tokenizer(self):
+        return _TokenIdTokenizer()
+
+    def get_processor(self):
+        return None
+
+    def load_prompt_batches(self, _dataset, *, batch_size, max_prompt_tokens):
+        del max_prompt_tokens
+        assert batch_size == 1
+        for index in range(self.candidate_count):
+            yield _prompt_batch(index)
+
+    def train(self, batch, loss_fn, *, mini_bs, gradient_accumulation_steps):
+        self.train_calls.append((batch, loss_fn, mini_bs, gradient_accumulation_steps))
+        return self.train_result
+
+    def finish_step(self):
+        self.finish_calls += 1
+
+
+class _ScriptedDAPOTrainer(DAPOTrainer):
+    def __init__(self, *args, groups, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.groups = groups
+        self.generation_calls = 0
+
+    def _generate_candidate_groups(self, tokenizer, sampling_params, prompt_batch, *, epoch, step):
+        del tokenizer, sampling_params, epoch, step
+        index = int(prompt_batch.items[0].prompt.rsplit("-", 1)[1])
+        self.generation_calls += 1
+        groups = self.groups[index]
+        return groups if isinstance(groups, list) else [groups]
+
+
+def _dapo_config(**overrides) -> DAPOTrainerConfig:
+    values = dict(
+        algo="dapo",
+        ckpt="unused",
+        dataset_path="unused",
+        epochs=1,
+        max_steps=1,
+        batch_size=2,
+        mini_bs=2,
+        n_samples=2,
+        dapo_gen_batch_size=1,
+        dapo_max_num_gen_batches=3,
+        save_path=None,
+    )
+    values.update(overrides)
+    return DAPOTrainerConfig(**values)
+
+
+class DAPODynamicSamplingTest(unittest.TestCase):
+    """Dynamic sampling fills complete informative batches before training."""
+
+    def test_trainer_requires_callable_reward_function(self):
+        trainer = DAPOTrainer(
+            _dapo_config(),
+            instance=SimpleNamespace(),
+            dataset=[],
+            reward_fn=None,
+            loss_fn=dapo_loss_fn,
+        )
+
+        with self.assertRaisesRegex(ValueError, "callable reward_fn"):
+            trainer._fit_initialized()
+
+    def test_reward_variance_uses_raw_rewards_before_overlong_shaping(self):
+        config = _dapo_config(max_new_tokens=4, dapo_overlong_buffer_len=2)
+        trainer = DAPOTrainer(
+            config,
+            instance=SimpleNamespace(),
+            dataset=[],
+            reward_fn=lambda _record: 1.0,
+            loss_fn=dapo_loss_fn,
+        )
+        item = _prompt_batch(0).items[0]
+        result = RolloutResult(
+            sequences=[
+                RolloutSequence(resp_tokens=[1], resp_logprobs=[-0.1]),
+                RolloutSequence(resp_tokens=[2, 3, 4, 5], resp_logprobs=[-0.1] * 4),
+            ]
+        )
+
+        group = trainer._score_prompt_group(_TokenIdTokenizer(), item, result, prompt_index=0)
+
+        self.assertFalse(group.informative)
+        self.assertEqual(group.raw_rewards, [1.0, 1.0])
+        self.assertEqual(group.shaped_rewards, [1.0, 0.0])
+
+    def test_scoring_rejects_non_finite_rollout_logprobs(self):
+        trainer = DAPOTrainer(
+            _dapo_config(),
+            instance=SimpleNamespace(),
+            dataset=[],
+            reward_fn=lambda record: float(record.metadata["sample_index"]),
+            loss_fn=dapo_loss_fn,
+        )
+        result = RolloutResult(
+            sequences=[
+                RolloutSequence(resp_tokens=[1], resp_logprobs=[float("nan")]),
+                RolloutSequence(resp_tokens=[2], resp_logprobs=[-0.1]),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "finite rollout logprobs"):
+            trainer._score_prompt_group(
+                _TokenIdTokenizer(),
+                _prompt_batch(0).items[0],
+                result,
+                prompt_index=0,
+            )
+
+    def test_materialization_rejects_misaligned_raw_reward_count(self):
+        trainer = DAPOTrainer(
+            _dapo_config(),
+            instance=SimpleNamespace(),
+            dataset=[],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=dapo_loss_fn,
+        )
+        group = _group(0, [0.0, 1.0])
+        group.raw_rewards = [0.0]
+
+        with self.assertRaisesRegex(ValueError, "sequence and raw reward counts"):
+            trainer._materialize_scored_groups(_TokenIdTokenizer(), [group])
+
+    def test_dynamic_sampling_retries_until_training_batch_is_full(self):
+        areno = _DAPOFakeAreno(candidate_count=3)
+        trainer = _ScriptedDAPOTrainer(
+            _dapo_config(),
+            instance=areno,
+            dataset=[{}, {}, {}],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=dapo_loss_fn,
+            groups=[_group(0, [1.0, 1.0]), _group(1, [0.0, 1.0]), _group(2, [1.0, 2.0])],
+        )
+
+        trainer._fit_initialized()
+
+        self.assertEqual(trainer.generation_calls, 3)
+        self.assertEqual(len(areno.train_calls), 1)
+        batch, _, mini_bs, gradient_accumulation_steps = areno.train_calls[0]
+        self.assertEqual(len(batch), 4)
+        self.assertEqual([sequence.reward for sequence in batch], [0.0, 1.0, 1.0, 2.0])
+        self.assertEqual([sequence.tokens for sequence in batch], [[2, 11], [2, 12], [3, 21], [3, 22]])
+        self.assertEqual([sequence.logprobs for sequence in batch], [[0.0, -0.1]] * 4)
+        self.assertEqual(mini_bs, 2)
+        self.assertEqual(gradient_accumulation_steps, 1)
+        self.assertEqual(areno.train_result["dapo_gen_batches"], 3.0)
+        self.assertEqual(areno.train_result["dapo_filtered_groups"], 1.0)
+        self.assertEqual(areno.train_result["dapo_qualified_groups"], 2.0)
+
+    def test_dynamic_sampling_cap_fails_without_training_partial_batch(self):
+        areno = _DAPOFakeAreno(candidate_count=2)
+        trainer = _ScriptedDAPOTrainer(
+            _dapo_config(batch_size=1, dapo_max_num_gen_batches=2),
+            instance=areno,
+            dataset=[{}, {}],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=dapo_loss_fn,
+            groups=[_group(0, [1.0, 1.0]), _group(1, [2.0, 2.0])],
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "generated_groups=2 qualified_groups=0 filtered_groups=2"):
+            trainer._fit_initialized()
+
+        self.assertEqual(areno.train_calls, [])
+
+    def test_qualified_buffer_truncates_only_at_group_boundaries(self):
+        areno = _DAPOFakeAreno(candidate_count=1)
+        trainer = _ScriptedDAPOTrainer(
+            _dapo_config(batch_size=2, dapo_max_num_gen_batches=1),
+            instance=areno,
+            dataset=[{}],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=dapo_loss_fn,
+            groups=[
+                [
+                    _group(0, [0.0, 1.0]),
+                    _group(1, [1.0, 2.0]),
+                    _group(2, [2.0, 3.0]),
+                ]
+            ],
+        )
+
+        trainer._fit_initialized()
+
+        batch = areno.train_calls[0][0]
+        self.assertEqual([sequence.reward for sequence in batch], [0.0, 1.0, 1.0, 2.0])
+        self.assertEqual(areno.train_result["dapo_discarded_qualified_groups"], 1.0)
+
+    def test_dataset_exhaustion_drops_incomplete_batch(self):
+        areno = _DAPOFakeAreno(candidate_count=1)
+        trainer = _ScriptedDAPOTrainer(
+            _dapo_config(batch_size=2, dapo_max_num_gen_batches=3),
+            instance=areno,
+            dataset=[{}],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=dapo_loss_fn,
+            groups=[_group(0, [0.0, 1.0])],
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "no complete training batch"):
+            trainer._fit_initialized()
+
+        self.assertEqual(areno.train_calls, [])
+        self.assertEqual(areno.finish_calls, 1)
+
+    def test_overlong_penalty_is_linear_and_bounded(self):
+        self.assertEqual(_overlong_penalty(5, max_response_length=10, buffer_length=4, factor=1.0), 0.0)
+        self.assertAlmostEqual(_overlong_penalty(7, max_response_length=10, buffer_length=4, factor=1.0), -0.25)
+        self.assertEqual(_overlong_penalty(10, max_response_length=10, buffer_length=4, factor=1.0), -1.0)
+        self.assertEqual(_overlong_penalty(20, max_response_length=10, buffer_length=4, factor=1.0), -1.0)
+        self.assertTrue(_has_reward_variance([0.0, 1.0]))
+        self.assertFalse(_has_reward_variance([1.0, 1.0]))
+        self.assertFalse(_has_reward_variance([1.0, 1.0 + 1.0e-9]))
+
+
+class DAPODataPipelineAccuracyTest(unittest.TestCase):
+    """Hand-derived fixtures verify each field from rollout through packed loss."""
+
+    def test_rollout_reward_advantage_and_packed_actions_remain_aligned(self):
+        from areno.api.backend.cuda.training import make_train_pack
+        from areno.engine.runtime.train_step import _pack_train_data
+
+        reward_records = []
+
+        def reward_fn(record):
+            reward_records.append(record)
+            return [2.0, 4.0][record.metadata["sample_index"]]
+
+        trainer = DAPOTrainer(
+            _dapo_config(
+                max_new_tokens=3,
+                dapo_overlong_buffer_len=2,
+                dapo_overlong_penalty_factor=0.5,
+            ),
+            instance=SimpleNamespace(),
+            dataset=[],
+            reward_fn=reward_fn,
+            loss_fn=dapo_loss_fn,
+        )
+        item = PromptItem(
+            prompt="check alignment",
+            solutions="expected answer",
+            input_tokens=[7, 8],
+            record={"features": {"source": 3}, "row_id": "row-7"},
+        )
+        rollout = RolloutResult(
+            sequences=[
+                RolloutSequence(resp_tokens=[21, 22], resp_logprobs=[-0.2, -0.4]),
+                RolloutSequence(resp_tokens=[31], resp_logprobs=[-0.6]),
+            ]
+        )
+
+        group = trainer._score_prompt_group(_TokenIdTokenizer(), item, rollout, prompt_index=5)
+        train_batch, raw_rewards, shaped_rewards, rollout_logprobs = trainer._materialize_scored_groups(
+            _TokenIdTokenizer(), [group]
+        )
+        packed = _pack_train_data(make_train_pack(train_batch))
+
+        self.assertEqual([record.tokens for record in reward_records], [[7, 8, 21, 22], [7, 8, 31]])
+        self.assertEqual(
+            [record.logprobs for record in reward_records],
+            [[0.0, 0.0, -0.2, -0.4], [0.0, 0.0, -0.6]],
+        )
+        self.assertEqual(
+            [record.loss_mask for record in reward_records],
+            [[False, False, True, True], [False, False, True]],
+        )
+        self.assertEqual(
+            [record.metadata for record in reward_records],
+            [{"prompt_index": 5, "sample_index": 0}, {"prompt_index": 5, "sample_index": 1}],
+        )
+        self.assertEqual([record.prompt for record in reward_records], ["check alignment", "check alignment"])
+        self.assertEqual([record.completion for record in reward_records], ["21", "31"])
+        self.assertEqual([record.answer for record in reward_records], ["expected answer", "expected answer"])
+        self.assertEqual([record.source_record for record in reward_records], [item.record, item.record])
+        self.assertEqual(raw_rewards, [2.0, 4.0])
+        self.assertEqual(shaped_rewards, [1.75, 4.0])
+        self.assertEqual(rollout_logprobs, [-0.2, -0.4, -0.6])
+        self.assertEqual([sequence.tokens for sequence in train_batch], [[7, 8, 21, 22], [7, 8, 31]])
+        self.assertEqual(
+            [sequence.prompt_mask for sequence in train_batch],
+            [[True, True, False, False], [True, True, False]],
+        )
+        self.assertEqual([sequence.reward for sequence in train_batch], [1.75, 4.0])
+        self.assertEqual([sequence.features for sequence in train_batch], [{"source": 3}, {"source": 3}])
+        for actual, expected in zip(
+            [sequence.advantages for sequence in train_batch],
+            [[0.0, 0.0, -1.0, -1.0], [0.0, 0.0, 1.0]],
+            strict=True,
+        ):
+            self.assertTrue(torch.allclose(torch.tensor(actual), torch.tensor(expected), atol=1e-6))
+        self.assertEqual(packed["packed_response_mask"].tolist(), [False, True, True, False, True])
+        self.assertTrue(
+            torch.allclose(
+                packed["packed_logprobs"],
+                torch.tensor([0.0, -0.2, -0.4, 0.0, -0.6]),
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                packed["packed_advantages"],
+                torch.tensor([0.0, -1.0, -1.0, 0.0, 1.0]),
+                atol=1e-6,
+            )
+        )
+        self.assertEqual(packed["packed_seq_ids"].tolist(), [0, 0, 0, 1, 1])
+
+        current_logprobs = packed["packed_logprobs"].clone()
+        current_logprobs += torch.tensor([9.0, math.log(0.5), math.log(1.5), -9.0, math.log(1.5)])
+        current_logprobs.requires_grad_()
+        loss, stats = dapo_loss_fn(packed, current_logprobs, clip_eps_low=0.2, clip_eps_high=0.28)
+        loss.backward()
+
+        self.assertAlmostEqual(float(loss.detach()), 0.34, places=6)
+        self.assertTrue(
+            torch.allclose(
+                current_logprobs.grad,
+                torch.tensor([0.0, 0.0, 0.5, 0.0, 0.0]),
+                atol=1e-6,
+            )
+        )
+        self.assertAlmostEqual(float(stats["ratio_mean"]), (0.5 + 1.5 + 1.5) / 3.0, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dapo_cpu.py
+++ b/tests/test_dapo_cpu.py
@@ -182,6 +182,18 @@ class DAPOLossTest(unittest.TestCase):
 class DAPOBackendNormalizationTest(unittest.TestCase):
     """Backend metadata compensates for accumulation and DP gradient averaging."""
 
+    @staticmethod
+    def _train_sequence(advantage: float, *, response_tokens: int = 1):
+        from areno.api.models import TrainSequence
+
+        return TrainSequence(
+            prompt_mask=[True] + [False] * response_tokens,
+            tokens=[1] + list(range(2, response_tokens + 2)),
+            logprobs=[0.0] * (response_tokens + 1),
+            advantages=[0.0] + [advantage] * response_tokens,
+            eos_token_id=99,
+        )
+
     def test_annotations_cover_sharded_and_replicated_microbatches(self):
         from areno.api.backend.cuda.training import annotate_response_token_mean_packs
 
@@ -246,6 +258,89 @@ class DAPOBackendNormalizationTest(unittest.TestCase):
 
         self.assertAlmostEqual(float(dp_averaged_loss.detach()), -5.0 / 3.0, places=6)
         self.assertAlmostEqual(float(theta.grad), -5.0 / 3.0, places=6)
+
+    def test_real_uneven_dp_split_matches_unsplit_response_token_gradient(self):
+        """A real 3-to-2 DP split must preserve the global token mean."""
+        from areno.api.backend.cuda.training import annotate_response_token_mean_packs, make_train_pack
+        from areno.engine.runtime.common import split_data_pack_by_dp
+        from areno.engine.runtime.train_step import _pack_train_data
+
+        sequences = [self._train_sequence(value) for value in (1.0, 2.0, 3.0)]
+        pack = make_train_pack(sequences)
+        annotate_response_token_mean_packs(
+            [pack],
+            [3],
+            gradient_accumulation_steps=1,
+            data_parallel_size=2,
+        )
+        shards = split_data_pack_by_dp(pack, 2)
+        theta = torch.tensor(0.0, requires_grad=True)
+        shard_losses = []
+        for shard in shards:
+            packed = _pack_train_data(shard)
+            loss, _ = dapo_loss_fn(
+                packed,
+                theta.expand(int(packed["packed_response_mask"].numel())),
+            )
+            shard_losses.append(loss)
+        dp_averaged_loss = sum(shard_losses) / 2
+        dp_averaged_loss.backward()
+
+        self.assertEqual([int(shard["input_ids"].shape[0]) for shard in shards], [2, 1])
+        self.assertAlmostEqual(float(dp_averaged_loss.detach()), -2.0, places=6)
+        self.assertAlmostEqual(float(theta.grad), -2.0, places=6)
+
+    def test_real_dp_split_and_accumulation_match_unsplit_response_token_gradient(self):
+        """Sharded and replicated packs in one accumulation group must normalize together."""
+        from areno.api.backend.cuda.training import annotate_response_token_mean_packs, make_train_pack
+        from areno.engine.runtime.common import split_data_pack_by_dp
+        from areno.engine.runtime.train_step import _pack_train_data
+
+        sequences = [
+            self._train_sequence(1.0),
+            self._train_sequence(3.0),
+            self._train_sequence(5.0, response_tokens=2),
+        ]
+        packs = [make_train_pack(sequences[:2]), make_train_pack(sequences[2:])]
+        annotate_response_token_mean_packs(
+            packs,
+            [2, 2],
+            gradient_accumulation_steps=2,
+            data_parallel_size=2,
+        )
+        shards_by_pack = [split_data_pack_by_dp(pack, 2) for pack in packs]
+
+        theta = torch.tensor(0.0, requires_grad=True)
+        rank_losses = []
+        for rank in range(2):
+            accumulated_loss = torch.zeros(())
+            for shards in shards_by_pack:
+                packed = _pack_train_data(shards[rank])
+                loss, _ = dapo_loss_fn(
+                    packed,
+                    theta.expand(int(packed["packed_response_mask"].numel())),
+                )
+                accumulated_loss = accumulated_loss + loss / 2
+            rank_losses.append(accumulated_loss)
+        dp_averaged_loss = sum(rank_losses) / 2
+        dp_averaged_loss.backward()
+
+        reference_theta = torch.tensor(0.0, requires_grad=True)
+        reference_pack = _pack_train_data(make_train_pack(sequences))
+        reference_loss, _ = dapo_loss_fn(
+            reference_pack,
+            reference_theta.expand(int(reference_pack["packed_response_mask"].numel())),
+        )
+        reference_loss.backward()
+
+        self.assertEqual(
+            [[int(shard["input_ids"].shape[0]) for shard in shards] for shards in shards_by_pack],
+            [[1, 1], [1, 1]],
+        )
+        self.assertAlmostEqual(float(dp_averaged_loss.detach()), -3.5, places=6)
+        self.assertAlmostEqual(float(theta.grad), -3.5, places=6)
+        self.assertAlmostEqual(float(dp_averaged_loss.detach()), float(reference_loss.detach()), places=6)
+        self.assertAlmostEqual(float(theta.grad), float(reference_theta.grad), places=6)
 
 
 class DAPORegistrationTest(unittest.TestCase):
@@ -369,6 +464,16 @@ class _ScriptedDAPOTrainer(DAPOTrainer):
         return groups if isinstance(groups, list) else [groups]
 
 
+class _ScriptedRolloutDAPOTrainer(DAPOTrainer):
+    def __init__(self, *args, rollout_results, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.rollout_results = rollout_results
+
+    async def _run_prompt_rollout(self, sampling_params, prompt_batch):
+        del sampling_params, prompt_batch
+        return self.rollout_results
+
+
 def _dapo_config(**overrides) -> DAPOTrainerConfig:
     values = dict(
         algo="dapo",
@@ -441,6 +546,25 @@ class DAPODynamicSamplingTest(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, "finite rollout logprobs"):
+            trainer._score_prompt_group(
+                _TokenIdTokenizer(),
+                _prompt_batch(0).items[0],
+                result,
+                prompt_index=0,
+            )
+
+    def test_scoring_rejects_incomplete_prompt_group(self):
+        """Dynamic sampling must never train a group smaller than n_samples."""
+        trainer = DAPOTrainer(
+            _dapo_config(n_samples=2),
+            instance=SimpleNamespace(),
+            dataset=[],
+            reward_fn=lambda _record: 0.0,
+            loss_fn=dapo_loss_fn,
+        )
+        result = RolloutResult(sequences=[RolloutSequence(resp_tokens=[1], resp_logprobs=[-0.1])])
+
+        with self.assertRaisesRegex(ValueError, "expected n_samples=2, got 1"):
             trainer._score_prompt_group(
                 _TokenIdTokenizer(),
                 _prompt_batch(0).items[0],
@@ -526,6 +650,57 @@ class DAPODynamicSamplingTest(unittest.TestCase):
         batch = areno.train_calls[0][0]
         self.assertEqual([sequence.reward for sequence in batch], [0.0, 1.0, 1.0, 2.0])
         self.assertEqual(areno.train_result["dapo_discarded_qualified_groups"], 1.0)
+
+    def test_real_multi_prompt_generation_filters_and_truncates_whole_groups(self):
+        """Real scoring preserves prompt order across filtering and overflow."""
+        prompt_batch = PromptBatch(
+            items=[_prompt_batch(index).items[0] for index in range(3)],
+            scanned=3,
+            skipped_long=0,
+            total_skipped_long=0,
+        )
+        rollout_results = [
+            RolloutResult(
+                sequences=[
+                    RolloutSequence(resp_tokens=[index * 10 + sample + 1], resp_logprobs=[-0.1]) for sample in range(2)
+                ]
+            )
+            for index in range(3)
+        ]
+
+        def reward_fn(record):
+            prompt_index = int(record.metadata["prompt_index"])
+            sample_index = int(record.metadata["sample_index"])
+            if prompt_index == 0:
+                return 1.0
+            return float(prompt_index + sample_index)
+
+        trainer = _ScriptedRolloutDAPOTrainer(
+            _dapo_config(batch_size=1, dapo_gen_batch_size=3, dapo_max_num_gen_batches=1),
+            instance=SimpleNamespace(record_rollout_sample=lambda _sample: None),
+            dataset=[],
+            reward_fn=reward_fn,
+            loss_fn=dapo_loss_fn,
+            rollout_results=rollout_results,
+        )
+
+        collection = trainer._collect_qualified_groups(
+            _TokenIdTokenizer(),
+            SimpleNamespace(),
+            iter([prompt_batch]),
+            epoch=0,
+            step=0,
+        )
+
+        self.assertEqual(collection.generated_groups, 3)
+        self.assertEqual(collection.filtered_groups, 1)
+        self.assertEqual(collection.discarded_qualified_groups, 1)
+        self.assertEqual([group.item.prompt for group in collection.groups], ["prompt-1"])
+        self.assertEqual(collection.groups[0].raw_rewards, [1.0, 2.0])
+        self.assertEqual(
+            [sequence.resp_tokens for sequence in collection.groups[0].rollout_result.sequences],
+            [[11], [12]],
+        )
 
     def test_dataset_exhaustion_drops_incomplete_batch(self):
         areno = _DAPOFakeAreno(candidate_count=1)

--- a/tests/test_train_cli_config_cpu.py
+++ b/tests/test_train_cli_config_cpu.py
@@ -18,6 +18,7 @@ from areno.cli.train import (
     _format_training_config_summary,
     _trainer_config_from_options,
 )
+from areno.experimental.dapo.config import DAPOTrainerConfig
 
 
 def test_train_config_requires_ckpt():
@@ -144,6 +145,78 @@ def test_train_config_does_not_validate_unused_rollout_clip_eps():
 
     assert isinstance(gspo, PolicyTrainerConfig)
     assert isinstance(ppo, PPOTrainerConfig)
+
+
+def test_train_config_builds_dapo_experimental_shape():
+    cfg = _trainer_config_from_options(
+        **_options(
+            algo="dapo",
+            dapo_gen_batch_size=6,
+            dapo_max_num_gen_batches=7,
+            dapo_clip_eps_low=0.1,
+            dapo_clip_eps_high=0.3,
+            dapo_overlong_buffer_len=4,
+            dapo_overlong_penalty_factor=0.5,
+        )
+    )
+
+    assert isinstance(cfg, DAPOTrainerConfig)
+    assert cfg.dapo_gen_batch_size == 6
+    assert cfg.dapo_max_num_gen_batches == 7
+    assert cfg.dapo_clip_eps_low == 0.1
+    assert cfg.dapo_clip_eps_high == 0.3
+    assert cfg.dapo_overlong_buffer_len == 4
+    assert cfg.dapo_overlong_penalty_factor == 0.5
+    assert cfg.gradient_accumulation_steps == 1
+    assert cfg.resolved_max_running_prompts() == 6 * cfg.n_samples
+
+
+def test_train_config_requires_reward_function_for_dapo():
+    with pytest.raises(UsageError, match="--reward-fn-path is required for DAPO"):
+        _trainer_config_from_options(**_options(algo="dapo", reward_fn_path=None, reward_ckpt="reward-model"))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("n_samples", 1, "--n-samples must be at least 2 for DAPO"),
+        ("dapo_gen_batch_size", 0, "--dapo-gen-batch-size must be positive"),
+        ("dapo_max_num_gen_batches", 0, "--dapo-max-num-gen-batches must be positive"),
+        ("dapo_clip_eps_low", 0.0, "--dapo-clip-eps-low must be positive"),
+        ("dapo_clip_eps_high", 0.0, "--dapo-clip-eps-high must be positive"),
+        ("dapo_overlong_buffer_len", -1, "--dapo-overlong-buffer-len must be non-negative"),
+        ("dapo_overlong_penalty_factor", -0.1, "--dapo-overlong-penalty-factor must be non-negative"),
+    ],
+)
+def test_train_config_validates_dapo_fields(field, value, message):
+    with pytest.raises(UsageError, match=message):
+        _trainer_config_from_options(**_options(algo="dapo", **{field: value}))
+
+
+def test_train_config_rejects_invalid_dapo_modes_and_bounds():
+    with pytest.raises(UsageError, match="DAPO currently supports only the CUDA backend"):
+        _trainer_config_from_options(**_options(algo="dapo", backend="mlx"))
+    with pytest.raises(UsageError, match="--greedy is not supported for DAPO"):
+        _trainer_config_from_options(**_options(algo="dapo", greedy=True))
+    with pytest.raises(UsageError, match="--agent-fn is not supported for DAPO"):
+        _trainer_config_from_options(**_options(algo="dapo", agent_fn="agent.py"))
+    with pytest.raises(UsageError, match="--dapo-clip-eps-high must be greater than or equal"):
+        _trainer_config_from_options(**_options(algo="dapo", dapo_clip_eps_low=0.3, dapo_clip_eps_high=0.2))
+    with pytest.raises(UsageError, match="must not exceed --max-new-tokens"):
+        _trainer_config_from_options(**_options(algo="dapo", max_new_tokens=8, dapo_overlong_buffer_len=9))
+
+
+def test_train_config_ignores_dapo_only_validation_for_other_algorithms():
+    cfg = _trainer_config_from_options(
+        **_options(
+            algo="gspo",
+            dapo_clip_eps_low=0.0,
+            dapo_clip_eps_high=0.0,
+            dapo_overlong_buffer_len=-1,
+        )
+    )
+
+    assert isinstance(cfg, PolicyTrainerConfig)
 
 
 @pytest.mark.parametrize(
@@ -1014,6 +1087,12 @@ def _options(**overrides):
         train_tool_results=False,
         gspo_clip_eps=3.0e-4,
         grpo_clip_eps=0.2,
+        dapo_gen_batch_size=None,
+        dapo_max_num_gen_batches=10,
+        dapo_clip_eps_low=0.2,
+        dapo_clip_eps_high=0.28,
+        dapo_overlong_buffer_len=0,
+        dapo_overlong_penalty_factor=1.0,
         ref_ckpt=None,
         dpo_beta=0.1,
         reward_ckpt="reward-model",
@@ -1033,4 +1112,6 @@ def _options(**overrides):
     defaults.update(overrides)
     if defaults["algo"] == "sft" and "dataset_loader_fn" not in overrides:
         defaults["dataset_loader_fn"] = "examples/sft/alpaca/dataset_loader.py"
+    if defaults["algo"] == "dapo" and "reward_fn_path" not in overrides:
+        defaults["reward_fn_path"] = "examples/math/math_verify_reward.py"
     return defaults


### PR DESCRIPTION
## What does this PR do?

Adds opt-in, experimental DAPO training support, following the [DAPO paper](https://arxiv.org/abs/2503.14476) and the maintained [verl DAPO recipe](https://github.com/verl-project/verl-recipe/blob/main/dapo/README.md).

The implementation includes:

- asymmetric Clip-Higher policy clipping
- dynamic sampling that collects complete informative prompt groups
- response-token-mean policy-gradient normalization across uneven microbatches, gradient accumulation, and data parallelism
- soft overlong reward shaping
- rollout-policy logprobs as the old-policy reference, so importance ratios can evolve across optimizer updates
- additive experimental registry, CLI, and documentation surfaces; existing stable algorithms remain unchanged
- data-integrity checks for rollout token/logprob alignment, finite old logprobs, exact `n_samples`, and reward/group cardinality

### Latest-main integration

The branch is rebased onto upstream `main` at `01b2321` and adapted to the new backend architecture introduced by #493:

- DAPO now consumes the canonical packed CUDA loss layout
- response-token normalization hooks live in `areno.api.backend.cuda.training`
- DAPO metrics use the shared backend metric-reduction contract
- all current common trainer options are propagated into `DAPOTrainerConfig`
- the CLI rejects DAPO with MLX before initialization because the experimental loss currently has a CUDA/Torch implementation only

## Related issue

Fixes #485

A follow-up numerical clarification is documented in [this issue comment](https://github.com/inclusionAI/AReno/issues/485#issuecomment-5300678712): AReno's current on-policy surrogate has forward value `exp(new - new.detach()) = 1`, which leaves Clip-Higher numerically inactive. This PR therefore keeps the real rollout-policy ratio scoped to experimental DAPO while leaving stable GRPO/GSPO behavior unchanged.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## How was it tested?

Fresh validation for rebased head `790995e`:

- `python -m pytest tests/test_dapo_cpu.py -q` — 27 passed
- `CUDA_VISIBLE_DEVICES= python -m pytest tests/test_train_cli_config_cpu.py -q -k dapo` — 11 passed, 99 deselected
- `ruff check areno/api/algorithms.py areno/api/backend/cuda/backend.py areno/api/backend/cuda/training.py areno/cli/train.py areno/experimental/dapo tests/test_dapo_cpu.py tests/test_train_cli_config_cpu.py` — passed
- `ruff format --check ...` on the same changed Python paths — passed
- `python -m compileall -q areno/experimental/dapo areno/api/backend/cuda areno/cli/train.py` — passed
- `python -m sphinx -W --keep-going -b html -D html_copy_source=0 docs <output>` — 46 documents built without warnings
- `TORCH_CUDA_ARCH_LIST=12.0 MAX_JOBS=2 python setup.py build_ext --inplace` — all 12 extension units compiled and linked for `sm_120`
- `git diff --check` — passed

Algorithm and data correctness coverage includes:

- hand-derived Clip-Higher loss, clip fractions, and analytical gradients across all clipped/unclipped sign branches
- central finite-difference gradient agreement
- exact rollout → reward record → overlong shaping → group advantage → `TrainSequence` → canonical packed action tensor field alignment
- inactive packed-token masking equivalence
- real `split_data_pack_by_dp` loss/gradient equivalence for an uneven 3-to-2 split
- combined gradient-accumulation and DP equivalence, including a microbatch smaller than the DP world that is replicated by the runtime
- real multi-prompt scoring order through filtering, accepted-group selection, and whole-group overflow truncation
- exact `n_samples` enforcement before prompt-group scoring
- mutation checks confirming the DP scale, prompt index, hand-derived Clip-Higher, and packed-data alignment tests fail when their respective production paths are intentionally corrupted

The full CPU suite is designed for the CPU-only GitHub matrix. In the available CUDA PyTorch environment, installing Triton makes three untouched upstream MoE CPU tests run instead of skip; they fail because their `SimpleNamespace` fixtures do not contain the newly required `routing_layer_slot`. With CUDA hidden, the run reached 586 passed and 8 skipped before those 3 unrelated failures, then was stopped at a blocked Hugging Face download. None of the reported failing files are changed by this PR.

### Real-model validation

Environment: Python 3.12.13, PyTorch 2.11.0+cu128, CUDA 12.8, one NVIDIA GeForce RTX 5090. Exact source archive SHA-256: `529f91bb4c6b5d7b3ee7e26ef45f2d4f2ca8fd27c7d97779cf2efc25529ff15e` (`790995e`).

The following bounded Qwen3-0.6B run deliberately makes the first prompt group uninformative and the second informative, so it exercises filter → retry → train rather than only a direct training smoke:

```jsonl
{"prompt":"Continue this short sequence: 1, 2,"}
{"prompt":"Name one primary color:"}
```

```python
def reward_fn(record):
    prompt = record.source_record.get("prompt", "")
    if prompt.startswith("Continue this short sequence"):
        return 1.0
    return float(record.metadata["sample_index"])
```

```bash
ARENO_LOG_COMPLETIONS=1 python -m areno.cli.main train \
  --algo dapo \
  --ckpt Qwen/Qwen3-0.6B \
  --model-hub modelscope \
  --dataset-path <validation.jsonl> \
  --reward-fn-path <reward.py> \
  --epochs 1 \
  --max-steps 1 \
  --world-size 1 \
  --tp-size 1 \
  --train-devices 0 \
  --batch-size 1 \
  --dapo-gen-batch-size 1 \
  --dapo-max-num-gen-batches 2 \
  --n-samples 2 \
  --mini-bs 1 \
  --gradient-accumulation-steps 1 \
  --max-prompt-tokens 64 \
  --max-new-tokens 4 \
  --temperature 1.0 \
  --attn-backend native \
  --eager-decode \
  --no-activation-checkpointing
```

Observed result (exit code 0):

- after candidate 1: `gen_batches=1 generated_groups=1 qualified_groups=0 filtered_groups=1`
- after candidate 2: `gen_batches=2 generated_groups=2 qualified_groups=1 filtered_groups=1`
- final sampling metrics: `dapo_sampling_efficiency=0.5`, `dapo_discarded_qualified_groups=0`
- finite training metrics: `loss=1.4305115e-06`, `grad_norm=0.6675834`
- real ratio metrics: `ratio_mean=1.0000181`, `ratio_std=2.9320003e-05`
- logged policy values: `rollout_logprobs_mean=-0.00108719`, `train_logprobs_mean=-0.00107050`

The real-model run is a bounded integration test, not a convergence or benchmark reproduction. I did not run a paper-scale AIME experiment or a multi-GPU end-to-end training job; distributed response-token normalization is covered by hand-derived CPU references and tests that invoke the runtime's real DP split function.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`); the clean CPU-only GitHub matrix is the authoritative full-suite run.
- [x] New behavior is covered by tests.
- [x] Described the test commands run and hardware scope.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
