### PR TITLE
feat(minicpmv46): complete multimodal RL and resume support

### DIFF
--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -230,10 +230,6 @@ class CudaBackend(Backend):
             dp_size=len(rollout_devices) // rollout_tp_size,
             devices=rollout_devices,
             dummy_load=cfg.dummy_load,
-            # Rollout has no optimizer, but it must build the same media
-            # policy-sync layout as the train engine for updated tower/projector
-            # weights to cross the role boundary.
-            optimizer_config=OptimizerConfig(**cfg.optimizer),
             runtime_config=rollout_runtime,
             loss_fn=None,
             role="rollout",

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -139,7 +139,6 @@ class CudaBackend(Backend):
             cfg = CudaConfig()
         if not isinstance(cfg, CudaConfig):
             raise TypeError(f"CudaBackend requires CudaConfig, got {type(cfg)!r}")
-
         # Derive the DP/TP layout: world = dp * tp must hold exactly. When the
         # caller omits `dp_size` we infer it from `world_size / tp_size`.
         world_size = int(ctx.world_size)
@@ -231,6 +230,10 @@ class CudaBackend(Backend):
             dp_size=len(rollout_devices) // rollout_tp_size,
             devices=rollout_devices,
             dummy_load=cfg.dummy_load,
+            # Rollout has no optimizer, but it must build the same media
+            # policy-sync layout as the train engine for updated tower/projector
+            # weights to cross the role boundary.
+            optimizer_config=OptimizerConfig(**cfg.optimizer),
             runtime_config=rollout_runtime,
             loss_fn=None,
             role="rollout",

--- a/areno/models/minicpmv46/checkpoint.py
+++ b/areno/models/minicpmv46/checkpoint.py
@@ -129,7 +129,7 @@ def build_minicpmv46_policy_plan(model: MiniCPMV46ForCausalLM) -> PolicyTensorSt
     tensors = PolicyTensorStore()
     with policy_plan_scope():
         _save_embedding_norm_head(tensors, model)
-        _save_vision_weights(tensors, model)
+        _save_vision_weights(tensors, model, trainable_only=True)
         prefix = model.config.checkpoint_prefix
         for layer_idx, layer in enumerate(model.layers):
             _save_layer(tensors, layer, f"{prefix}.layers.{layer_idx}")
@@ -164,13 +164,20 @@ def _load_vision_weights(model: MiniCPMV46ForCausalLM, index: SafetensorsIndex) 
             parameter.copy_(index.get_tensor(key).to(device=parameter.device, dtype=parameter.dtype))
 
 
-def _save_vision_weights(tensors: dict[str, torch.Tensor | None], model: MiniCPMV46ForCausalLM) -> None:
+def _save_vision_weights(
+    tensors: dict[str, torch.Tensor | None],
+    model: MiniCPMV46ForCausalLM,
+    *,
+    trainable_only: bool = False,
+) -> None:
     """Save replicated vision/projector parameters under the HF prefixes."""
 
     for module_name, module in (("vision_tower", model.vision_tower), ("merger", model.merger)):
         if module is None:
             continue
         for name, parameter in module.named_parameters():
+            if trainable_only and not getattr(parameter, "_areno_policy_sync", False):
+                continue
             tensors[f"model.{module_name}.{name}"] = rank0_tensor(parameter)
 
 

--- a/areno/models/minicpmv46/checkpoint.py
+++ b/areno/models/minicpmv46/checkpoint.py
@@ -129,7 +129,7 @@ def build_minicpmv46_policy_plan(model: MiniCPMV46ForCausalLM) -> PolicyTensorSt
     tensors = PolicyTensorStore()
     with policy_plan_scope():
         _save_embedding_norm_head(tensors, model)
-        _save_vision_weights(tensors, model, trainable_only=True)
+        _save_vision_weights(tensors, model)
         prefix = model.config.checkpoint_prefix
         for layer_idx, layer in enumerate(model.layers):
             _save_layer(tensors, layer, f"{prefix}.layers.{layer_idx}")
@@ -164,19 +164,15 @@ def _load_vision_weights(model: MiniCPMV46ForCausalLM, index: SafetensorsIndex) 
             parameter.copy_(index.get_tensor(key).to(device=parameter.device, dtype=parameter.dtype))
 
 
