### PR TITLE
fix(engine): empty CUDA cache after every train step

### DIFF
--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -184,7 +184,7 @@ class TrainingManager:
             worker.optimizer.step()
             worker.optimizer.zero_grad(set_to_none=True)
             worker._global_step += 1
-            if worker.device.type == "cuda" and worker._global_step % 10 == 0:
+            if worker.device.type == "cuda":
                 torch.cuda.empty_cache()
         else:
             current_lr = worker.optimizer.lr


### PR DESCRIPTION
## Summary

- remove the ten-step cadence from the training-loop CUDA cache cleanup
- call `torch.cuda.empty_cache()` after every completed optimizer/global step
- keep gradient-accumulation microbatches unchanged because cleanup remains inside the `stepped` path

## Testing

- `pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual`
- targeted CPU tests could not be collected locally because the active Python 3.13 environment does not have PyTorch installed (`ModuleNotFoundError: torch`)
