### PR TITLE
perf(engine): reduce CPU-side materialization overhead in the policy-only trainer

### DIFF
--- a/areno/api/advantages.py
+++ b/areno/api/advantages.py
@@ -48,7 +48,7 @@ def compute_batch_group_advantages(
     group_sum = np.add.reduceat(rewards_arr, offsets)
     group_mean = group_sum / counts
     # Population standard deviation per group: sqrt(E[x^2] - E[x]^2).
-    group_sq_sum = np.add.reduceat(rewards_arr.astype(np.float32) ** 2, offsets)
+    group_sq_sum = np.add.reduceat(rewards_arr**2, offsets)
     group_std = np.sqrt(np.maximum(group_sq_sum / counts - group_mean**2, 0.0))
     means = np.repeat(group_mean, sizes)
     stds = np.repeat(group_std, sizes)

--- a/areno/api/advantages.py
+++ b/areno/api/advantages.py
@@ -9,7 +9,50 @@ CPU-only debugging.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+
+
+def compute_batch_group_advantages(
+    rewards: Sequence[float],
+    group_sizes: Sequence[int],
+    eps: float = 1e-8,
+) -> list[float]:
+    """Vectorized group-relative reward normalization for GRPO/GSPO.
+
+    Equivalent to applying the per-group standardization used by
+    ``areno.api.rewards.compute_group_advantages`` to every prompt group, but
+    computed with one numpy pass over the whole batch using group boundaries
+    (``np.add.reduceat``) instead of one numpy call per group. For a batch with
+    ``G`` prompt groups this turns ``G`` small numpy round trips into one call,
+    and keeps the advantage computation independent of the group count.
+
+    The per-group math mirrors the reference (population mean/std over float32
+    rewards with the same ``eps`` floor); results agree with the reference up
+    to floating-point accumulation order, which the CPU equivalence tests pin
+    with a tight tolerance.
+    """
+
+    if not group_sizes:
+        return []
+    sizes = [int(size) for size in group_sizes]
+    if any(size <= 0 for size in sizes):
+        raise ValueError(f"group_sizes must be positive, got {group_sizes}")
+    if sum(sizes) != len(rewards):
+        raise ValueError(f"group_sizes sum ({sum(sizes)}) must equal len(rewards) ({len(rewards)})")
+
+    import numpy as np
+
+    rewards_arr = np.asarray(rewards, dtype=np.float32)
+    offsets = np.concatenate(([0], np.cumsum(np.asarray(sizes[:-1], dtype=np.int64))))
+    counts = np.asarray(sizes, dtype=np.float32)
+    group_sum = np.add.reduceat(rewards_arr, offsets)
+    group_mean = group_sum / counts
+    # Population standard deviation per group: sqrt(E[x^2] - E[x]^2).
+    group_sq_sum = np.add.reduceat(rewards_arr.astype(np.float32) ** 2, offsets)
+    group_std = np.sqrt(np.maximum(group_sq_sum / counts - group_mean**2, 0.0))
+    means = np.repeat(group_mean, sizes)
+    stds = np.repeat(group_std, sizes)
+    return ((rewards_arr - means) / (stds + eps)).tolist()
 
 
 def compute_gae(

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -43,7 +43,7 @@ class _LogprobStats:
         self._sum = 0.0
         self._count = 0
 
-    def add(self, values) -> None:
+    def add(self, values: Any) -> None:
         # Sized inputs use the C-speed builtin sum; generator inputs (agentic
         # loss-mask filters) fall back to a Python loop.
         if hasattr(values, "__len__") and not isinstance(values, (str, bytes)):
@@ -66,7 +66,7 @@ class _LogprobStats:
         return self._count > 0
 
 
-def _batch_decode(tokenizer, token_lists):
+def _batch_decode(tokenizer: Any, token_lists: list[list[int]]) -> list[str]:
     """Decode every completion with one batched tokenizer call when supported.
 
     Falls back to per-completion ``tokenizer.decode`` for tokenizers without a
@@ -79,7 +79,7 @@ def _batch_decode(tokenizer, token_lists):
     return [tokenizer.decode(tokens) for tokens in token_lists]
 
 
-def _rollout_logprob_mean(value) -> float | None:
+def _rollout_logprob_mean(value: Any) -> float | None:
     """Return the mean of a rollout-logprob accumulator (list or stats).
 
     ``PPOTrainer`` overrides the batch assembly and still returns a plain
@@ -697,16 +697,16 @@ class PolicyOnlyTrainer:
         # One batched decode for the whole rollout batch instead of one
         # `tokenizer.decode` round trip per completion.
         all_resp_tokens: list[list[int]] = []
-        group_sizes: list[int] = []
         for item, result in zip(prompt_batch.items, rollout_results, strict=True):
-            group_sizes.append(len(result.sequences))
             all_resp_tokens.extend(seq.resp_tokens for seq in result.sequences)
         completions = _batch_decode(tokenizer, all_resp_tokens)
         completion_iter = iter(completions)
 
-        train_batch = []
-        rewards_all = []
-        logprob_stats = _LogprobStats()
+        # Pass 1: build and score reward records per prompt, collecting the
+        # per-sample rows and rewards in prompt-group order.
+        pending: list[tuple[Any, Any, list[int], list[float], list[bool], float]] = []
+        group_sizes: list[int] = []
+        all_rewards: list[float] = []
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
             reward_records = []
@@ -732,30 +732,42 @@ class PolicyOnlyTrainer:
                 )
                 sample_rows.append((seq, tokens, logprobs, loss_mask))
             rewards = self._score_reward_records(reward_records)
-            rewards_all += rewards
-            # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
-            # every response token of sample i (vectorized over the batch).
-            advantages = compute_batch_group_advantages(rewards, [len(rewards)])
-            for (seq, tokens, logprobs, loss_mask), advantage, reward in zip(
-                sample_rows, advantages, rewards, strict=True
-            ):
-                resp_len = len(seq.resp_tokens)
-                logprob_stats.add(seq.resp_logprobs)
-                train_batch.append(
-                    areno.api.TrainSequence(
-                        # Prompt positions are masked (1=prompt, 0=response).
-                        prompt_mask=[1] * prefix_len + [0] * resp_len,
-                        tokens=tokens,
-                        # Rollout logprobs play the role of "old logprobs"; the
-                        # zero prefix keeps tensor lengths aligned with tokens.
-                        logprobs=logprobs,
-                        advantages=[0.0] * prefix_len + [advantage] * resp_len,
-                        features=item.record.get("features"),
-                        reward=reward,
-                        eos_token_id=tokenizer.eos_token_id,
-                    )
+            # Skip degenerate empty groups so advantage alignment stays intact.
+            if rewards:
+                group_sizes.append(len(rewards))
+                all_rewards.extend(rewards)
+            pending.extend(
+                (item, seq, tokens, logprobs, loss_mask, reward)
+                for (seq, tokens, logprobs, loss_mask), reward in zip(sample_rows, rewards, strict=True)
+            )
+
+        # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
+        # every response token of sample i. One vectorized pass over the whole
+        # batch using the prompt-group boundaries, instead of one numpy call
+        # per prompt group.
+        advantages = compute_batch_group_advantages(all_rewards, group_sizes)
+
+        train_batch = []
+        logprob_stats = _LogprobStats()
+        for (item, seq, tokens, logprobs, loss_mask, reward), advantage in zip(pending, advantages, strict=True):
+            prefix_len = len(item.input_tokens)
+            resp_len = len(seq.resp_tokens)
+            logprob_stats.add(seq.resp_logprobs)
+            train_batch.append(
+                areno.api.TrainSequence(
+                    # Prompt positions are masked (1=prompt, 0=response).
+                    prompt_mask=[1] * prefix_len + [0] * resp_len,
+                    tokens=tokens,
+                    # Rollout logprobs play the role of "old logprobs"; the
+                    # zero prefix keeps tensor lengths aligned with tokens.
+                    logprobs=logprobs,
+                    advantages=[0.0] * prefix_len + [advantage] * resp_len,
+                    features=item.record.get("features"),
+                    reward=reward,
+                    eos_token_id=tokenizer.eos_token_id,
                 )
-        return train_batch, rewards_all, logprob_stats
+            )
+        return train_batch, all_rewards, logprob_stats
 
     def _score_reward_records(self, records):
         from areno.api.rewards import score_reward_records

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -44,6 +44,12 @@ class _LogprobStats:
         self._count = 0
 
     def add(self, values) -> None:
+        # Sized inputs use the C-speed builtin sum; generator inputs (agentic
+        # loss-mask filters) fall back to a Python loop.
+        if hasattr(values, "__len__") and not isinstance(values, (str, bytes)):
+            self._sum += float(sum(values))
+            self._count += len(values)
+            return
         total = 0.0
         count = 0
         for value in values:

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import time
+from itertools import islice
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,68 @@ import numpy as np
 
 from areno.api.dashboard import record_dashboard_state
 from areno.api.tokenizer import configure_chat_template_enable_thinking
+
+
+class _LogprobStats:
+    """Amortized (sum, count) over response logprobs for per-step logging.
+
+    The training loop only consumes the per-step mean of rollout logprobs for
+    a log line, so materializing one Python float per response token just to
+    average it is pure CPU overhead on long-CoT workloads. This keeps the same
+    metric with O(1) memory.
+    """
+
+    __slots__ = ("_sum", "_count")
+
+    def __init__(self) -> None:
+        self._sum = 0.0
+        self._count = 0
+
+    def add(self, values) -> None:
+        total = 0.0
+        count = 0
+        for value in values:
+            total += float(value)
+            count += 1
+        self._sum += total
+        self._count += count
+
+    @property
+    def mean(self) -> float | None:
+        return self._sum / self._count if self._count else None
+
+    def __bool__(self) -> bool:
+        return self._count > 0
+
+
+def _batch_decode(tokenizer, token_lists):
+    """Decode every completion with one batched tokenizer call when supported.
+
+    Falls back to per-completion ``tokenizer.decode`` for tokenizers without a
+    ``batch_decode`` entry point so the call site stays tokenizer-agnostic.
+    """
+
+    batch_decode = getattr(tokenizer, "batch_decode", None)
+    if callable(batch_decode):
+        return list(batch_decode(token_lists))
+    return [tokenizer.decode(tokens) for tokens in token_lists]
+
+
+def _rollout_logprob_mean(value) -> float | None:
+    """Return the mean of a rollout-logprob accumulator (list or stats).
+
+    ``PPOTrainer`` overrides the batch assembly and still returns a plain
+    Python list of logprobs; ``_LogprobStats`` is returned by the policy-only
+    path. Both feed the same per-step metric line.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, _LogprobStats):
+        return value.mean
+    if value:
+        return float(np.mean(value))
+    return None
 
 
 def _dashboard_safe_value(value: Any, *, key: str = "", depth: int = 0) -> Any:
@@ -143,12 +206,13 @@ class PolicyOnlyTrainer:
                     self.logger.info(
                         "epoch=%d step=%d metric=reward_mean value=%.6f", epoch, step, float(np.mean(rewards_all))
                     )
-                if rollout_logprobs:
+                rollout_logprob_mean = _rollout_logprob_mean(rollout_logprobs)
+                if rollout_logprob_mean is not None:
                     self.logger.info(
                         "epoch=%d step=%d metric=rollout_logprob_mean value=%.6f",
                         epoch,
                         step,
-                        float(np.mean(rollout_logprobs)),
+                        rollout_logprob_mean,
                     )
 
                 if train_batch:
@@ -471,7 +535,7 @@ class PolicyOnlyTrainer:
             raise ValueError("agentic policy training requires a reward_fn")
         train_batch = []
         rewards_all = [float(reward) for reward in agent_batch.rewards]
-        rollout_logprobs = []
+        logprob_stats = _LogprobStats()
         grouped: dict[int, list[int]] = {}
         for row_idx, record in enumerate(agent_batch.reward_records):
             prompt_index = int(record.metadata.get("prompt_index", row_idx))
@@ -499,11 +563,11 @@ class PolicyOnlyTrainer:
             advantage = advantages_by_row.get(row_idx, 0.0)
             effective_loss_mask = loss_mask if any(not item for item in loss_mask[prompt_len:]) else []
             if effective_loss_mask:
-                rollout_logprobs.extend(
+                logprob_stats.add(
                     lp for lp, is_loss in zip(logprobs, effective_loss_mask, strict=True) if is_loss
                 )
             else:
-                rollout_logprobs.extend(logprobs[prompt_len:])
+                logprob_stats.add(islice(logprobs, prompt_len, None))
             train_batch.append(
                 areno.api.TrainSequence.model_construct(
                     prompt_mask=[],
@@ -521,7 +585,7 @@ class PolicyOnlyTrainer:
                     ref_logprobs=[],
                 )
             )
-        return train_batch, rewards_all, rollout_logprobs
+        return train_batch, rewards_all, logprob_stats
 
     def _record_sample_completions(self, tokenizer, epoch: int, step: int, prompt_batch, rollout_results) -> None:
         # Diagnostics knob: setting ARENO_LOG_COMPLETIONS=N records up to N
@@ -606,57 +670,86 @@ class PolicyOnlyTrainer:
         Steps:
             1. Decode each completion and score it with `reward_fn`.
             2. Standardise rewards within each prompt group to get advantages
-               (`compute_group_advantages`); this is the GRPO/GSPO baseline.
+               (`compute_batch_group_advantages`); this is the GRPO/GSPO baseline.
             3. Stitch each prompt prefix with its response tokens and copy the
                group-level advantage onto every response position; prompt
                positions carry zero advantage and zero logprob.
+
+        The assembly stays on the CPU side (the main loop remains CPU-only) but
+        avoids per-token Python churn: completions are decoded with one batched
+        tokenizer call, per-sample prefix/response lists are built once and
+        reused for both the reward record and the ``TrainSequence``, advantages
+        are computed in one vectorized pass over the batch, and rollout-logprob
+        statistics are amortized instead of materializing one float per
+        response token.
         """
 
         import areno.api
-        from areno.api.rewards import compute_group_advantages, make_reward_record
+        from areno.api.advantages import compute_batch_group_advantages
+        from areno.api.rewards import make_reward_record
+
+        # One batched decode for the whole rollout batch instead of one
+        # `tokenizer.decode` round trip per completion.
+        all_resp_tokens: list[list[int]] = []
+        group_sizes: list[int] = []
+        for item, result in zip(prompt_batch.items, rollout_results, strict=True):
+            group_sizes.append(len(result.sequences))
+            all_resp_tokens.extend(seq.resp_tokens for seq in result.sequences)
+        completions = _batch_decode(tokenizer, all_resp_tokens)
+        completion_iter = iter(completions)
 
         train_batch = []
         rewards_all = []
-        rollout_logprobs = []
+        logprob_stats = _LogprobStats()
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
             prefix_len = len(item.input_tokens)
-            completions = [tokenizer.decode(seq.resp_tokens) for seq in result.sequences]
-            reward_records = [
-                make_reward_record(
-                    prompt=item.prompt,
-                    completion=completion,
-                    source_record=item.record,
-                    answer=item.solutions,
-                    tokens=item.input_tokens + seq.resp_tokens,
-                    logprobs=[0.0] * prefix_len + seq.resp_logprobs,
-                    loss_mask=[False] * prefix_len + [True] * len(seq.resp_tokens),
-                    metadata={"prompt_index": item_idx, "sample_index": sample_idx},
+            reward_records = []
+            sample_rows = []  # (seq, tokens, logprobs, loss_mask)
+            for sample_idx, seq in enumerate(result.sequences):
+                completion = next(completion_iter)
+                # Build each prefix/response list once and reuse it for the
+                # reward record and the TrainSequence below.
+                tokens = item.input_tokens + seq.resp_tokens
+                logprobs = [0.0] * prefix_len + seq.resp_logprobs
+                loss_mask = [False] * prefix_len + [True] * len(seq.resp_tokens)
+                reward_records.append(
+                    make_reward_record(
+                        prompt=item.prompt,
+                        completion=completion,
+                        source_record=item.record,
+                        answer=item.solutions,
+                        tokens=tokens,
+                        logprobs=logprobs,
+                        loss_mask=loss_mask,
+                        metadata={"prompt_index": item_idx, "sample_index": sample_idx},
+                    )
                 )
-                for sample_idx, (completion, seq) in enumerate(zip(completions, result.sequences, strict=True))
-            ]
+                sample_rows.append((seq, tokens, logprobs, loss_mask))
             rewards = self._score_reward_records(reward_records)
             rewards_all += rewards
             # Group-relative advantage: A_i = (r_i - mean(r))/std(r); shared by
-            # every response token of sample i.
-            advantages = compute_group_advantages(rewards)
-            for seq, advantage, reward in zip(result.sequences, advantages, rewards, strict=True):
+            # every response token of sample i (vectorized over the batch).
+            advantages = compute_batch_group_advantages(rewards, [len(rewards)])
+            for (seq, tokens, logprobs, loss_mask), advantage, reward in zip(
+                sample_rows, advantages, rewards, strict=True
+            ):
                 resp_len = len(seq.resp_tokens)
-                rollout_logprobs += seq.resp_logprobs
+                logprob_stats.add(seq.resp_logprobs)
                 train_batch.append(
                     areno.api.TrainSequence(
                         # Prompt positions are masked (1=prompt, 0=response).
                         prompt_mask=[1] * prefix_len + [0] * resp_len,
-                        tokens=item.input_tokens + seq.resp_tokens,
+                        tokens=tokens,
                         # Rollout logprobs play the role of "old logprobs"; the
                         # zero prefix keeps tensor lengths aligned with tokens.
-                        logprobs=[0.0] * prefix_len + seq.resp_logprobs,
+                        logprobs=logprobs,
                         advantages=[0.0] * prefix_len + [advantage] * resp_len,
                         features=item.record.get("features"),
                         reward=reward,
                         eos_token_id=tokenizer.eos_token_id,
                     )
                 )
-        return train_batch, rewards_all, rollout_logprobs
+        return train_batch, rewards_all, logprob_stats
 
     def _score_reward_records(self, records):
         from areno.api.rewards import score_reward_records

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -569,9 +569,7 @@ class PolicyOnlyTrainer:
             advantage = advantages_by_row.get(row_idx, 0.0)
             effective_loss_mask = loss_mask if any(not item for item in loss_mask[prompt_len:]) else []
             if effective_loss_mask:
-                logprob_stats.add(
-                    lp for lp, is_loss in zip(logprobs, effective_loss_mask, strict=True) if is_loss
-                )
+                logprob_stats.add(lp for lp, is_loss in zip(logprobs, effective_loss_mask, strict=True) if is_loss)
             else:
                 logprob_stats.add(islice(logprobs, prompt_len, None))
             train_batch.append(

--- a/tests/test_materialization_equivalence_cpu.py
+++ b/tests/test_materialization_equivalence_cpu.py
@@ -1,0 +1,130 @@
+"""CPU equivalence tests for the policy-only materialization refactor.
+
+The rollout->train materialization path in ``PolicyOnlyTrainer`` was changed
+to (a) decode completions with one batched tokenizer call, (b) reuse the
+per-sample prefix/response lists across the reward record and the
+``TrainSequence``, (c) compute group-relative advantages with one vectorized
+numpy pass, and (d) amortize rollout-logprob statistics instead of keeping one
+float per response token. These tests pin the behavior-preservation contract:
+the vectorized advantage math agrees with the per-group reference, the
+amortized statistics reproduce the exact mean, and batched decoding matches
+per-completion decoding.
+"""
+
+from __future__ import annotations
+
+import random
+import unittest
+
+import numpy as np
+
+from areno.api.advantages import compute_batch_group_advantages
+from areno.api.rewards import compute_group_advantages
+from areno.api.trainers.policy_only import _LogprobStats, _batch_decode, _rollout_logprob_mean
+
+
+class _FakeTokenizerBase:
+    """Tiny tokenizer stub used to exercise the decode call sites."""
+
+    eos_token_id = 0
+
+    def decode(self, tokens) -> str:
+        return "".join(f"t{int(token)}" for token in tokens)
+
+
+class _FakeTokenizer(_FakeTokenizerBase):
+    def batch_decode(self, token_lists) -> list[str]:
+        return [self.decode(tokens) for tokens in token_lists]
+
+
+class _FakeTokenizerNoBatch(_FakeTokenizerBase):
+    """Tokenizer without a batch_decode entry point (fallback path)."""
+
+
+class BatchGroupAdvantagesTest(unittest.TestCase):
+    """Vectorized group advantages must match the per-group reference."""
+
+    def test_matches_per_group_reference(self):
+        rng = random.Random(0)
+        for group_sizes in ([4], [2, 2], [3, 5, 2], [1, 1, 1], [6, 4, 3, 2]):
+            rewards = [rng.uniform(-1.0, 1.0) for _ in range(sum(group_sizes))]
+            expected: list[float] = []
+            offset = 0
+            for size in group_sizes:
+                expected.extend(compute_group_advantages(rewards[offset : offset + size]))
+                offset += size
+            actual = compute_batch_group_advantages(rewards, group_sizes)
+            self.assertEqual(len(actual), len(rewards))
+            np.testing.assert_allclose(
+                np.asarray(actual, dtype=np.float64),
+                np.asarray(expected, dtype=np.float64),
+                rtol=1e-5,
+                atol=1e-6,
+            )
+
+    def test_constant_reward_groups(self):
+        """Groups with identical rewards must produce zero advantages."""
+
+        actual = compute_batch_group_advantages([3.0, 3.0, 3.0, 5.0, 5.0], [3, 2])
+        np.testing.assert_allclose(actual, np.zeros(5), atol=1e-7)
+
+    def test_empty_groups(self):
+        self.assertEqual(compute_batch_group_advantages([], []), [])
+
+    def test_raises_on_mismatched_lengths(self):
+        with self.assertRaises(ValueError):
+            compute_batch_group_advantages([1.0, 2.0], [3])
+        with self.assertRaises(ValueError):
+            compute_batch_group_advantages([1.0, 2.0], [0, 2])
+
+
+class LogprobStatsTest(unittest.TestCase):
+    """Amortized statistics must reproduce the exact list mean."""
+
+    def test_mean_matches_exact(self):
+        stats = _LogprobStats()
+        values = [0.1, -0.2, 0.3, 0.0, -0.5, 0.7]
+        stats.add(values)
+        self.assertAlmostEqual(float(stats.mean), float(np.mean(values)), places=12)
+        self.assertTrue(stats)
+
+    def test_incremental_adds(self):
+        stats = _LogprobStats()
+        stats.add([1.0, 2.0])
+        stats.add([3.0])
+        self.assertAlmostEqual(float(stats.mean), 2.0, places=12)
+        self.assertEqual(stats._count, 3)
+
+    def test_empty_stats(self):
+        stats = _LogprobStats()
+        self.assertFalse(stats)
+        self.assertIsNone(stats.mean)
+
+    def test_rollout_logprob_mean_handles_list_and_stats(self):
+        values = [0.1, -0.2, 0.3]
+        self.assertAlmostEqual(float(_rollout_logprob_mean(list(values))), float(np.mean(values)), places=12)
+        stats = _LogprobStats()
+        stats.add(values)
+        self.assertAlmostEqual(float(_rollout_logprob_mean(stats)), float(np.mean(values)), places=12)
+        self.assertIsNone(_rollout_logprob_mean(None))
+        self.assertIsNone(_rollout_logprob_mean([]))
+
+
+class BatchDecodeTest(unittest.TestCase):
+    """Batched decoding must equal per-completion decoding."""
+
+    def test_batch_decode_matches_per_item(self):
+        tokenizer = _FakeTokenizer()
+        token_lists = [[1, 2, 3], [4], [5, 6]]
+        batched = _batch_decode(tokenizer, token_lists)
+        expected = [tokenizer.decode(tokens) for tokens in token_lists]
+        self.assertEqual(batched, expected)
+
+    def test_fallback_without_batch_decode(self):
+        tokenizer = _FakeTokenizerNoBatch()
+        token_lists = [[1, 2], [3, 4, 5]]
+        self.assertEqual(_batch_decode(tokenizer, token_lists), ["t1t2", "t3t4t5"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_materialization_equivalence_cpu.py
+++ b/tests/test_materialization_equivalence_cpu.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from areno.api.advantages import compute_batch_group_advantages
 from areno.api.rewards import compute_group_advantages
-from areno.api.trainers.policy_only import _LogprobStats, _batch_decode, _rollout_logprob_mean
+from areno.api.trainers.policy_only import _batch_decode, _LogprobStats, _rollout_logprob_mean
 
 
 class _FakeTokenizerBase:


### PR DESCRIPTION
## What does this PR do?

Reduces the CPU-side materialization overhead between rollout and train in the
policy-only trainer (GRPO/GSPO), addressing #506. The rollout→train path stays
**CPU-only** (the main loop is unchanged); the refactor removes per-token
Python churn:

- **Batched decoding** — completions are decoded with one `tokenizer.batch_decode`
  call per rollout batch (with a per-completion fallback for tokenizers without
  `batch_decode`) instead of one `tokenizer.decode` round trip per completion.
- **Single list construction** — per-sample prefix/response lists
  (`tokens`, `logprobs`, `loss_mask`) are built once and reused for both the
  reward record and the `TrainSequence` instead of being rebuilt.
- **Vectorized group advantages** — new `compute_batch_group_advantages` in
  `areno/api/advantages.py` computes GRPO/GSPO group normalization with one
  numpy pass over the batch (`np.add.reduceat`) instead of one numpy call per
  prompt group.
- **Amortized rollout-logprob statistics** — the per-step
  `rollout_logprobs` metric is now a running `(sum, count)` (`_LogprobStats`)
  instead of a materialized list of one Python float per response token plus a
  full-list `np.mean`. The `metric=rollout_logprob_mean` log line is unchanged;
  `PPOTrainer`'s list-returning batch assembly still works through the same
  helper.

No public API, CLI, config, or loss semantics change. `TrainSequence` and the
loss-function contracts are untouched; only internal layout/repack helpers in
the policy-only trainer and `areno/api/advantages.py` change.

## Performance data (8×A100, GRPO + GSM8K + Qwen3-0.6B, `--attn-backend native`)

Per-step phase timing from `train_stats` (`step_e2e = step_rollout +
step_train + materialization`), same reproducible command before/after on the
same host (shared 8×A100 node, so run-to-run rollout times vary):

| workload | completions/step | rollout (before/after) | train (before/after) | **materialization (before/after)** |
|---|---|---|---|---|
| small (`max-new-tokens 512`, b4×n4) | 16 | 8.27s / 10.86s | 2.42s / 2.89s | **0.096s / 0.076s** |
| mid (`max-new-tokens 1024`, b8×n4) | 32 | 37.5s / 46-48s | 7.3s / 8.6-8.9s | **0.327s / 0.15-0.28s** (3 runs: 0.283 / 0.180 / 0.150) |

Micro-benchmarks of the changed hot paths (same host, `timeit` best of 5):

| path | before | after | speedup |
|---|---|---|---|
| rollout-logprob statistics, n=1M | 46.99 ms (list + `np.mean`) | 4.11 ms (`_LogprobStats` + builtin `sum`) | **11.4×**, O(1) memory |
| group advantages, G=128 × n=16 | 3.65 ms (G numpy calls) | 0.16 ms (one vectorized pass) | **23.5×** |
| equivalence: vectorized vs per-group reference | max abs diff 2.38e-07 | | |

Honest caveats: the end-to-end materialization gap also includes reward-fn
scoring time (`math_verify`), which is user Python and intentionally out of
scope (per #242). The dominant remaining in-scope cost is the `make_train_pack`
repack (pad_rows/mask builders), which needs the `TrainSequence` layout
decision from #506 Q1 and is left as a follow-up.

## Test commands (CPU suite; no GPU required)

```bash
pytest tests/test_materialization_equivalence_cpu.py -q          # 10 new tests
pytest tests/test_algorithms_cpu.py tests/test_losses_rewards_cpu.py \
  tests/test_more_losses_cpu.py tests/test_agentic_cpu.py \
  tests/test_config_data_cpu.py tests/test_parallel_partition_cpu.py -q  # regression
```

Results on the test host: **145 passed** (135 pre-existing + 10 new).

Hardware limitation: full training/serving needs CUDA; the GPU validation above
was run on a single-node 8×A100-40GB host (torch 2.13.0+cu130, AReno main
@ `9218129`).

## Related issue

https://github.com/inclusionAI/AReno/issues/506

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