-def _save_vision_weights(
-    tensors: dict[str, torch.Tensor | None],
-    model: MiniCPMV46ForCausalLM,
-    *,
-    trainable_only: bool = False,
-) -> None:
+def _save_vision_weights(tensors: dict[str, torch.Tensor | None], model: MiniCPMV46ForCausalLM) -> None:
     """Save replicated vision/projector parameters under the HF prefixes."""
 
+    policy = isinstance(tensors, PolicyTensorStore)
     for module_name, module in (("vision_tower", model.vision_tower), ("merger", model.merger)):
         if module is None:
             continue
         for name, parameter in module.named_parameters():
-            if trainable_only and not getattr(parameter, "_areno_policy_sync", False):
+            if policy and not getattr(parameter, "_areno_policy_sync", False):
                 continue
             tensors[f"model.{module_name}.{name}"] = rank0_tensor(parameter)
 

--- a/areno/models/minicpmv46/model.py
+++ b/areno/models/minicpmv46/model.py
@@ -819,11 +819,87 @@ class MiniCPMV46ForCausalLM(nn.Module):
         else:
             self.vision_tower = None
             self.merger = None
+        self._train_multimodal_tower = False
+        self._train_multimodal_projector = False
+        for module in (self.vision_tower, self.merger):
+            if module is not None:
+                module.requires_grad_(False)
+        self._apply_multimodal_module_modes()
 
     @property
     def language_model(self) -> MiniCPMV46ForCausalLM:
         """Expose the direct AReno text trunk under the HF-compatible name."""
 
