### PR TITLE
fix(cuda): reuse inference state across agentic turns

### DIFF
--- a/areno/api/backend/cuda/generation.py
+++ b/areno/api/backend/cuda/generation.py
@@ -30,8 +30,17 @@ def rollout_options(ctx: Context, sampling_params: SamplingParams):
 
     from areno import SamplingParams as CudaSamplingParams
 
+    max_prompt_len = sampling_params.max_prompt_len
+    if sampling_params.max_context_len is not None:
+        # Agentic turns repeatedly submit a growing transcript. Reserve the
+        # full configured context on the first turn so paged KV storage and
+        # CUDA graphs do not get rebuilt every time the transcript crosses a
+        # new block boundary.
+        context_prompt_capacity = max(int(sampling_params.max_context_len) - int(sampling_params.max_new_tokens), 1)
+        max_prompt_len = max(int(max_prompt_len or 0), context_prompt_capacity)
+
     return {
-        "max_prompt_len": sampling_params.max_prompt_len,
+        "max_prompt_len": max_prompt_len,
         "eos_token_id": eos_token_ids,
         "max_running_prompts": cfg.max_running_prompts,
         "decode_progress_interval_s": cfg.decode_progress_interval_s,

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -141,6 +141,8 @@ class InferenceManager:
         max_cache_len = int(spec.max_cache_len)
         max_blocks_per_seq = int(spec.max_blocks_per_seq)
         self._prepare_actor_onloaded()
+        can_reuse_weights = getattr(self.worker, "_can_reuse_rollout_session_infer_weights", None)
+        reuse_session_weights = can_reuse_weights() if callable(can_reuse_weights) else False
         if self._infer_cache_spec is not None:
             # Reuse path: the existing cache is large enough along every
             # dimension. We must match block_size exactly (it's baked into
@@ -156,8 +158,7 @@ class InferenceManager:
                 if onload_kv is not None:
                     onload_kv(self.device)
                 self.model.reset_kv_caches()
-                can_reuse_weights = getattr(self.worker, "_can_reuse_rollout_session_infer_weights", None)
-                if not (can_reuse_weights() if callable(can_reuse_weights) else False):
+                if not reuse_session_weights:
                     self.model.onload_train_weights(self.device)
                     self.model.prepare_infer_weights()
                     self._train_state_ready = False
@@ -195,12 +196,13 @@ class InferenceManager:
         self._train_state_ready = False
         # Materialise infer weights from train weights (e.g. dequantize / fuse),
         # then drop the train copies for the rollout's duration.
-        self.model.onload_train_weights(self.device)
-        self.model.prepare_infer_weights()
-        self.model.offload_train_weights()
-        mark_ready = getattr(self.worker, "_mark_rollout_session_infer_weights_ready", None)
-        if callable(mark_ready):
-            mark_ready()
+        if not reuse_session_weights:
+            self.model.onload_train_weights(self.device)
+            self.model.prepare_infer_weights()
+            self.model.offload_train_weights()
+            mark_ready = getattr(self.worker, "_mark_rollout_session_infer_weights_ready", None)
+            if callable(mark_ready):
+                mark_ready()
         if self.device.type == "cuda":
             self._init_decode_graphs()
 

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -260,7 +260,9 @@ class InferenceManager:
         finally:
             if was_training:
                 self.model.train()
-            if not self.config.runtime.keep_rollout_state:
+            should_drop = getattr(self.worker, "_should_drop_rollout_hbm_after_infer", None)
+            drop_after_infer = should_drop() if callable(should_drop) else not self.config.runtime.keep_rollout_state
+            if drop_after_infer:
                 self._drop_rollout_hbm()
 
     @torch.inference_mode()

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -156,10 +156,15 @@ class InferenceManager:
                 if onload_kv is not None:
                     onload_kv(self.device)
                 self.model.reset_kv_caches()
-                self.model.onload_train_weights(self.device)
-                self.model.prepare_infer_weights()
-                self._train_state_ready = False
-                self.model.offload_train_weights()
+                can_reuse_weights = getattr(self.worker, "_can_reuse_rollout_session_infer_weights", None)
+                if not (can_reuse_weights() if callable(can_reuse_weights) else False):
+                    self.model.onload_train_weights(self.device)
+                    self.model.prepare_infer_weights()
+                    self._train_state_ready = False
+                    self.model.offload_train_weights()
+                    mark_ready = getattr(self.worker, "_mark_rollout_session_infer_weights_ready", None)
+                    if callable(mark_ready):
+                        mark_ready()
                 if self.device.type == "cuda":
                     self._init_decode_graphs()
                 return
@@ -193,6 +198,9 @@ class InferenceManager:
         self.model.onload_train_weights(self.device)
         self.model.prepare_infer_weights()
         self.model.offload_train_weights()
+        mark_ready = getattr(self.worker, "_mark_rollout_session_infer_weights_ready", None)
+        if callable(mark_ready):
+            mark_ready()
         if self.device.type == "cuda":
             self._init_decode_graphs()
 

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -124,6 +124,7 @@ class ArenoWorker:
         # rollout-only state resident for the whole explicit session and apply
         # drop-rollout-state once at ROLLOUT_SESSION_END, not after every turn.
         self._rollout_session_active = False
+        self._rollout_session_infer_weights_ready = False
         self._current_request_ids: list[int | None] = []
         self._policy_sync_plan = None
         self._policy_sync_metadata = None
@@ -427,6 +428,7 @@ class ArenoWorker:
         del payload
         self._prepare_actor_onloaded()
         self._rollout_session_active = True
+        self._rollout_session_infer_weights_ready = False
 
     def rollout_session_sync(self, payload: None) -> None:
         """Synchronize TP ranks before agentic request-driven rollout starts."""
@@ -457,11 +459,21 @@ class ArenoWorker:
                 self._prepare_for_train()
         finally:
             self._rollout_session_active = False
+            self._rollout_session_infer_weights_ready = False
 
     def _should_drop_rollout_hbm_after_infer(self) -> bool:
         """Return whether one inference call owns the rollout-state teardown."""
 
         return not self.config.runtime.keep_rollout_state and not self._rollout_session_active
+
+    def _can_reuse_rollout_session_infer_weights(self) -> bool:
+        """Return whether actor inference weights are unchanged within this session."""
+
+        return self._rollout_session_active and self._rollout_session_infer_weights_ready
+
+    def _mark_rollout_session_infer_weights_ready(self) -> None:
+        if self._rollout_session_active:
+            self._rollout_session_infer_weights_ready = True
 
     def _prepare_for_train(self) -> None:
         """Ensure the actor is on-device and train weights are loaded."""

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -120,6 +120,10 @@ class ArenoWorker:
         self._infer_cache_spec: tuple[int, int, int, int, int] | None = None
         self._train_state_ready = False
         self._actor_on_device = True
+        # Agentic rollouts issue one inference request per tool-call turn. Keep
+        # rollout-only state resident for the whole explicit session and apply
+        # drop-rollout-state once at ROLLOUT_SESSION_END, not after every turn.
+        self._rollout_session_active = False
         self._current_request_ids: list[int | None] = []
         self._policy_sync_plan = None
         self._policy_sync_metadata = None
@@ -422,6 +426,7 @@ class ArenoWorker:
 
         del payload
         self._prepare_actor_onloaded()
+        self._rollout_session_active = True
 
     def rollout_session_sync(self, payload: None) -> None:
         """Synchronize TP ranks before agentic request-driven rollout starts."""
@@ -445,10 +450,18 @@ class ArenoWorker:
         """Finalize rollout state before scoring or training starts."""
 
         del payload
-        if not self.config.runtime.keep_rollout_state:
-            self._drop_rollout_hbm()
-        if self.config.role == "train":
-            self._prepare_for_train()
+        try:
+            if not self.config.runtime.keep_rollout_state:
+                self._drop_rollout_hbm()
+            if self.config.role == "train":
+                self._prepare_for_train()
+        finally:
+            self._rollout_session_active = False
+
+    def _should_drop_rollout_hbm_after_infer(self) -> bool:
+        """Return whether one inference call owns the rollout-state teardown."""
+
+        return not self.config.runtime.keep_rollout_state and not self._rollout_session_active
 
     def _prepare_for_train(self) -> None:
         """Ensure the actor is on-device and train weights are loaded."""

--- a/tests/test_cuda_generation_cpu.py
+++ b/tests/test_cuda_generation_cpu.py
@@ -48,3 +48,16 @@ def test_cuda_rollout_keeps_stop_tokens_sampleable_until_stop_detection():
 
     assert native.stop_token_ids == (49,)
     assert 49 not in native.suppress_token_ids
+
+
+def test_cuda_rollout_reserves_full_agentic_context_capacity():
+    ctx = SimpleNamespace(
+        tokenizer=_StructuredOutputTokenizer(),
+        eos_token_ids=(106,),
+        custom_config=CudaConfig(),
+    )
+    params = SamplingParams(max_new_tokens=256, max_prompt_len=2048, max_context_len=5000)
+
+    options = rollout_options(ctx, params)
+
+    assert options["max_prompt_len"] == 4744

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -10,7 +10,7 @@ import areno.engine.worker as worker_mod
 from areno.engine.api import ArenoEngine, _chunk_prompts_for_prefill_budget, _merge_async_dp_rollouts
 from areno.engine.data import SamplingParams
 from areno.engine.data.rollout_state import InferenceBatchState
-from areno.engine.inference import InferenceManager
+from areno.engine.inference import InferCacheSpec, InferenceManager
 from areno.engine.protocol import Command, Op, RolloutPayload
 from areno.engine.runtime.rollout import _build_rollout_from_rows
 from tests.helpers import PatchedContext
@@ -70,13 +70,18 @@ def test_drop_rollout_state_is_deferred_until_agentic_session_end():
         runtime=SimpleNamespace(keep_rollout_state=False),
     )
     worker._rollout_session_active = False
