### PR TITLE
fix(cuda): avoid optimizer hangs and non-disk slowdown

### DIFF
--- a/areno/api/backend/cuda/roles.py
+++ b/areno/api/backend/cuda/roles.py
@@ -43,6 +43,21 @@ class _ScaleGradient(torch.autograd.Function):
         return grad * ctx.scale, None
 
 
+def accumulate_role_main_gradients(role: WorkerRole) -> None:
+    """Fold one role microbatch into resident FP32 parameter gradients."""
+
+    for param in role.parameters():
+        if param.grad is None:
+            continue
+        grad = param.grad.detach()
+        main_grad = getattr(param, "main_grad", None)
+        if isinstance(main_grad, torch.Tensor):
+            main_grad.add_(grad.to(dtype=main_grad.dtype))
+        else:
+            param.main_grad = grad.to(dtype=torch.float32)
+        param.grad = None
+
+
 def _reward_head_bias_key(weight_key: str) -> str:
     """Map a `*.weight` head key to its matching `*.bias` key."""
 
@@ -596,7 +611,10 @@ class RoleManager:
         loss_clipped = (clipped - target).pow(2)
         loss = value_loss_coef * 0.5 * torch.maximum(loss_unclipped[valid], loss_clipped[valid]).mean()
         (loss / max(group_size, 1)).backward()
-        self.worker._sync_role_grads(role)
+        if role.optimizer_offload_mode == "disk":
+            self.worker._sync_role_grads(role, stream_gradient_shards=True)
+        else:
+            accumulate_role_main_gradients(role)
         stats.add(loss, loss_unclipped, loss_clipped, values, target, baseline, valid)
         if allow_step:
             self._maybe_step_role(role)
@@ -606,6 +624,8 @@ class RoleManager:
 
         has_grad = role.optimizer.has_gradients() or any(param_grad(param) is not None for param in role.parameters())
         if has_grad:
+            if role.optimizer_offload_mode != "disk":
+                self.worker._sync_role_grads(role, stream_gradient_shards=False)
             role.optimizer.step()
         role.optimizer.zero_grad(set_to_none=True)
 

--- a/areno/engine/optim/adamw_8bit.py
+++ b/areno/engine/optim/adamw_8bit.py
@@ -385,7 +385,6 @@ class AdamW8bit(AdamWFP32Master):
 
         exp_avg = _dequantize_symmetric(state.exp_avg_q, state.exp_avg_scale)
         exp_avg_sq = _dequantize_positive(state.exp_avg_sq_q, state.exp_avg_sq_scale)
-        updated_refs: list[_ParamRef] = []
         for ref in bucket.refs:
             grad = self._gradient_for_ref(bucket, ref)
             if grad is None:
@@ -404,15 +403,16 @@ class AdamW8bit(AdamWFP32Master):
                 step_size,
                 bias_correction2_sqrt,
             )
-            updated_refs.append(ref)
             if ref.param_start + ref.numel == ref.model_param.numel():
                 ref.model_param.grad = None
                 if isinstance(getattr(ref.model_param, "main_grad", None), torch.Tensor):
                     ref.model_param.main_grad = None
         state.exp_avg_q, state.exp_avg_scale = _quantize_symmetric(exp_avg)
         state.exp_avg_sq_q, state.exp_avg_sq_scale = _quantize_positive(exp_avg_sq)
-        if updated_refs:
-            self._all_gather_bucket(bucket, updated_refs)
+        # Collective order is bucket-global, not rank-local. A rank can own
+        # no values from a small DP bucket and must still join the gather that
+        # refreshes every replicated model parameter.
+        self._all_gather_bucket(bucket)
         bucket.grad_shard = None
         bucket.grad_param_ids = frozenset()
 

--- a/areno/engine/optim/adamw_fp32_master.py
+++ b/areno/engine/optim/adamw_fp32_master.py
@@ -446,7 +446,6 @@ class AdamWFP32Master:
         bias_correction1 = 1.0 - beta1**bucket.step
         bias_correction2 = 1.0 - beta2**bucket.step
         bias_correction2_sqrt = bias_correction2**0.5
