### PR TITLE
fix: reset Bailing recurrent slots and aggregate logp metrics

### DIFF
--- a/areno/api/backend/common.py
+++ b/areno/api/backend/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from enum import Enum
 
 from areno.api.models import RolloutResult, RolloutSequence
@@ -26,12 +27,23 @@ class MetricReduction(str, Enum):
 
     FIRST = "first"
     MEAN = "mean"
+    WEIGHTED_MEAN = "weighted_mean"
 
     def __str__(self) -> str:
         return self.value
 
 
-_FIRST_MICROBATCH_METRICS = frozenset(TrainMetric)
+LOGP_METRIC_WEIGHT = "_logp_metric_weight"
+
+_FIRST_MICROBATCH_METRICS = frozenset({TrainMetric.RATIO_MEAN, TrainMetric.RATIO_STD})
+_TOKEN_WEIGHTED_METRICS = frozenset(
+    {
+        TrainMetric.ROLLOUT_LOGPROBS_MEAN,
+        TrainMetric.TRAIN_LOGPROBS_MEAN,
+        TrainMetric.LOGP_DIFF_MEAN,
+        TrainMetric.LOGP_ABS_DIFF_MEAN,
+    }
+)
 
 
 def accumulation_steps(microbatch_count: int, requested_steps: int | None) -> int:
@@ -52,7 +64,36 @@ def accumulation_group_size(index: int, microbatch_count: int, steps: int) -> in
 def metric_reduction(key: str) -> MetricReduction:
     """Return the backend-independent reduction for a microbatch metric."""
 
-    return MetricReduction.FIRST if key in _FIRST_MICROBATCH_METRICS else MetricReduction.MEAN
+    if key in _FIRST_MICROBATCH_METRICS:
+        return MetricReduction.FIRST
+    if key in _TOKEN_WEIGHTED_METRICS:
+        return MetricReduction.WEIGHTED_MEAN
+    return MetricReduction.MEAN
+
+
+def reduce_microbatch_metrics(rows: Iterable[Mapping[str, float]]) -> dict[str, float]:
+    """Reduce microbatch metrics, weighting logprob means by active tokens."""
+
+    first: dict[str, float] = {}
+    totals: dict[str, float] = {}
+    denominators: dict[str, float] = {}
+    for row in rows:
+        weight = float(row.get(LOGP_METRIC_WEIGHT, 1.0))
+        for raw_key, raw_value in row.items():
+            key = str(raw_key)
+            if key == LOGP_METRIC_WEIGHT:
+                continue
+            value = float(raw_value)
+            reduction = metric_reduction(key)
+            if reduction is MetricReduction.FIRST:
+                first.setdefault(key, value)
+                continue
+            item_weight = weight if reduction is MetricReduction.WEIGHTED_MEAN else 1.0
+            totals[key] = totals.get(key, 0.0) + value * item_weight
+            denominators[key] = denominators.get(key, 0.0) + item_weight
+    reduced = {key: total / max(denominators[key], 1.0) for key, total in totals.items()}
+    reduced.update(first)
+    return reduced
 
 
 def expand_prompts(prompt_tokens: list[list[int]], n_samples: int) -> list[list[int]]:
@@ -96,7 +137,9 @@ __all__ = [
     "expand_prompt_features",
     "expand_prompts",
     "group_rollout_sequences",
+    "LOGP_METRIC_WEIGHT",
     "metric_reduction",
     "MetricReduction",
+    "reduce_microbatch_metrics",
     "TrainMetric",
 ]

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -24,11 +24,10 @@ from threading import Lock
 
 from areno.api.backend.base import Backend, BackendCapabilities, register_backend
 from areno.api.backend.common import (
-    MetricReduction,
     expand_prompt_features,
     expand_prompts,
     group_rollout_sequences,
-    metric_reduction,
+    reduce_microbatch_metrics,
 )
 from areno.api.backend.cuda.checkpoint import save_checkpoint
 from areno.api.backend.cuda.generation import rollout_options
@@ -481,7 +480,6 @@ class CudaBackend(Backend):
             self._step_e2e_start = train_start
             self._step_rollout_time_s = 0.0
         losses = []
-        metrics: dict[str, float] = {}
         # Slice the batch into `mini_bs` chunks; each chunk becomes one tensor
         # pack and the loss function is stamped onto each pack so the engine's
         # forward worker can call it without having to know about the loss API.
@@ -505,25 +503,12 @@ class CudaBackend(Backend):
         if self._separate_rollout and any(bool(stats.stepped) for stats in stats_list):
             self._train_policy_version += 1
         train_time_s = time.perf_counter() - train_start
