### PR TITLE
fix(cuda): isolate recurrent decode graph scratch state

### DIFF
--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -175,6 +175,11 @@ class InferenceManager:
             self._decode_graph_skipped_buckets.clear()
             self._decode_graph_init_attempted = False
         self._infer_batch_size = max_running_seqs
+        # Recurrent models need their own scratch slot for CUDA-graph warmup,
+        # capture, and padded replay rows.  Real requests exclusively own
+        # slots [0, max_running_seqs); the extra slot must never be admitted
+        # by InferenceBatchState.
+        self._scratch_recurrent_slot = max_running_seqs
         # Allocate one extra block past `num_blocks` to use as a fixed scratch
         # block for padded rows during graph-shape decode (see _init_decode_graphs).
         self._infer_cache_blocks = num_blocks + 1
@@ -192,7 +197,7 @@ class InferenceManager:
             self._max_blocks_per_seq,
         )
         caches = self.model.allocate_kv_caches(self._infer_cache_blocks, block_size, self.device)
-        self.model.set_kv_caches(caches, num_slots=max_running_seqs)
+        self.model.set_kv_caches(caches, num_slots=max_running_seqs + 1)
         self._train_state_ready = False
         # Materialise infer weights from train weights (e.g. dequantize / fuse),
         # then drop the train copies for the rollout's duration.
@@ -1077,6 +1082,7 @@ class InferenceManager:
                 bucket,
                 self._max_blocks_per_seq,
                 self._scratch_block,
+                self._scratch_recurrent_slot,
                 self.device,
             )
             # Warmup: run a few eager forwards at this bucket size to (a) trim

--- a/areno/engine/runtime/decode_graph.py
+++ b/areno/engine/runtime/decode_graph.py
@@ -94,9 +94,7 @@ class DecodeGraph:
         # Graph warmup/capture executes the model before any request is
         # admitted. Point every dummy row at the dedicated scratch recurrent
         # slot so it cannot seed live request state with synthetic tokens.
-        self.recurrent_slots = torch.full(
-            (bucket,), scratch_recurrent_slot, device=device, dtype=torch.long
-        )
+        self.recurrent_slots = torch.full((bucket,), scratch_recurrent_slot, device=device, dtype=torch.long)
         # Padding columns point to `scratch_block`, a dedicated block that the
         # scheduler never assigns to a real sequence. This keeps the attention
         # kernel safe when actual batch size < bucket.

--- a/areno/engine/runtime/decode_graph.py
+++ b/areno/engine/runtime/decode_graph.py
@@ -75,6 +75,7 @@ class DecodeGraph:
         bucket: int,
         max_blocks_per_seq: int,
         scratch_block: int,
+        scratch_recurrent_slot: int,
         device: torch.device,
     ):
         """Allocate static input buffers and the `InferMeta` baked into capture."""
@@ -82,6 +83,7 @@ class DecodeGraph:
         self.model = model
         self.bucket = bucket
         self.scratch_block = scratch_block
+        self.scratch_recurrent_slot = scratch_recurrent_slot
         self.device = device
         # Stable input pointers. The captured CUDA graph remembers these as
         # source/destination addresses, so replay must write through the same
@@ -89,7 +91,12 @@ class DecodeGraph:
         self.input_ids = torch.zeros((1, bucket), device=device, dtype=torch.long)
         self.position_ids = torch.zeros((1, bucket), device=device, dtype=torch.long)
         self.cache_seqlens = torch.zeros(bucket, device=device, dtype=torch.int32)
-        self.recurrent_slots = torch.arange(bucket, device=device, dtype=torch.long)
+        # Graph warmup/capture executes the model before any request is
+        # admitted. Point every dummy row at the dedicated scratch recurrent
+        # slot so it cannot seed live request state with synthetic tokens.
+        self.recurrent_slots = torch.full(
+            (bucket,), scratch_recurrent_slot, device=device, dtype=torch.long
+        )
         # Padding columns point to `scratch_block`, a dedicated block that the
         # scheduler never assigns to a real sequence. This keeps the attention
         # kernel safe when actual batch size < bucket.
@@ -176,7 +183,7 @@ class DecodeGraph:
             self.position_ids[0, actual : self.bucket].fill_(0)
             self.block_table[actual : self.bucket].fill_(self.scratch_block)
             self.cache_seqlens[actual : self.bucket].fill_(0)