-        updated_refs: list[_ParamRef] = []
         try:
             for ref in bucket.refs:
                 grad = self._gradient_for_ref(bucket, ref)
@@ -464,17 +463,18 @@ class AdamWFP32Master:
                     step_size,
                     bias_correction2_sqrt,
                 )
-                updated_refs.append(ref)
                 # Once the final chunk of a parameter has consumed its grad,
                 # release the autograd buffer immediately.
                 if ref.param_start + ref.numel == ref.model_param.numel():
                     ref.model_param.grad = None
                     if isinstance(getattr(ref.model_param, "main_grad", None), torch.Tensor):
                         ref.model_param.main_grad = None
-            if updated_refs:
-                self._commit_master(bucket)
-                # Re-gather the updated BF16 shards back into every DP rank.
-                self._all_gather_bucket(bucket, updated_refs)
+            self._commit_master(bucket)
+            # Every rank that stepped this bucket must enter the same
+            # collective, including ranks whose equal-sized DP shard contains
+            # no real values. Gather the complete bucket rather than the
+            # rank-local set of refs so every model replica is refreshed.
+            self._all_gather_bucket(bucket)
         finally:
             # The FP32 master is a step-local bucket buffer, not persistent
             # optimizer state.
@@ -495,7 +495,6 @@ class AdamWFP32Master:
         bucket.step += 1
         bias_correction1 = 1.0 - beta1**bucket.step
         bias_correction2_sqrt = (1.0 - beta2**bucket.step) ** 0.5
-        updated_refs: list[_ParamRef] = []
         try:
             for ref in bucket.refs:
                 grad = self._gradient_for_ref(bucket, ref)
@@ -527,13 +526,14 @@ class AdamWFP32Master:
                         step_size=effective_lr / bias_correction1,
                         bias_correction2_sqrt=bias_correction2_sqrt,
                     )
-                updated_refs.append(ref)
                 if ref.param_start + ref.numel == ref.model_param.numel():
                     ref.model_param.grad = None
                     if isinstance(getattr(ref.model_param, "main_grad", None), torch.Tensor):
                         ref.model_param.main_grad = None
-            if updated_refs:
-                self._all_gather_bucket(bucket, updated_refs)
+            # `_step_bucket_cuda` is called only for an active bucket. Some DP
+            # ranks may nevertheless own a zero-length shard, so collective
+            # participation cannot depend on their local updated refs.
+            self._all_gather_bucket(bucket)
         finally:
             bucket.grad_shard = None
             bucket.grad_param_ids = frozenset()
@@ -579,11 +579,11 @@ class AdamWFP32Master:
             model_shard.copy_(master)
 
     @torch.no_grad()
-    def _all_gather_bucket(self, bucket: _MasterBucket, refs: list[_ParamRef] | None = None) -> None:
+    def _all_gather_bucket(self, bucket: _MasterBucket) -> None:
         """Gather updated DP shards and copy the full bucket back to BF16 params."""
         if self.dp_size == 1:
             return
-        refs = bucket.refs if refs is None else refs
+        refs = bucket.refs
         if not refs:
             return
         device = refs[0].model_param.device

--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -16,6 +16,8 @@ from areno.engine.runtime.logprobs import (
     packed_next_token_logprobs_from_hidden,
 )
 from areno.engine.runtime.train_step import (
+    _clip_grad_norm,
+    _grad_norms,
     _grad_norms_from_shards,
     _merge_metrics,
     _pack_train_data,
@@ -76,6 +78,7 @@ class TrainingManager:
                         data_pack_shards,
                         allow_step=allow_step,
                         grad_scale=group_size,
+                        stream_gradient_shards=offload_mode == "disk",
                     )
                 )
             return results
@@ -89,7 +92,14 @@ class TrainingManager:
                 if worker.device.type == "cuda":
                     torch.cuda.empty_cache()
 
