### PR TITLE
fix(cuda): index Bailing recurrent caches by slots

### DIFF
--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -94,6 +94,14 @@ from areno.models.bailing.checkpoint import CHECKPOINT_SPEC
 from areno.models.base import CausalLMOutput, ModelAdapter
 
 
+def _recurrent_cache_slots(infer_meta: InferMeta) -> torch.Tensor:
+    if infer_meta.recurrent_slots is not None:
+        return infer_meta.recurrent_slots.long()
+    if infer_meta.block_table is None:
+        raise RuntimeError("Bailing linear attention inference requires recurrent_slots or block_table")
+    return infer_meta.block_table[:, 0].long()
+
+
 class BailingDenseMLP(nn.Module):
     """Plain SwiGLU MLP used for shared experts and for the first
     ``first_k_dense_replace`` decoder layers (before MoE kicks in)."""
@@ -952,8 +960,7 @@ class BailingLinearAttention(nn.Module):
             raise RuntimeError("linear attention inference requires block_table")
         if self.state_cache.numel() == 0:
             raise RuntimeError("linear attention inference requires recurrent state cache")
-        # Each request maps to one state-cache slot (first column of its block table).
-        slots = infer_meta.block_table[:, 0].long()
+        slots = _recurrent_cache_slots(infer_meta)
         if infer_meta.mode == "decode":
             return self._forward_decode(q, k, v, slots)
         if infer_meta.mode == "prefill":

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -102,6 +102,14 @@ from areno.models.bailing_v3.checkpoint import CHECKPOINT_SPEC
 from areno.models.base import CausalLMOutput, ModelAdapter
 
 
+def _recurrent_cache_slots(infer_meta: InferMeta) -> torch.Tensor:
+    if infer_meta.recurrent_slots is not None:
+        return infer_meta.recurrent_slots.long()
+    if infer_meta.block_table is None:
+        raise RuntimeError("Bailing V3 recurrent attention inference requires recurrent_slots or block_table")
+    return infer_meta.block_table[:, 0].long()
+
+
 class BailingDenseMLP(nn.Module):
     """Plain SwiGLU MLP used for shared experts and for the first
     ``first_k_dense_replace`` decoder layers (before MoE kicks in)."""
@@ -1000,8 +1008,7 @@ class BailingLinearAttention(nn.Module):
             raise RuntimeError("linear attention inference requires block_table")
         if self.state_cache.numel() == 0:
             raise RuntimeError("linear attention inference requires recurrent state cache")
-        # Each request maps to one state-cache slot (first column of its block table).
-        slots = infer_meta.block_table[:, 0].long()
+        slots = _recurrent_cache_slots(infer_meta)
         if infer_meta.mode == "decode":
             return self._forward_decode(q, k, v, slots)
         if infer_meta.mode == "prefill":
@@ -1199,7 +1206,7 @@ class BailingKDAAttention(nn.Module):
             raise RuntimeError("Bailing V3 KDA inference requires block_table")
         if self.conv_cache.numel() == 0:
             raise RuntimeError("Bailing V3 KDA inference requires conv state cache")
-        slots = infer_meta.block_table[:, 0].long()
+        slots = _recurrent_cache_slots(infer_meta)
         if infer_meta.mode == "decode":
             current = x.reshape(-1, x.shape[-1])
             history = self.conv_cache.index_select(0, slots)[:, cache_idx].to(dtype=current.dtype)
@@ -1295,7 +1302,7 @@ class BailingKDAAttention(nn.Module):
             raise RuntimeError("Bailing V3 KDA inference requires block_table")
         if self.state_cache.numel() == 0:
             raise RuntimeError("Bailing V3 KDA inference requires recurrent state cache")
-        slots = infer_meta.block_table[:, 0].long()
+        slots = _recurrent_cache_slots(infer_meta)
         initial_state = self.state_cache.index_select(0, slots).to(device=q.device)
         cu = (
             torch.arange(slots.numel() + 1, device=q.device, dtype=torch.long)

--- a/tests/test_bailing_kv_cache_cpu.py
+++ b/tests/test_bailing_kv_cache_cpu.py
@@ -69,3 +69,31 @@ def test_bailing_v3_kda_attention_respects_explicit_num_slots(monkeypatch: pytes
 
     assert tuple(attention.state_cache.shape) == (7, 2, 4, 6)
     assert tuple(attention.conv_state.shape) == (7, 3, 8, 2)
+
+
+def test_bailing_linear_attention_uses_recurrent_slots_instead_of_kv_blocks() -> None:
+    pytest.importorskip("triton")
+    from areno.engine.runtime.metadata import InferMeta
+    from areno.models.bailing.model import _recurrent_cache_slots
+
+    meta = InferMeta(
+        mode="decode",
+        block_table=torch.tensor([[23], [17]]),
+        recurrent_slots=torch.tensor([1, 0]),
+    )
+
+    assert _recurrent_cache_slots(meta).tolist() == [1, 0]
+
+
+def test_bailing_v3_recurrent_attention_uses_recurrent_slots_instead_of_kv_blocks() -> None:
+    pytest.importorskip("triton")
+    from areno.engine.runtime.metadata import InferMeta
+    from areno.models.bailing_v3.model import _recurrent_cache_slots
+
+    meta = InferMeta(
+        mode="decode",
+        block_table=torch.tensor([[95], [38]]),
+        recurrent_slots=torch.tensor([0, 1]),
+    )
+
+    assert _recurrent_cache_slots(meta).tolist() == [0, 1]


### PR DESCRIPTION
## What does this PR do?

Fixes Bailing recurrent-cache indexing during continuous rollout.

The rollout scheduler tracks paged KV-cache blocks and recurrent-state slots independently. Bailing V2 linear attention and Bailing V3 linear/KDA attention incorrectly used the first paged KV block ID to index recurrent state and convolution caches. Once a block ID exceeded the recurrent cache's slot count, CUDA failed with `indexSelectSmallIndex: srcIndex < srcSelectDimSize`.

This change makes all Bailing recurrent attention paths prefer `InferMeta.recurrent_slots`, while retaining the previous block-table fallback for backward compatibility with older direct callers.

## Related issue

No related issue.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

- `pre-commit run --files areno/models/bailing/model.py areno/models/bailing_v3/model.py tests/test_bailing_kv_cache_cpu.py`
- Added CPU regressions where paged block IDs are intentionally outside the recurrent cache range and recurrent slots remain valid.
- Local pytest was unavailable because the local Python environment does not contain PyTorch; the added CPU tests will run in CI.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