+    worker._rollout_session_infer_weights_ready = False
     events = []
     worker._prepare_actor_onloaded = lambda: events.append("prepare")
     worker._drop_rollout_hbm = lambda: events.append("drop")
 
     worker.rollout_session_begin(None)
     assert worker._rollout_session_active
+    assert not worker._can_reuse_rollout_session_infer_weights()
     assert events == ["prepare"]
+
+    worker._mark_rollout_session_infer_weights_ready()
+    assert worker._can_reuse_rollout_session_infer_weights()
 
     # InferenceManager's per-call finally guard must retain state between
     # agentic turns while the explicit rollout session is active.
@@ -85,9 +90,41 @@ def test_drop_rollout_state_is_deferred_until_agentic_session_end():
 
     worker.rollout_session_end(None)
     assert not worker._rollout_session_active
+    assert not worker._can_reuse_rollout_session_infer_weights()
     assert events == ["prepare", "drop"]
 
     assert worker._should_drop_rollout_hbm_after_infer()
+
+
+def test_infer_cache_reuse_skips_weight_conversion_within_agentic_session():
+    calls = []
+    model = SimpleNamespace(
+        onload_kv_caches=lambda device: calls.append(("onload_kv", device.type)),
+        reset_kv_caches=lambda: calls.append(("reset_kv",)),
+        onload_train_weights=lambda device: calls.append(("onload_weights", device.type)),
+        prepare_infer_weights=lambda: calls.append(("prepare_weights",)),
+        offload_train_weights=lambda: calls.append(("offload_weights",)),
+    )
+    worker = SimpleNamespace(
+        device=torch.device("cpu"),
+        model=model,
+        _infer_cache_spec=(4, 8, 4, 16, 4),
+        _infer_batch_size=4,
+        _infer_cache_blocks=9,
+        _max_cache_len=16,
+        _max_blocks_per_seq=4,
+        _train_state_ready=False,
+        _prepare_actor_onloaded=lambda: calls.append(("prepare_actor",)),
+        _can_reuse_rollout_session_infer_weights=lambda: True,
+        _mark_rollout_session_infer_weights_ready=lambda: calls.append(("mark_ready",)),
+    )
+    manager = InferenceManager(worker)
+
+    manager._init_infer_cache(
+        InferCacheSpec(max_running_seqs=4, num_blocks=8, block_size=4, max_cache_len=16, max_blocks_per_seq=4)
+    )
+
+    assert calls == [("prepare_actor",), ("onload_kv", "cpu"), ("reset_kv",)]
 
 
 def test_no_sync_rollout_continues_pending_prompts_beyond_running_slots():

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -63,6 +63,33 @@ class _FakeInferenceManager(InferenceManager):
         return next_tokens + 1, torch.zeros_like(next_tokens, dtype=torch.float32) - float(sample_step)
 
 
