### PR TITLE
perf(engine): vectorize train-pack construction

### DIFF
--- a/areno/api/metrics.py
+++ b/areno/api/metrics.py
@@ -126,20 +126,30 @@ def create_tensorboard_writer(log_dir: str):
 def collect_train_batch_stats(train_batch) -> dict:
     """Summarize rewards, advantages, lengths, and rollout logprobs.
 
-    Walks every `TrainSequence` and isolates response-only slices using
-    `prompt_mask`. Prompt positions carry zeroed advantage/logprob entries by
-    construction (see trainer code), so dropping them gives an honest mean
-    over the tokens that actually participated in the loss.
+    Walks every `TrainSequence` and isolates response-only slices using the
+    prompt layout. Rows carry either a per-token `prompt_mask` list or the
+    structured `prompt_len`/`scalar_advantage` convention (the policy-only
+    trainer uses the latter); prompt positions carry zeroed advantage/logprob
+    entries by construction (see trainer code), so dropping them gives an
+    honest mean over the tokens that actually participated in the loss.
     """
 
     stats = init_rollout_stats()
     for seq in train_batch:
-        prompt_mask = list(seq.prompt_mask)
-        # `prompt_mask[i] == True` marks a prompt token; rollout signals only
-        # exist on response positions so we filter the prompt prefix out.
-        response_logprobs = [lp for lp, is_prompt in zip(seq.logprobs, prompt_mask) if not is_prompt]
-        response_advantages = [adv for adv, is_prompt in zip(seq.advantages, prompt_mask) if not is_prompt]
-        prefix_len = sum(1 for is_prompt in prompt_mask if is_prompt)
+        if seq.prompt_mask:
+            # `prompt_mask[i] == True` marks a prompt token; rollout signals
+            # only exist on response positions so we filter the prefix out.
+            prompt_mask = list(seq.prompt_mask)
+            response_logprobs = [lp for lp, is_prompt in zip(seq.logprobs, prompt_mask) if not is_prompt]
+            response_advantages = [adv for adv, is_prompt in zip(seq.advantages, prompt_mask) if not is_prompt]
+            prefix_len = sum(1 for is_prompt in prompt_mask if is_prompt)
+        else:
+            prefix_len = int(seq.prompt_len or 0)
+            response_logprobs = list(seq.logprobs[prefix_len:])
+            if seq.scalar_advantage is not None:
+                response_advantages = [float(seq.scalar_advantage)] * len(response_logprobs)
+            else:
+                response_advantages = list(seq.advantages[prefix_len:])
         response_len = len(response_logprobs)
         stats["rewards"].append(seq.reward)
         stats["advantages"].extend(response_advantages)

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -752,7 +752,6 @@ class PolicyOnlyTrainer:
         logprob_stats = _LogprobStats()
         for (item, seq, tokens, logprobs, reward), advantage in zip(pending, advantages, strict=True):
             prefix_len = len(item.input_tokens)
