### PR TITLE
fix(cuda): allow structured special tokens during rollout

### DIFF
--- a/areno/api/backend/cuda/generation.py
+++ b/areno/api/backend/cuda/generation.py
@@ -12,9 +12,13 @@ def rollout_options(ctx: Context, sampling_params: SamplingParams):
 
     eos_token_ids = () if sampling_params.ignore_eos else ctx.eos_token_ids
     stop_token_ids = tuple(sampling_params.stop_token_ids or ())
+    # Protocol markers are often registered as special tokens.  Gemma 4 uses
+    # <|tool_call> / <tool_call|> and Qwen-family templates may likewise rely
+    # on special tokens in generated structured output, so suppressing every
+    # tokenizer special id makes valid tool calls impossible.  EOS is handled
+    # separately by the inference manager; only tokens that are never valid
+    # generated content belong in this explicit mask.
     suppress_candidates = set(explicit_suppress_token_ids(ctx.tokenizer))
-    if not sampling_params.ignore_eos:
-        suppress_candidates.update(int(token_id) for token_id in getattr(ctx.tokenizer, "all_special_ids", ()) or ())
     suppress_token_ids = tuple(
         sorted(token_id for token_id in suppress_candidates if token_id not in {*eos_token_ids, *stop_token_ids})
     )
@@ -37,7 +41,7 @@ def rollout_options(ctx: Context, sampling_params: SamplingParams):
             top_k=max(0, sampling_params.top_k),
             stop_token_ids=stop_token_ids,
             suppress_token_ids=suppress_token_ids,
-            suppress_special_tokens=not sampling_params.ignore_eos,
+            suppress_special_tokens=False,
         ),
     }
 

--- a/tests/test_cuda_generation_cpu.py
+++ b/tests/test_cuda_generation_cpu.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from areno.api.backend.cuda.generation import explicit_suppress_token_ids, rollout_options
+from areno.api.config import CudaConfig
+from areno.api.models import SamplingParams
+
+
+class _StructuredOutputTokenizer:
+    pad_token_id = 0
+    bos_token_id = 1
+    unk_token_id = 2
+    eos_token_id = 106
+    # Gemma 4 tool-call delimiters and turn markers are special tokens. Qwen
+    # multimodal tokenizers can also register generated protocol markers here.
+    all_special_ids = [0, 1, 2, 48, 49, 105, 106]
+
+
+def test_explicit_suppression_only_contains_never_generated_tokens():
+    assert explicit_suppress_token_ids(_StructuredOutputTokenizer()) == (0, 1, 2)
+
+
+def test_cuda_rollout_does_not_suppress_structured_output_special_tokens():
+    ctx = SimpleNamespace(
+        tokenizer=_StructuredOutputTokenizer(),
+        eos_token_ids=(106,),
+        custom_config=CudaConfig(),
+    )
+
+    options = rollout_options(ctx, SamplingParams())
+    native = options["sampling_params"]
+
+    assert native.suppress_token_ids == (0, 1, 2)
+    assert native.suppress_special_tokens is False
+    assert 48 not in native.suppress_token_ids
+    assert 49 not in native.suppress_token_ids
+    assert options["eos_token_id"] == (106,)
+
+
+def test_cuda_rollout_keeps_stop_tokens_sampleable_until_stop_detection():
+    ctx = SimpleNamespace(
+        tokenizer=_StructuredOutputTokenizer(),
+        eos_token_ids=(106,),
+        custom_config=CudaConfig(),
+    )
+
+    options = rollout_options(ctx, SamplingParams(stop_token_ids=[49]))
+    native = options["sampling_params"]
+
+    assert native.stop_token_ids == (49,)
+    assert 49 not in native.suppress_token_ids


### PR DESCRIPTION
## What does this PR do?

Fixes CUDA rollout suppressing every tokenizer `all_special_ids` entry after the backend refactor in #493.

Structured-output protocols may intentionally generate special tokens. In particular, Gemma 4 uses `<|tool_call>` and `<tool_call|>` as special-token delimiters, so the blanket mask made native tool calls impossible and caused agentic AVE rollouts to return plain `None` responses.

This restores the pre-refactor behavior:

- suppress only pad, BOS, and UNK during generation;
- keep EOS handling in the inference manager;
- keep explicit stop tokens sampleable so stop detection can observe them;
- disable the blanket `suppress_special_tokens` flag in CUDA-native sampling params.

Qwen3.5 was checked as well. Its `<tool_call>` / `</tool_call>` tokens are not classified as tokenizer special tokens, while `<|im_end|>` is EOS and remains managed by the dedicated EOS path. The fix therefore preserves Qwen image/tool-call behavior and removes the unsafe generic suppression rule.

## Related issue

N/A.

## Type of change

- [x] 🐛 Bug fix

## How was it tested?

Remote Linux environment, with CUDA hidden for the CPU suite:

```bash
CUDA_VISIBLE_DEVICES=-1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q \
  tests/test_cuda_generation_cpu.py tests/test_agentic_cpu.py
```

Result: `60 passed, 1 warning in 2.87s`.

Additional tokenizer inspection:

- Gemma 4 tool-call delimiters are special tokens and were previously masked.
- Qwen3.5 `<tool_call>` / `</tool_call>` are not in `all_special_tokens`.
- Qwen3.5 `<|im_end|>` is EOS and remains handled independently.

Local static checks:

```bash
python -m compileall -q areno/api/backend/cuda/generation.py tests/test_cuda_generation_cpu.py
ruff check areno/api/backend/cuda/generation.py tests/test_cuda_generation_cpu.py
ruff format --check areno/api/backend/cuda/generation.py tests/test_cuda_generation_cpu.py
git diff --check
```

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (N/A; no separate issue).
- [x] Existing targeted CPU tests pass.
- [x] New behavior is covered by tests.
- [x] Described the test commands run and hardware limitations.
- [x] Public API / CLI behavior is unchanged.