-    def _train_step(self, data_pack_shards: list[dict], *, allow_step: bool, grad_scale: int) -> dict | None:
+    def _train_step(
+        self,
+        data_pack_shards: list[dict],
+        *,
+        allow_step: bool,
+        grad_scale: int,
+        stream_gradient_shards: bool,
+    ) -> dict | None:
         """Run a single actor forward + backward microbatch."""
 
         worker = self.worker
@@ -145,32 +155,48 @@ class TrainingManager:
         if not isinstance(loss, torch.Tensor):
             raise TypeError("train_loss_fn must return a torch.Tensor")
         (loss / max(grad_scale, 1)).backward()
-        # Consume every microbatch immediately: TP-replicated grads are
-        # finalized, then DP reduce-scatter writes only this rank's FP32
-        # accumulation shard and releases the full autograd gradients.
-        self._sync_tensor_parallel_replicated_gradients()
-        worker.optimizer.reduce_scatter_gradients()
+        if stream_gradient_shards:
+            # Offloaded optimizers consume every microbatch immediately so a
+            # full persistent FP32 gradient never overlaps streamed state.
+            self._sync_tensor_parallel_replicated_gradients()
+            worker.optimizer.reduce_scatter_gradients()
+        else:
+            # For none/CPU offload, retain the original fast path:
+            # accumulate once per parameter and defer DP/TP collectives until
+            # the actual optimizer step instead of scanning every bucket for
+            # every microbatch.
+            self._accumulate_main_gradients()
         stepped = allow_step
         grad_norm = None
         multimodal_grad_metrics = None
         clipped_grad_norm = None
         if stepped:
+            if not stream_gradient_shards:
+                self._sync_data_parallel_gradients()
+                self._sync_tensor_parallel_replicated_gradients()
             self._finalize_router_expert_bias()
             multimodal_groups = tuple(
                 group
                 for group in worker.multimodal_lr_schedules
                 if any(getattr(param, "_areno_lr_group", None) == group for param in worker.model.parameters())
             )
-            grad_norms = _grad_norms_from_shards(worker.optimizer.grad_shards(), multimodal_groups)
+            grad_norms = (
+                _grad_norms_from_shards(worker.optimizer.grad_shards(), multimodal_groups)
+                if stream_gradient_shards
+                else _grad_norms(worker.model.parameters(), multimodal_groups)
+            )
             grad_norm = grad_norms.pop("global")
             multimodal_grad_metrics = (
                 {f"{group}_grad_norm": grad_norms[group] for group in multimodal_groups} if multimodal_groups else None
             )
             clipped_grad_norm = grad_norm
             if worker.grad_clip_norm is not None:
-                clip_coef = float(worker.grad_clip_norm) / (grad_norm + 1e-6) if grad_norm > 0.0 else 1.0
-                if clip_coef < 1.0:
-                    worker.optimizer.scale_gradients(clip_coef)
+                if stream_gradient_shards:
+                    clip_coef = float(worker.grad_clip_norm) / (grad_norm + 1e-6) if grad_norm > 0.0 else 1.0
+                    if clip_coef < 1.0:
+                        worker.optimizer.scale_gradients(clip_coef)
+                else:
+                    _clip_grad_norm(worker.model.parameters(), grad_norm, worker.grad_clip_norm)
                 clipped_grad_norm = min(grad_norm, float(worker.grad_clip_norm))
             current_lr = self._lr_for_step(worker._global_step + 1)
             worker.optimizer.lr = current_lr
@@ -278,6 +304,34 @@ class TrainingManager:
             if grad is None or not bool(getattr(param, "tp_grad_allreduce", False)):
                 continue
             dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=ctx.group)