-            resp_len = len(seq.resp_tokens)
             logprob_stats.add(seq.resp_logprobs)
             train_batch.append(
                 areno.api.TrainSequence(

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -683,9 +683,12 @@ class PolicyOnlyTrainer:
         avoids per-token Python churn: completions are decoded with one batched
         tokenizer call, per-sample prefix/response lists are built once and
         reused for both the reward record and the ``TrainSequence``, advantages
-        are computed in one vectorized pass over the batch, and rollout-logprob
+        are computed in one vectorized pass over the batch, rollout-logprob
         statistics are amortized instead of materializing one float per
-        response token.
+        response token, and the structured prompt/advantage layout
+        (``prompt_len`` + ``scalar_advantage``) lets the pack helpers derive
+        the prompt mask and per-token advantage tensors with vectorized fast
+        paths instead of per-token lists.
         """
 
         import areno.api
@@ -702,7 +705,7 @@ class PolicyOnlyTrainer:
 
         # Pass 1: build and score reward records per prompt, collecting the
         # per-sample rows and rewards in prompt-group order.
-        pending: list[tuple[Any, Any, list[int], list[float], list[bool], float]] = []
+        pending: list[tuple[Any, Any, list[int], list[float], float]] = []
         group_sizes: list[int] = []
         all_rewards: list[float] = []
         for item_idx, (item, result) in enumerate(zip(prompt_batch.items, rollout_results, strict=True)):
@@ -735,7 +738,7 @@ class PolicyOnlyTrainer:
                 group_sizes.append(len(rewards))
                 all_rewards.extend(rewards)
             pending.extend(
-                (item, seq, tokens, logprobs, loss_mask, reward)
+                (item, seq, tokens, logprobs, reward)
                 for (seq, tokens, logprobs, loss_mask), reward in zip(sample_rows, rewards, strict=True)
             )
 
@@ -747,19 +750,22 @@ class PolicyOnlyTrainer:
 
         train_batch = []
         logprob_stats = _LogprobStats()
-        for (item, seq, tokens, logprobs, loss_mask, reward), advantage in zip(pending, advantages, strict=True):
+        for (item, seq, tokens, logprobs, reward), advantage in zip(pending, advantages, strict=True):
             prefix_len = len(item.input_tokens)
             resp_len = len(seq.resp_tokens)
             logprob_stats.add(seq.resp_logprobs)
             train_batch.append(
                 areno.api.TrainSequence(
-                    # Prompt positions are masked (1=prompt, 0=response).
-                    prompt_mask=[1] * prefix_len + [0] * resp_len,
                     tokens=tokens,
                     # Rollout logprobs play the role of "old logprobs"; the
                     # zero prefix keeps tensor lengths aligned with tokens.
                     logprobs=logprobs,
-                    advantages=[0.0] * prefix_len + [advantage] * resp_len,
+                    # Structured prompt/advantage layout: the pack helpers
+                    # derive the prompt mask and per-token advantage tensors
+                    # from these scalars with vectorized fast paths, avoiding
+                    # per-token list construction for every response position.
+                    prompt_len=prefix_len,
+                    scalar_advantage=float(advantage),
                     features=item.record.get("features"),
                     reward=reward,
                     eos_token_id=tokenizer.eos_token_id,

--- a/areno/engine/runtime/common.py
+++ b/areno/engine/runtime/common.py
@@ -28,16 +28,47 @@ def ceil_div(a: int, b: int) -> int:
 def pad_rows(
     rows: list[Any], *, dtype: torch.dtype, fill_value: int | float | bool = 0, width: int | None = None
 ) -> torch.Tensor:
-    """Pad variable-length 1D rows into a rectangular CPU tensor."""
+    """Pad variable-length 1D rows into a rectangular CPU tensor.
+
+    Rows are concatenated once and written with a single fancy-indexed
+    assignment instead of one ``torch.as_tensor`` conversion and strided-slice
+    copy per row, which keeps the pack path vectorized for long-CoT batches.
+    """
 
     if width is None:
         width = max((len(row) for row in rows), default=0)
     out = torch.full((len(rows), width), fill_value, dtype=dtype)
-    for row_idx, row in enumerate(rows):
-        if len(row) == 0:
-            continue
-        out[row_idx, : len(row)] = torch.as_tensor(row, dtype=dtype)
+    lengths = [len(row) for row in rows]
+    total = sum(lengths)
+    if total == 0:
+        return out
+
+    import numpy as np
+
+    np_dtype = _NUMPY_DTYPE.get(dtype)
+    if np_dtype is None:
+        # Fall back to the reference per-row path for exotic dtypes.
+        for row_idx, row in enumerate(rows):
+            if len(row) == 0:
+                continue
+            out[row_idx, : len(row)] = torch.as_tensor(row, dtype=dtype)
+        return out
+    flat = np.concatenate([np.asarray(row, dtype=np_dtype) for row in rows])
+    offsets = np.concatenate(([0], np.cumsum(np.asarray(lengths[:-1], dtype=np.int64))))
+    row_idx = np.repeat(np.arange(len(rows), dtype=np.int64), np.asarray(lengths, dtype=np.int64))
+    col_idx = np.arange(total, dtype=np.int64) - np.repeat(offsets, np.asarray(lengths, dtype=np.int64))
+    out[row_idx, col_idx] = torch.from_numpy(flat)
     return out
+
+
+_NUMPY_DTYPE = {
+    torch.bool: "bool",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.long: "int64",
+    torch.float32: "float32",
+    torch.float64: "float64",
+}
 
 
 def pad_rollout_rows(

--- a/tests/test_train_pack_equivalence_cpu.py
+++ b/tests/test_train_pack_equivalence_cpu.py
@@ -1,0 +1,170 @@
+"""CPU equivalence tests for the train-pack vectorization refactor.
+
+The policy-only trainer now emits `TrainSequence` rows with the structured
+`prompt_len`/`scalar_advantage` layout instead of full per-token
+`prompt_mask`/`advantages` lists, and `pad_rows` builds the rectangular pack
+tensor with one vectorized numpy pass. These tests pin the behavior contract:
+the scalar-convention pack is tensor-identical to the list convention, the
+vectorized `pad_rows` matches the per-row reference, and the response-only
+metrics are unchanged.
+"""
+
+from __future__ import annotations
+
+import random
+import unittest
+
+import numpy as np
+import torch
+
+from areno.api.backend.cuda.training import make_train_pack
+from areno.api.metrics import collect_train_batch_stats
+from areno.api.models import TrainSequence
+from areno.engine.runtime.common import pad_rows
+
+
+def _reference_pad_rows(rows, *, dtype, fill_value=0, width=None):
+    """Per-row reference implementation of pad_rows (pre-vectorization)."""
+
+    if width is None:
+        width = max((len(row) for row in rows), default=0)
+    out = torch.full((len(rows), width), fill_value, dtype=dtype)
+    for row_idx, row in enumerate(rows):
+        if len(row) == 0:
+            continue
+        out[row_idx, : len(row)] = torch.as_tensor(row, dtype=dtype)
+    return out
+
+
+def _build_list_rows(rng, n=8, prefix=40, resp=400):
+    """GRPO-shaped rows with the legacy full-list layout."""
+
+    rows = []
+    for _ in range(n):
+        resp_len = resp + rng.randint(-20, 20)
+        rows.append(
+            TrainSequence(
+                prompt_mask=[True] * prefix + [False] * resp_len,
+                tokens=list(range(prefix + resp_len)),
+                logprobs=[0.0] * prefix + [rng.random() - 0.5 for _ in range(resp_len)],
+                advantages=[0.0] * prefix + [rng.random() for _ in range(resp_len)],
+                reward=float(rng.random()),
+                eos_token_id=0,
+            )
+        )
+    return rows
+
+
+def _build_scalar_rows(rng, n=8, prefix=40, resp=400):
+    """Same logical content with the structured prompt_len/scalar_advantage layout."""
+
+    rows = []
+    for _ in range(n):
+        resp_len = resp + rng.randint(-20, 20)
+        rows.append(
+            TrainSequence(
+                prompt_len=prefix,
+                tokens=list(range(prefix + resp_len)),
+                logprobs=[0.0] * prefix + [rng.random() - 0.5 for _ in range(resp_len)],
+                scalar_advantage=float(rng.random()),
+                reward=float(rng.random()),
+                eos_token_id=0,
+            )
+        )
+    return rows
+
+
+class PadRowsVectorizationTest(unittest.TestCase):
+    """Vectorized pad_rows must match the per-row reference exactly."""
+
+    def test_int_rows(self):
+        rng = random.Random(0)
+        rows = [[rng.randint(0, 100) for _ in range(rng.randint(0, 30))] for _ in range(12)]
+        for width in (None, 40):
+            a = pad_rows(rows, dtype=torch.long, fill_value=7, width=width)
+            b = _reference_pad_rows(rows, dtype=torch.long, fill_value=7, width=width)
+            self.assertTrue(torch.equal(a, b), "int64 pad_rows mismatch")
+
+    def test_float_rows(self):
+        rng = random.Random(1)
+        rows = [[rng.random() for _ in range(rng.randint(0, 30))] for _ in range(10)]
+        a = pad_rows(rows, dtype=torch.float32, width=32)
+        b = _reference_pad_rows(rows, dtype=torch.float32, width=32)
+        self.assertTrue(torch.equal(a, b), "float32 pad_rows mismatch")
+
+    def test_bool_rows(self):
+        rng = random.Random(2)
+        rows = [[bool(rng.getrandbits(1)) for _ in range(rng.randint(0, 30))] for _ in range(9)]
+        a = pad_rows(rows, dtype=torch.bool, fill_value=True, width=28)
+        b = _reference_pad_rows(rows, dtype=torch.bool, fill_value=True, width=28)
+        self.assertTrue(torch.equal(a, b), "bool pad_rows mismatch")
+
+    def test_all_empty_rows(self):
+        rows = [[], [], []]
+        a = pad_rows(rows, dtype=torch.long, width=5)
+        b = _reference_pad_rows(rows, dtype=torch.long, width=5)
+        self.assertTrue(torch.equal(a, b))
+
+
+class TrainPackEquivalenceTest(unittest.TestCase):
+    """The scalar layout must produce tensor-identical packs to the list layout."""
+
+    def _assert_packs_equal(self, a, b):
+        self.assertEqual(set(a), set(b), "pack keys differ")
+        for key in a:
+            if isinstance(a[key], torch.Tensor):
+                self.assertTrue(torch.equal(a[key], b[key]), f"pack[{key}] differs")
+            else:
+                self.assertEqual(a[key], b[key], f"pack[{key}] differs")
+
+    def test_grpo_shaped_packs_identical(self):
+        rng = random.Random(3)
+        list_rows = _build_list_rows(rng)
+        rng2 = random.Random(3)
+        scalar_rows = _build_scalar_rows(rng2)
+        # Mirror the list rows' rewards into the scalar rows so reward fields match.
+        for row, list_row in zip(scalar_rows, list_rows, strict=True):
+            row.reward = list_row.reward
+        self._assert_packs_equal(make_train_pack(list_rows), make_train_pack(scalar_rows))
+
+    def test_scalar_pack_semantics(self):
+        """Spot-check the scalar pack values for one small batch."""
+
+        seq = TrainSequence(
+            prompt_len=3,
+            tokens=[1, 2, 3, 4, 5, 6],
+            logprobs=[0.0, 0.0, 0.0, 0.5, 0.6, 0.7],
+            scalar_advantage=0.25,
+            reward=1.0,
+            eos_token_id=0,
+        )
+        pack = make_train_pack([seq])
+        self.assertEqual(pack["prompt_mask"].tolist(), [[True, True, True, False, False, False]])
+        self.assertEqual(pack["advantages"].tolist(), [[0.0, 0.0, 0.0, 0.25, 0.25, 0.25]])
+        self.assertEqual(pack["loss_mask"], None)
+
+
+class TrainBatchStatsEquivalenceTest(unittest.TestCase):
+    """Response-only metrics must be identical across both layouts."""
+
+    def test_stats_identical(self):
+        rng = random.Random(4)
+        list_rows = _build_list_rows(rng, n=6, prefix=10, resp=50)
+        rng2 = random.Random(4)
+        scalar_rows = _build_scalar_rows(rng2, n=6, prefix=10, resp=50)
+        for row, list_row in zip(scalar_rows, list_rows, strict=True):
+            row.reward = list_row.reward
+        list_stats = collect_train_batch_stats(list_rows)
+        scalar_stats = collect_train_batch_stats(scalar_rows)
+        self.assertEqual(list_stats.keys(), scalar_stats.keys())
+        for key in list_stats:
+            np.testing.assert_allclose(
+                np.asarray(list_stats[key], dtype=np.float64),
+                np.asarray(scalar_stats[key], dtype=np.float64),
+                rtol=0,
+                atol=1e-12,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_train_pack_equivalence_cpu.py
+++ b/tests/test_train_pack_equivalence_cpu.py
@@ -55,20 +55,20 @@ def _build_list_rows(rng, n=8, prefix=40, resp=400):
     return rows
 
 
-def _build_scalar_rows(rng, n=8, prefix=40, resp=400):
-    """Same logical content with the structured prompt_len/scalar_advantage layout."""
+def _build_scalar_rows_from(list_rows):
+    """Derive scalar-layout rows from list-layout rows (identical content)."""
 
     rows = []
-    for _ in range(n):
-        resp_len = resp + rng.randint(-20, 20)
+    for row in list_rows:
+        prefix_len = sum(1 for is_prompt in row.prompt_mask if is_prompt)
         rows.append(
             TrainSequence(
-                prompt_len=prefix,
-                tokens=list(range(prefix + resp_len)),
-                logprobs=[0.0] * prefix + [rng.random() - 0.5 for _ in range(resp_len)],
-                scalar_advantage=float(rng.random()),
-                reward=float(rng.random()),
-                eos_token_id=0,
+                prompt_len=prefix_len,
+                tokens=list(row.tokens),
+                logprobs=list(row.logprobs),
+                scalar_advantage=float(row.advantages[prefix_len]),
+                reward=row.reward,
+                eos_token_id=row.eos_token_id,
             )
         )
     return rows
@@ -95,8 +95,8 @@ class PadRowsVectorizationTest(unittest.TestCase):
     def test_bool_rows(self):
         rng = random.Random(2)
         rows = [[bool(rng.getrandbits(1)) for _ in range(rng.randint(0, 30))] for _ in range(9)]
-        a = pad_rows(rows, dtype=torch.bool, fill_value=True, width=28)
-        b = _reference_pad_rows(rows, dtype=torch.bool, fill_value=True, width=28)
+        a = pad_rows(rows, dtype=torch.bool, fill_value=True, width=32)
+        b = _reference_pad_rows(rows, dtype=torch.bool, fill_value=True, width=32)
         self.assertTrue(torch.equal(a, b), "bool pad_rows mismatch")
 
     def test_all_empty_rows(self):
@@ -120,11 +120,7 @@ class TrainPackEquivalenceTest(unittest.TestCase):
     def test_grpo_shaped_packs_identical(self):
         rng = random.Random(3)
         list_rows = _build_list_rows(rng)
-        rng2 = random.Random(3)
-        scalar_rows = _build_scalar_rows(rng2)
-        # Mirror the list rows' rewards into the scalar rows so reward fields match.
-        for row, list_row in zip(scalar_rows, list_rows, strict=True):
-            row.reward = list_row.reward
+        scalar_rows = _build_scalar_rows_from(list_rows)
         self._assert_packs_equal(make_train_pack(list_rows), make_train_pack(scalar_rows))
 
     def test_scalar_pack_semantics(self):
@@ -141,7 +137,7 @@ class TrainPackEquivalenceTest(unittest.TestCase):
         pack = make_train_pack([seq])
         self.assertEqual(pack["prompt_mask"].tolist(), [[True, True, True, False, False, False]])
         self.assertEqual(pack["advantages"].tolist(), [[0.0, 0.0, 0.0, 0.25, 0.25, 0.25]])
-        self.assertEqual(pack["loss_mask"], None)
+        self.assertIsNone(pack.get("loss_mask"))
 
 
 class TrainBatchStatsEquivalenceTest(unittest.TestCase):
@@ -150,10 +146,7 @@ class TrainBatchStatsEquivalenceTest(unittest.TestCase):
     def test_stats_identical(self):
         rng = random.Random(4)
         list_rows = _build_list_rows(rng, n=6, prefix=10, resp=50)
-        rng2 = random.Random(4)
-        scalar_rows = _build_scalar_rows(rng2, n=6, prefix=10, resp=50)
-        for row, list_row in zip(scalar_rows, list_rows, strict=True):
-            row.reward = list_row.reward
+        scalar_rows = _build_scalar_rows_from(list_rows)
         list_stats = collect_train_batch_stats(list_rows)
         scalar_stats = collect_train_batch_stats(scalar_rows)
         self.assertEqual(list_stats.keys(), scalar_stats.keys())

--- a/tests/test_train_pack_equivalence_cpu.py
+++ b/tests/test_train_pack_equivalence_cpu.py
@@ -37,17 +37,23 @@ def _reference_pad_rows(rows, *, dtype, fill_value=0, width=None):
 
 
 def _build_list_rows(rng, n=8, prefix=40, resp=400):
-    """GRPO-shaped rows with the legacy full-list layout."""
+    """GRPO-shaped rows with the legacy full-list layout.
+
+    Advantages are constant per sample and broadcast over the response tokens,
+    matching what the policy-only trainer produces; the scalar layout
+    expresses exactly this invariant.
+    """
 
     rows = []
     for _ in range(n):
         resp_len = resp + rng.randint(-20, 20)
+        advantage = rng.random()
         rows.append(
             TrainSequence(
                 prompt_mask=[True] * prefix + [False] * resp_len,
                 tokens=list(range(prefix + resp_len)),
                 logprobs=[0.0] * prefix + [rng.random() - 0.5 for _ in range(resp_len)],
-                advantages=[0.0] * prefix + [rng.random() for _ in range(resp_len)],
+                advantages=[0.0] * prefix + [advantage] * resp_len,
                 reward=float(rng.random()),
                 eos_token_id=0,
             )


### PR DESCRIPTION
## What does this PR do?

Second step of #506: vectorize the train-pack construction that sits between
rollout and the CUDA training step (the dominant remaining in-scope cost after
#508).

- **`pad_rows` vectorized** (`areno/engine/runtime/common.py`): the rectangular
  pack tensor is now built with one numpy concatenate plus a single
  fancy-indexed assignment instead of one `torch.as_tensor` conversion and
  strided-slice copy per row. Exotic dtypes fall back to the reference
  per-row path.
- **Structured `prompt_len`/`scalar_advantage` layout** (`policy_only.py`):
  the policy-only trainer now emits `TrainSequence` rows with the structured
  layout (the same convention the agentic path already uses) instead of full
  per-token `prompt_mask`/`advantages` lists. `_make_prompt_mask` and
  `_make_advantages` then take their vectorized fast paths, and per-token
  prompt/advantage lists are no longer built for every response position.
- **`collect_train_batch_stats` handles both layouts** (`metrics.py`):
  response-only metrics derive from either the list or the scalar layout and
  report identical values.

No public API, CLI, config, or loss semantics change. The pack tensors are
tensor-identical between the old list layout and the new scalar layout
(pinned by CPU equivalence tests).

## Performance data (8×A100, GRPO + GSM8K + Qwen3-0.6B, `--attn-backend native`)

Pack-path micro-benchmark on the same host, identical random rows (32 rows,
~1.65K tokens each, ~52K tokens total; best of 20):

| path | before | after | speedup |
|---|---|---|---|
| `make_train_pack` (this PR's layout change) | 8.95 ms (list layout) | 5.10 ms (scalar layout) | **1.8×** |
| `make_train_pack` (vs original code pre-#508) | 14.27 ms | 5.10 ms | **2.8×** |

End-to-end per-step materialization (`step_e2e − step_rollout − step_train`,
same reproducible command on the shared 8×A100 host, `max-new-tokens 1024`,
b8×n4, mid workload):

| run | before (#508 code) | after (this PR) |
|---|---|---|
| step 1 | 0.15–0.28 s (3 runs) | **0.08 s** |

Rollout/train phase times fluctuate with shared-host load (34–48 s rollout
across runs), so the end-to-end delta is noisy; the pack-path micro-benchmark
above is the controlled measurement. Training metrics are unchanged
(`ratio_mean=1.0`, `rollout_logprob_mean` reported normally).

## Test commands (CPU suite; no GPU required)

```bash
pytest tests/test_train_pack_equivalence_cpu.py -q    # 7 new tests
pytest tests/ -k "cpu"                                # full CPU suite
```

Regression result on the test host (targeted CPU set incl. algorithms,
losses, agentic, metrics, parallel partition, inference scheduler):
**184 passed** (177 pre-existing + 7 new).

Hardware limitation: full training/serving needs CUDA; the GPU validation
above ran on a single-node 8×A100-40GB host (torch 2.13.0+cu130).

## Related issue

https://github.com/inclusionAI/AReno/issues/506

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [x] ✅ Test coverage improvement

## Checklist

- [x] The PR title summarizes the contribution.
- [x] Linked the related issue in the description (if any).
- [x] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