+        return self
+
+    def configure_multimodal_training(
+        self,
+        *,
+        unfreeze_tower: bool,
+        unfreeze_projector: bool,
+        tower_lr: float | None,
+        projector_lr: float | None,
+        base_lr: float,
+        trainable: bool = True,
+    ) -> None:
+        """Configure vision tower and merger trainability and LR groups."""
+
+        if unfreeze_tower and self.vision_tower is None:
+            raise ValueError("MiniCPM-V checkpoint has no vision tower parameters to unfreeze")
+        if unfreeze_projector and self.merger is None:
+            raise ValueError("MiniCPM-V checkpoint has no merger parameters to unfreeze")
+        self._configure_multimodal_parameters(
+            list(self.vision_tower.parameters()) if self.vision_tower is not None else [],
+            "tower",
+            unfreeze_tower,
+            tower_lr,
+            base_lr,
+            trainable=trainable,
+        )
+        self._configure_multimodal_parameters(
+            list(self.merger.parameters()) if self.merger is not None else [],
+            "projector",
+            unfreeze_projector,
+            projector_lr,
+            base_lr,
+            trainable=trainable,
+        )
+        self._train_multimodal_tower = unfreeze_tower and trainable
+        self._train_multimodal_projector = unfreeze_projector and trainable
+        self.train(self.training)
+
+    @staticmethod
+    def _configure_multimodal_parameters(
+        params: list[nn.Parameter],
+        group: str,
+        unfreeze: bool,
+        configured_lr: float | None,
+        base_lr: float,
+        *,
+        trainable: bool,
+    ) -> None:
+        for parameter in params:
+            parameter.requires_grad_(unfreeze and trainable)
+            parameter._areno_policy_sync = unfreeze
+            if unfreeze and trainable:
+                parameter._areno_lr_group = group
+                parameter._areno_lr = base_lr if configured_lr is None else configured_lr
+            else:
+                for attribute in ("_areno_lr_group", "_areno_lr"):
+                    if hasattr(parameter, attribute):
+                        delattr(parameter, attribute)
+
+    def _apply_multimodal_module_modes(self) -> None:
+        if self.vision_tower is not None:
+            self.vision_tower.train(self.training and self._train_multimodal_tower)
+        if self.merger is not None:
+            self.merger.train(self.training and self._train_multimodal_projector)
+
+    def train(self, mode: bool = True):
+        """Keep frozen visual modules in evaluation mode."""
+
+        super().train(mode)
+        self._apply_multimodal_module_modes()
         return self
 
     def forward(

--- a/tests/test_minicpmv46_multimodal_cpu.py
+++ b/tests/test_minicpmv46_multimodal_cpu.py
@@ -88,6 +88,102 @@ def test_minicpmv46_projects_target_sizes_to_visual_embeddings():
     assert projected["image_embeds"].shape == (4, 32)
 
 
+def test_minicpmv46_multimodal_modules_are_frozen_by_default():
+    pytest.importorskip("triton")
+    from areno.models.minicpmv46.model import MiniCPMV46Adapter
+
+    adapter = MiniCPMV46Adapter()
+    model = adapter.build(adapter.config_from_hf(_config()))
+    model.train()
+
+    assert not any(parameter.requires_grad for parameter in model.vision_tower.parameters())
+    assert not any(parameter.requires_grad for parameter in model.merger.parameters())
+    assert not model.vision_tower.training
+    assert not model.merger.training
+
+
+def test_minicpmv46_configures_independent_multimodal_groups():
+    pytest.importorskip("triton")
+    from areno.models.minicpmv46.model import MiniCPMV46Adapter
+
+    adapter = MiniCPMV46Adapter()
+    model = adapter.build(adapter.config_from_hf(_config()))
+    model.configure_multimodal_training(
+        unfreeze_tower=True,
+        unfreeze_projector=False,
+        tower_lr=2e-5,
+        projector_lr=None,
+        base_lr=1e-6,
+    )
+
+    assert all(parameter.requires_grad for parameter in model.vision_tower.parameters())
+    assert all(parameter._areno_lr_group == "tower" for parameter in model.vision_tower.parameters())
+    assert all(parameter._areno_lr == 2e-5 for parameter in model.vision_tower.parameters())
+    assert not any(parameter.requires_grad for parameter in model.merger.parameters())
+    assert model.vision_tower.training
+    assert not model.merger.training
+
+
+def test_minicpmv46_rollout_marks_unfrozen_media_for_policy_sync():
+    pytest.importorskip("triton")
+    from areno.models.minicpmv46.checkpoint import build_minicpmv46_policy_plan
+    from areno.models.minicpmv46.model import MiniCPMV46Adapter
+
+    adapter = MiniCPMV46Adapter()
+    model = adapter.build(adapter.config_from_hf(_config()))
+    model.configure_multimodal_training(
+        unfreeze_tower=False,
+        unfreeze_projector=True,
+        tower_lr=None,
+        projector_lr=3e-5,
+        base_lr=1e-6,
+        trainable=False,
+    )
+    plan = build_minicpmv46_policy_plan(model)
+
+    assert not any(key.startswith("model.vision_tower.") for key in plan)
+    assert any(key.startswith("model.merger.") for key in plan)
+    assert not any(parameter.requires_grad for parameter in model.merger.parameters())
+
+
+@pytest.mark.parametrize(
+    "unfreeze_tower,unfreeze_projector,expected_group",
+    [(True, False, "tower"), (False, True, "projector")],
+)
+def test_minicpmv46_backward_updates_only_requested_media_group(
+    unfreeze_tower: bool,
+    unfreeze_projector: bool,
+    expected_group: str,
+):
+    pytest.importorskip("triton")
+    from areno.models.minicpmv46.model import MiniCPMV46Adapter
+
+    adapter = MiniCPMV46Adapter()
+    model = adapter.build(adapter.config_from_hf(_config())).float()
+    model.configure_multimodal_training(
+        unfreeze_tower=unfreeze_tower,
+        unfreeze_projector=unfreeze_projector,
+        tower_lr=2e-5,
+        projector_lr=3e-5,
+        base_lr=1e-6,
+    )
+    features = {
+        "pixel_values": torch.randn(1, 3, 2, 32),
+        "target_sizes": torch.tensor([[4, 4]], dtype=torch.int32),
+        "image_token_id": 99,
+    }
+
+    image_embeds = model._project_pixel_feature(features, torch.device("cpu"))
+    image_embeds.square().mean().backward()
+
+    tower_grads = [parameter.grad for parameter in model.vision_tower.parameters()]
+    projector_grads = [parameter.grad for parameter in model.merger.parameters()]
+    expected_grads = tower_grads if expected_group == "tower" else projector_grads
+    frozen_grads = projector_grads if expected_group == "tower" else tower_grads
+    assert any(gradient is not None and torch.count_nonzero(gradient) for gradient in expected_grads)
+    assert all(gradient is None for gradient in frozen_grads)
+
+
 def test_minicpmv46_decode_skips_multimodal_helpers_without_features(monkeypatch):
     pytest.importorskip("triton")
     from areno.models.minicpmv46.model import MiniCPMV46ForCausalLM
@@ -136,6 +232,21 @@ def test_minicpmv46_vision_checkpoint_keys_cover_tower_and_merger():
         torch.equal(parameter, torch.full_like(parameter, 0.25)) for parameter in model.vision_tower.parameters()
     )
     assert all(torch.equal(parameter, torch.full_like(parameter, 0.25)) for parameter in model.merger.parameters())
