### PR TITLE
fix(cuda): keep disk gradients on the original path

### DIFF
--- a/areno/api/backend/cuda/roles.py
+++ b/areno/api/backend/cuda/roles.py
@@ -611,10 +611,7 @@ class RoleManager:
         loss_clipped = (clipped - target).pow(2)
         loss = value_loss_coef * 0.5 * torch.maximum(loss_unclipped[valid], loss_clipped[valid]).mean()
         (loss / max(group_size, 1)).backward()
-        if role.optimizer_offload_mode == "disk":
-            self.worker._sync_role_grads(role, stream_gradient_shards=True)
-        else:
-            accumulate_role_main_gradients(role)
+        accumulate_role_main_gradients(role)
         stats.add(loss, loss_unclipped, loss_clipped, values, target, baseline, valid)
         if allow_step:
             self._maybe_step_role(role)
@@ -624,8 +621,7 @@ class RoleManager:
 
         has_grad = role.optimizer.has_gradients() or any(param_grad(param) is not None for param in role.parameters())
         if has_grad:
-            if role.optimizer_offload_mode != "disk":
-                self.worker._sync_role_grads(role, stream_gradient_shards=False)
+            self.worker._sync_role_grads(role)
             role.optimizer.step()
         role.optimizer.zero_grad(set_to_none=True)
 

--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -18,7 +18,6 @@ from areno.engine.runtime.logprobs import (
 from areno.engine.runtime.train_step import (
     _clip_grad_norm,
     _grad_norms,
-    _grad_norms_from_shards,
     _merge_metrics,
     _pack_train_data,
     _train_meta,
@@ -78,7 +77,6 @@ class TrainingManager:
                         data_pack_shards,
                         allow_step=allow_step,
                         grad_scale=group_size,
-                        stream_gradient_shards=offload_mode == "disk",
                     )
                 )
             return results
@@ -98,7 +96,6 @@ class TrainingManager:
         *,
         allow_step: bool,
         grad_scale: int,
-        stream_gradient_shards: bool,
     ) -> dict | None:
         """Run a single actor forward + backward microbatch."""
 
@@ -155,48 +152,31 @@ class TrainingManager:
         if not isinstance(loss, torch.Tensor):
             raise TypeError("train_loss_fn must return a torch.Tensor")
         (loss / max(grad_scale, 1)).backward()
-        if stream_gradient_shards:
-            # Offloaded optimizers consume every microbatch immediately so a
-            # full persistent FP32 gradient never overlaps streamed state.
-            self._sync_tensor_parallel_replicated_gradients()
-            worker.optimizer.reduce_scatter_gradients()
-        else:
-            # For none/CPU offload, retain the original fast path:
-            # accumulate once per parameter and defer DP/TP collectives until
-            # the actual optimizer step instead of scanning every bucket for
-            # every microbatch.
-            self._accumulate_main_gradients()
+        # Keep the original full-gradient path for every optimizer residency
+        # mode, including disk. Disk offload still streams optimizer state,
+        # but it does not alter gradient accumulation or synchronization.
+        self._accumulate_main_gradients()
         stepped = allow_step
         grad_norm = None
         multimodal_grad_metrics = None
         clipped_grad_norm = None
         if stepped:
-            if not stream_gradient_shards:
-                self._sync_data_parallel_gradients()
-                self._sync_tensor_parallel_replicated_gradients()
+            self._sync_data_parallel_gradients()
+            self._sync_tensor_parallel_replicated_gradients()
             self._finalize_router_expert_bias()
             multimodal_groups = tuple(
                 group
                 for group in worker.multimodal_lr_schedules
                 if any(getattr(param, "_areno_lr_group", None) == group for param in worker.model.parameters())
             )
-            grad_norms = (
-                _grad_norms_from_shards(worker.optimizer.grad_shards(), multimodal_groups)
-                if stream_gradient_shards
-                else _grad_norms(worker.model.parameters(), multimodal_groups)
-            )
+            grad_norms = _grad_norms(worker.model.parameters(), multimodal_groups)
             grad_norm = grad_norms.pop("global")
             multimodal_grad_metrics = (
                 {f"{group}_grad_norm": grad_norms[group] for group in multimodal_groups} if multimodal_groups else None
             )
             clipped_grad_norm = grad_norm
             if worker.grad_clip_norm is not None:
-                if stream_gradient_shards:
-                    clip_coef = float(worker.grad_clip_norm) / (grad_norm + 1e-6) if grad_norm > 0.0 else 1.0
-                    if clip_coef < 1.0:
-                        worker.optimizer.scale_gradients(clip_coef)
-                else:
-                    _clip_grad_norm(worker.model.parameters(), grad_norm, worker.grad_clip_norm)
+                _clip_grad_norm(worker.model.parameters(), grad_norm, worker.grad_clip_norm)
                 clipped_grad_norm = min(grad_norm, float(worker.grad_clip_norm))
             current_lr = self._lr_for_step(worker._global_step + 1)
             worker.optimizer.lr = current_lr

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -594,17 +594,16 @@ class ArenoWorker:
             raise RuntimeError("rollout workers cannot execute training operations")
         return self.training.train(payload)
 