-        # `first_policy_metrics` keeps the per-step rollout/policy diagnostics
-        # untouched (we want the value seen on the first microbatch, not the
-        # average over microbatches), while everything else gets mean-averaged.
-        first_policy_metrics: dict[str, float] = {}
-        averaged_metric_counts: dict[str, int] = {}
+        metric_rows: list[dict[str, float]] = []
         for stats in stats_list:
             losses.append(stats.loss)
             if stats.metrics:
-                for key, value in stats.metrics.items():
-                    key = str(key)
-                    value_float = float(value)
-                    if metric_reduction(key) is MetricReduction.FIRST:
-                        first_policy_metrics.setdefault(key, value_float)
-                    else:
-                        metrics[key] = metrics.get(key, 0.0) + value_float
-                        averaged_metric_counts[key] = averaged_metric_counts.get(key, 0) + 1
-        if metrics:
-            metrics = {key: value / averaged_metric_counts[key] for key, value in metrics.items()}
-        metrics.update(first_policy_metrics)
+                metric_rows.append({str(key): float(value) for key, value in stats.metrics.items()})
+        metrics = reduce_microbatch_metrics(metric_rows)
         result = {"loss": sum(losses) / max(len(losses), 1)}
         result.update(metrics)
         result.update(self._pending_policy_sync_metrics)

--- a/areno/api/backend/cuda/losses.py
+++ b/areno/api/backend/cuda/losses.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from areno.api.backend.common import TrainMetric
+from areno.api.backend.common import LOGP_METRIC_WEIGHT, TrainMetric
 
 if TYPE_CHECKING:
     import torch
@@ -179,6 +179,7 @@ def grpo_loss_fn(data_pack, logprobs, *, clip_eps: float = 0.2):
         else torch.zeros((), device=logprobs.device),
         "advantage_mean": masked_mean(layout.advantages, layout).detach(),
         "response_len": layout.response_len.mean().detach(),
+        LOGP_METRIC_WEIGHT: layout.valid_count.detach(),
         TrainMetric.ROLLOUT_LOGPROBS_MEAN: masked_mean(layout.old_logprobs, layout).detach(),
         TrainMetric.TRAIN_LOGPROBS_MEAN: masked_mean(logprobs.detach(), layout).detach(),
         TrainMetric.LOGP_DIFF_MEAN: masked_mean(difference, layout).detach(),
@@ -204,6 +205,7 @@ def gspo_loss_fn(data_pack, logprobs, *, clip_eps: float = 3e-4):
         TrainMetric.RATIO_STD: seq_ratio.std(unbiased=False).detach(),
         "advantage_mean": seq_advantage.mean().detach(),
         "response_len": layout.response_len.mean().detach(),
+        LOGP_METRIC_WEIGHT: layout.valid_count.detach(),
         TrainMetric.ROLLOUT_LOGPROBS_MEAN: masked_mean(layout.old_logprobs, layout).detach(),
         TrainMetric.TRAIN_LOGPROBS_MEAN: masked_mean(logprobs.detach(), layout).detach(),
         TrainMetric.LOGP_DIFF_MEAN: masked_mean(difference, layout).detach(),

--- a/areno/api/backend/mlx/backend.py
+++ b/areno/api/backend/mlx/backend.py
@@ -10,10 +10,9 @@ from typing import Any
 from areno.api.algorithms import describe_loss_fn
 from areno.api.backend.base import Backend, BackendCapabilities, BackendRuntimeComponents, register_backend
 from areno.api.backend.common import (
-    MetricReduction,
     accumulation_group_size,
     accumulation_steps,
-    metric_reduction,
+    reduce_microbatch_metrics,
 )
 from areno.api.backend.mlx.checkpoint import save_checkpoint
 from areno.api.backend.mlx.generation import ContinuousBatchScheduler, GenerationConfig
@@ -223,9 +222,7 @@ class MlxBackend(Backend):
         grad_accum = None
         group_count = 0
         losses: list[float] = []
-        metric_totals: dict[str, float] = {}
-        metric_counts: dict[str, int] = {}
-        first_policy_metrics: dict[str, float] = {}
+        metric_rows: list[dict[str, float]] = []
         grad_norms: list[float] = []
         learning_rates = set_group_learning_rates(self._optimizer_groups, ctx.global_step)
         learning_rate = learning_rates["model"]
@@ -260,20 +257,12 @@ class MlxBackend(Backend):
                 mx.eval(loss, grads)
 
             losses.append(float(loss.item()))
-            for key, value in stats.items():
-                key = str(key)
-                scalar = float(value.item())
-                if metric_reduction(key) is MetricReduction.FIRST:
-                    first_policy_metrics.setdefault(key, scalar)
-                else:
-                    metric_totals[key] = metric_totals.get(key, 0.0) + scalar
-                    metric_counts[key] = metric_counts.get(key, 0) + 1
+            metric_rows.append({str(key): float(value.item()) for key, value in stats.items()})
 
         self._policy_version += 1
         self._rollout_version = -1
         mx.clear_cache()