+def test_drop_rollout_state_is_deferred_until_agentic_session_end():
+    worker = object.__new__(worker_mod.ArenoWorker)
+    worker.config = SimpleNamespace(
+        role="rollout",
+        runtime=SimpleNamespace(keep_rollout_state=False),
+    )
+    worker._rollout_session_active = False
+    events = []
+    worker._prepare_actor_onloaded = lambda: events.append("prepare")
+    worker._drop_rollout_hbm = lambda: events.append("drop")
+
+    worker.rollout_session_begin(None)
+    assert worker._rollout_session_active
+    assert events == ["prepare"]
+
+    # InferenceManager's per-call finally guard must retain state between
+    # agentic turns while the explicit rollout session is active.
+    assert not worker._should_drop_rollout_hbm_after_infer()
+    assert events == ["prepare"]
+
+    worker.rollout_session_end(None)
+    assert not worker._rollout_session_active
+    assert events == ["prepare", "drop"]
+
+    assert worker._should_drop_rollout_hbm_after_infer()
+
+
 def test_no_sync_rollout_continues_pending_prompts_beyond_running_slots():
     """A single rollout call should drain pending rows while respecting slot limits."""
 

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -101,6 +101,11 @@ def test_infer_cache_reuse_skips_weight_conversion_within_agentic_session():
     model = SimpleNamespace(
         onload_kv_caches=lambda device: calls.append(("onload_kv", device.type)),
         reset_kv_caches=lambda: calls.append(("reset_kv",)),
+        allocate_kv_caches=lambda blocks, block_size, device: calls.append(
+            ("allocate_kv", blocks, block_size, device.type)
+        )
+        or [],
+        set_kv_caches=lambda caches, num_slots: calls.append(("set_kv", len(caches), num_slots)),
         onload_train_weights=lambda device: calls.append(("onload_weights", device.type)),
         prepare_infer_weights=lambda: calls.append(("prepare_weights",)),
         offload_train_weights=lambda: calls.append(("offload_weights",)),
@@ -114,6 +119,9 @@ def test_infer_cache_reuse_skips_weight_conversion_within_agentic_session():
         _max_cache_len=16,
         _max_blocks_per_seq=4,
         _train_state_ready=False,
+        _decode_graphs={},
+        _decode_graph_skipped_buckets=set(),
+        _decode_graph_init_attempted=False,
         _prepare_actor_onloaded=lambda: calls.append(("prepare_actor",)),
         _can_reuse_rollout_session_infer_weights=lambda: True,
         _mark_rollout_session_infer_weights_ready=lambda: calls.append(("mark_ready",)),
@@ -125,6 +133,17 @@ def test_infer_cache_reuse_skips_weight_conversion_within_agentic_session():
     )
 
     assert calls == [("prepare_actor",), ("onload_kv", "cpu"), ("reset_kv",)]