-            self.recurrent_slots[actual : self.bucket].fill_(0)
+            self.recurrent_slots[actual : self.bucket].fill_(self.scratch_recurrent_slot)
 
         self.graph.replay()
         assert self.logits_shard is not None

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -101,10 +101,9 @@ def test_infer_cache_reuse_skips_weight_conversion_within_agentic_session():
     model = SimpleNamespace(
         onload_kv_caches=lambda device: calls.append(("onload_kv", device.type)),
         reset_kv_caches=lambda: calls.append(("reset_kv",)),
-        allocate_kv_caches=lambda blocks, block_size, device: calls.append(
-            ("allocate_kv", blocks, block_size, device.type)
-        )
-        or [],
+        allocate_kv_caches=lambda blocks, block_size, device: (
+            calls.append(("allocate_kv", blocks, block_size, device.type)) or []
+        ),
         set_kv_caches=lambda caches, num_slots: calls.append(("set_kv", len(caches), num_slots)),
         onload_train_weights=lambda device: calls.append(("onload_weights", device.type)),
         prepare_infer_weights=lambda: calls.append(("prepare_weights",)),

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -142,7 +142,7 @@ def test_infer_cache_reuse_skips_weight_conversion_within_agentic_session():
     assert calls == [
         ("prepare_actor",),
         ("allocate_kv", 13, 4, "cpu"),
-        ("set_kv", 0, 4),
+        ("set_kv", 0, 5),
     ]
 
 

--- a/tests/test_runtime_utils_cpu.py
+++ b/tests/test_runtime_utils_cpu.py
@@ -18,7 +18,7 @@ from areno.engine.runtime.common import (
     split_data_pack_by_dp,
     split_list_by_dp,
 )
-from areno.engine.runtime.decode_graph import bucket_for, ceil_div
+from areno.engine.runtime.decode_graph import DecodeGraph, bucket_for, ceil_div
 from areno.engine.runtime.rollout import _empty_rollout, _merge_dp_rollouts_in_input_order, _merge_rollouts
 from areno.engine.runtime.train_step import _grad_norms
 
@@ -149,6 +149,31 @@ class DecodeGraphUtilityTest(unittest.TestCase):
         """Ceil division is used for block counts and should round up."""
         self.assertEqual(ceil_div(9, 4), 3)
         self.assertEqual(ceil_div(8, 4), 2)
+
+    def test_recurrent_padding_uses_dedicated_scratch_slot(self):
+        """Graph capture and padded rows must not mutate a live request slot."""
+
+        fake_graph = SimpleNamespace(replay=lambda: None)
+        with patch("torch.cuda.CUDAGraph", return_value=fake_graph):
+            graph = DecodeGraph(
+                SimpleNamespace(),
+                bucket=4,
+                max_blocks_per_seq=2,
+                scratch_block=9,
+                scratch_recurrent_slot=4,
+                device=torch.device("cpu"),
+            )
+        graph.logits_shard = torch.zeros(1, 4, 1)
+
+        graph.replay_tensors(
+            input_ids=torch.tensor([11, 12]),
+            position_ids=torch.tensor([3, 7]),
+            cache_seqlens=torch.tensor([3, 7], dtype=torch.int32),
+            block_table=torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
+            recurrent_slots=torch.tensor([0, 2]),
+        )
+
+        self.assertEqual(graph.recurrent_slots.tolist(), [0, 2, 4, 4])
 
 
 class RolloutMergeTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- reserve a dedicated recurrent-state scratch slot for CUDA graph warmup, capture, and padded replay rows
- keep scheduler-owned recurrent slots unchanged for real requests
- add CPU regression coverage for recurrent cache sizing and decode graph padding

## Root cause

CUDA graph capture initialized recurrent slots with live request slot IDs, so dummy warmup/capture tokens mutated recurrent model state before any request was admitted. During replay, padded graph rows also reused slot 0 and could concurrently corrupt a real request. This caused large rollout/train log-prob divergence for hybrid recurrent-attention models such as MiniCPM-V 4.6 and Qwen3.5.

## Validation

- `pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual`
- MiniCPM-V-4.6 text, TP=2, latest site-packages flash-linear-attention, identical 4x8 rollout config:
  - fixed: `logp_abs_diff_mean=0.0075718`, `grad_norm=1.7097`
  - main bb4448e: `logp_abs_diff_mean=0.8190528`, `grad_norm=6.3079`
- pre-multimodal baseline 8a81e9b: `logp_abs_diff_mean=0.0068649`, confirming the fix restores the expected range

Qwen3.5 TP=8 regression is also running with the same rollout settings.