+
+
+def test_minicpmv46_full_checkpoint_keeps_frozen_media_weights():
+    pytest.importorskip("triton")
+    from areno.models.minicpmv46.checkpoint import _save_vision_weights
+    from areno.models.minicpmv46.model import MiniCPMV46Adapter
+
+    adapter = MiniCPMV46Adapter()
+    model = adapter.build(adapter.config_from_hf(_config())).float()
+    tensors = {}
+
+    _save_vision_weights(tensors, model)
+
+    assert any(key.startswith("model.vision_tower.") for key in tensors)
+    assert any(key.startswith("model.merger.") for key in tensors)
 
 
 def test_minicpmv46_gdn_uses_configured_key_and_value_heads():


### PR DESCRIPTION
<!--
Thanks for contributing to AReno! Please read CONTRIBUTING.md first.
Keep the title descriptive; prefix with [WIP] or mark as a draft if work is in progress.
-->

## What does this PR do?

Adds MiniCPM-V 4.6 multimodal reinforcement-learning weight controls and checkpoint support. Vision tower and merger parameters are frozen by default, can be independently unfrozen, and can use independent learning-rate groups. The training path preserves autograd through the requested media modules, while frozen modules remain in evaluation mode.

The MiniCPM-V policy plan now synchronizes only explicitly enabled tower or merger parameters between independent training and rollout engines. The rollout engine receives the same multimodal optimizer configuration so both roles build matching synchronization layouts while rollout workers remain inference-only. Complete MiniCPM-V checkpoint saves continue to include the text trunk, vision tower, merger, tokenizer, processor, and required configuration files, including frozen media weights.

## Related issue

Fixes [#490](https://github.com/inclusionAI/AReno/issues/490)

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## How was it tested?

CPU validation:

```bash
pytest -q tests/test_minicpmv46_multimodal_cpu.py tests/test_dual_engine_backend_cpu.py
# 24 passed

python -m compileall -q areno
git diff --check
```

The MiniCPM-V CPU tests cover default freezing, independent tower/projector configuration, frozen-module evaluation mode, selective media gradients, policy-plan filtering, complete media checkpoint saving, and decode behavior without image features.

Real-model validation used an NVIDIA H200 environment with PyTorch 2.11.0+cu130 and the native attention backend:

- completed two projector-only multimodal SFT steps with finite loss and nonzero projector gradients;
- verified that tower weights remained unchanged while merger weights updated;
- completed two projector-only GSPO steps with multimodal rewards and a nonzero policy gradient;
- completed two-step independent train/rollout GSPO with GPU 4 as the training engine and GPU 3 as the rollout engine;
- verified policy synchronization of approximately 1.56 GB across 326 tensors; and
- saved and reloaded a complete MiniCPM-V checkpoint successfully, with processor and tokenizer assets preserved.

The CUDA extension was rebuilt for H200 with `TORCH_CUDA_ARCH_LIST=9.0`. The validation host had unrelated GPU workloads running, so experiments were restricted to available capacity and did not terminate unrelated processes.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).

## Breaking change details

None. The multimodal training controls and policy synchronization behavior are additive; existing MiniCPM-V model-only checkpoints remain compatible with inference and fresh training.