### PR TITLE
fix(bailing): correct MLA tensor-parallel gradient reduction

### DIFF
--- a/areno/engine/layers/linear.py
+++ b/areno/engine/layers/linear.py
@@ -76,7 +76,15 @@ class ColumnParallelLinear(nn.Module):
     ``gather_output`` requests an all-gather to materialize the full output.
     """
 
-    def __init__(self, in_features: int, out_features: int, bias: bool = False, gather_output: bool = False):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        gather_output: bool = False,
+        *,
+        input_grad_allreduce: bool = True,
+    ):
         super().__init__()
         ctx = get_tp_context()
         start, end = _shard_range(out_features, ctx.rank, ctx.world_size)
@@ -84,6 +92,7 @@ class ColumnParallelLinear(nn.Module):
         self.out_features = out_features
         self.local_out_features = end - start
         self.gather_output = gather_output
+        self.input_grad_allreduce = input_grad_allreduce
         self.weight = nn.Parameter(torch.empty(self.local_out_features, in_features))
         self.bias = nn.Parameter(torch.empty(self.local_out_features)) if bias else None
         mark_tensor_parallel_parameter(self.weight, True, sequence_parallel=True)
@@ -100,12 +109,12 @@ class ColumnParallelLinear(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # In sequence-parallel mode the activation is sharded along the
         # sequence dim, so we all-gather it back to the full sequence before
-        # the matmul; otherwise we just copy through the TP region.
-        x = (
-            gather_from_sequence_parallel_region(x)
-            if is_sequence_parallel_active()
-            else copy_to_tensor_parallel_region(x)
-        )
+        # the matmul. A replicated-to-column chain can move the non-SP input
+        # gradient all-reduce before its replicated projection.
+        if is_sequence_parallel_active():
+            x = gather_from_sequence_parallel_region(x)
+        elif self.input_grad_allreduce:
+            x = copy_to_tensor_parallel_region(x)
         out = _areno_linear_forward(x, self.weight, self.bias)
         if self.gather_output:
             # Concatenate column-shards along the last dim to recover the

--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -81,6 +81,7 @@ from areno.engine.layers.rotary import PartialRotaryEmbedding
 from areno.engine.layers.vocab import VocabParallelEmbedding, VocabParallelLMHead
 from areno.engine.parallel.collectives import (
     all_reduce,
+    copy_to_tensor_parallel_region,
     gather_from_sequence_parallel_region,
     is_sequence_parallel_active,
     reduce_scatter_to_sequence_parallel_region,
@@ -684,7 +685,12 @@ class BailingSoftmaxAttention(nn.Module):
             # low-rank bottleneck (``kv_a_proj_with_mqa``) plus a per-head
             # decompression (``kv_b_proj``). The ``kv_a`` output also carries
             # the rope channels in its tail (``qk_rope_head_dim`` cols).
-            self.q_proj = ColumnParallelLinear(config.hidden_size, self.num_heads * self.head_dim, bias=False)
+            self.q_proj = ColumnParallelLinear(
+                config.hidden_size,
+                self.num_heads * self.head_dim,
+                bias=False,
+                input_grad_allreduce=False,
+            )
             self.kv_a_proj_with_mqa = nn.Linear(
                 config.hidden_size, self.kv_lora_rank + self.qk_rope_head_dim, bias=False
             )
@@ -693,7 +699,10 @@ class BailingSoftmaxAttention(nn.Module):
             )
             self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, config.rms_norm_eps)
             self.kv_b_proj = ColumnParallelLinear(
-                config.kv_lora_rank, self.num_heads * (self.qk_nope_head_dim + self.v_head_dim), bias=False
+                config.kv_lora_rank,
+                self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+                bias=False,
+                input_grad_allreduce=False,
             )
             self.query_layernorm = None
             self.key_layernorm = None
@@ -762,9 +771,10 @@ class BailingSoftmaxAttention(nn.Module):
             and self.kv_a_layernorm is not None
             and self.kv_b_proj is not None
         )
-        q = self.q_proj(hidden_states).view(bsz, seqlen, self.local_heads, self.head_dim)
+        mla_input = hidden_states if is_sequence_parallel_active() else copy_to_tensor_parallel_region(hidden_states)
+        q = self.q_proj(mla_input).view(bsz, seqlen, self.local_heads, self.head_dim)
         q_nope, q_rope = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        kv_a = self.kv_a_proj_with_mqa(hidden_states)
+        kv_a = self.kv_a_proj_with_mqa(mla_input)
         compressed_kv, k_rope = kv_a.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
         kv = self.kv_b_proj(self.kv_a_layernorm(compressed_kv)).view(
             bsz, seqlen, self.local_heads, self.qk_nope_head_dim + self.v_head_dim

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -82,6 +82,7 @@ from areno.engine.layers.rotary import PartialRotaryEmbedding
 from areno.engine.layers.vocab import VocabParallelEmbedding, VocabParallelLMHead
 from areno.engine.parallel.collectives import (
     all_reduce,
+    copy_to_tensor_parallel_region,
     gather_from_sequence_parallel_region,
     is_sequence_parallel_active,
     reduce_scatter_to_sequence_parallel_region,
@@ -703,7 +704,12 @@ class BailingSoftmaxAttention(nn.Module):
             # decompression (``kv_b_proj``). The ``kv_a`` output also carries
             # the rope channels in its tail (``qk_rope_head_dim`` cols).
             if self.q_lora_rank is None:
-                self.q_proj = ColumnParallelLinear(config.hidden_size, self.num_heads * self.head_dim, bias=False)
+                self.q_proj = ColumnParallelLinear(
+                    config.hidden_size,
+                    self.num_heads * self.head_dim,
+                    bias=False,
+                    input_grad_allreduce=False,
+                )
                 _cast_linear_weights(self.q_proj, config.dtype)
             else:
                 self.q_a_proj = nn.Linear(config.hidden_size, self.q_lora_rank, bias=False)
@@ -712,7 +718,12 @@ class BailingSoftmaxAttention(nn.Module):
                     self.q_a_proj.weight, False, sequence_parallel=True, tp_grad_allreduce=True
                 )
                 self.q_a_layernorm = RMSNorm(self.q_lora_rank, config.rms_norm_eps)
-                self.q_b_proj = ColumnParallelLinear(self.q_lora_rank, self.num_heads * self.head_dim, bias=False)
+                self.q_b_proj = ColumnParallelLinear(
+                    self.q_lora_rank,
+                    self.num_heads * self.head_dim,
+                    bias=False,
+                    input_grad_allreduce=False,
+                )
                 _cast_linear_weights(self.q_b_proj, config.dtype)
             self.kv_a_proj_with_mqa = nn.Linear(
                 config.hidden_size, self.kv_lora_rank + self.qk_rope_head_dim, bias=False
@@ -723,7 +734,10 @@ class BailingSoftmaxAttention(nn.Module):
             )
             self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, config.rms_norm_eps)
             self.kv_b_proj = ColumnParallelLinear(
-                config.kv_lora_rank, self.num_heads * (self.qk_nope_head_dim + self.v_head_dim), bias=False
+                config.kv_lora_rank,
+                self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+                bias=False,
+                input_grad_allreduce=False,
             )
             _cast_linear_weights(self.kv_b_proj, config.dtype)
             self.query_layernorm = None
@@ -798,16 +812,17 @@ class BailingSoftmaxAttention(nn.Module):
         # MLA path: split Q into nope/rope chunks, decompress KV from the
         # shared low-rank rep, then re-attach a broadcast rope channel.
         assert self.kv_a_proj_with_mqa is not None and self.kv_a_layernorm is not None and self.kv_b_proj is not None
+        mla_input = hidden_states if is_sequence_parallel_active() else copy_to_tensor_parallel_region(hidden_states)
         if self.q_lora_rank is None:
             assert self.q_proj is not None
-            q = self.q_proj(hidden_states).view(bsz, seqlen, self.local_heads, self.head_dim)
+            q = self.q_proj(mla_input).view(bsz, seqlen, self.local_heads, self.head_dim)
         else:
             assert self.q_a_proj is not None and self.q_a_layernorm is not None and self.q_b_proj is not None
-            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states))).view(
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(mla_input))).view(
                 bsz, seqlen, self.local_heads, self.head_dim
             )
         q_nope, q_rope = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        kv_a = self.kv_a_proj_with_mqa(hidden_states)
+        kv_a = self.kv_a_proj_with_mqa(mla_input)
         compressed_kv, k_rope = kv_a.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
         kv = self.kv_b_proj(self.kv_a_layernorm(compressed_kv)).view(
             bsz, seqlen, self.local_heads, self.qk_nope_head_dim + self.v_head_dim


### PR DESCRIPTION
## Summary

Fix incorrect tensor-parallel gradient reduction in the Bailing V2 and Bailing V3 MLA projection paths when `TP > 1` and sequence parallelism is disabled.

## Root Cause

The MLA projection contains replicated A projections followed by column-parallel B projections:

`hidden → replicated q_a/kv_a → RMSNorm → column-parallel q_b/kv_b`

Without sequence parallelism, `ColumnParallelLinear` places a TP copy boundary at its input. During backward, this boundary already all-reduces the input gradient across TP ranks.

The replicated A parameters are then all-reduced again by `TrainingManager`, causing a second reduction.

For the Q path:

- `q_b` backward already gives every rank the complete `q_a` output gradient.
- The subsequent parameter all-reduce multiplies the `q_a` and RMSNorm gradients by the TP size.

For the KV path:

- The compressed rows pass through `kv_b` and are reduced before reaching `kv_a`.
- The RoPE rows bypass `kv_b` and remain rank-local.
- The subsequent whole-parameter all-reduce therefore reduces the two parts differently.

For TP=2, the incorrect KV gradient is:

`[2 × (c0 + c1), r0 + r1]`

The expected gradient is:

`[c0 + c1, r0 + r1]`

This is not only a uniform gradient-scaling issue: it also changes the KV gradient direction.

## Fix

Move the non-SP TP input-gradient boundary before the replicated MLA projections:

`hidden → shared TP copy boundary → replicated q_a/kv_a → RMSNorm → q_b/kv_b`

`ColumnParallelLinear` now has an `input_grad_allreduce` constructor option:

- It defaults to `True`, preserving existing behavior.
- It only controls the non-SP input-gradient all-reduce.
- Sequence-parallel inputs are still always gathered.
- MLA column projections set it to `False` because their TP boundary is established before the replicated A projection.

After the change:

- Each replicated A projection receives only its rank-local head contribution.
- Existing parameter synchronization performs exactly one TP reduction.
- The shared pre-A boundary performs exactly one reduction for the upstream hidden-state gradient.

## Scope

Updated:

- Bailing V2 MLA Q/KV projections
- Bailing V3 MLA Q/KV projections
- Move ownership of the non-SP input-gradient TP reduction from the MLA B projections to the shared input before the replicated A projections.


## Validation

- Passed Ruff checks.
- Passed Python compilation checks.
- Compared Bailing V2 and V3 MLA projection gradients with a dense reference during development.
- Verified replicated A/norm gradients, column-sharded B gradients, and hidden-state gradients.