-        result = {key: value / metric_counts[key] for key, value in metric_totals.items()}
-        result.update(first_policy_metrics)
+        result = reduce_microbatch_metrics(metric_rows)
         result.update(
             {
                 "loss": sum(losses) / len(losses),

--- a/areno/api/backend/mlx/losses.py
+++ b/areno/api/backend/mlx/losses.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from areno.api.backend.common import TrainMetric
+from areno.api.backend.common import LOGP_METRIC_WEIGHT, TrainMetric
 
 MlxLoss = Callable[[dict[str, Any], Any], tuple[Any, dict[str, Any]]]
 
@@ -178,6 +178,7 @@ def _policy_stats(batch, logprobs, ratio, loss):
         TrainMetric.RATIO_STD: mx.sqrt(mx.maximum(masked_mean((ratio - masked_mean(ratio)) ** 2), mx.array(0.0))),
         "advantage_mean": masked_mean(batch["advantages"]),
         "response_len": mx.maximum(mask.sum(axis=-1), mx.array(1.0)).mean(),
+        LOGP_METRIC_WEIGHT: count,
         TrainMetric.ROLLOUT_LOGPROBS_MEAN: masked_mean(old),
         TrainMetric.TRAIN_LOGPROBS_MEAN: masked_mean(mx.stop_gradient(logprobs)),
         TrainMetric.LOGP_DIFF_MEAN: masked_mean(diff),

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -1567,6 +1567,18 @@ class BailingMoeV3ForCausalLM(nn.Module):
             layer.attention.reset_kv_cache()
 
     @torch.no_grad()
+    def reset_recurrent_cache_slots(self, slots: torch.Tensor) -> None:
+        """Clear recurrent state before a released inference slot is reused."""
+
+        slots = slots.to(device=next(self.parameters()).device, dtype=torch.long)
+        for layer in self.layers:
+            attn = layer.attention
+            if isinstance(attn, (BailingLinearAttention, BailingKDAAttention)) and attn.state_cache.numel() > 0:
+                attn.state_cache.index_fill_(0, slots, 0)
+            if isinstance(attn, BailingKDAAttention) and attn.conv_cache.numel() > 0:
+                attn.conv_cache.index_fill_(0, slots, 0)
+
+    @torch.no_grad()
     def offload_kv_caches(self) -> None:
         for layer in self.layers:
             attn = layer.attention

--- a/tests/test_bailing_kv_cache_cpu.py
+++ b/tests/test_bailing_kv_cache_cpu.py
@@ -97,3 +97,30 @@ def test_bailing_v3_recurrent_attention_uses_recurrent_slots_instead_of_kv_block
     )
 
     assert _recurrent_cache_slots(meta).tolist() == [0, 1]
+
+
+def test_bailing_v3_clears_released_recurrent_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("triton")
+    from areno.models.bailing_v3 import model as bailing_v3
+
+    linear_attention = _LinearAttention()
+    linear_attention.state_cache = torch.ones(3, 2, 4, 4)
+    kda_attention = _KDAAttention()
+    kda_attention.state_cache = torch.ones(3, 2, 4, 6)
+    kda_attention.conv_cache = torch.ones(3, 3, 8, 2)
+    parameter = torch.nn.Parameter(torch.zeros(1))
+    model = SimpleNamespace(
+        layers=[SimpleNamespace(attention=linear_attention), SimpleNamespace(attention=kda_attention)],
+        parameters=lambda: iter((parameter,)),
+    )
+    monkeypatch.setattr(bailing_v3, "BailingLinearAttention", _LinearAttention)
+    monkeypatch.setattr(bailing_v3, "BailingKDAAttention", _KDAAttention)
+
+    bailing_v3.BailingMoeV3ForCausalLM.reset_recurrent_cache_slots(model, torch.tensor([1]))
+
+    assert torch.count_nonzero(linear_attention.state_cache[1]) == 0
+    assert torch.count_nonzero(kda_attention.state_cache[1]) == 0
+    assert torch.count_nonzero(kda_attention.conv_cache[1]) == 0
+    assert torch.all(linear_attention.state_cache[[0, 2]] == 1)
+    assert torch.all(kda_attention.state_cache[[0, 2]] == 1)
+    assert torch.all(kda_attention.conv_cache[[0, 2]] == 1)

--- a/tests/test_mlx_training_cpu.py
+++ b/tests/test_mlx_training_cpu.py
@@ -9,11 +9,13 @@ import numpy as np
 import pytest
 
 from areno.api.backend.common import (
+    LOGP_METRIC_WEIGHT,
     MetricReduction,
     TrainMetric,
     accumulation_group_size,
     accumulation_steps,
     metric_reduction,
+    reduce_microbatch_metrics,
 )
 from areno.api.backend.mlx.generation import ContinuousBatchScheduler, GenerationConfig, _Request
 from areno.api.backend.mlx.provider import parameter_group
@@ -68,9 +70,37 @@ def test_accumulation_windows_match_cuda_mini_batch_semantics():
 def test_policy_metric_reductions_use_typed_names():
     assert str(TrainMetric.LOGP_ABS_DIFF_MEAN) == "logp_abs_diff_mean"
     assert str(MetricReduction.FIRST) == "first"
-    assert metric_reduction(TrainMetric.LOGP_ABS_DIFF_MEAN) is MetricReduction.FIRST
-    assert metric_reduction(str(TrainMetric.LOGP_ABS_DIFF_MEAN)) is MetricReduction.FIRST
+    assert metric_reduction(TrainMetric.LOGP_ABS_DIFF_MEAN) is MetricReduction.WEIGHTED_MEAN
+    assert metric_reduction(str(TrainMetric.LOGP_ABS_DIFF_MEAN)) is MetricReduction.WEIGHTED_MEAN
+    assert metric_reduction(TrainMetric.RATIO_MEAN) is MetricReduction.FIRST
     assert metric_reduction("policy_loss") is MetricReduction.MEAN
+
+
+def test_logprob_metrics_are_weighted_by_active_tokens_across_microbatches():
+    reduced = reduce_microbatch_metrics(
+        [
+            {
+                TrainMetric.LOGP_ABS_DIFF_MEAN: 0.1,
+                TrainMetric.TRAIN_LOGPROBS_MEAN: -0.2,
+                TrainMetric.RATIO_MEAN: 1.0,
+                "policy_loss": 2.0,
+                LOGP_METRIC_WEIGHT: 2.0,
+            },
+            {
+                TrainMetric.LOGP_ABS_DIFF_MEAN: 0.01,
+                TrainMetric.TRAIN_LOGPROBS_MEAN: -0.5,
+                TrainMetric.RATIO_MEAN: 1.1,
+                "policy_loss": 4.0,
+                LOGP_METRIC_WEIGHT: 8.0,
+            },
+        ]
+    )
+
+    assert reduced[TrainMetric.LOGP_ABS_DIFF_MEAN] == pytest.approx(0.028)
+    assert reduced[TrainMetric.TRAIN_LOGPROBS_MEAN] == pytest.approx(-0.44)
+    assert reduced[TrainMetric.RATIO_MEAN] == pytest.approx(1.0)
+    assert reduced["policy_loss"] == pytest.approx(3.0)
+    assert LOGP_METRIC_WEIGHT not in reduced
 
 
 def test_multimodal_projector_group_takes_precedence_over_parent_tower():


### PR DESCRIPTION
## Summary

- Clear Bailing V3 KDA state and convolution caches when recurrent inference slots are released.
- Aggregate rollout/train log-prob diagnostics across all microbatches using active-token weighting.
- Add regression coverage for recurrent slot cleanup and unequal microbatch metric weights.

## Root cause

Bailing V3 did not implement the recurrent-slot reset hook used by the inference scheduler. A released slot could therefore retain KDA recurrent state and convolution history, and later agent/tool turns that reused the slot were prefetched from stale state. The effect accumulated on longer trajectories and inflated rollout-versus-training log-prob differences.

The train log also reduced all log-prob diagnostics with FIRST, so mini_bs=1 reported only the first trajectory rather than the complete training batch. This could display a much larger value than the token-weighted batch result.

## Fix

- Zero only the released slots in BailingLinearAttention/BailingKDAAttention state_cache and BailingKDAAttention conv_cache.
- Keep ratio diagnostics on their existing FIRST contract.
- Reduce rollout_logprobs_mean, train_logprobs_mean, logp_diff_mean, and logp_abs_diff_mean across microbatches, weighted by active response-token count.
- Share the reduction implementation between CUDA and MLX.

## Regression

Ling 3.0 Tiny office agentic RL, TP=1, mini_bs=1, batch_size=2, n_samples=4, 10k context, Flash Attention, Adam 8-bit, optimizer state offload to disk:

- Completed one rollout and training step successfully.
- Valid trajectories: 6.
- response_len: 646.8333.
- grad_norm: 2.1443.
- logp_diff_mean: 0.0076436.
- logp_abs_diff_mean: 0.0232489.

The reported log-prob values now cover every active response token in the six valid trajectories instead of only the first microbatch.

## Checks

- pytest -q tests/test_bailing_kv_cache_cpu.py tests/test_mlx_training_cpu.py::test_logprob_metrics_are_weighted_by_active_tokens_across_microbatches (6 passed)
- pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage manual (passed)