+
+    def _sync_data_parallel_gradients(self) -> None:
+        """Average resident full gradients across data-parallel replicas."""
+
+        worker = self.worker
+        ctx = get_tp_context()
+        if ctx.dp_size == 1:
+            return
+        for param in worker.model.parameters():
+            grad = param_grad(param)
+            if grad is None:
+                continue
+            dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=ctx.dp_group)
+            grad.div_(ctx.dp_size)
+
+    def _accumulate_main_gradients(self) -> None:
+        """Fold one microbatch into resident FP32 parameter gradients."""
+
+        for param in self.worker.model.parameters():
+            if param.grad is None:
+                continue
+            grad = param.grad.detach()
+            main_grad = getattr(param, "main_grad", None)
+            if isinstance(main_grad, torch.Tensor):
+                main_grad.add_(grad.to(dtype=main_grad.dtype))
+            else:
+                param.main_grad = grad.to(dtype=torch.float32)
+            param.grad = None
 
     def _finalize_router_expert_bias(self) -> None:
         """Apply MoE router/expert bias corrections after gradient sync."""

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -594,14 +594,23 @@ class ArenoWorker:
             raise RuntimeError("rollout workers cannot execute training operations")
         return self.training.train(payload)
 
-    def _sync_role_grads(self, role: WorkerRole) -> None:
+    def _sync_role_grads(self, role: WorkerRole, *, stream_gradient_shards: bool) -> None:
         """Sync a role's gradients across DP and TP groups.
 
-        DP gradients are reduce-scattered into optimizer-owned FP32 shards.
+        Disk-offloaded gradients are reduce-scattered into optimizer-owned
+        FP32 shards. Resident none/CPU gradients keep the original full-gradient
+        DP synchronization path.
         TP-replicated value-head params (`role_tp_average=True`) get averaged
         across TP; TP-sharded params marked with `tp_grad_allreduce` get summed.
         """
         ctx = get_tp_context()
+        if not stream_gradient_shards and ctx.dp_size > 1:
+            for param in role.parameters():
+                grad = param_grad(param)
+                if grad is None:
+                    continue
+                dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=ctx.dp_group)
+                grad.div_(ctx.dp_size)
         if ctx.world_size > 1:
             for param in role.parameters():
                 grad = param_grad(param)
@@ -612,7 +621,8 @@ class ArenoWorker:
                     grad.div_(ctx.world_size)
                 elif bool(getattr(param, "tp_grad_allreduce", False)):
                     dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=ctx.group)
-        role.optimizer.reduce_scatter_gradients()
+        if stream_gradient_shards:
+            role.optimizer.reduce_scatter_gradients()
 
     def save_checkpoint(self, payload: SaveCheckpointPayload) -> dict | None:
         """Persist the actor's weights to disk (rank 0 returns the resolved path)."""

--- a/tests/test_engine_roles_cpu.py
+++ b/tests/test_engine_roles_cpu.py
@@ -3,7 +3,12 @@ from unittest.mock import patch
 
 import torch
 
-from areno.api.backend.cuda.roles import RoleManager, WorkerRole, _gather_packed_hidden
+from areno.api.backend.cuda.roles import (
+    RoleManager,
+    WorkerRole,
+    _gather_packed_hidden,
+    accumulate_role_main_gradients,
+)
 from areno.engine.protocol import ScorePayload
 from areno.engine.worker import ArenoWorker
 
@@ -209,6 +214,35 @@ def test_gather_packed_hidden_averages_replicated_head_backbone_gradient():
         gathered.sum().backward()
 
     assert torch.equal(hidden.grad, torch.full_like(hidden, 0.25))