+
+    calls.clear()
+    manager._init_infer_cache(
+        InferCacheSpec(max_running_seqs=4, num_blocks=12, block_size=4, max_cache_len=20, max_blocks_per_seq=5)
+    )
+
+    assert calls == [
+        ("prepare_actor",),
+        ("allocate_kv", 13, 4, "cpu"),
+        ("set_kv", 0, 4),
+    ]
 
 
 def test_no_sync_rollout_continues_pending_prompts_beyond_running_slots():


### PR DESCRIPTION
## What does this PR do?

Fixes repeated train/inference state transitions during multi-turn agentic rollouts.

- Defers `--drop-rollout-state` cleanup until `ROLLOUT_SESSION_END` instead of dropping after every turn.
- Reuses prepared inference weights for subsequent turns in the same rollout session.
- Reuses those weights even when the KV cache must be reallocated.
- Reserves prompt capacity from `max_context_len - max_new_tokens` up front so growing multi-turn prompts do not repeatedly resize the cache.
- Resets the session flags at session boundaries and on worker cleanup.

This is isolated from the elevator and logic-circuit examples and does not change public CLI or SDK contracts.

## Related issue

N/A

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

- `ruff check areno/api/backend/cuda/generation.py areno/engine/inference.py areno/engine/worker.py tests/test_cuda_generation_cpu.py tests/test_inference_scheduler_cpu.py`
- `ruff format --check areno/api/backend/cuda/generation.py areno/engine/inference.py areno/engine/worker.py tests/test_cuda_generation_cpu.py tests/test_inference_scheduler_cpu.py`
- Multi-turn elevator GSPO rollout on Linux/CUDA: verified that turns continue without repeated `onload_train_weights`; the initial session onload remains expected.
- Added CPU regression coverage for session-end state dropping, inference-weight reuse across cache reuse/reallocation, and `max_context_len` prompt-capacity reservation.
- Targeted pytest collection was attempted locally, but AReno rejects Darwin/x86_64 before test execution because no native CUDA/MLX backend exists; Linux CPU CI is expected to execute these tests.

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (N/A).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (no public API/CLI changes).
