### PR TITLE
fix(cuda): respect rollout slots in Bailing caches

### DIFF
--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -1133,17 +1133,16 @@ class BailingMoeLinearV2ForCausalLM(nn.Module):
         ``kv_caches`` lists KV pairs *only* for softmax layers (in order of
         appearance); linear layers get a fresh zero state of shape
         ``[num_slots, heads, head_dim, head_dim]`` sized from the first KV
-        cache.
+        cache when ``num_slots`` is not provided explicitly.
         """
-        del num_slots
+        device = kv_caches[0][0].device if kv_caches else next(self.parameters()).device
+        num_slots = int(num_slots) if num_slots is not None else (int(kv_caches[0][0].shape[0]) if kv_caches else 1)
         softmax_idx = 0
         for layer in self.layers:
             if isinstance(layer.attention, BailingSoftmaxAttention):
                 layer.attention.set_kv_cache(*kv_caches[softmax_idx])
                 softmax_idx += 1
             elif isinstance(layer.attention, BailingLinearAttention):
-                num_slots = kv_caches[0][0].shape[0] if kv_caches else 1
-                device = kv_caches[0][0].device if kv_caches else next(self.parameters()).device
                 state = torch.zeros(
                     num_slots,
                     layer.attention.local_heads,

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -1446,23 +1446,25 @@ class BailingMoeV3ForCausalLM(nn.Module):
                 logits_input = hidden_states.float()
             return CausalLMOutput(logits_shard=self.lm_head(logits_input), hidden_states=hidden_states)
 
-    def set_kv_caches(self, kv_caches: list[tuple[torch.Tensor, torch.Tensor]]) -> None:
+    def set_kv_caches(
+        self, kv_caches: list[tuple[torch.Tensor, torch.Tensor]], *, num_slots: int | None = None
+    ) -> None:
         """Bind per-softmax-layer KV caches and pre-allocate per-linear-layer
         recurrent state cache.
 
         ``kv_caches`` lists KV pairs *only* for softmax layers (in order of
         appearance); linear layers get a fresh zero state of shape
         ``[num_slots, heads, head_dim, head_dim]`` sized from the first KV
-        cache.
+        cache when ``num_slots`` is not provided explicitly.
         """
+        device = kv_caches[0][0].device if kv_caches else next(self.parameters()).device
+        num_slots = int(num_slots) if num_slots is not None else (int(kv_caches[0][0].shape[0]) if kv_caches else 1)
         softmax_idx = 0
         for layer in self.layers:
             if isinstance(layer.attention, BailingSoftmaxAttention):
                 layer.attention.set_kv_cache(*kv_caches[softmax_idx])
                 softmax_idx += 1
             elif isinstance(layer.attention, BailingKDAAttention):
-                num_slots = kv_caches[0][0].shape[0] if kv_caches else 1
-                device = kv_caches[0][0].device if kv_caches else next(self.parameters()).device
                 state = torch.zeros(
                     num_slots,
                     layer.attention.local_heads,

--- a/tests/test_bailing_kv_cache_cpu.py
+++ b/tests/test_bailing_kv_cache_cpu.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+class _Attention:
+    pass
+
+
+class _SoftmaxAttention(_Attention):
+    pass
+
+
+class _LinearAttention(_Attention):
+    local_heads = 2
+    head_dim = 4
+
+    def set_state_cache(self, state: torch.Tensor) -> None:
+        self.state_cache = state
+
+
+class _KDAAttention(_Attention):
+    local_heads = 2
+    head_dim = 4
+    v_head_dim = 6
+    local_proj_dim = 8
+    conv_kernel_size = 3
+
+    def set_state_cache(self, state: torch.Tensor, conv_state: torch.Tensor) -> None:
+        self.state_cache = state
+        self.conv_state = conv_state
+
+
+def _model_with(attention: _Attention) -> SimpleNamespace:
+    parameter = torch.nn.Parameter(torch.zeros(1))
+    return SimpleNamespace(
+        layers=[SimpleNamespace(attention=attention)],
+        parameters=lambda: iter((parameter,)),
+    )
+
+
+def test_bailing_linear_attention_respects_explicit_num_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("triton")
+    from areno.models.bailing import model as bailing
+
+    attention = _LinearAttention()
+    model = _model_with(attention)
+    monkeypatch.setattr(bailing, "BailingSoftmaxAttention", _SoftmaxAttention)
+    monkeypatch.setattr(bailing, "BailingLinearAttention", _LinearAttention)
+
+    bailing.BailingMoeLinearV2ForCausalLM.set_kv_caches(model, [], num_slots=5)
+
+    assert tuple(attention.state_cache.shape) == (5, 2, 4, 4)
+
+
+def test_bailing_v3_kda_attention_respects_explicit_num_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("triton")
+    from areno.models.bailing_v3 import model as bailing_v3
+
+    attention = _KDAAttention()
+    model = _model_with(attention)
+    monkeypatch.setattr(bailing_v3, "BailingSoftmaxAttention", _SoftmaxAttention)
+    monkeypatch.setattr(bailing_v3, "BailingKDAAttention", _KDAAttention)
+
+    bailing_v3.BailingMoeV3ForCausalLM.set_kv_caches(model, [], num_slots=7)
+
+    assert tuple(attention.state_cache.shape) == (7, 2, 4, 6)
+    assert tuple(attention.conv_state.shape) == (7, 3, 8, 2)


### PR DESCRIPTION
## What does this PR do?

Fixes Bailing rollout cache initialization so it follows the inference engine's `set_kv_caches(..., num_slots=...)` contract.

- Accepts `num_slots` in `BailingMoeV3ForCausalLM`, preventing rollout startup from failing with an unexpected keyword argument.
- Makes Bailing V2 and V3 recurrent state caches honor the explicit rollout slot count even when the model has no softmax-attention KV cache to infer it from.
- Adds focused CPU tests for all-linear Bailing V2 and KDA Bailing V3 cache allocation.

## Related issue

No related issue.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

- `pre-commit run --files areno/models/bailing/model.py areno/models/bailing_v3/model.py tests/test_bailing_kv_cache_cpu.py`
- Local pytest was unavailable because the local Python environment does not contain PyTorch; the added CPU tests will run in CI.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