+
+
+def test_resident_role_gradient_accumulation_stays_fp32():
+    model = torch.nn.Linear(2, 1, bias=False, dtype=torch.bfloat16)
+    role = WorkerRole("model", model, optimizer=None, value_head=None)
+    parameter = model.weight
+
+    parameter.grad = torch.tensor([[0.25, -0.5]], dtype=torch.bfloat16)
+    accumulate_role_main_gradients(role)
+    parameter.grad = torch.tensor([[0.75, 0.25]], dtype=torch.bfloat16)
+    accumulate_role_main_gradients(role)
+
+    assert parameter.grad is None
+    assert parameter.main_grad.dtype == torch.float32
+    torch.testing.assert_close(parameter.main_grad, torch.tensor([[1.0, -0.25]]))
+
+
+def test_role_gradient_sharding_is_only_used_for_disk_streaming():
+    calls = []
+    optimizer = SimpleNamespace(reduce_scatter_gradients=lambda: calls.append("reduce_scatter"))
+    role = WorkerRole("model", torch.nn.Linear(2, 1), optimizer=optimizer, value_head=None)
+    ctx = SimpleNamespace(world_size=1, dp_size=1)
+
+    with patch("areno.engine.worker.get_tp_context", return_value=ctx):
+        ArenoWorker._sync_role_grads(SimpleNamespace(), role, stream_gradient_shards=False)
+        assert calls == []
+        ArenoWorker._sync_role_grads(SimpleNamespace(), role, stream_gradient_shards=True)
+
+    assert calls == ["reduce_scatter"]
 
 
 def test_prepare_actor_for_inference_rebuilds_weights_and_invalidates_train_state():

--- a/tests/test_fp32_master_optimizer_cpu.py
+++ b/tests/test_fp32_master_optimizer_cpu.py
@@ -98,6 +98,35 @@ def _gloo_sharded_optimizer_worker(rank: int, port: int, output_queue) -> None:
         dist.destroy_process_group()
 
 
+def _gloo_zero_length_optimizer_shard_worker(rank: int, port: int, optimizer_name: str, output_queue) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        parameter = torch.nn.Parameter(torch.tensor([1.0], dtype=torch.bfloat16))
+        optimizer_cls = {"fp32": AdamWFP32Master, "8bit": AdamW8bit}[optimizer_name]
+        optimizer = optimizer_cls(
+            [parameter],
+            lr=1.0e-2,
+            betas=(0.0, 0.0),
+            weight_decay=0.0,
+            bucket_numel=1,
+            dp_rank=rank,
+            dp_size=2,
+            dp_group=dist.group.WORLD,
+        )
+        parameter.grad = torch.tensor([1.0 + rank], dtype=torch.bfloat16)
+        optimizer.reduce_scatter_gradients()
+        shard_numel = optimizer.buckets[0].shard_numel
+        optimizer.step()
+        output_queue.put((rank, shard_numel, parameter.detach().float().tolist()))
+    finally:
+        dist.destroy_process_group()
+
+
 def test_fp32_master_adamw_matches_torch_reference_across_buckets() -> None:
     initial = torch.linspace(-1.5, 1.5, 37, dtype=torch.float32).to(torch.bfloat16)
     candidate_param = torch.nn.Parameter(initial.clone())
@@ -535,3 +564,31 @@ def test_real_gloo_dp_reduce_scatter_matches_averaged_reference() -> None:
     torch.testing.assert_close(joined_master, reference_param, rtol=2e-6, atol=2e-7)
     assert rank0_is_fp32 and rank1_is_fp32
     assert (rank0_shard_numel, rank1_shard_numel) == (9, 8)