-    def _sync_role_grads(self, role: WorkerRole, *, stream_gradient_shards: bool) -> None:
+    def _sync_role_grads(self, role: WorkerRole) -> None:
         """Sync a role's gradients across DP and TP groups.
 
-        Disk-offloaded gradients are reduce-scattered into optimizer-owned
-        FP32 shards. Resident none/CPU gradients keep the original full-gradient
-        DP synchronization path.
+        All optimizer residency modes keep the original full-gradient DP
+        synchronization path.
         TP-replicated value-head params (`role_tp_average=True`) get averaged
         across TP; TP-sharded params marked with `tp_grad_allreduce` get summed.
         """
         ctx = get_tp_context()
-        if not stream_gradient_shards and ctx.dp_size > 1:
+        if ctx.dp_size > 1:
             for param in role.parameters():
                 grad = param_grad(param)
                 if grad is None:
@@ -621,8 +620,6 @@ class ArenoWorker:
                     grad.div_(ctx.world_size)
                 elif bool(getattr(param, "tp_grad_allreduce", False)):
                     dist.all_reduce(grad, op=dist.ReduceOp.SUM, group=ctx.group)
-        if stream_gradient_shards:
-            role.optimizer.reduce_scatter_gradients()
 
     def save_checkpoint(self, payload: SaveCheckpointPayload) -> dict | None:
         """Persist the actor's weights to disk (rank 0 returns the resolved path)."""

--- a/tests/test_engine_roles_cpu.py
+++ b/tests/test_engine_roles_cpu.py
@@ -231,18 +231,16 @@ def test_resident_role_gradient_accumulation_stays_fp32():
     torch.testing.assert_close(parameter.main_grad, torch.tensor([[1.0, -0.25]]))
 
 
-def test_role_gradient_sharding_is_only_used_for_disk_streaming():
+def test_role_gradient_sync_keeps_full_gradient_path():
     calls = []
     optimizer = SimpleNamespace(reduce_scatter_gradients=lambda: calls.append("reduce_scatter"))
     role = WorkerRole("model", torch.nn.Linear(2, 1), optimizer=optimizer, value_head=None)
     ctx = SimpleNamespace(world_size=1, dp_size=1)
 
     with patch("areno.engine.worker.get_tp_context", return_value=ctx):
-        ArenoWorker._sync_role_grads(SimpleNamespace(), role, stream_gradient_shards=False)
-        assert calls == []
-        ArenoWorker._sync_role_grads(SimpleNamespace(), role, stream_gradient_shards=True)
+        ArenoWorker._sync_role_grads(SimpleNamespace(), role)
 
-    assert calls == ["reduce_scatter"]
+    assert calls == []
 
 
 def test_prepare_actor_for_inference_rebuilds_weights_and_invalidates_train_state():

--- a/tests/test_fp32_master_optimizer_cpu.py
+++ b/tests/test_fp32_master_optimizer_cpu.py
@@ -265,7 +265,7 @@ def test_training_manager_offloads_optimizer_state_when_requested(
     optimizer_state_offload: str,
     expected_offloads: list[tuple[str, str | None]],
 ) -> None:
-    calls = {"events": [], "offload": [], "stream_gradient_shards": []}
+    calls = {"events": [], "offload": [], "train_steps": 0}
 
     class _Optimizer:
         def configure_state_offload(self, *, mode: str, directory: str | None, batch_size: int) -> None:
@@ -304,8 +304,8 @@ def test_training_manager_offloads_optimizer_state_when_requested(
     worker._prepare_for_train = _prepare_for_train
     manager = TrainingManager(worker)
 
-    def _train_step(*_args, **kwargs):
-        calls["stream_gradient_shards"].append(kwargs["stream_gradient_shards"])
+    def _train_step(*_args, **_kwargs):
+        calls["train_steps"] += 1
         return {"ok": True}
 
     manager._train_step = _train_step
@@ -321,7 +321,7 @@ def test_training_manager_offloads_optimizer_state_when_requested(
     assert calls == {
         "events": expected_events,
         "offload": expected_offloads,
-        "stream_gradient_shards": [optimizer_state_offload == "disk"],
+        "train_steps": 1,
     }
 
 


### PR DESCRIPTION
## Summary

Keep `disk` optimizer offload on the same original full FP32 `main_grad` accumulation and synchronization path now used by `none` and `cpu`.

PR #512 is already merged into the latest `main`; this PR is a focused follow-up that removes the remaining per-microbatch gradient reduce-scatter path from disk mode.

Disk offload still streams optimizer state to and from disk. This change only prevents optimizer-state residency from changing the gradient lifecycle.

## Why

In observed end-to-end runs, per-microbatch gradient reduce-scatter did not provide an obvious peak-memory benefit, but it had a large performance cost. It repeatedly scans and copies gradient buckets and adds collectives to every microbatch instead of synchronizing once per accumulated optimizer step.

## Changes

- Accumulate full FP32 `main_grad` tensors after each microbatch in disk mode.
- Perform DP and TP gradient synchronization once before the optimizer step.
- Use the original full-gradient norm and clipping path.
- Apply the same behavior to critic/value-role training.
- Preserve disk streaming for optimizer state.

## Trade-off

Disk mode retains complete FP32 accumulated gradients until the optimizer step. This intentionally favors substantially better training throughput over the theoretical gradient-memory reduction from per-microbatch sharding, which did not produce an obvious end-to-end peak-memory improvement in observed runs.

## Tests

- `python -m pytest -q tests/test_fp32_master_optimizer_cpu.py tests/test_engine_roles_cpu.py` — 30 passed
- `pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual` — passed