+
+
+@pytest.mark.parametrize("optimizer_name", ["fp32", "8bit"])
+def test_real_gloo_dp_zero_length_shard_joins_parameter_gather(optimizer_name: str) -> None:
+    spawn = mp.get_context("spawn")
+    output_queue = spawn.Queue()
+    port = _free_port()
+    processes = [
+        spawn.Process(
+            target=_gloo_zero_length_optimizer_shard_worker,
+            args=(rank, port, optimizer_name, output_queue),
+        )
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    try:
+        results = dict((item[0], item[1:]) for item in (output_queue.get(timeout=20) for _ in processes))
+    finally:
+        for process in processes:
+            process.join(timeout=5)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+    assert all(process.exitcode == 0 for process in processes)
+    assert results[0][0] == 1
+    assert results[1][0] == 0
+    assert results[0][1] == results[1][1]

--- a/tests/test_fp32_master_optimizer_cpu.py
+++ b/tests/test_fp32_master_optimizer_cpu.py
@@ -265,7 +265,7 @@ def test_training_manager_offloads_optimizer_state_when_requested(
     optimizer_state_offload: str,
     expected_offloads: list[tuple[str, str | None]],
 ) -> None:
-    calls = {"events": [], "offload": []}
+    calls = {"events": [], "offload": [], "stream_gradient_shards": []}
 
     class _Optimizer:
         def configure_state_offload(self, *, mode: str, directory: str | None, batch_size: int) -> None:
@@ -303,7 +303,12 @@ def test_training_manager_offloads_optimizer_state_when_requested(
 
     worker._prepare_for_train = _prepare_for_train
     manager = TrainingManager(worker)
-    manager._train_step = lambda *_args, **_kwargs: {"ok": True}
+
+    def _train_step(*_args, **kwargs):
+        calls["stream_gradient_shards"].append(kwargs["stream_gradient_shards"])
+        return {"ok": True}
+
+    manager._train_step = _train_step
     payload = SimpleNamespace(data_packs_by_dp=[[{}]], gradient_accumulation_steps=1)
 
     assert manager.train(payload) == [{"ok": True}]
@@ -313,7 +318,27 @@ def test_training_manager_offloads_optimizer_state_when_requested(
     if optimizer_state_offload == "disk":
         expected_events.append(("prefetch",))
     expected_events.append(("zero_grad",))
-    assert calls == {"events": expected_events, "offload": expected_offloads}
+    assert calls == {
+        "events": expected_events,
+        "offload": expected_offloads,
+        "stream_gradient_shards": [optimizer_state_offload == "disk"],
+    }
+
+
+def test_training_manager_resident_gradient_accumulation_stays_fp32() -> None:
+    parameter = torch.nn.Parameter(torch.tensor([1.0, -2.0], dtype=torch.bfloat16))
+    worker = SimpleNamespace(model=torch.nn.Module())
+    worker.model.register_parameter("weight", parameter)
+    manager = TrainingManager(worker)
+
+    parameter.grad = torch.tensor([0.25, -0.5], dtype=torch.bfloat16)
+    manager._accumulate_main_gradients()
+    parameter.grad = torch.tensor([0.75, 0.25], dtype=torch.bfloat16)
+    manager._accumulate_main_gradients()
+
+    assert parameter.grad is None
+    assert parameter.main_grad.dtype == torch.float32
+    torch.testing.assert_close(parameter.main_grad, torch.tensor([1.0, -0.25]))
 
 
 def test_fp32_master_disk_offload_is_lazy_and_preserves_next_update(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Fix two optimizer regressions exposed by #498:

- Prevent DP optimizer all-gather hangs when a rank owns a zero-length shard.
- Keep `none` and `cpu` optimizer offload modes on the original resident FP32 `main_grad` accumulation path. Only `disk` uses per-microbatch gradient reduce-scatter and shard streaming.

The resident path is restored for both actor training and auxiliary critic/value-role training.

## Root cause

The bucket all-gather was conditional on rank-local updated references. A rank with a zero-length shard could skip the collective while peers entered it, causing a distributed hang.

Separately, gradient reduce-scatter was run after every microbatch regardless of offload mode. For `none` and `cpu`, this repeatedly scanned and copied optimizer buckets and added collectives to the hot training path, causing a severe performance regression.

## Fix

- Make every rank participate in the full active-bucket all-gather, including zero-length shard ranks.
- Route gradient handling by effective offload mode:
  - `none` / `cpu`: accumulate full FP32 `main_grad` tensors and perform DP/TP synchronization once at optimizer step.
  - `disk`: retain per-microbatch TP synchronization and gradient reduce-scatter.
- Apply the same routing to critic/value roles.
- Restore full-gradient norm calculation and clipping for resident modes.

## Tests

- `python -m pytest -q tests/test_fp32_master_optimizer_cpu.py tests/test_engine_roles_cpu.py` — 30 passed
- Real two-rank Gloo coverage for zero-length FP32 and Adam8bit optimizer shards
- `pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual` — passed