### PR TITLE
feat(models): add Phi-4 Multimodal text-only adapter

### DIFF
--- a/areno/accel/ops.py
+++ b/areno/accel/ops.py
@@ -12,10 +12,7 @@ attention). Adds two small utilities used throughout the layer code:
 
 from __future__ import annotations
 
-import logging
 from typing import Any
-
-import torch
 
 from areno.accel.activations import areno_gelu_tanh_and_mul, areno_silu_and_mul
 from areno.accel.attention import (
@@ -28,46 +25,7 @@ from areno.accel.kernels.fused_moe import fused_experts as areno_fused_experts
 from areno.accel.kernels.fused_moe import is_available as fused_moe_is_available
 from areno.accel.kernels.group_rmsnorm import rms_norm_gate_fwd
 from areno.accel.kernels.seg_la import SegLaMeta, seg_la_fwd
-
-logger = logging.getLogger(__name__)
-# Process-wide set of message keys already emitted by log_once/warn_once.
-_LOGGED: set[str] = set()
-
-
-def log_once(key: str, message: str, *, level: int = logging.DEBUG) -> None:
-    """Log ``message`` at most once per process for the given ``key``."""
-
-    if key in _LOGGED:
-        return
-    logger.log(level, message)
-    _LOGGED.add(key)
-
-
-def warn_once(key: str, message: str) -> None:
-    """Emit a warning at most once per process for the given ``key``."""
-
-    log_once(key, message, level=logging.WARNING)
-
-
-@torch._dynamo.disable
-def is_cuda_graph_capturing(tensor: torch.Tensor) -> bool:
-    """True if the tensor lives on CUDA and we are inside a graph capture."""
-
-    return tensor.is_cuda and torch.cuda.is_current_stream_capturing()
-
-
-@torch._dynamo.disable
-def can_use_cuda_kernel(tensor: torch.Tensor, name: str, *, allow_sm121: bool = False) -> bool:
-    """Decide whether to take the fused kernel path for ``tensor``.
-
-    Returns False only on non-CUDA tensors. ``name`` and ``allow_sm121`` are
-    kept for compatibility with existing call sites.
-    """
-
-    if not tensor.is_cuda:
-        return False
-    return True
-
+from areno.accel.utils import can_use_cuda_kernel, is_cuda_graph_capturing, log_once, warn_once
 
 __all__ = [
     "Any",

--- a/areno/accel/utils.py
+++ b/areno/accel/utils.py
@@ -1,0 +1,41 @@
+"""Lightweight acceleration helpers that do not import optional kernels."""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+_LOGGED: set[str] = set()
+
+
+def log_once(key: str, message: str, *, level: int = logging.DEBUG) -> None:
+    """Log ``message`` at most once per process for the given ``key``."""
+
+    if key in _LOGGED:
+        return
+    logger.log(level, message)
+    _LOGGED.add(key)
+
+
+def warn_once(key: str, message: str) -> None:
+    """Emit a warning at most once per process for the given ``key``."""
+
+    log_once(key, message, level=logging.WARNING)
+
+
+@torch._dynamo.disable
+def is_cuda_graph_capturing(tensor: torch.Tensor) -> bool:
+    """True if the tensor lives on CUDA and we are inside a graph capture."""
+
+    return tensor.is_cuda and torch.cuda.is_current_stream_capturing()
+
+
+@torch._dynamo.disable
+def can_use_cuda_kernel(tensor: torch.Tensor, name: str, *, allow_sm121: bool = False) -> bool:
+    """Return whether a fused CUDA kernel can run for ``tensor``."""
+
+    if not tensor.is_cuda:
+        return False
+    return True

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -73,6 +73,7 @@ def messages_to_prompt_tokens(
 
     messages = normalize_messages(messages)
     if getattr(tokenizer, "chat_template", None):
+        messages = _embed_tools_in_system_message(tokenizer, messages, tools)
         kwargs: dict[str, Any] = {"tokenize": True, "add_generation_prompt": True}
         if tools:
             kwargs["tools"] = tools
@@ -88,6 +89,42 @@ def messages_to_prompt_tokens(
             kwargs.pop("tools", None)
             return normalize_token_ids(apply_chat_template_with_options(tokenizer, messages, **kwargs))
     return normalize_token_ids(tokenizer.encode(messages_to_text(messages) or fallback_prompt))
+
+
+def _embed_tools_in_system_message(
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Adapt templates that read a JSON tool list from the system message.
+
+    Phi-4-Multimodal's published template ignores the conventional global
+    ``tools`` variable and instead concatenates ``message['tools']`` between
+    ``<|tool|>`` markers. Keep the normal ``tools=`` call contract while also
+    supplying that model-specific message field when the template declares it.
+    """
+
+    template = str(getattr(tokenizer, "chat_template", "") or "")
+    embeds_message_tools = "<|tool|>" in template and (
+        "'tools' in message" in template or '"tools" in message' in template
+    )
+    if not tools or not embeds_message_tools:
+        return messages
+
+    flat_tools = []
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        flat_tools.append(function if isinstance(function, dict) else tool)
+    serialized_tools = json.dumps(flat_tools, ensure_ascii=False, separators=(",", ":"))
+
+    rendered_messages = [dict(message) for message in messages]
+    for message in rendered_messages:
+        if message.get("role") == "system":
+            message.setdefault("tools", serialized_tools)
+            break
+    else:
+        rendered_messages.insert(0, {"role": "system", "content": "", "tools": serialized_tools})
+    return rendered_messages
 
 
 def _normalize_tools_for_chat_template(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/areno/api/tokenizer.py
+++ b/areno/api/tokenizer.py
@@ -51,14 +51,21 @@ def apply_chat_template_with_options(tokenizer, messages, **kwargs):
 
 
 def eos_token_ids(model_path: str | Path, tokenizer) -> tuple[int, ...]:
-    """Collect EOS ids from tokenizer and HF config.
+    """Collect EOS ids from generation config, tokenizer, and model config.
 
-    Some multimodal/chat configs expose multiple EOS ids at the top level and
-    inside `text_config`; rollout should stop on any of them. Duplicates are
-    removed while preserving first-seen order.
+    Generation config is authoritative for chat checkpoints whose tokenizer
+    exposes only a generic end-of-text token. Some multimodal configs also
+    expose EOS ids at the top level and inside ``text_config``; rollout should
+    stop on any of them. Duplicates are removed while preserving first-seen
+    order.
     """
 
     ids: list[int] = []
+    generation_config_path = Path(model_path) / "generation_config.json"
+    if generation_config_path.exists():
+        with generation_config_path.open("r", encoding="utf-8") as f:
+            generation_config = json.load(f)
+        _extend_token_ids(ids, generation_config.get("eos_token_id"))
     _extend_token_ids(ids, getattr(tokenizer, "eos_token_id", None))
     config_path = Path(model_path) / "config.json"
     if config_path.exists():

--- a/areno/api/tool_call_parser.py
+++ b/areno/api/tool_call_parser.py
@@ -218,7 +218,14 @@ def _parse_json_call_object(obj: Any, chosen_name: str | None) -> tuple[str, dic
         args = function.get("arguments", obj.get("arguments", {}))
     else:
         name = obj.get("name") or chosen_name
-        args = obj.get("arguments") if "arguments" in obj else obj
+        if "arguments" in obj:
+            args = obj.get("arguments")
+        elif isinstance(obj.get("name"), str) and "parameters" in obj:
+            # Phi-family checkpoints sometimes emit a call-shaped
+            # ``parameters`` object instead of OpenAI's ``arguments``.
+            args = obj.get("parameters")
+        else:
+            args = obj
     if not isinstance(name, str) or not name:
         return None
     if isinstance(args, str):

--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -28,7 +28,11 @@ from areno.api.multimodal import (
     mrope_position_ids_from_image_grid,
 )
 from areno.api.openai_chat import build_chat_completion_response, messages_to_prompt_tokens
-from areno.api.tokenizer import apply_chat_template_with_options, configure_chat_template_enable_thinking
+from areno.api.tokenizer import (
+    apply_chat_template_with_options,
+    configure_chat_template_enable_thinking,
+    eos_token_ids,
+)
 from areno.api.tool_call_parser import ToolCallParser, get_tool_call_parser, infer_tool_call_parser_name
 from areno.cli.model_refs import resolve_model_ref
 from areno.engine.data.tokenizer import load_processor, load_tokenizer
@@ -933,21 +937,7 @@ def _image_token_id(tokenizer: Any, processor: Any) -> int | None:
 def _generation_eos_token_ids(model_path: str, tokenizer: Any) -> tuple[int, ...]:
     """Use the checkpoint generation config's complete EOS set when available."""
 
-    tokenizer_eos = getattr(tokenizer, "eos_token_id", None)
-    fallback = (int(tokenizer_eos),) if isinstance(tokenizer_eos, int) else tuple(tokenizer_eos or ())
-    try:
-        from transformers import GenerationConfig
-
-        configured = GenerationConfig.from_pretrained(model_path).eos_token_id
-    except (OSError, ValueError):
-        configured = None
-    if isinstance(configured, int):
-        configured = (configured,)
-    if isinstance(configured, list | tuple):
-        # Preserve checkpoint order: the first value is also passed to samplers
-        # that accept only one EOS id.  Dict deduplication is deterministic.
-        return tuple(dict.fromkeys(int(value) for value in tuple(configured) + fallback))
-    return tuple(int(value) for value in fallback)
+    return eos_token_ids(model_path, tokenizer)
 
 
 def _normalize_stop(stop: str | list[str] | None) -> list[str]:

--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -172,6 +172,8 @@ class ServeState:
     default_max_tokens: int
     max_model_len: int
     tool_call_parser: ToolCallParser
+    stop_token_ids: tuple[int, ...]
+    eos_token_id: int | None
     active_tasks: set[asyncio.Task] = field(default_factory=set)
     closing: bool = False
     rollout_session_started: bool = False
@@ -390,6 +392,7 @@ def create_app(
         processor = engine.processor
         configure_chat_template_enable_thinking(tokenizer, chat_template_enable_thinking)
         configure_chat_template_enable_thinking(processor, chat_template_enable_thinking)
+    generation_eos_token_ids = _generation_eos_token_ids(model_path, tokenizer)
     state = ServeState(
         model_path=model_path,
         tokenizer=tokenizer,
@@ -399,6 +402,8 @@ def create_app(
         default_max_tokens=default_max_tokens,
         max_model_len=int(engine.max_model_len),
         tool_call_parser=get_tool_call_parser(infer_tool_call_parser_name(parser_trainer)),
+        stop_token_ids=generation_eos_token_ids,
+        eos_token_id=generation_eos_token_ids[0] if generation_eos_token_ids else None,
     )
     app = FastAPI(title="areno OpenAI-compatible server")
     app.state.areno_serve = state
@@ -469,8 +474,8 @@ def create_app(
             top_p=float(request.top_p),
             top_k=int(request.top_k),
             seed=request.seed,
-            stop_token_ids=_stop_token_ids(state.tokenizer),
-            eos_token_id=_first_eos_token_id(state.tokenizer),
+            stop_token_ids=state.stop_token_ids,
+            eos_token_id=state.eos_token_id,
         )
         pending = PendingRequest(
             request=request,
@@ -925,24 +930,24 @@ def _image_token_id(tokenizer: Any, processor: Any) -> int | None:
     return None
 
 
-def _first_eos_token_id(tokenizer: Any) -> int | None:
-    """Return the first eos id when the tokenizer reports one (handles list/int forms)."""
-    eos = getattr(tokenizer, "eos_token_id", None)
-    if isinstance(eos, int):
-        return eos
-    if isinstance(eos, list | tuple) and eos:
-        return int(eos[0])
-    return None
+def _generation_eos_token_ids(model_path: str, tokenizer: Any) -> tuple[int, ...]:
+    """Use the checkpoint generation config's complete EOS set when available."""
 
+    tokenizer_eos = getattr(tokenizer, "eos_token_id", None)
+    fallback = (int(tokenizer_eos),) if isinstance(tokenizer_eos, int) else tuple(tokenizer_eos or ())
+    try:
+        from transformers import GenerationConfig
 
-def _stop_token_ids(tokenizer: Any) -> tuple[int, ...]:
-    """Return the tokenizer's eos id(s) as a tuple of ints for use in `BatchKey`."""
-    eos = getattr(tokenizer, "eos_token_id", None)
-    if isinstance(eos, int):
-        return (eos,)
-    if isinstance(eos, list | tuple):
-        return tuple(int(value) for value in eos)
-    return ()
+        configured = GenerationConfig.from_pretrained(model_path).eos_token_id
+    except (OSError, ValueError):
+        configured = None
+    if isinstance(configured, int):
+        configured = (configured,)
+    if isinstance(configured, list | tuple):
+        # Preserve checkpoint order: the first value is also passed to samplers
+        # that accept only one EOS id.  Dict deduplication is deterministic.
+        return tuple(dict.fromkeys(int(value) for value in tuple(configured) + fallback))
+    return tuple(int(value) for value in fallback)
 
 
 def _normalize_stop(stop: str | list[str] | None) -> list[str]:

--- a/areno/engine/checkpoints/common.py
+++ b/areno/engine/checkpoints/common.py
@@ -99,6 +99,16 @@ class MergedColumnSpec:
 
 
 @dataclass(frozen=True, slots=True)
+class PackedSectionColumnSpec:
+    """One HF tensor whose semantic row sections are TP-sharded separately."""
+
+    key: str
+    tensor_attr: str
+    global_sizes_attr: str
+    local_sizes_attr: str
+
+
+@dataclass(frozen=True, slots=True)
 class KSharedQKVColumnSpec:
     """QKV load spec for checkpoints where later layers may share K/V."""
 
@@ -403,6 +413,8 @@ def save_checkpoint_weights(
     source_path: str | None,
     spec: CheckpointSpec,
     extra_tensors_fn: Callable[[CheckpointTensorStore], None] | None = None,
+    *,
+    copy_passthrough: bool = True,
 ) -> str | None:
     """Save a tensor-parallel model as a HF sharded safetensors checkpoint."""
 
@@ -430,7 +442,7 @@ def save_checkpoint_weights(
             writer.write(tensors, "extra-tensors")
             tensors.clear()
     saved_path = writer.finish()
-    if saved_path is not None and source_path is not None:
+    if copy_passthrough and saved_path is not None and source_path is not None:
         copy_source_passthrough_weights(
             source_path, saved_path, protected_prefix=_protected_prefix_from_top_level(spec.top_level)
         )
@@ -599,6 +611,9 @@ def load_layer_op(
     if isinstance(op, MergedColumnSpec):
         load_merged_column_spec(module, index, prefix, op, rank, world_size)
         return
+    if isinstance(op, PackedSectionColumnSpec):
+        load_packed_section_column_spec(module, index, prefix, op, rank, world_size)
+        return
     if isinstance(op, KSharedQKVColumnSpec):
         load_k_shared_qkv_column_spec(module, index, prefix, op, rank, world_size)
         return
@@ -641,6 +656,9 @@ def save_layer_op(
         return
     if isinstance(op, SplitColumnSpec):
         save_split_column_spec(tensors, module, prefix, op)
+        return
+    if isinstance(op, PackedSectionColumnSpec):
+        save_packed_section_column_spec(tensors, module, prefix, op)
         return
     if isinstance(op, RangedSplitColumnSpec):
         save_ranged_split_column_spec(tensors, module, prefix, op)
@@ -751,6 +769,47 @@ def load_merged_column_spec(
     copy_merged_column_from_index(dst, index, tensor_keys, rank, world_size)
 
 
+def load_packed_section_column_spec(
+    module: nn.Module,
+    index: SafetensorsIndex,
+    prefix: str,
+    spec: PackedSectionColumnSpec,
+    rank: int,
+    world_size: int,
+) -> None:
+    """Shard each row section of one packed HF tensor independently."""
+
+    dst = attr_path(module, spec.tensor_attr)
+    global_sizes = tuple(int(size) for size in attr_path(module, spec.global_sizes_attr))
+    local_sizes = tuple(int(size) for size in attr_path(module, spec.local_sizes_attr))
+    if len(global_sizes) != len(local_sizes):
+        raise ValueError("packed-section global and local size counts differ")
+    ranges = tuple(_shard_range(size, rank, world_size) for size in global_sizes)
+    expected_local_sizes = tuple(end - start for start, end in ranges)
+    if local_sizes != expected_local_sizes:
+        raise ValueError(f"packed-section local sizes {local_sizes} do not match TP shard sizes {expected_local_sizes}")
+    if dst.shape[0] != sum(local_sizes):
+        raise ValueError(f"packed-section destination has {dst.shape[0]} rows, expected {sum(local_sizes)}")
+
+    tensor_key = key(spec.key, prefix)
+    filename = index.weight_map.get(tensor_key)
+    if filename is None:
+        raise KeyError(f"missing HF weight {tensor_key}")
+    with safe_open(index.model_path / filename, framework="pt", device="cpu") as handle:
+        source = handle.get_slice(tensor_key)
+        source_shape = tuple(source.get_shape())
+        expected_shape = (sum(global_sizes), *dst.shape[1:])
+        if source_shape != expected_shape:
+            raise ValueError(f"checkpoint tensor {tensor_key} has shape {source_shape}, expected {expected_shape}")
+        source_offset = 0
+        destination_offset = 0
+        for global_size, local_size, (start, end) in zip(global_sizes, local_sizes, ranges, strict=True):
+            shard = source[source_offset + start : source_offset + end]
+            dst[destination_offset : destination_offset + local_size].copy_(shard.to(dtype=dst.dtype))
+            source_offset += global_size
+            destination_offset += local_size
+
+
 def load_k_shared_qkv_column_spec(
     module: nn.Module, index: SafetensorsIndex, prefix: str, spec: KSharedQKVColumnSpec, rank: int, world_size: int
 ) -> None:
@@ -808,6 +867,28 @@ def save_split_column_spec(
     gathered = gather_tensor_parallel_column_tensors(list(parts))
     for template, tensor in zip(spec.keys, gathered, strict=True):
         tensors[key(template, prefix)] = tensor
+
+
+def save_packed_section_column_spec(
+    tensors: dict[str, torch.Tensor | None],
+    module: nn.Module,
+    prefix: str,
+    spec: PackedSectionColumnSpec,
+) -> None:
+    """Gather local packed sections into their original single HF tensor."""
+
+    tensor = attr_path(module, spec.tensor_attr)
+    global_sizes = tuple(int(size) for size in attr_path(module, spec.global_sizes_attr))
+    local_sizes = [int(size) for size in attr_path(module, spec.local_sizes_attr)]
+    world_size = get_tp_context().world_size
+    if any(
+        global_size != local_size * world_size
+        for global_size, local_size in zip(global_sizes, local_sizes, strict=True)
+    ):
+        raise ValueError("packed-section sizes are incompatible with the tensor-parallel world size")
+    if tensor.shape[0] != sum(local_sizes):
+        raise ValueError(f"packed-section source has {tensor.shape[0]} rows, expected {sum(local_sizes)}")
+    tensors[key(spec.key, prefix)] = gather_tensor_parallel_split_column_tensor(tensor, local_sizes)
 
 
 def save_ranged_split_column_spec(

--- a/areno/engine/checkpoints/common.py
+++ b/areno/engine/checkpoints/common.py
@@ -468,7 +468,13 @@ def build_checkpoint_policy_plan(
     return tensors
 
 
-def copy_source_passthrough_weights(source_path: str | Path, output_path: str | Path, protected_prefix: str) -> None:
+def copy_source_passthrough_weights(
+    source_path: str | Path,
+    output_path: str | Path,
+    protected_prefix: str,
+    *,
+    allowed_keys: set[str] | None = None,
+) -> None:
     """Copy source checkpoint tensors outside the runtime trunk into output.
 
     Multimodal HF checkpoints often store text weights under
@@ -487,9 +493,18 @@ def copy_source_passthrough_weights(source_path: str | Path, output_path: str | 
     source_weight_map = _read_weight_map(source)
     output_index = json.loads(output_index_path.read_text())
     output_weight_map = dict(output_index["weight_map"])
-    passthrough_keys = [
-        key for key in source_weight_map if not key.startswith(protected_prefix) and key not in output_weight_map
-    ]
+    if allowed_keys is None:
+        passthrough_keys = [
+            key for key in source_weight_map if not key.startswith(protected_prefix) and key not in output_weight_map
+        ]
+    else:
+        missing = sorted(allowed_keys - set(source_weight_map))
+        if missing:
+            raise ValueError(f"source checkpoint is missing approved passthrough tensor {missing[0]}")
+        overlap = sorted(allowed_keys & set(output_weight_map))
+        if overlap:
+            raise ValueError(f"output checkpoint already owns approved passthrough tensor {overlap[0]}")
+        passthrough_keys = sorted(allowed_keys)
     if not passthrough_keys:
         return
 

--- a/areno/engine/data/rollout_state.py
+++ b/areno/engine/data/rollout_state.py
@@ -283,6 +283,83 @@ class InferenceBatchState:
                     raise RuntimeError("paged KV cache exhausted during decode")
                 blocks.append(self._free_blocks.pop(0))
 
+    def build_cache_reprefill_payload(
+        self,
+        seq_ids: list[int],
+        generated: torch.Tensor,
+        response_lens: torch.Tensor,
+    ) -> dict:
+        """Rebuild selected live KV rows from their complete token history.
+
+        Models may request this when a cache representation becomes invalid at a
+        sequence-length boundary.  The scheduler owns token/block history, so
+        the rebuild stays runtime-generic and reuses each row's existing pages.
+        """
+
+        input_ids: list[int] = []
+        position_ids: list[int] = []
+        mrope_position_parts: list[torch.Tensor] = []
+        has_mrope_positions = False
+        feature_mask: list[bool] = []
+        image_features: list[dict] = []
+        cu_seqlens = [0]
+        sample_indices: list[int] = []
+        block_table: list[list[int]] = []
+        cache_block_ids: list[int] = []
+        cache_block_offsets: list[int] = []
+        recurrent_slots: list[int] = []
+        for seq_id in seq_ids:
+            response_len = int(response_lens[seq_id].item())
+            history = self.prompts[seq_id] + generated[seq_id, :response_len].detach().cpu().tolist()
+            if not history:
+                raise ValueError("cache re-prefill requires at least one token")
+            blocks = self._seq_to_blocks[seq_id]
+            if len(blocks) < ceil_div(len(history), self.kv_block_size):
+                raise RuntimeError("cache re-prefill is missing paged KV blocks")
+            input_ids.extend(history)
+            position_ids.extend(range(len(history)))
+            prompt_mask, prompt_image_features = _slice_prompt_image_features(
+                self.prompt_features[seq_id], self.prompts[seq_id], 0, len(self.prompts[seq_id])
+            )
+            feature_mask.extend(prompt_mask)
+            feature_mask.extend([False] * response_len)
+            if prompt_image_features is not None:
+                image_features.append(prompt_image_features)
+            prompt_mrope = _slice_prompt_mrope_positions(self.prompt_features[seq_id], 0, len(self.prompts[seq_id]))
+            if prompt_mrope is not None:
+                has_mrope_positions = True
+                generated_positions = (
+                    torch.arange(len(self.prompts[seq_id]), len(history), dtype=torch.long).view(1, -1).expand(3, -1)
+                )
+                generated_positions.add_(
+                    _prompt_mrope_position_delta(self.prompt_features[seq_id], len(self.prompts[seq_id]))
+                )
+                mrope_position_parts.append(torch.cat((prompt_mrope, generated_positions), dim=1))
+            else:
+                mrope_position_parts.append(torch.arange(len(history), dtype=torch.long).view(1, -1).expand(3, -1))
+            for token_idx in range(len(history)):
+                cache_block_ids.append(blocks[token_idx // self.kv_block_size])
+                cache_block_offsets.append(token_idx % self.kv_block_size)
+            cu_seqlens.append(len(input_ids))
+            sample_indices.append(len(input_ids) - 1)
+            block_table.append(_pad_blocks(blocks, self.max_blocks_per_seq))
+            recurrent_slots.append(self._seq_to_recurrent_slot[seq_id])
+        return self._prefill_payload(
+            input_ids,
+            position_ids,
+            mrope_position_parts if has_mrope_positions else None,
+            feature_mask,
+            image_features,
+            cu_seqlens,
+            sample_indices,
+            block_table,
+            cache_block_ids,
+            cache_block_offsets,
+            recurrent_slots,
+            [],
+            seq_ids,
+        )
+
     def decode_position_deltas(self, seq_ids: list[int]) -> list[int]:
         """Return per-sequence MRoPE decode position deltas."""
 

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -469,18 +469,37 @@ class InferenceManager:
             self._ensure_decode_kv_blocks(state, active_rows, cache_seqlens)
             block_table = self._block_table_for_active_rows(state, active_rows)
             recurrent_slots = self._recurrent_slots_for_active_rows(state, active_rows)
-            next_tokens, next_logprobs = self._infer_decode_next_token_tensor(
-                next_tokens,
-                position_ids,
-                cache_seqlens,
-                block_table,
-                recurrent_slots,
-                active_count,
-                sampling_params,
-                sample_generator,
-                sample_step=sample_step,
-                eos_token_id=eos_token_id,
-            )
+            reprefill_mask = self._cache_reprefill_mask(cache_seqlens)
+            if bool(reprefill_mask.any().item()):
+                next_tokens, next_logprobs = self._infer_with_cache_reprefill(
+                    state,
+                    generated,
+                    response_lens,
+                    active_rows,
+                    next_tokens,
+                    position_ids,
+                    cache_seqlens,
+                    block_table,
+                    recurrent_slots,
+                    reprefill_mask,
+                    sampling_params,
+                    sample_generator,
+                    sample_step=sample_step,
+                    eos_token_id=eos_token_id,
+                )
+            else:
+                next_tokens, next_logprobs = self._infer_decode_next_token_tensor(
+                    next_tokens,
+                    position_ids,
+                    cache_seqlens,
+                    block_table,
+                    recurrent_slots,
+                    active_count,
+                    sampling_params,
+                    sample_generator,
+                    sample_step=sample_step,
+                    eos_token_id=eos_token_id,
+                )
             state.record_decode_routing(active_rows, cache_seqlens, self._last_routing_capture)
             sample_step += 1
             # Write the new tokens into the per-row response buffer using
@@ -635,6 +654,71 @@ class InferenceManager:
             [int(row) for row in active_rows.detach().cpu().tolist()],
             [int(pos) for pos in cache_seqlens.detach().cpu().tolist()],
         )
+
+    def _cache_reprefill_mask(self, cache_seqlens: torch.Tensor) -> torch.Tensor:
+        """Ask the active model whether any cached rows must be rebuilt."""
+
+        required = getattr(getattr(self.worker, "model", None), "cache_reprefill_required", None)
+        if required is None:
+            return torch.zeros_like(cache_seqlens, dtype=torch.bool)
+        mask = required(cache_seqlens)
+        if not isinstance(mask, torch.Tensor) or mask.shape != cache_seqlens.shape or mask.dtype != torch.bool:
+            raise TypeError("model cache_reprefill_required must return a bool tensor matching cache_seqlens")
+        return mask
+
+    def _infer_with_cache_reprefill(
+        self,
+        state: InferenceBatchState,
+        generated: torch.Tensor,
+        response_lens: torch.Tensor,
+        active_rows: torch.Tensor,
+        next_tokens: torch.Tensor,
+        position_ids: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        block_table: torch.Tensor,
+        recurrent_slots: torch.Tensor,
+        reprefill_mask: torch.Tensor,
+        sampling_params: SamplingParams,
+        sample_generator: torch.Generator | None,
+        *,
+        sample_step: int,
+        eos_token_id: int | tuple[int, ...] | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Re-prefill invalid rows, then decode the remaining rows normally."""
+
+        refreshed_indices = torch.nonzero(reprefill_mask, as_tuple=False).flatten()
+        refreshed_rows = [int(row) for row in active_rows[refreshed_indices].detach().cpu().tolist()]
+        payload = PrefillPayload.from_state_payload(
+            state.build_cache_reprefill_payload(refreshed_rows, generated, response_lens),
+            sampling_params=sampling_params,
+            sample_step=sample_step,
+            eos_token_id=eos_token_id,
+            sample_generator=sample_generator,
+            return_logprobs=True,
+        )
+        refreshed_tokens, refreshed_logprobs = self._infer_next_token_tensor(payload)
+        result_tokens = torch.empty_like(next_tokens)
+        result_logprobs = torch.empty(next_tokens.shape, device=self.device, dtype=refreshed_logprobs.dtype)
+        result_tokens[refreshed_indices] = refreshed_tokens
+        result_logprobs[refreshed_indices] = refreshed_logprobs
+        decode_indices = torch.nonzero(~reprefill_mask, as_tuple=False).flatten()
+        if decode_indices.numel() == 0:
+            return result_tokens, result_logprobs
+        decoded_tokens, decoded_logprobs = self._infer_decode_next_token_tensor(
+            next_tokens[decode_indices],
+            position_ids[decode_indices],
+            cache_seqlens[decode_indices],
+            block_table[decode_indices],
+            recurrent_slots[decode_indices],
+            int(decode_indices.numel()),
+            sampling_params,
+            sample_generator,
+            sample_step=sample_step,
+            eos_token_id=eos_token_id,
+        )
+        result_tokens[decode_indices] = decoded_tokens
+        result_logprobs[decode_indices] = decoded_logprobs
+        return result_tokens, result_logprobs
 
     def _block_table_for_active_rows(self, state: InferenceBatchState, active_rows: torch.Tensor) -> torch.Tensor:
         """Build a device block table for the current active rows."""

--- a/areno/engine/layers/attention.py
+++ b/areno/engine/layers/attention.py
@@ -32,7 +32,7 @@ class CausalSelfAttention(nn.Module):
     reduces across ranks to reassemble the full hidden state.
     """
 
-    def __init__(self, config: ModelConfig, layer_idx: int):
+    def __init__(self, config: ModelConfig, layer_idx: int, *, rotary_embedding: nn.Module | None = None):
         super().__init__()
         ctx = get_tp_context()
         self.layer_idx = layer_idx
@@ -58,7 +58,11 @@ class CausalSelfAttention(nn.Module):
         # Row-parallel output projection: input is already sharded along
         # head dimension, output is all-reduced across ranks.
         self.o_proj = RowParallelLinear(self.num_heads * self.head_dim, config.hidden_size, bias=False)
-        self.rope = RotaryEmbedding(config.head_dim, config.max_position_embeddings, config.rope_theta)
+        self.rope = (
+            rotary_embedding
+            if rotary_embedding is not None
+            else RotaryEmbedding(config.head_dim, config.max_position_embeddings, config.rope_theta)
+        )
         # Optional per-head QK normalization (used by some recent models).
         self.q_norm = RMSNorm(config.head_dim, config.rms_norm_eps) if config.qk_norm else None
         self.k_norm = RMSNorm(config.head_dim, config.rms_norm_eps) if config.qk_norm else None
@@ -93,13 +97,26 @@ class CausalSelfAttention(nn.Module):
             k = self.k_norm(k)
         # Rotary embedding is applied on the head dim using position-indexed
         # cos/sin tables; positions are broadcast across heads.
-        q, k = self.rope(q, k, position_ids)
+        q, k = self.apply_rotary(q, k, position_ids, train_meta, infer_meta)
 
         # Presence of infer_meta selects the paged KV-cache backend; otherwise
         # we run the training-mode FlashAttention (padded or varlen packed).
         if infer_meta is not None:
             return self.forward_infer(q, k, v, infer_meta)
         return self.forward_train(q, k, v, train_meta)
+
+    def apply_rotary(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply the model's rotary embedding, with a model override hook."""
+
+        del train_meta, infer_meta
+        return self.rope(q, k, position_ids)
 
     def forward_train(
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, train_meta: TrainMeta | None

--- a/areno/engine/layers/mlp.py
+++ b/areno/engine/layers/mlp.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from areno.accel.ops import areno_silu_and_mul, log_once
+from areno.accel.activations import areno_silu_and_mul
+from areno.accel.utils import log_once
 from areno.engine.config import ModelConfig
 from areno.engine.layers.linear import MergedColumnParallelLinear, RowParallelLinear
 

--- a/areno/engine/layers/norm.py
+++ b/areno/engine/layers/norm.py
@@ -13,7 +13,7 @@ import torch
 from torch import nn
 
 from areno.accel import areno_rmsnorm
-from areno.accel.ops import can_use_cuda_kernel, log_once, rms_norm_gate_fwd
+from areno.accel.utils import can_use_cuda_kernel, log_once
 from areno.engine.layers.linear import mark_tensor_parallel_parameter
 
 
@@ -90,8 +90,10 @@ class GroupRMSNormSigmoidGate(nn.Module):
         # Reshape last dim into (groups_per_rank, group_width) for the kernel.
         x = x.view(*shape[:-1], self.groups_per_rank, self.group_width)
         gate = gate.view(*shape[:-1], self.groups_per_rank, self.group_width)
-        if rms_norm_gate_fwd is None or not can_use_cuda_kernel(x, "fused group RMSNorm sigmoid gate kernel"):
+        if not can_use_cuda_kernel(x, "fused group RMSNorm sigmoid gate kernel"):
             raise RuntimeError("ARENO group RMSNorm sigmoid gate requires the fused CUDA kernel")
+        from areno.accel.kernels.group_rmsnorm import rms_norm_gate_fwd
+
         log_once("group_rmsnorm_sigmoid_gate", "using fused group RMSNorm sigmoid gate kernel")
         # Flatten the leading dims into a single batch so the kernel only
         # sees a 3D (B, groups, width) tensor.

--- a/areno/engine/runtime/decode_graph.py
+++ b/areno/engine/runtime/decode_graph.py
@@ -84,7 +84,6 @@ class DecodeGraph:
         """Allocate static input buffers and the `InferMeta` baked into capture."""
 
         self.model = model
-        self.decode_cache_length_limit = getattr(model, "decode_cache_length_limit", None)
         self.bucket = bucket
         self.scratch_block = scratch_block
         self.scratch_recurrent_slot = scratch_recurrent_slot
@@ -168,7 +167,6 @@ class DecodeGraph:
         actual = int(input_ids.numel())
         if actual > self.bucket:
             raise ValueError(f"decode payload has {actual} tokens, graph bucket is {self.bucket}")
-        _validate_decode_cache_length(cache_seqlens, actual, self.decode_cache_length_limit)
 
         # Copy the live values into the captured-stable buffers. The graph
         # was recorded against these buffer addresses so `copy_` here is what
@@ -199,14 +197,3 @@ class DecodeGraph:
         self.graph.replay()
         assert self.logits_shard is not None
         return self.logits_shard
-
-
-def _validate_decode_cache_length(
-    cache_seqlens: torch.Tensor,
-    actual: int,
-    limit: int | None,
-) -> None:
-    if limit is not None and actual and int(cache_seqlens[:actual].max().item()) >= limit:
-        raise ValueError(
-            "cached decode cannot cross the model's rotary-factor boundary; run a full long-context prefill"
-        )

--- a/areno/engine/runtime/decode_graph.py
+++ b/areno/engine/runtime/decode_graph.py
@@ -84,6 +84,7 @@ class DecodeGraph:
         """Allocate static input buffers and the `InferMeta` baked into capture."""
 
         self.model = model
+        self.decode_cache_length_limit = getattr(model, "decode_cache_length_limit", None)
         self.bucket = bucket
         self.scratch_block = scratch_block
         self.scratch_recurrent_slot = scratch_recurrent_slot
@@ -167,6 +168,7 @@ class DecodeGraph:
         actual = int(input_ids.numel())
         if actual > self.bucket:
             raise ValueError(f"decode payload has {actual} tokens, graph bucket is {self.bucket}")
+        _validate_decode_cache_length(cache_seqlens, actual, self.decode_cache_length_limit)
 
         # Copy the live values into the captured-stable buffers. The graph
         # was recorded against these buffer addresses so `copy_` here is what
@@ -197,3 +199,14 @@ class DecodeGraph:
         self.graph.replay()
         assert self.logits_shard is not None
         return self.logits_shard
+
+
+def _validate_decode_cache_length(
+    cache_seqlens: torch.Tensor,
+    actual: int,
+    limit: int | None,
+) -> None:
+    if limit is not None and actual and int(cache_seqlens[:actual].max().item()) >= limit:
+        raise ValueError(
+            "cached decode cannot cross the model's rotary-factor boundary; run a full long-context prefill"
+        )

--- a/areno/models/__init__.py
+++ b/areno/models/__init__.py
@@ -25,6 +25,13 @@ def _register_qwen35() -> None:
     register_adapter(Qwen35Adapter())
 
 
+def _register_phi4mm() -> None:
+    from areno.models.phi4mm import Phi4MMAdapter
+    from areno.models.registry import register_adapter
+
+    register_adapter(Phi4MMAdapter())
+
+
 def _register_bailing() -> None:
     from areno.models.bailing import BailingMoeLinearV2Adapter
     from areno.models.registry import register_adapter
@@ -71,6 +78,7 @@ _GROUPS = {
     "llama": _register_llama,
     "qwen3": _register_qwen3,
     "qwen3_5": _register_qwen35,
+    "phi4mm": _register_phi4mm,
     "bailing": _register_bailing,
     "bailing_v3": _register_bailing_v3,
     "gemma4": _register_gemma4,

--- a/areno/models/phi4mm/__init__.py
+++ b/areno/models/phi4mm/__init__.py
@@ -1,0 +1,21 @@
+"""Phi-4-Multimodal language-backbone adapter."""
+
+from __future__ import annotations
+
+from areno.models.phi4mm.model import (
+    Phi4MMAdapter,
+    Phi4MMAttention,
+    Phi4MMDecoderLayer,
+    Phi4MMForCausalLM,
+    Phi4MMLongRoPEScaledRotaryEmbedding,
+    Phi4MMModel,
+)
+
+__all__ = [
+    "Phi4MMAdapter",
+    "Phi4MMAttention",
+    "Phi4MMDecoderLayer",
+    "Phi4MMForCausalLM",
+    "Phi4MMLongRoPEScaledRotaryEmbedding",
+    "Phi4MMModel",
+]

--- a/areno/models/phi4mm/checkpoint.py
+++ b/areno/models/phi4mm/checkpoint.py
@@ -15,6 +15,8 @@ from areno.engine.checkpoints.common import (
     ParallelTensorSpec,
     ReplicatedTensorSpec,
     TopLevelSpec,
+    build_checkpoint_policy_plan,
+    copy_source_passthrough_weights,
     load_checkpoint_weights,
     save_checkpoint_weights,
 )
@@ -150,13 +152,41 @@ def save_phi4mm_weights(
     output_path: str | Path,
     source_path: str | Path | None,
 ) -> str | None:
-    """Save only Phi-4 base-language weights in official HF key layout."""
+    """Save an auditable official-style Phi-4 checkpoint without dropping modalities."""
 
     model.config.validate_tp(get_tp_context().world_size)
-    return save_checkpoint_weights(
+    if source_path is None:
+        raise ValueError("Phi4MM save requires source_path to preserve audited multimodal checkpoint tensors")
+    passthrough_keys = _phi4mm_passthrough_keys(source_path, len(model.layers))
+    saved_path = save_checkpoint_weights(
         model,
         str(output_path),
-        None if source_path is None else str(source_path),
+        str(source_path),
         CHECKPOINT_SPEC,
         copy_passthrough=False,
     )
+    if saved_path is not None:
+        copy_source_passthrough_weights(
+            source_path,
+            saved_path,
+            protected_prefix="model.",
+            allowed_keys=passthrough_keys,
+        )
+    return saved_path
+
+
+def build_phi4mm_policy_plan(model: nn.Module):
+    """Build the canonical text-backbone layout used for policy synchronization."""
+
+    return build_checkpoint_policy_plan(model, CHECKPOINT_SPEC)
+
+
+def _phi4mm_passthrough_keys(model_path: str | Path, num_hidden_layers: int) -> set[str]:
+    """Return the strictly-audited non-language tensors retained by a text-only runtime."""
+
+    audit_phi4mm_checkpoint(model_path, num_hidden_layers)
+    index = SafetensorsIndex(model_path, progress=False)
+    try:
+        return set(index.weight_map) - _required_base_keys(num_hidden_layers)
+    finally:
+        index.close()

--- a/areno/models/phi4mm/checkpoint.py
+++ b/areno/models/phi4mm/checkpoint.py
@@ -1,0 +1,162 @@
+"""Strict text-only checkpoint mapping for Phi-4-Multimodal."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from torch import nn
+
+from areno.engine.checkpoints.common import (
+    CheckpointSpec,
+    LayerSpec,
+    PackedSectionColumnSpec,
+    ParallelTensorSpec,
+    ReplicatedTensorSpec,
+    TopLevelSpec,
+    load_checkpoint_weights,
+    save_checkpoint_weights,
+)
+from areno.engine.checkpoints.io import SafetensorsIndex
+from areno.engine.parallel.context import get_tp_context
+
+TOP_LEVEL_SPEC = TopLevelSpec(
+    embedding_key="model.embed_tokens.weight",
+    embedding_attr="model.embed_tokens",
+    norm_key="model.norm.weight",
+    norm_attr="model.norm.weight",
+)
+LAYER_NORM_SPECS = (
+    ReplicatedTensorSpec("{prefix}.input_layernorm.weight", "input_layernorm.weight"),
+    ReplicatedTensorSpec("{prefix}.post_attention_layernorm.weight", "post_attention_layernorm.weight"),
+)
+QKV_SPEC = PackedSectionColumnSpec(
+    key="{prefix}.self_attn.qkv_proj.base_layer.weight",
+    tensor_attr="self_attn.qkv_proj.weight",
+    global_sizes_attr="self_attn.qkv_proj.out_features",
+    local_sizes_attr="self_attn.qkv_proj.local_out_features",
+)
+ATTN_OUT_SPEC = ParallelTensorSpec(
+    "{prefix}.self_attn.o_proj.base_layer.weight",
+    "self_attn.o_proj.weight",
+    1,
+)
+GATE_UP_SPEC = PackedSectionColumnSpec(
+    key="{prefix}.mlp.gate_up_proj.base_layer.weight",
+    tensor_attr="mlp.gate_up_proj.weight",
+    global_sizes_attr="mlp.gate_up_proj.out_features",
+    local_sizes_attr="mlp.gate_up_proj.local_out_features",
+)
+MLP_DOWN_SPEC = ParallelTensorSpec(
+    "{prefix}.mlp.down_proj.base_layer.weight",
+    "mlp.down_proj.weight",
+    1,
+)
+LAYER_SPEC = LayerSpec(
+    prefix="model.layers.{layer}",
+    replicated=LAYER_NORM_SPECS,
+    load_ops=(QKV_SPEC, ATTN_OUT_SPEC, GATE_UP_SPEC, MLP_DOWN_SPEC),
+    save_ops=(QKV_SPEC, ATTN_OUT_SPEC, GATE_UP_SPEC, MLP_DOWN_SPEC),
+)
+CHECKPOINT_SPEC = CheckpointSpec(top_level=TOP_LEVEL_SPEC, layer=LAYER_SPEC)
+
+_LAYER_BASE_SUFFIXES = (
+    "input_layernorm.weight",
+    "post_attention_layernorm.weight",
+    "self_attn.qkv_proj.base_layer.weight",
+    "self_attn.o_proj.base_layer.weight",
+    "mlp.gate_up_proj.base_layer.weight",
+    "mlp.down_proj.base_layer.weight",
+)
+_LORA_PATTERN = re.compile(
+    r"^model\.layers\.(\d+)\."
+    r"(?:self_attn\.(?:qkv_proj|o_proj)|mlp\.(?:gate_up_proj|down_proj))\."
+    r"lora_[AB]\.(vision|speech)\.weight$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Phi4MMCheckpointAudit:
+    total: int
+    consumed: int
+    vision_lora_skipped: int
+    speech_lora_skipped: int
+    vision_skipped: int
+    audio_skipped: int
+    unknown: int
+
+
+def _required_base_keys(num_hidden_layers: int) -> set[str]:
+    required = {"model.embed_tokens.weight", "model.norm.weight"}
+    for layer in range(num_hidden_layers):
+        required.update(f"model.layers.{layer}.{suffix}" for suffix in _LAYER_BASE_SUFFIXES)
+    return required
+
+
+def audit_phi4mm_checkpoint(model_path: str | Path, num_hidden_layers: int) -> Phi4MMCheckpointAudit:
+    """Classify every checkpoint key and reject missing or unknown tensors."""
+
+    index = SafetensorsIndex(model_path, progress=False)
+    try:
+        checkpoint_keys = set(index.weight_map)
+    finally:
+        index.close()
+    required = _required_base_keys(num_hidden_layers)
+    missing = sorted(required - checkpoint_keys)
+    if missing:
+        preview = ", ".join(missing[:5])
+        raise ValueError(f"Phi4MM checkpoint is missing {len(missing)} required base-language tensors: {preview}")
+
+    counts = {"vision_lora": 0, "speech_lora": 0, "vision": 0, "audio": 0}
+    unknown = []
+    for tensor_key in checkpoint_keys - required:
+        lora_match = _LORA_PATTERN.fullmatch(tensor_key)
+        if lora_match is not None and int(lora_match.group(1)) < num_hidden_layers:
+            counts[f"{lora_match.group(2)}_lora"] += 1
+        elif tensor_key.startswith("model.embed_tokens_extend.image_embed."):
+            counts["vision"] += 1
+        elif tensor_key.startswith("model.embed_tokens_extend.audio_embed."):
+            counts["audio"] += 1
+        else:
+            unknown.append(tensor_key)
+    if unknown:
+        preview = ", ".join(sorted(unknown)[:5])
+        raise ValueError(f"Phi4MM checkpoint contains {len(unknown)} unknown tensors: {preview}")
+    return Phi4MMCheckpointAudit(
+        total=len(checkpoint_keys),
+        consumed=len(required),
+        vision_lora_skipped=counts["vision_lora"],
+        speech_lora_skipped=counts["speech_lora"],
+        vision_skipped=counts["vision"],
+        audio_skipped=counts["audio"],
+        unknown=0,
+    )
+
+
+def load_phi4mm_weights(model: nn.Module, model_path: str | Path) -> Phi4MMCheckpointAudit:
+    """Audit and load the supported Phi-4 base-language tensors."""
+
+    model.config.validate_tp(get_tp_context().world_size)
+    audit = audit_phi4mm_checkpoint(model_path, len(model.layers))
+    load_checkpoint_weights(model, str(model_path), CHECKPOINT_SPEC)
+    if model.lm_head.weight is not model.model.embed_tokens.weight:
+        raise RuntimeError("Phi4MM embedding and LM head weight tying was lost during checkpoint loading")
+    return audit
+
+
+def save_phi4mm_weights(
+    model: nn.Module,
+    output_path: str | Path,
+    source_path: str | Path | None,
+) -> str | None:
+    """Save only Phi-4 base-language weights in official HF key layout."""
+
+    model.config.validate_tp(get_tp_context().world_size)
+    return save_checkpoint_weights(
+        model,
+        str(output_path),
+        None if source_path is None else str(source_path),
+        CHECKPOINT_SPEC,
+        copy_passthrough=False,
+    )

--- a/areno/models/phi4mm/model.py
+++ b/areno/models/phi4mm/model.py
@@ -150,10 +150,7 @@ def _phi4mm_longrope_sequence_length(
             raise ValueError("Phi4MM decode requires cache_seqlens for LongRoPE selection")
         sequence_length = int(infer_meta.cache_seqlens.max().item()) + 1
         if sequence_length > original_max_position_embeddings:
-            raise ValueError(
-                "Phi4MM cached decode cannot cross the LongRoPE boundary because cached keys may use short factors; "
-                "run a full long-context prefill"
-            )
+            raise ValueError("Phi4MM cached decode requires cache re-prefill before crossing the LongRoPE boundary")
         return sequence_length
 
     if infer_meta is not None:
@@ -275,7 +272,7 @@ class Phi4MMForCausalLM(nn.Module):
         if not config.tie_word_embeddings:
             raise ValueError("Phi4MMForCausalLM requires tied word embeddings")
         self.config = config
-        self.decode_cache_length_limit = int(config.hf_text_config["original_max_position_embeddings"])
+        self._longrope_cache_boundary = int(config.hf_text_config["original_max_position_embeddings"])
         self.model = Phi4MMModel(config)
         self.lm_head = VocabParallelLMHead(config.hidden_size, config.vocab_size, dtype=config.dtype)
         self._tie_word_embeddings()
@@ -358,6 +355,11 @@ class Phi4MMForCausalLM(nn.Module):
     def clear_kv_caches(self) -> None:
         for layer in self.layers:
             layer.self_attn.clear_kv_cache()
+
+    def cache_reprefill_required(self, cache_seqlens: torch.Tensor) -> torch.Tensor:
+        """Request a full long-factor KV rebuild immediately before the boundary decode."""
+
+        return cache_seqlens.eq(self._longrope_cache_boundary)
 
     @torch.no_grad()
     def reset_kv_caches(self) -> None:
@@ -465,3 +467,8 @@ class Phi4MMAdapter(ModelAdapter):
         from areno.models.phi4mm.checkpoint import save_phi4mm_weights
 
         return save_phi4mm_weights(model, output_path, source_path)
+
+    def build_policy_plan(self, model: nn.Module):
+        from areno.models.phi4mm.checkpoint import build_phi4mm_policy_plan
+
+        return build_phi4mm_policy_plan(model)

--- a/areno/models/phi4mm/model.py
+++ b/areno/models/phi4mm/model.py
@@ -14,6 +14,7 @@ from typing import Any
 import torch
 from torch import nn
 
+from areno.accel.utils import is_cuda_graph_capturing
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention import CausalSelfAttention
 from areno.engine.layers.mlp import GatedMLP
@@ -185,6 +186,26 @@ def _phi4mm_longrope_sequence_length(
     return int(position_ids.shape[-1])
 
 
+def _phi4mm_prefill_longrope_factor_mask(
+    position_ids: torch.Tensor,
+    infer_meta: InferMeta,
+    original_max_position_embeddings: int,
+) -> torch.Tensor:
+    """Select one LongRoPE factor per packed prefill sequence without scalars."""
+
+    if infer_meta.cu_seqlens is None:
+        raise ValueError("Phi4MM prefill requires cu_seqlens for LongRoPE selection")
+    flat_positions = position_ids.reshape(-1)
+    sequence_ends = infer_meta.cu_seqlens[1:].to(dtype=torch.long) - 1
+    long_by_sequence = flat_positions[sequence_ends].ge(original_max_position_embeddings)
+    # `cu_seqlens` boundaries identify which packed sequence owns each token.
+    # Unlike repeat_interleave, bucketize keeps the output shape statically
+    # determined by position_ids, which is safe for graph capture.
+    token_indices = torch.arange(flat_positions.numel(), device=position_ids.device)
+    sequence_indices = torch.bucketize(token_indices, infer_meta.cu_seqlens[1:-1], right=True)
+    return long_by_sequence[sequence_indices].reshape_as(position_ids)
+
+
 class Phi4MMAttention(CausalSelfAttention):
     """AReno GQA attention with a Phi-owned rotary implementation."""
 
@@ -213,6 +234,30 @@ class Phi4MMAttention(CausalSelfAttention):
                 k,
                 position_ids,
                 use_long_factor=position_ids.ge(self.rope.original_max_position_embeddings),
+            )
+        if infer_meta is not None:
+            # Prefill needs one factor for every token in a packed sequence:
+            # a full sequence crossing the boundary uses long factors even at
+            # position zero.  Do that with graph-safe tensor operations.  The
+            # eager validation remains a useful guard against a caller trying
+            # to append a chunk to short-factor cached keys, but must not run
+            # while Dynamo/CUDA Graph capture is active.
+            if not torch.compiler.is_compiling() and not is_cuda_graph_capturing(q):
+                _phi4mm_longrope_sequence_length(
+                    position_ids,
+                    train_meta,
+                    infer_meta,
+                    self.rope.original_max_position_embeddings,
+                )
+            return self.rope(
+                q,
+                k,
+                position_ids,
+                use_long_factor=_phi4mm_prefill_longrope_factor_mask(
+                    position_ids,
+                    infer_meta,
+                    self.rope.original_max_position_embeddings,
+                ),
             )
         sequence_length = _phi4mm_longrope_sequence_length(
             position_ids,

--- a/areno/models/phi4mm/model.py
+++ b/areno/models/phi4mm/model.py
@@ -14,7 +14,7 @@ from typing import Any
 import torch
 from torch import nn
 
-from areno.accel.ops import is_cuda_graph_capturing
+from areno.accel.utils import is_cuda_graph_capturing
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention import CausalSelfAttention
 from areno.engine.layers.mlp import GatedMLP

--- a/areno/models/phi4mm/model.py
+++ b/areno/models/phi4mm/model.py
@@ -14,7 +14,6 @@ from typing import Any
 import torch
 from torch import nn
 
-from areno.accel.utils import is_cuda_graph_capturing
 from areno.engine.config import ModelConfig, _parse_dtype
 from areno.engine.layers.attention import CausalSelfAttention
 from areno.engine.layers.mlp import GatedMLP
@@ -106,17 +105,30 @@ class Phi4MMLongRoPEScaledRotaryEmbedding(nn.Module):
         x: torch.Tensor,
         position_ids: torch.Tensor,
         sequence_length: int | None = None,
+        use_long_factor: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if sequence_length is None:
-            sequence_length = int(torch.max(position_ids).item()) + 1
-        inv_freq = (
-            self.long_inv_freq if sequence_length > self.original_max_position_embeddings else self.short_inv_freq
-        )
-        expanded_inv_freq = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
-        expanded_positions = position_ids[:, None, :].float()
+        if use_long_factor is not None:
+            if use_long_factor.shape != position_ids.shape:
+                raise ValueError("Phi4MM LongRoPE factor mask must match position_ids")
+            # Decode batches can contain both a short-cache row and a row
+            # rebuilt with long factors.  Keep that selection as tensor math:
+            # materialising cache_seqlens with .item() breaks torch.compile
+            # and prevents the decode CUDA graph from being captured/replayed.
+            positions = position_ids.float().unsqueeze(-1)
+            short_freqs = positions * self.short_inv_freq.float()
+            long_freqs = positions * self.long_inv_freq.float()
+            freqs = torch.where(use_long_factor.unsqueeze(-1), long_freqs, short_freqs)
+        else:
+            if sequence_length is None:
+                sequence_length = int(torch.max(position_ids).item()) + 1
+            inv_freq = (
+                self.long_inv_freq if sequence_length > self.original_max_position_embeddings else self.short_inv_freq
+            )
+            expanded_inv_freq = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+            expanded_positions = position_ids[:, None, :].float()
+            freqs = (expanded_inv_freq @ expanded_positions).transpose(1, 2)
         device_type = x.device.type if x.device.type != "mps" else "cpu"
         with torch.autocast(device_type=device_type, enabled=False):
-            freqs = (expanded_inv_freq @ expanded_positions).transpose(1, 2)
             embedding = torch.cat((freqs, freqs), dim=-1)
             cos = embedding.cos() * self.scaling_factor
             sin = embedding.sin() * self.scaling_factor
@@ -128,8 +140,9 @@ class Phi4MMLongRoPEScaledRotaryEmbedding(nn.Module):
         k: torch.Tensor,
         position_ids: torch.Tensor,
         sequence_length: int | None = None,
+        use_long_factor: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        cos, sin = self.cos_sin(q, position_ids, sequence_length)
+        cos, sin = self.cos_sin(q, position_ids, sequence_length, use_long_factor)
         cos = cos.unsqueeze(2)
         sin = sin.unsqueeze(2)
         q_rot, q_pass = q[..., : self.dim], q[..., self.dim :]
@@ -188,17 +201,25 @@ class Phi4MMAttention(CausalSelfAttention):
         train_meta: TrainMeta | None,
         infer_meta: InferMeta | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if infer_meta is not None and infer_meta.mode == "decode" and is_cuda_graph_capturing(q):
-            # DecodeGraph validates its dynamic cache lengths before replay.
-            # Capture itself always records the supported short-factor path.
-            sequence_length = self.rope.original_max_position_embeddings
-        else:
-            sequence_length = _phi4mm_longrope_sequence_length(
+        if infer_meta is not None and infer_meta.mode == "decode":
+            # A row that was re-prefilled across the boundary has its next
+            # position strictly above it; rows not rebuilt are still short.
+            # This tensor-only selection is essential for a captured graph:
+            # cache_seqlens.max().item() would force a Dynamo graph break.
+            # The scheduler requests a re-prefill at the equality boundary,
+            # so no short-factor KV cache is ever paired with a long query.
+            return self.rope(
+                q,
+                k,
                 position_ids,
-                train_meta,
-                infer_meta,
-                self.rope.original_max_position_embeddings,
+                use_long_factor=position_ids.ge(self.rope.original_max_position_embeddings),
             )
+        sequence_length = _phi4mm_longrope_sequence_length(
+            position_ids,
+            train_meta,
+            infer_meta,
+            self.rope.original_max_position_embeddings,
+        )
         return self.rope(q, k, position_ids, sequence_length)
 
 

--- a/areno/models/phi4mm/model.py
+++ b/areno/models/phi4mm/model.py
@@ -1,0 +1,467 @@
+"""Phi-4-Multimodal language-backbone adapter.
+
+PR1 intentionally supports the checkpoint's text path only. The vision and
+audio towers and their modality-specific LoRA adapters are not runtime model
+components here.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from areno.accel.ops import is_cuda_graph_capturing
+from areno.engine.config import ModelConfig, _parse_dtype
+from areno.engine.layers.attention import CausalSelfAttention
+from areno.engine.layers.mlp import GatedMLP
+from areno.engine.layers.norm import RMSNorm
+from areno.engine.layers.vocab import VocabParallelEmbedding, VocabParallelLMHead
+from areno.engine.parallel.collectives import (
+    scatter_to_sequence_parallel_region,
+    sequence_parallel_region,
+)
+from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.engine.runtime.recompute import checkpoint_layer
+from areno.models.base import CausalLMOutput, ModelAdapter
+
+
+def _require_bool(hf_config: dict[str, Any], key: str, expected: bool) -> None:
+    value = bool(hf_config.get(key, expected))
+    if value is not expected:
+        raise ValueError(f"Phi4MM requires {key}={expected}, got {value}")
+
+
+def _validated_longrope(hf_config: dict[str, Any], rotary_dim: int) -> dict[str, Any]:
+    rope = hf_config.get("rope_scaling")
+    if not isinstance(rope, dict):
+        raise ValueError("Phi4MM requires a rope_scaling mapping")
+    if set(rope) != {"type", "short_factor", "long_factor"}:
+        raise ValueError("Phi4MM rope_scaling must contain exactly: type, short_factor, long_factor")
+    if rope["type"] != "longrope":
+        raise ValueError(f"Phi4MM only supports rope_scaling.type='longrope', got {rope['type']!r}")
+
+    expected_factors = rotary_dim // 2
+    normalized = {"type": "longrope"}
+    for key in ("short_factor", "long_factor"):
+        factors = rope[key]
+        if not isinstance(factors, list) or len(factors) != expected_factors:
+            raise ValueError(f"Phi4MM {key} must contain {expected_factors} values")
+        if any(isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0 for value in factors):
+            raise ValueError(f"Phi4MM {key} values must be positive numbers")
+        normalized[key] = tuple(float(value) for value in factors)
+    return normalized
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    first, second = x.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+class Phi4MMLongRoPEScaledRotaryEmbedding(nn.Module):
+    """Official Phi-4 partial LongRoPE math without per-layer position caches."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        if config.hf_text_config is None:
+            raise ValueError("Phi4MM requires the validated HF text config")
+        self.dim = int(config.head_dim * config.partial_rotary_factor)
+        if self.dim <= 0 or self.dim % 2:
+            raise ValueError("Phi4MM rotary dimension must be a positive even number")
+        rope_scaling = config.hf_text_config["rope_scaling"]
+        expected_factors = self.dim // 2
+        short_factor = rope_scaling["short_factor"]
+        long_factor = rope_scaling["long_factor"]
+        if len(short_factor) != expected_factors or len(long_factor) != expected_factors:
+            raise ValueError(f"Phi4MM short_factor and long_factor must contain {expected_factors} values")
+
+        self.max_position_embeddings = int(config.max_position_embeddings)
+        self.original_max_position_embeddings = int(config.hf_text_config["original_max_position_embeddings"])
+        inv_freq_shape = torch.arange(0, self.dim, 2, dtype=torch.int64).float() / self.dim
+        base_freq = config.rope_theta**inv_freq_shape
+        self.register_buffer(
+            "short_inv_freq", 1.0 / (torch.tensor(short_factor, dtype=torch.float32) * base_freq), persistent=False
+        )
+        self.register_buffer(
+            "long_inv_freq", 1.0 / (torch.tensor(long_factor, dtype=torch.float32) * base_freq), persistent=False
+        )
+        scale = self.max_position_embeddings / self.original_max_position_embeddings
+        self.scaling_factor = (
+            1.0 if scale <= 1.0 else math.sqrt(1.0 + math.log(scale) / math.log(self.original_max_position_embeddings))
+        )
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        # Long-context phases must remain FP32 even when model weights are cast.
+        self.short_inv_freq = self.short_inv_freq.float()
+        self.long_inv_freq = self.long_inv_freq.float()
+        return self
+
+    @torch.no_grad()
+    def cos_sin(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        sequence_length: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if sequence_length is None:
+            sequence_length = int(torch.max(position_ids).item()) + 1
+        inv_freq = (
+            self.long_inv_freq if sequence_length > self.original_max_position_embeddings else self.short_inv_freq
+        )
+        expanded_inv_freq = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        expanded_positions = position_ids[:, None, :].float()
+        device_type = x.device.type if x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (expanded_inv_freq @ expanded_positions).transpose(1, 2)
+            embedding = torch.cat((freqs, freqs), dim=-1)
+            cos = embedding.cos() * self.scaling_factor
+            sin = embedding.sin() * self.scaling_factor
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: torch.Tensor,
+        sequence_length: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cos, sin = self.cos_sin(q, position_ids, sequence_length)
+        cos = cos.unsqueeze(2)
+        sin = sin.unsqueeze(2)
+        q_rot, q_pass = q[..., : self.dim], q[..., self.dim :]
+        k_rot, k_pass = k[..., : self.dim], k[..., self.dim :]
+        q_embed = torch.cat((q_rot * cos + _rotate_half(q_rot) * sin, q_pass), dim=-1)
+        k_embed = torch.cat((k_rot * cos + _rotate_half(k_rot) * sin, k_pass), dim=-1)
+        return q_embed, k_embed
+
+
+def _phi4mm_longrope_sequence_length(
+    position_ids: torch.Tensor,
+    train_meta: TrainMeta | None,
+    infer_meta: InferMeta | None,
+    original_max_position_embeddings: int,
+) -> int:
+    if infer_meta is not None and infer_meta.mode == "decode":
+        if infer_meta.cache_seqlens is None:
+            raise ValueError("Phi4MM decode requires cache_seqlens for LongRoPE selection")
+        sequence_length = int(infer_meta.cache_seqlens.max().item()) + 1
+        if sequence_length > original_max_position_embeddings:
+            raise ValueError(
+                "Phi4MM cached decode cannot cross the LongRoPE boundary because cached keys may use short factors; "
+                "run a full long-context prefill"
+            )
+        return sequence_length
+
+    if infer_meta is not None:
+        sequence_length = int(position_ids.max().item()) + 1
+        if sequence_length > original_max_position_embeddings:
+            if infer_meta.cu_seqlens is None:
+                raise ValueError("Phi4MM prefill requires cu_seqlens for LongRoPE boundary validation")
+            starts = infer_meta.cu_seqlens[:-1].to(dtype=torch.long)
+            flat_positions = position_ids.reshape(-1)
+            if bool(torch.any(flat_positions[starts] != 0)):
+                raise ValueError(
+                    "Phi4MM chunked prefill cannot cross the LongRoPE boundary because cached keys use short factors; "
+                    "increase the prefill token budget and run a full prefill"
+                )
+        return sequence_length
+
+    if train_meta is not None and train_meta.max_seqlen is not None:
+        return int(train_meta.max_seqlen)
+    return int(position_ids.shape[-1])
+
+
+class Phi4MMAttention(CausalSelfAttention):
+    """AReno GQA attention with a Phi-owned rotary implementation."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        if config.qk_norm:
+            raise ValueError("Phi4MMAttention requires qk_norm=False")
+        super().__init__(config, layer_idx, rotary_embedding=Phi4MMLongRoPEScaledRotaryEmbedding(config))
+
+    def apply_rotary(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if infer_meta is not None and infer_meta.mode == "decode" and is_cuda_graph_capturing(q):
+            # DecodeGraph validates its dynamic cache lengths before replay.
+            # Capture itself always records the supported short-factor path.
+            sequence_length = self.rope.original_max_position_embeddings
+        else:
+            sequence_length = _phi4mm_longrope_sequence_length(
+                position_ids,
+                train_meta,
+                infer_meta,
+                self.rope.original_max_position_embeddings,
+            )
+        return self.rope(q, k, position_ids, sequence_length)
+
+
+class Phi4MMDecoderLayer(nn.Module):
+    """Phi-4 pre-norm decoder block composed from AReno shared layers."""
+
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.self_attn = Phi4MMAttention(config, layer_idx)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.mlp = GatedMLP(config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = residual + self.self_attn(hidden_states, position_ids, train_meta, infer_meta)
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        return residual + self.mlp(hidden_states)
+
+
+class Phi4MMModel(nn.Module):
+    """Text-only Phi-4 transformer body."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size, dtype=config.dtype)
+        self.layers = nn.ModuleList([Phi4MMDecoderLayer(config, index) for index in range(config.num_hidden_layers)])
+        self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> torch.Tensor:
+        if position_ids is None:
+            position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).unsqueeze(0).expand_as(input_ids)
+        hidden_states = self.embed_tokens(input_ids)
+        use_sequence_parallel = bool(train_meta is not None and train_meta.sequence_parallel)
+        if use_sequence_parallel:
+            hidden_states = scatter_to_sequence_parallel_region(hidden_states)
+        with sequence_parallel_region(use_sequence_parallel):
+            for layer in self.layers:
+                hidden_states = checkpoint_layer(
+                    layer,
+                    hidden_states,
+                    position_ids,
+                    train_meta,
+                    infer_meta,
+                    train_meta=train_meta,
+                    infer_meta=infer_meta,
+                )
+            return self.norm(hidden_states)
+
+
+class Phi4MMForCausalLM(nn.Module):
+    """Text-only Phi-4 causal LM with a truly tied vocab-parallel head."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        if not config.tie_word_embeddings:
+            raise ValueError("Phi4MMForCausalLM requires tied word embeddings")
+        self.config = config
+        self.decode_cache_length_limit = int(config.hf_text_config["original_max_position_embeddings"])
+        self.model = Phi4MMModel(config)
+        self.lm_head = VocabParallelLMHead(config.hidden_size, config.vocab_size, dtype=config.dtype)
+        self._tie_word_embeddings()
+
+    def _tie_word_embeddings(self) -> None:
+        embedding = self.model.embed_tokens
+        if (self.lm_head.vocab_start, self.lm_head.vocab_end) != (embedding.vocab_start, embedding.vocab_end):
+            raise ValueError("Phi4MM embedding and LM head use different TP vocabulary ranges")
+        if self.lm_head.weight.shape != embedding.weight.shape:
+            raise ValueError("Phi4MM embedding and LM head local weight shapes differ")
+        self.lm_head.weight = embedding.weight
+
+    @property
+    def layers(self) -> nn.ModuleList:
+        """Expose decoder layers to the shared checkpoint machinery."""
+
+        return self.model.layers
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        train_meta: TrainMeta | None = None,
+        infer_meta: InferMeta | None = None,
+    ) -> CausalLMOutput:
+        use_sequence_parallel = bool(train_meta is not None and train_meta.sequence_parallel)
+        with sequence_parallel_region(use_sequence_parallel):
+            hidden_states = self.model(input_ids, position_ids, train_meta, infer_meta)
+            logits_shard = self.lm_head(hidden_states)
+        return CausalLMOutput(logits_shard=logits_shard, hidden_states=hidden_states)
+
+    def set_kv_caches(
+        self, kv_caches: list[tuple[torch.Tensor, torch.Tensor]], *, num_slots: int | None = None
+    ) -> None:
+        """Bind one paged KV-cache pair to each decoder layer."""
+        del num_slots
+        if len(kv_caches) != len(self.layers):
+            raise ValueError(f"expected {len(self.layers)} layer caches, got {len(kv_caches)}")
+        for layer, (k_cache, v_cache) in zip(self.layers, kv_caches, strict=True):
+            layer.self_attn.set_kv_cache(k_cache, v_cache)
+
+    @torch.no_grad()
+    def prepare_infer_weights(self) -> None:
+        return None
+
+    @torch.no_grad()
+    def clear_infer_weights(self) -> None:
+        return None
+
+    @torch.no_grad()
+    def offload_train_weights(self) -> None:
+        return None
+
+    @torch.no_grad()
+    def onload_train_weights(self, device: torch.device) -> None:
+        del device
+        return None
+
+    @torch.no_grad()
+    def finalize_router_expert_bias(self, tp_group, dp_group) -> None:
+        del tp_group, dp_group
+        return None
+
+    def allocate_kv_caches(
+        self, num_blocks: int, block_size: int, device: torch.device
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Allocate the standard paged GQA cache layout for every layer."""
+        caches = []
+        for layer in self.layers:
+            attention = layer.self_attn
+            shape = (num_blocks, block_size, attention.local_kv_heads, attention.head_dim)
+            caches.append(
+                (
+                    torch.empty(shape, device=device, dtype=self.config.dtype),
+                    torch.empty(shape, device=device, dtype=self.config.dtype),
+                )
+            )
+        return caches
+
+    def clear_kv_caches(self) -> None:
+        for layer in self.layers:
+            layer.self_attn.clear_kv_cache()
+
+    @torch.no_grad()
+    def reset_kv_caches(self) -> None:
+        return None
+
+    @torch.no_grad()
+    def offload_kv_caches(self) -> None:
+        for layer in self.layers:
+            attention = layer.self_attn
+            if attention.k_cache.numel() > 0:
+                attention.k_cache = attention.k_cache.to(device="cpu")
+            if attention.v_cache.numel() > 0:
+                attention.v_cache = attention.v_cache.to(device="cpu")
+            attention.infer_backend = None
+
+    @torch.no_grad()
+    def onload_kv_caches(self, device: torch.device) -> bool:
+        found = False
+        for layer in self.layers:
+            attention = layer.self_attn
+            if attention.k_cache.numel() > 0:
+                found = True
+                if attention.k_cache.device != device:
+                    attention.k_cache = attention.k_cache.to(device=device)
+            if attention.v_cache.numel() > 0 and attention.v_cache.device != device:
+                attention.v_cache = attention.v_cache.to(device=device)
+        return found
+
+
+class Phi4MMAdapter(ModelAdapter):
+    """Translate the official Phi-4-Multimodal config into AReno semantics."""
+
+    name = "phi4mm"
+
+    def match_hf_config(self, hf_config: dict[str, Any]) -> bool:
+        return str(hf_config.get("model_type", "")).lower() == self.name
+
+    def config_from_hf(self, hf_config: dict[str, Any]) -> ModelConfig:
+        hidden_size = int(hf_config["hidden_size"])
+        num_attention_heads = int(hf_config["num_attention_heads"])
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError("Phi4MM hidden_size must be divisible by num_attention_heads")
+        head_dim = hidden_size // num_attention_heads
+        partial_rotary_factor = float(hf_config.get("partial_rotary_factor", 1.0))
+        if not 0.0 < partial_rotary_factor <= 1.0:
+            raise ValueError("Phi4MM partial_rotary_factor must be in (0, 1]")
+        rotary_dim = int(head_dim * partial_rotary_factor)
+        if rotary_dim <= 0 or rotary_dim % 2 != 0:
+            raise ValueError("Phi4MM rotary dimension must be a positive even number")
+
+        if str(hf_config.get("hidden_act", "silu")) != "silu":
+            raise ValueError("Phi4MM language backbone requires hidden_act='silu'")
+        _require_bool(hf_config, "attention_bias", False)
+        _require_bool(hf_config, "mlp_bias", False)
+        _require_bool(hf_config, "lm_head_bias", False)
+        _require_bool(hf_config, "tie_word_embeddings", True)
+
+        original_max_position_embeddings = int(hf_config.get("original_max_position_embeddings", 4096))
+        max_position_embeddings = int(hf_config.get("max_position_embeddings", original_max_position_embeddings))
+        if original_max_position_embeddings <= 0 or max_position_embeddings < original_max_position_embeddings:
+            raise ValueError("Phi4MM max_position_embeddings must be at least original_max_position_embeddings > 0")
+        rope_scaling = _validated_longrope(hf_config, rotary_dim)
+
+        # Preserve the validated LongRoPE fields for the Phi-specific rotary implementation.
+        text_config = dict(hf_config)
+        text_config["rope_scaling"] = rope_scaling
+        text_config["original_max_position_embeddings"] = original_max_position_embeddings
+
+        return ModelConfig(
+            model_type=self.name,
+            checkpoint_prefix="model",
+            vocab_size=int(hf_config["vocab_size"]),
+            pad_token_id=int(hf_config.get("pad_token_id", 0) or 0),
+            hidden_size=hidden_size,
+            intermediate_size=int(hf_config["intermediate_size"]),
+            num_hidden_layers=int(hf_config["num_hidden_layers"]),
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=int(hf_config.get("num_key_value_heads", num_attention_heads)),
+            head_dim=head_dim,
+            rms_norm_eps=float(hf_config.get("rms_norm_eps", 1e-5)),
+            rope_theta=float(hf_config.get("rope_theta", 10_000.0)),
+            max_position_embeddings=max_position_embeddings,
+            tie_word_embeddings=True,
+            qkv_bias=False,
+            qk_norm=False,
+            dtype=_parse_dtype(hf_config.get("torch_dtype") or hf_config.get("dtype")),
+            hidden_act="silu",
+            sliding_window=hf_config.get("sliding_window"),
+            partial_rotary_factor=partial_rotary_factor,
+            sequence_parallel=bool(hf_config.get("sequence_parallel", True)),
+            hf_text_config=text_config,
+        )
+
+    def build(self, config: ModelConfig) -> nn.Module:
+        if config.model_type != self.name:
+            raise ValueError(f"Phi4MMAdapter cannot build model_type={config.model_type!r}")
+        return Phi4MMForCausalLM(config)
+
+    def load_weights(self, model: nn.Module, model_path: str | Path) -> None:
+        from areno.models.phi4mm.checkpoint import load_phi4mm_weights
+
+        load_phi4mm_weights(model, model_path)
+
+    def save_weights(self, model: nn.Module, output_path: str | Path, source_path: str | Path | None) -> str | None:
+        from areno.models.phi4mm.checkpoint import save_phi4mm_weights
+
+        return save_phi4mm_weights(model, output_path, source_path)

--- a/areno/models/phi4mm/model.py
+++ b/areno/models/phi4mm/model.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from areno.accel.utils import is_cuda_graph_capturing
@@ -21,6 +22,9 @@ from areno.engine.layers.mlp import GatedMLP
 from areno.engine.layers.norm import RMSNorm
 from areno.engine.layers.vocab import VocabParallelEmbedding, VocabParallelLMHead
 from areno.engine.parallel.collectives import (
+    copy_to_tensor_parallel_region,
+    gather_from_sequence_parallel_region,
+    is_sequence_parallel_active,
     scatter_to_sequence_parallel_region,
     sequence_parallel_region,
 )
@@ -330,6 +334,25 @@ class Phi4MMModel(nn.Module):
             return self.norm(hidden_states)
 
 
+class Phi4MMLMHead(VocabParallelLMHead):
+    """Keep vocabulary projection output in FP32 before computing logprobs.
+
+    Casting BF16 logits after the projection cannot recover the rounding
+    lost there. Preserve the tied BF16 parameter and its TP/SP gradient
+    boundaries while doing the final projection in FP32.
+    """
+
+    @torch._dynamo.disable
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = (
+            gather_from_sequence_parallel_region(hidden_states)
+            if is_sequence_parallel_active()
+            else copy_to_tensor_parallel_region(hidden_states)
+        )
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
+            return F.linear(hidden_states.float(), self.weight.float())
+
+
 class Phi4MMForCausalLM(nn.Module):
     """Text-only Phi-4 causal LM with a truly tied vocab-parallel head."""
 
@@ -340,7 +363,7 @@ class Phi4MMForCausalLM(nn.Module):
         self.config = config
         self._longrope_cache_boundary = int(config.hf_text_config["original_max_position_embeddings"])
         self.model = Phi4MMModel(config)
-        self.lm_head = VocabParallelLMHead(config.hidden_size, config.vocab_size, dtype=config.dtype)
+        self.lm_head = Phi4MMLMHead(config.hidden_size, config.vocab_size, dtype=config.dtype)
         self._tie_word_embeddings()
 
     def _tie_word_embeddings(self) -> None:

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -212,6 +212,29 @@ def test_messages_to_prompt_tokens_passes_tools_to_chat_template():
     assert tokenizer.calls == [(messages, tools)]
 
 
+def test_messages_to_prompt_tokens_embeds_tools_for_phi_message_template():
+    tokenizer = _MessageEmbeddedToolsTokenizer()
+    messages = [{"role": "system", "content": "play"}, {"role": "user", "content": "choose"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "choose_square",
+                "description": "Choose a square.",
+                "parameters": {"type": "object", "properties": {"square": {"type": "integer"}}},
+            },
+        }
+    ]
+
+    tokens = agentic._messages_to_prompt_tokens(tokenizer, messages, tools=tools, fallback_prompt="fallback")
+
+    assert tokens == [2]
+    rendered_messages, passed_tools = tokenizer.calls[0]
+    assert passed_tools == tools
+    assert json.loads(rendered_messages[0]["tools"]) == [tools[0]["function"]]
+    assert "tools" not in messages[0]
+
+
 def test_normalize_messages_rewrites_null_tool_call_content_for_templates():
     tokenizer = _StrictContentTokenizer()
     messages = agentic._normalize_messages(
@@ -1642,6 +1665,19 @@ class _ToolAwareTokenizer(_FakeTokenizer):
         assert add_generation_prompt is True
         self.calls.append((messages, tools))
         return [len(messages), len(tools or [])]
+
+
+class _MessageEmbeddedToolsTokenizer(_ToolAwareTokenizer):
+    chat_template = "{% if message['role'] == 'system' and 'tools' in message %}<|tool|>{% endif %}"
+
+    def apply_chat_template(self, messages, *, tools=None, tokenize, add_generation_prompt):
+        super().apply_chat_template(
+            messages,
+            tools=tools,
+            tokenize=tokenize,
+            add_generation_prompt=add_generation_prompt,
+        )
+        return [len(messages)]
 
 
 class _DisplayTokenizer(_FakeTokenizer):

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -1190,6 +1190,31 @@ def test_agentic_tool_request_returns_tool_call_and_reward_record():
     assert record.loss_mask == [True, True]
 
 
+def test_json_tool_call_parser_accepts_phi_parameters_wrapper():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "choose_square",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"square": {"type": "integer"}},
+                },
+            },
+        }
+    ]
+
+    parsed = JsonToolCallParser().parse(
+        '{"name":"choose_square","parameters":{"square":3}}',
+        tools,
+        {"type": "function", "function": {"name": "choose_square"}},
+    )
+
+    assert len(parsed.tool_calls) == 1
+    assert parsed.tool_calls[0]["function"]["name"] == "choose_square"
+    assert json.loads(parsed.tool_calls[0]["function"]["arguments"]) == {"square": 3}
+
+
 def test_json_tool_call_parser_rejects_explicit_direction_in_plain_text():
     tools = [
         {

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -227,6 +227,46 @@ def test_chunked_prefill_runs_intermediate_chunks_without_sampling():
     assert state.finish_reason == ["length"]
 
 
+def test_cached_generation_reprefills_at_model_declared_cache_boundary():
+    """The generic scheduler replaces a stale cache with a full prefill before decode."""
+
+    class RePrefillManager(_FakeInferenceManager):
+        def __init__(self):
+            super().__init__()
+            self.reprefill_payload = None
+
+        def _infer_next_token_tensor(self, payload):
+            if int(payload.input_ids.numel()) == 33:
+                self.reprefill_payload = payload
+            return super()._infer_next_token_tensor(payload)
+
+    manager = RePrefillManager()
+    manager.worker.model = SimpleNamespace(cache_reprefill_required=lambda lengths: lengths.eq(32))
+    state = InferenceBatchState(
+        prompts=[list(range(32))],
+        max_new_tokens=2,
+        max_running_seqs=1,
+        max_cache_len=40,
+        max_prefill_tokens=64,
+        kv_block_size=8,
+        num_cache_blocks=5,
+    )
+    ctx = SimpleNamespace(is_rank0=True, dp_rank=0, dp_size=1)
+
+    with PatchedContext(inference_mod, get_tp_context=lambda: ctx, broadcast_object=lambda value, src=0: value):
+        manager._generate_rollout_tokens_no_sync(
+            state,
+            SamplingParams(),
+            eos_token_id=None,
+            prompt_indices=[0],
+        )
+
+    assert state.generated == [[1, 1]]
+    assert manager.reprefill_payload is not None
+    assert manager.reprefill_payload.input_ids.tolist() == [*range(32), 1]
+    assert manager.ops == [("sample_prefill", 1), ("sample_prefill", 1)]
+
+
 def test_prefill_reserves_prompt_blocks_without_max_new_token_overreservation():
     """Paged KV should grow for decode instead of reserving full response length upfront."""
 

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -7,6 +7,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+pytest.importorskip("triton")
+
 import areno.models
 from areno.engine.config import ModelConfig, OptimizerConfig
 from areno.engine.layers import mlp, norm, vocab

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -15,7 +15,6 @@ from areno.engine.layers import mlp, norm, vocab
 from areno.engine.modeling import build_optimizer
 from areno.engine.parallel.collectives import is_sequence_parallel_active
 from areno.engine.parallel.context import TPContext, get_tp_context, set_tp_context
-from areno.engine.runtime.decode_graph import _validate_decode_cache_length
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.models import registry
 from areno.models.phi4mm import Phi4MMAdapter, Phi4MMForCausalLM
@@ -410,19 +409,39 @@ def test_phi4mm_longrope_rejects_chunked_prefill_crossing_boundary():
         _phi4mm_longrope_sequence_length(positions, None, infer_meta, 32)
 
 
-def test_phi4mm_longrope_rejects_cached_decode_crossing_boundary():
+def test_phi4mm_longrope_requires_runtime_reprefill_for_cached_boundary_crossing():
     below_boundary = InferMeta(mode="decode", cache_seqlens=torch.tensor([31], dtype=torch.int32))
     crossing_boundary = InferMeta(mode="decode", cache_seqlens=torch.tensor([32], dtype=torch.int32))
 
     assert _phi4mm_longrope_sequence_length(torch.tensor([[31]]), None, below_boundary, 32) == 32
-    with pytest.raises(ValueError, match="cached decode cannot cross"):
+    with pytest.raises(ValueError, match="requires cache re-prefill"):
         _phi4mm_longrope_sequence_length(torch.tensor([[32]]), None, crossing_boundary, 32)
 
 
-def test_phi4mm_longrope_decode_graph_replay_enforces_same_boundary():
-    _validate_decode_cache_length(torch.tensor([31, 99], dtype=torch.int32), actual=1, limit=32)
-    with pytest.raises(ValueError, match="rotary-factor boundary"):
-        _validate_decode_cache_length(torch.tensor([32], dtype=torch.int32), actual=1, limit=32)
+def test_phi4mm_longrope_reprefill_matches_full_long_factor_recompute():
+    rope = Phi4MMLongRoPEScaledRotaryEmbedding(_tiny_model_config())
+    q = torch.randn(1, 33, 2, 8)
+    k = torch.randn(1, 33, 1, 8)
+    positions = torch.arange(33).unsqueeze(0)
+
+    full_q, full_k = rope(q, k, positions, sequence_length=33)
+    short_q, short_k = rope(q[:, :32], k[:, :32], positions[:, :32], sequence_length=32)
+    rebuilt_q, rebuilt_k = rope(q, k, positions, sequence_length=33)
+
+    assert not torch.allclose(short_q, full_q[:, :32])
+    assert not torch.allclose(short_k, full_k[:, :32])
+    torch.testing.assert_close(rebuilt_q, full_q, rtol=0, atol=0)
+    torch.testing.assert_close(rebuilt_k, full_k, rtol=0, atol=0)
+
+
+def test_phi4mm_declares_exact_longrope_cache_reprefill_boundary():
+    model = Phi4MMAdapter().build(_tiny_model_config())
+
+    assert model.cache_reprefill_required(torch.tensor([31, 32, 33], dtype=torch.int32)).tolist() == [
+        False,
+        True,
+        False,
+    ]
 
 
 @pytest.mark.parametrize("tp_size", [1, 2, 4])

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 import math
+import subprocess
+import sys
 
 import pytest
 import torch
 import torch.nn.functional as F
-
-pytest.importorskip("triton")
 
 import areno.models
 from areno.engine.config import ModelConfig, OptimizerConfig
@@ -95,6 +95,18 @@ def _tiny_model_config() -> ModelConfig:
             },
         },
     )
+
+
+def test_phi4mm_import_does_not_require_triton():
+    script = """
+import sys
+sys.modules['triton'] = None
+import areno.models.phi4mm
+assert 'areno.accel.kernels.fused_moe' not in sys.modules
+assert 'areno.accel.kernels.group_rmsnorm' not in sys.modules
+assert 'areno.accel.kernels.seg_la' not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
 
 
 @pytest.fixture

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -418,6 +418,50 @@ def test_phi4mm_longrope_requires_runtime_reprefill_for_cached_boundary_crossing
         _phi4mm_longrope_sequence_length(torch.tensor([[32]]), None, crossing_boundary, 32)
 
 
+def test_phi4mm_decode_longrope_factor_selection_is_fullgraph_compatible():
+    attention = Phi4MMAdapter().build(_tiny_model_config()).model.layers[0].self_attn
+    q = torch.randn(1, 2, attention.local_heads, attention.head_dim)
+    k = torch.randn(1, 2, attention.local_kv_heads, attention.head_dim)
+    # One short-cache row and one row rebuilt with long factors.  The runtime
+    # re-prefills at equality (32), so position 33 is a valid long-cache row.
+    positions = torch.tensor([[31, 33]])
+    infer_meta = InferMeta(mode="decode", cache_seqlens=torch.tensor([31, 33], dtype=torch.int32))
+
+    compiled_apply_rotary = torch.compile(attention.apply_rotary, backend="eager", fullgraph=True)
+    actual_q, actual_k = compiled_apply_rotary(q, k, positions, None, infer_meta)
+    short_q, short_k = attention.rope(q[:, :1], k[:, :1], positions[:, :1], sequence_length=32)
+    long_q, long_k = attention.rope(q[:, 1:], k[:, 1:], positions[:, 1:], sequence_length=34)
+
+    torch.testing.assert_close(actual_q, torch.cat((short_q, long_q), dim=1))
+    torch.testing.assert_close(actual_k, torch.cat((short_k, long_k), dim=1))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph regression test requires CUDA")
+def test_phi4mm_decode_longrope_factor_selection_captures_cuda_graph():
+    attention = Phi4MMAdapter().build(_tiny_model_config()).model.layers[0].self_attn.cuda().eval()
+    q = torch.randn(1, 2, attention.local_heads, attention.head_dim, device="cuda")
+    k = torch.randn(1, 2, attention.local_kv_heads, attention.head_dim, device="cuda")
+    positions = torch.tensor([[31, 33]], device="cuda")
+    infer_meta = InferMeta(mode="decode", cache_seqlens=torch.tensor([31, 33], device="cuda", dtype=torch.int32))
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            attention.apply_rotary(q, k, positions, None, infer_meta)
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_q, captured_k = attention.apply_rotary(q, k, positions, None, infer_meta)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_q.shape == q.shape
+    assert captured_k.shape == k.shape
+
+
 def test_phi4mm_longrope_reprefill_matches_full_long_factor_recompute():
     rope = Phi4MMLongRoPEScaledRotaryEmbedding(_tiny_model_config())
     q = torch.randn(1, 33, 2, 8)

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import areno.models
+from areno.engine.config import ModelConfig, OptimizerConfig
+from areno.engine.layers import mlp, norm, vocab
+from areno.engine.modeling import build_optimizer
+from areno.engine.parallel.collectives import is_sequence_parallel_active
+from areno.engine.parallel.context import TPContext, get_tp_context, set_tp_context
+from areno.engine.runtime.decode_graph import _validate_decode_cache_length
+from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.models import registry
+from areno.models.phi4mm import Phi4MMAdapter, Phi4MMForCausalLM
+from areno.models.phi4mm.model import (
+    Phi4MMLongRoPEScaledRotaryEmbedding,
+    _phi4mm_longrope_sequence_length,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tp_context():
+    previous_context = get_tp_context()
+    set_tp_context(TPContext(rank=0, world_size=1, device=torch.device("cpu"), group=None))
+    try:
+        yield
+    finally:
+        set_tp_context(previous_context)
+
+
+def _phi4mm_config() -> dict:
+    return {
+        "model_type": "phi4mm",
+        "vocab_size": 200064,
+        "hidden_size": 3072,
+        "intermediate_size": 8192,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 24,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-5,
+        "rope_theta": 10_000.0,
+        "max_position_embeddings": 131072,
+        "original_max_position_embeddings": 4096,
+        "partial_rotary_factor": 0.75,
+        "rope_scaling": {
+            "type": "longrope",
+            "short_factor": [1.0] * 48,
+            "long_factor": [float(index + 1) for index in range(48)],
+        },
+        "sliding_window": 262144,
+        "hidden_act": "silu",
+        "attention_bias": False,
+        "mlp_bias": False,
+        "lm_head_bias": False,
+        "tie_word_embeddings": True,
+        "pad_token_id": 199999,
+        "torch_dtype": "bfloat16",
+    }
+
+
+def _tiny_model_config() -> ModelConfig:
+    return ModelConfig(
+        model_type="phi4mm",
+        vocab_size=32,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=8,
+        rms_norm_eps=1e-5,
+        rope_theta=10_000.0,
+        max_position_embeddings=64,
+        tie_word_embeddings=True,
+        qkv_bias=False,
+        qk_norm=False,
+        dtype=torch.float32,
+        hidden_act="silu",
+        partial_rotary_factor=0.75,
+        sequence_parallel=False,
+        attn_backend="native",
+        hf_text_config={
+            "original_max_position_embeddings": 32,
+            "rope_scaling": {
+                "type": "longrope",
+                "short_factor": (1.0, 1.0, 1.0),
+                "long_factor": (1.0, 2.0, 3.0),
+            },
+        },
+    )
+
+
+@pytest.fixture
+def cpu_reference_kernels(monkeypatch):
+    def embedding(input_ids, weight, vocab_start, vocab_end):
+        local_ids = input_ids - vocab_start
+        local_mask = (input_ids >= vocab_start) & (input_ids < vocab_end)
+        safe_ids = local_ids.masked_fill(~local_mask, 0)
+        return F.embedding(safe_ids, weight) * local_mask.unsqueeze(-1)
+
+    def rms_norm(x, weight, eps):
+        normalized = x.float() * torch.rsqrt(x.float().square().mean(dim=-1, keepdim=True) + eps)
+        return normalized.to(dtype=x.dtype) * weight.to(dtype=x.dtype)
+
+    def silu_and_mul(x):
+        gate, up = x.chunk(2, dim=-1)
+        return F.silu(gate) * up
+
+    monkeypatch.setattr(vocab, "areno_vocab_embedding", embedding)
+    monkeypatch.setattr(norm, "_areno_rmsnorm_no_compile", rms_norm)
+    monkeypatch.setattr(mlp, "_areno_silu_and_mul_no_compile", silu_and_mul)
+
+
+def test_phi4mm_config_translation_matches_official_language_backbone():
+    config = Phi4MMAdapter().config_from_hf(_phi4mm_config())
+
+    assert config.model_type == "phi4mm"
+    assert config.vocab_size == 200064
+    assert config.hidden_size == 3072
+    assert config.intermediate_size == 8192
+    assert config.num_hidden_layers == 32
+    assert config.num_attention_heads == 24
+    assert config.num_key_value_heads == 8
+    assert config.head_dim == 128
+    assert config.partial_rotary_factor == 0.75
+    assert config.qk_norm is False
+    assert config.qkv_bias is False
+    assert config.tie_word_embeddings is True
+    assert config.dtype == torch.bfloat16
+    assert config.hf_text_config is not None
+    assert config.hf_text_config["original_max_position_embeddings"] == 4096
+    assert config.hf_text_config["rope_scaling"]["short_factor"] == (1.0,) * 48
+
+
+@pytest.mark.parametrize(
+    ("update", "message"),
+    [
+        ({"tie_word_embeddings": False}, "tie_word_embeddings=True"),
+        ({"attention_bias": True}, "attention_bias=False"),
+        ({"hidden_act": "gelu"}, "hidden_act='silu'"),
+        ({"rope_scaling": {"type": "linear", "short_factor": [1.0] * 48, "long_factor": [1.0] * 48}}, "longrope"),
+        ({"rope_scaling": {"type": "longrope", "short_factor": [1.0] * 47, "long_factor": [1.0] * 48}}, "48 values"),
+    ],
+)
+def test_phi4mm_config_rejects_unsupported_language_semantics(update, message):
+    hf_config = _phi4mm_config()
+    hf_config.update(update)
+
+    with pytest.raises(ValueError, match=message):
+        Phi4MMAdapter().config_from_hf(hf_config)
+
+
+def test_phi4mm_registry_resolves_config(tmp_path, monkeypatch):
+    (tmp_path / "config.json").write_text(json.dumps(_phi4mm_config()), encoding="utf-8")
+    monkeypatch.setattr(registry, "_PLUGINS_LOADED", False)
+    monkeypatch.setattr(areno.models, "_REGISTERED_GROUPS", set())
+    monkeypatch.setattr(registry, "_ADAPTERS", {})
+
+    config = registry.config_from_hf(tmp_path)
+
+    assert config.model_type == "phi4mm"
+    assert isinstance(registry.adapter_from_hf(tmp_path), Phi4MMAdapter)
+
+
+def test_phi4mm_tp_validation_rejects_non_divisible_kv_heads():
+    config = Phi4MMAdapter().config_from_hf(_phi4mm_config())
+
+    config.validate_tp(1)
+    config.validate_tp(2)
+    config.validate_tp(4)
+    config.validate_tp(8)
+    with pytest.raises(ValueError, match="num_key_value_heads must be divisible"):
+        config.validate_tp(3)
+    with pytest.raises(ValueError, match="num_key_value_heads must be divisible"):
+        config.validate_tp(6)
+
+
+def test_phi4mm_model_construction_has_expected_text_layers():
+    config = _tiny_model_config()
+    model = Phi4MMAdapter().build(config)
+
+    assert isinstance(model, Phi4MMForCausalLM)
+    assert len(model.model.layers) == 2
+    assert model.model.embed_tokens.weight.shape == (32, 64)
+    assert model.lm_head.weight.shape == (32, 64)
+    assert model.model.norm.eps == 1e-5
+    for layer in model.model.layers:
+        assert layer.input_layernorm.eps == 1e-5
+        assert layer.post_attention_layernorm.eps == 1e-5
+        assert layer.self_attn.qkv_proj.out_features == (64, 32, 32)
+        assert layer.self_attn.qkv_proj.local_out_features == [64, 32, 32]
+        assert layer.self_attn.o_proj.weight.shape == (64, 64)
+        assert layer.mlp.gate_up_proj.out_features == (128, 128)
+        assert layer.mlp.gate_up_proj.weight.shape == (256, 64)
+        assert layer.mlp.down_proj.weight.shape == (64, 128)
+
+
+def test_phi4mm_projection_biases_and_qk_norm_are_disabled():
+    model = Phi4MMAdapter().build(_tiny_model_config())
+
+    assert not hasattr(model.lm_head, "bias")
+    for layer in model.model.layers:
+        assert layer.self_attn.qkv_proj.bias is None
+        assert layer.self_attn.o_proj.bias is None
+        assert layer.self_attn.q_norm is None
+        assert layer.self_attn.k_norm is None
+        assert layer.mlp.gate_up_proj.bias is None
+        assert layer.mlp.down_proj.bias is None
+
+
+def test_phi4mm_embedding_and_lm_head_share_one_optimizer_parameter():
+    model = Phi4MMAdapter().build(_tiny_model_config())
+
+    assert model.lm_head.weight is model.model.embed_tokens.weight
+    parameter_ids = [id(parameter) for parameter in model.parameters()]
+    assert len(parameter_ids) == len(set(parameter_ids))
+
+    optimizer = build_optimizer(
+        model.parameters(),
+        OptimizerConfig(),
+        type("Context", (), {"dp_rank": 0, "dp_size": 1, "dp_group": None})(),
+    )
+    optimizer_parameter_ids = [id(parameter) for parameter in optimizer.model_params]
+    assert len(optimizer_parameter_ids) == len(set(optimizer_parameter_ids))
+    assert optimizer_parameter_ids.count(id(model.model.embed_tokens.weight)) == 1
+
+
+def test_phi4mm_text_forward_shapes_and_causal_prefix(cpu_reference_kernels):
+    del cpu_reference_kernels
+    torch.manual_seed(0)
+    model = Phi4MMAdapter().build(_tiny_model_config()).eval()
+    input_ids = torch.tensor([[1, 2, 3], [1, 2, 4]])
+
+    output = model(input_ids)
+
+    assert output.hidden_states is not None
+    assert output.logits_shard is not None
+    assert output.hidden_states.shape == (2, 3, 64)
+    assert output.logits_shard.shape == (2, 3, 32)
+    assert torch.isfinite(output.hidden_states).all()
+    assert torch.isfinite(output.logits_shard).all()
+    torch.testing.assert_close(output.logits_shard[0, :2], output.logits_shard[1, :2])
+
+
+def test_phi4mm_lm_head_runs_inside_sequence_parallel_region(cpu_reference_kernels, monkeypatch):
+    del cpu_reference_kernels
+    model = Phi4MMAdapter().build(_tiny_model_config()).eval()
+    original_forward = model.lm_head.forward
+    sequence_parallel_states = []
+
+    def record_sequence_parallel_state(hidden_states):
+        sequence_parallel_states.append(is_sequence_parallel_active())
+        return original_forward(hidden_states)
+
+    monkeypatch.setattr(model.lm_head, "forward", record_sequence_parallel_state)
+    model(torch.tensor([[1, 2, 3]]), train_meta=TrainMeta(sequence_parallel=True))
+
+    assert sequence_parallel_states == [True]
+
+
+def test_phi4mm_kv_cache_lifecycle():
+    model = Phi4MMAdapter().build(_tiny_model_config())
+    caches = model.allocate_kv_caches(num_blocks=3, block_size=4, device=torch.device("cpu"))
+
+    assert len(caches) == len(model.layers)
+    assert caches[0][0].shape == (3, 4, 4, 8)
+    assert caches[0][0].dtype == model.config.dtype
+
+    model.set_kv_caches(caches)
+    assert model.layers[0].self_attn.k_cache is caches[0][0]
+    assert model.onload_kv_caches(torch.device("cpu"))
+
+    model.offload_kv_caches()
+    assert model.layers[0].self_attn.infer_backend is None
+    model.clear_kv_caches()
+    assert model.layers[0].self_attn.k_cache.numel() == 0
+    assert not model.onload_kv_caches(torch.device("cpu"))
+
+    with pytest.raises(ValueError, match="expected 2 layer caches"):
+        model.set_kv_caches(caches[:1])
+
+
+def _official_longrope_reference(
+    x: torch.Tensor,
+    position_ids: torch.Tensor,
+    dim: int,
+    base: float,
+    factors: tuple[float, ...],
+    max_position_embeddings: int,
+    original_max_position_embeddings: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    ext_factors = torch.tensor(factors, dtype=torch.float32, device=x.device)
+    inv_freq_shape = torch.arange(0, dim, 2, dtype=torch.int64, device=x.device).float() / dim
+    inv_freq = 1.0 / (ext_factors * base**inv_freq_shape)
+    inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    position_ids_expanded = position_ids[:, None, :].float()
+    freqs = (inv_freq_expanded @ position_ids_expanded).transpose(1, 2)
+    embedding = torch.cat((freqs, freqs), dim=-1)
+    scale = max_position_embeddings / original_max_position_embeddings
+    scaling_factor = (
+        1.0 if scale <= 1.0 else math.sqrt(1.0 + math.log(scale) / math.log(original_max_position_embeddings))
+    )
+    return (embedding.cos() * scaling_factor).to(x.dtype), (embedding.sin() * scaling_factor).to(x.dtype)
+
+
+def test_phi4mm_official_config_builds_partial_longrope_without_position_caches():
+    config = Phi4MMAdapter().config_from_hf(_phi4mm_config())
+
+    rope = Phi4MMLongRoPEScaledRotaryEmbedding(config)
+
+    assert rope.dim == 96
+    assert config.head_dim - rope.dim == 32
+    assert rope.short_inv_freq.shape == (48,)
+    assert rope.long_inv_freq.shape == (48,)
+    assert all("cached" not in name for name, _ in rope.named_buffers())
+
+
+def test_phi4mm_longrope_keeps_inverse_frequencies_in_fp32_when_model_is_cast():
+    rope = Phi4MMLongRoPEScaledRotaryEmbedding(_tiny_model_config()).to(dtype=torch.bfloat16)
+
+    assert rope.short_inv_freq.dtype == torch.float32
+    assert rope.long_inv_freq.dtype == torch.float32
+
+
+@pytest.mark.parametrize(
+    ("sequence_length", "positions", "factor_key"),
+    [
+        (32, [0, 1, 7, 31], "short_factor"),
+        (64, [0, 1, 31, 32, 63], "long_factor"),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_phi4mm_longrope_cos_sin_matches_official_reference(sequence_length, positions, factor_key, dtype):
+    config = _tiny_model_config()
+    rope = Phi4MMLongRoPEScaledRotaryEmbedding(config)
+    x = torch.zeros(1, len(positions), 1, config.head_dim, dtype=dtype)
+    position_ids = torch.tensor([positions])
+
+    actual_cos, actual_sin = rope.cos_sin(x, position_ids, sequence_length)
+    expected_cos, expected_sin = _official_longrope_reference(
+        x,
+        position_ids,
+        rope.dim,
+        config.rope_theta,
+        config.hf_text_config["rope_scaling"][factor_key],
+        config.max_position_embeddings,
+        config.hf_text_config["original_max_position_embeddings"],
+    )
+
+    torch.testing.assert_close(actual_cos, expected_cos, rtol=0, atol=0)
+    torch.testing.assert_close(actual_sin, expected_sin, rtol=0, atol=0)
+
+
+def test_phi4mm_longrope_preserves_non_rotary_head_dimensions_and_applies_scale():
+    config = _tiny_model_config()
+    rope = Phi4MMLongRoPEScaledRotaryEmbedding(config)
+    q = torch.randn(1, 3, 2, config.head_dim)
+    k = torch.randn(1, 3, 1, config.head_dim)
+    position_ids = torch.tensor([[0, 1, 2]])
+
+    rotated_q, rotated_k = rope(q, k, position_ids, sequence_length=3)
+    cos, sin = rope.cos_sin(q, torch.tensor([[0]]), sequence_length=3)
+
+    torch.testing.assert_close(rotated_q[..., rope.dim :], q[..., rope.dim :])
+    torch.testing.assert_close(rotated_k[..., rope.dim :], k[..., rope.dim :])
+    assert cos[0, 0, 0].item() == pytest.approx(rope.scaling_factor)
+    assert sin[0, 0, 0].item() == 0.0
+
+
+def test_phi4mm_longrope_full_long_prefill_selects_long_factors():
+    attention = Phi4MMAdapter().build(_tiny_model_config()).model.layers[0].self_attn
+    positions = torch.arange(40).unsqueeze(0)
+    infer_meta = InferMeta(mode="prefill", cu_seqlens=torch.tensor([0, 40], dtype=torch.int32), max_seqlen=40)
+    q = torch.randn(1, 40, attention.local_heads, attention.head_dim)
+    k = torch.randn(1, 40, attention.local_kv_heads, attention.head_dim)
+
+    sequence_length = _phi4mm_longrope_sequence_length(positions, None, infer_meta, 32)
+    actual_q, actual_k = attention.apply_rotary(q, k, positions, None, infer_meta)
+    expected_q, expected_k = attention.rope(q, k, positions, sequence_length=40)
+
+    assert sequence_length == 40
+    torch.testing.assert_close(actual_q, expected_q)
+    torch.testing.assert_close(actual_k, expected_k)
+
+
+def test_phi4mm_longrope_rejects_chunked_prefill_crossing_boundary():
+    positions = torch.arange(28, 40).unsqueeze(0)
+    infer_meta = InferMeta(mode="prefill", cu_seqlens=torch.tensor([0, 12], dtype=torch.int32), max_seqlen=12)
+
+    with pytest.raises(ValueError, match="chunked prefill cannot cross"):
+        _phi4mm_longrope_sequence_length(positions, None, infer_meta, 32)
+
+
+def test_phi4mm_longrope_rejects_cached_decode_crossing_boundary():
+    below_boundary = InferMeta(mode="decode", cache_seqlens=torch.tensor([31], dtype=torch.int32))
+    crossing_boundary = InferMeta(mode="decode", cache_seqlens=torch.tensor([32], dtype=torch.int32))
+
+    assert _phi4mm_longrope_sequence_length(torch.tensor([[31]]), None, below_boundary, 32) == 32
+    with pytest.raises(ValueError, match="cached decode cannot cross"):
+        _phi4mm_longrope_sequence_length(torch.tensor([[32]]), None, crossing_boundary, 32)
+
+
+def test_phi4mm_longrope_decode_graph_replay_enforces_same_boundary():
+    _validate_decode_cache_length(torch.tensor([31, 99], dtype=torch.int32), actual=1, limit=32)
+    with pytest.raises(ValueError, match="rotary-factor boundary"):
+        _validate_decode_cache_length(torch.tensor([32], dtype=torch.int32), actual=1, limit=32)
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+def test_phi4mm_tp_construction_uses_compatible_local_shards(tp_size):
+    old_context = get_tp_context()
+    try:
+        set_tp_context(TPContext(rank=0, world_size=tp_size, device=torch.device("cpu"), group=None))
+        config = _tiny_model_config()
+        config.validate_tp(tp_size)
+        model = Phi4MMAdapter().build(config)
+    finally:
+        set_tp_context(old_context)
+
+    attention = model.model.layers[0].self_attn
+    assert attention.local_heads == 8 // tp_size
+    assert attention.local_kv_heads == 4 // tp_size
+    assert attention.qkv_proj.local_out_features == [64 // tp_size, 32 // tp_size, 32 // tp_size]
+    assert attention.o_proj.weight.shape == (64, 64 // tp_size)
+    assert model.model.layers[0].mlp.gate_up_proj.weight.shape == (256 // tp_size, 64)
+    assert model.model.layers[0].mlp.down_proj.weight.shape == (64, 128 // tp_size)
+    assert model.model.embed_tokens.weight.shape == (32 // tp_size, 64)
+    assert model.lm_head.weight.shape == (32 // tp_size, 64)
+    assert model.lm_head.weight is model.model.embed_tokens.weight

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -401,6 +401,21 @@ def test_phi4mm_longrope_full_long_prefill_selects_long_factors():
     torch.testing.assert_close(actual_k, expected_k)
 
 
+def test_phi4mm_prefill_longrope_factor_selection_is_fullgraph_compatible():
+    attention = Phi4MMAdapter().build(_tiny_model_config()).model.layers[0].self_attn
+    positions = torch.arange(40).unsqueeze(0)
+    infer_meta = InferMeta(mode="prefill", cu_seqlens=torch.tensor([0, 40], dtype=torch.int32), max_seqlen=40)
+    q = torch.randn(1, 40, attention.local_heads, attention.head_dim)
+    k = torch.randn(1, 40, attention.local_kv_heads, attention.head_dim)
+
+    compiled_apply_rotary = torch.compile(attention.apply_rotary, backend="eager", fullgraph=True)
+    actual_q, actual_k = compiled_apply_rotary(q, k, positions, None, infer_meta)
+    expected_q, expected_k = attention.rope(q, k, positions, sequence_length=40)
+
+    torch.testing.assert_close(actual_q, expected_q)
+    torch.testing.assert_close(actual_k, expected_k)
+
+
 def test_phi4mm_longrope_rejects_chunked_prefill_crossing_boundary():
     positions = torch.arange(28, 40).unsqueeze(0)
     infer_meta = InferMeta(mode="prefill", cu_seqlens=torch.tensor([0, 12], dtype=torch.int32), max_seqlen=12)
@@ -443,6 +458,36 @@ def test_phi4mm_decode_longrope_factor_selection_captures_cuda_graph():
     k = torch.randn(1, 2, attention.local_kv_heads, attention.head_dim, device="cuda")
     positions = torch.tensor([[31, 33]], device="cuda")
     infer_meta = InferMeta(mode="decode", cache_seqlens=torch.tensor([31, 33], device="cuda", dtype=torch.int32))
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            attention.apply_rotary(q, k, positions, None, infer_meta)
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_q, captured_k = attention.apply_rotary(q, k, positions, None, infer_meta)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_q.shape == q.shape
+    assert captured_k.shape == k.shape
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph regression test requires CUDA")
+def test_phi4mm_prefill_longrope_factor_selection_captures_cuda_graph():
+    attention = Phi4MMAdapter().build(_tiny_model_config()).model.layers[0].self_attn.cuda().eval()
+    q = torch.randn(1, 40, attention.local_heads, attention.head_dim, device="cuda")
+    k = torch.randn(1, 40, attention.local_kv_heads, attention.head_dim, device="cuda")
+    positions = torch.arange(40, device="cuda").unsqueeze(0)
+    infer_meta = InferMeta(
+        mode="prefill",
+        cu_seqlens=torch.tensor([0, 40], device="cuda", dtype=torch.int32),
+        max_seqlen=40,
+    )
 
     warmup_stream = torch.cuda.Stream()
     warmup_stream.wait_stream(torch.cuda.current_stream())

--- a/tests/test_phi4mm_adapter_cpu.py
+++ b/tests/test_phi4mm_adapter_cpu.py
@@ -108,6 +108,26 @@ assert 'areno.accel.kernels.seg_la' not in sys.modules
     subprocess.run([sys.executable, "-c", script], check=True)
 
 
+def test_phi4mm_head_preserves_fp32_logits_and_tied_gradients():
+    torch.manual_seed(17)
+    model = Phi4MMForCausalLM(_tiny_model_config()).to(dtype=torch.bfloat16)
+    hidden = torch.randn(1, 5, 64, dtype=torch.bfloat16, requires_grad=True)
+    ref_hidden = hidden.detach().float().requires_grad_()
+    ref_weight = model.lm_head.weight.detach().float().requires_grad_()
+    reference = F.linear(ref_hidden, ref_weight)
+    # An enclosing mixed-precision context must not round the output back.
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        logits = model.lm_head(hidden)
+    assert logits.dtype == torch.float32
+    torch.testing.assert_close(logits, reference, rtol=0, atol=0)
+    assert torch.any(logits != logits.bfloat16().float())
+    logits.square().mean().backward()
+    reference.square().mean().backward()
+    torch.testing.assert_close(hidden.grad, ref_hidden.grad.bfloat16(), rtol=0, atol=0)
+    assert model.lm_head.weight is model.model.embed_tokens.weight
+    torch.testing.assert_close(model.model.embed_tokens.weight.grad, ref_weight.grad.bfloat16(), rtol=0, atol=0)
+
+
 @pytest.fixture
 def cpu_reference_kernels(monkeypatch):
     def embedding(input_ids, weight, vocab_start, vocab_end):

--- a/tests/test_phi4mm_checkpoint_cpu.py
+++ b/tests/test_phi4mm_checkpoint_cpu.py
@@ -7,8 +7,6 @@ import torch
 from safetensors import safe_open
 from safetensors.torch import save_file
 
-pytest.importorskip("triton")
-
 from areno.engine.checkpoints.common import load_packed_section_column_spec, save_packed_section_column_spec
 from areno.engine.checkpoints.io import PolicyTensorStore, SafetensorsIndex
 from areno.engine.config import ModelConfig

--- a/tests/test_phi4mm_checkpoint_cpu.py
+++ b/tests/test_phi4mm_checkpoint_cpu.py
@@ -11,6 +11,7 @@ from areno.engine.checkpoints.common import load_packed_section_column_spec, sav
 from areno.engine.checkpoints.io import PolicyTensorStore, SafetensorsIndex
 from areno.engine.config import ModelConfig
 from areno.engine.parallel.context import TPContext, get_tp_context, set_tp_context
+from areno.engine.policy_sync import build_policy_plan
 from areno.models.phi4mm import Phi4MMAdapter
 from areno.models.phi4mm.checkpoint import QKV_SPEC, audit_phi4mm_checkpoint
 
@@ -260,10 +261,19 @@ def test_phi4mm_text_only_checkpoint_load_save_reload_closes(tmp_path, monkeypat
         assert first_name == second_name
         torch.testing.assert_close(first_parameter, second_parameter, rtol=0, atol=0)
     audit = audit_phi4mm_checkpoint(output, num_hidden_layers=2)
-    assert audit.total == audit.consumed == 14
+    assert audit.total == 18
+    assert audit.consumed == 14
     with open(output / "model.safetensors.index.json", encoding="utf-8") as handle:
         saved_keys = set(json.load(handle)["weight_map"])
-    assert not any("embed_tokens_extend" in key or ".lora_" in key for key in saved_keys)
+    assert saved_keys == set(tensors)
+    source_index = SafetensorsIndex(source, progress=False)
+    output_index = SafetensorsIndex(output, progress=False)
+    try:
+        for key in sorted(tensors):
+            torch.testing.assert_close(output_index.get_tensor(key), source_index.get_tensor(key), rtol=0, atol=0)
+    finally:
+        source_index.close()
+        output_index.close()
     with safe_open(output / "model-rank00000-00002-layer-00000.safetensors", framework="pt") as handle:
         torch.testing.assert_close(
             handle.get_tensor("model.layers.0.self_attn.qkv_proj.base_layer.weight"),
@@ -273,3 +283,88 @@ def test_phi4mm_text_only_checkpoint_load_save_reload_closes(tmp_path, monkeypat
             handle.get_tensor("model.layers.0.mlp.gate_up_proj.base_layer.weight"),
             tensors["model.layers.0.mlp.gate_up_proj.base_layer.weight"],
         )
+
+
+@pytest.mark.parametrize(("train_tp", "rollout_tp"), [(1, 2), (2, 1), (2, 4)])
+def test_phi4mm_policy_plan_constructs_for_mismatched_topologies(train_tp, rollout_tp):
+    """Canonical Phi tensors stay identical while physical TP shards change."""
+
+    old_context = get_tp_context()
+    try:
+        plans = []
+        for tp_size in (train_tp, rollout_tp):
+            set_tp_context(TPContext(rank=0, world_size=tp_size, device=torch.device("cpu"), group=None))
+            model = Phi4MMAdapter().build(_tiny_config())
+            worker = type(
+                "Worker",
+                (),
+                {"model": model, "config": type("Config", (), {"model": model.config})(), "adapter_registry": None},
+            )()
+            plan, metadata = build_policy_plan(worker)
+            assert tuple(plan) == tuple(meta.key for meta in metadata)
+            plans.append(metadata)
+    finally:
+        set_tp_context(old_context)
+
+    assert plans[0] == plans[1]
+    assert "model.embed_tokens.weight" in {meta.key for meta in plans[0]}
+    assert "model.layers.0.self_attn.qkv_proj.base_layer.weight" in {meta.key for meta in plans[0]}
+    assert "model.layers.0.mlp.gate_up_proj.base_layer.weight" in {meta.key for meta in plans[0]}
+
+
+@pytest.mark.parametrize(("train_tp", "rollout_tp"), [(1, 2), (2, 1), (2, 4)])
+def test_phi4mm_policy_plan_reshards_all_canonical_weights_for_mismatched_topologies(
+    tmp_path, monkeypatch, train_tp, rollout_tp
+):
+    monkeypatch.setenv("ARENO_CKPT_PROGRESS", "0")
+    source = tmp_path / "source"
+    _write_checkpoint(source, _synthetic_weights())
+    old_context = get_tp_context()
+    try:
+        train_layouts = []
+        for rank in range(train_tp):
+            set_tp_context(TPContext(rank=rank, world_size=train_tp, device=torch.device("cpu"), group=None))
+            model = Phi4MMAdapter().build(_tiny_config())
+            Phi4MMAdapter().load_weights(model, source)
+            worker = type(
+                "Worker",
+                (),
+                {"model": model, "config": type("Config", (), {"model": model.config})(), "adapter_registry": None},
+            )()
+            plan, _ = build_policy_plan(worker)
+            train_layouts.append({key: task.policy_layout() for key, task in plan.items()})
+
+        canonical = {}
+        for key in train_layouts[0]:
+            layout = train_layouts[0][key]
+            full = torch.zeros(layout.numel, dtype=layout.dtype)
+            for rank, layouts in enumerate(train_layouts):
+                contribution = torch.empty_like(full)
+                layouts[key].read_chunk(0, contribution, include_replicated=rank == 0)
+                full.add_(contribution)
+            canonical[key] = full
+
+        rollout_layouts = []
+        for rank in range(rollout_tp):
+            set_tp_context(TPContext(rank=rank, world_size=rollout_tp, device=torch.device("cpu"), group=None))
+            model = Phi4MMAdapter().build(_tiny_config())
+            worker = type(
+                "Worker",
+                (),
+                {"model": model, "config": type("Config", (), {"model": model.config})(), "adapter_registry": None},
+            )()
+            plan, _ = build_policy_plan(worker)
+            rollout_layouts.append({key: task.policy_layout() for key, task in plan.items()})
+        for key, full in canonical.items():
+            for layouts in rollout_layouts:
+                layouts[key].write_chunk(0, full)
+
+        for key, full in canonical.items():
+            reconstructed = torch.zeros_like(full)
+            for rank, layouts in enumerate(rollout_layouts):
+                contribution = torch.empty_like(full)
+                layouts[key].read_chunk(0, contribution, include_replicated=rank == 0)
+                reconstructed.add_(contribution)
+            torch.testing.assert_close(reconstructed, full, rtol=0, atol=0)
+    finally:
+        set_tp_context(old_context)

--- a/tests/test_phi4mm_checkpoint_cpu.py
+++ b/tests/test_phi4mm_checkpoint_cpu.py
@@ -7,6 +7,8 @@ import torch
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+pytest.importorskip("triton")
+
 from areno.engine.checkpoints.common import load_packed_section_column_spec, save_packed_section_column_spec
 from areno.engine.checkpoints.io import PolicyTensorStore, SafetensorsIndex
 from areno.engine.config import ModelConfig

--- a/tests/test_phi4mm_checkpoint_cpu.py
+++ b/tests/test_phi4mm_checkpoint_cpu.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from areno.engine.checkpoints.common import load_packed_section_column_spec, save_packed_section_column_spec
+from areno.engine.checkpoints.io import PolicyTensorStore, SafetensorsIndex
+from areno.engine.config import ModelConfig
+from areno.engine.parallel.context import TPContext, get_tp_context, set_tp_context
+from areno.models.phi4mm import Phi4MMAdapter
+from areno.models.phi4mm.checkpoint import QKV_SPEC, audit_phi4mm_checkpoint
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tp_context():
+    previous_context = get_tp_context()
+    set_tp_context(TPContext(rank=0, world_size=1, device=torch.device("cpu"), group=None))
+    try:
+        yield
+    finally:
+        set_tp_context(previous_context)
+
+
+def _tiny_config() -> ModelConfig:
+    return ModelConfig(
+        model_type="phi4mm",
+        vocab_size=32,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=8,
+        rms_norm_eps=1e-5,
+        rope_theta=10_000.0,
+        max_position_embeddings=64,
+        tie_word_embeddings=True,
+        qkv_bias=False,
+        qk_norm=False,
+        dtype=torch.float32,
+        hidden_act="silu",
+        partial_rotary_factor=0.75,
+        sequence_parallel=False,
+        attn_backend="native",
+        hf_text_config={
+            "original_max_position_embeddings": 32,
+            "rope_scaling": {
+                "type": "longrope",
+                "short_factor": (1.0, 1.0, 1.0),
+                "long_factor": (1.0, 2.0, 3.0),
+            },
+        },
+    )
+
+
+def _row_values(rows: int, columns: int, base: float) -> torch.Tensor:
+    return (base + torch.arange(rows, dtype=torch.float32)).unsqueeze(1).expand(rows, columns).clone()
+
+
+def _column_values(rows: int, columns: int, base: float) -> torch.Tensor:
+    return (base + torch.arange(columns, dtype=torch.float32)).unsqueeze(0).expand(rows, columns).clone()
+
+
+def _synthetic_weights(*, skipped: bool = False) -> dict[str, torch.Tensor]:
+    config = _tiny_config()
+    tensors = {
+        "model.embed_tokens.weight": torch.arange(config.vocab_size * config.hidden_size, dtype=torch.float32).view(
+            config.vocab_size, config.hidden_size
+        ),
+        "model.norm.weight": torch.arange(config.hidden_size, dtype=torch.float32) + 10,
+    }
+    for layer in range(config.num_hidden_layers):
+        prefix = f"model.layers.{layer}"
+        offset = layer * 10_000
+        q = _row_values(64, 64, 1_000 + offset)
+        k = _row_values(32, 64, 2_000 + offset)
+        v = _row_values(32, 64, 3_000 + offset)
+        gate = _row_values(128, 64, 4_000 + offset)
+        up = _row_values(128, 64, 5_000 + offset)
+        tensors.update(
+            {
+                f"{prefix}.input_layernorm.weight": torch.arange(64, dtype=torch.float32) + 20 + offset,
+                f"{prefix}.post_attention_layernorm.weight": torch.arange(64, dtype=torch.float32) + 30 + offset,
+                f"{prefix}.self_attn.qkv_proj.base_layer.weight": torch.cat((q, k, v)),
+                f"{prefix}.self_attn.o_proj.base_layer.weight": _column_values(64, 64, 6_000 + offset),
+                f"{prefix}.mlp.gate_up_proj.base_layer.weight": torch.cat((gate, up)),
+                f"{prefix}.mlp.down_proj.base_layer.weight": _column_values(64, 128, 7_000 + offset),
+            }
+        )
+    if skipped:
+        tensors.update(
+            {
+                "model.layers.0.self_attn.qkv_proj.lora_A.vision.weight": torch.ones(1),
+                "model.layers.0.self_attn.qkv_proj.lora_B.speech.weight": torch.ones(1),
+                "model.embed_tokens_extend.image_embed.img_projection.weight": torch.ones(1),
+                "model.embed_tokens_extend.audio_embed.audio_projection.weight": torch.ones(1),
+            }
+        )
+    return tensors
+
+
+def _write_checkpoint(path, tensors: dict[str, torch.Tensor]) -> None:
+    path.mkdir()
+    save_file(tensors, path / "model.safetensors")
+    (path / "config.json").write_text(json.dumps({"model_type": "phi4mm"}), encoding="utf-8")
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+def test_phi4mm_checkpoint_loads_each_packed_section_independently(tmp_path, monkeypatch, tp_size):
+    monkeypatch.setenv("ARENO_CKPT_PROGRESS", "0")
+    tensors = _synthetic_weights()
+    checkpoint = tmp_path / "source"
+    _write_checkpoint(checkpoint, tensors)
+    old_context = get_tp_context()
+    try:
+        for rank in range(tp_size):
+            set_tp_context(TPContext(rank=rank, world_size=tp_size, device=torch.device("cpu"), group=None))
+            model = Phi4MMAdapter().build(_tiny_config())
+            Phi4MMAdapter().load_weights(model, checkpoint)
+
+            layer = model.model.layers[0]
+            q, k, v = tensors["model.layers.0.self_attn.qkv_proj.base_layer.weight"].split((64, 32, 32))
+            gate, up = tensors["model.layers.0.mlp.gate_up_proj.base_layer.weight"].split((128, 128))
+            expected_qkv = torch.cat((q.chunk(tp_size)[rank], k.chunk(tp_size)[rank], v.chunk(tp_size)[rank]))
+            expected_gate_up = torch.cat((gate.chunk(tp_size)[rank], up.chunk(tp_size)[rank]))
+
+            torch.testing.assert_close(layer.self_attn.qkv_proj.weight, expected_qkv)
+            torch.testing.assert_close(layer.mlp.gate_up_proj.weight, expected_gate_up)
+            torch.testing.assert_close(
+                layer.self_attn.o_proj.weight,
+                tensors["model.layers.0.self_attn.o_proj.base_layer.weight"].chunk(tp_size, dim=1)[rank],
+            )
+            torch.testing.assert_close(
+                layer.mlp.down_proj.weight,
+                tensors["model.layers.0.mlp.down_proj.base_layer.weight"].chunk(tp_size, dim=1)[rank],
+            )
+            torch.testing.assert_close(
+                model.model.embed_tokens.weight,
+                tensors["model.embed_tokens.weight"].chunk(tp_size)[rank],
+            )
+            torch.testing.assert_close(layer.input_layernorm.weight, tensors["model.layers.0.input_layernorm.weight"])
+            torch.testing.assert_close(
+                layer.post_attention_layernorm.weight,
+                tensors["model.layers.0.post_attention_layernorm.weight"],
+            )
+            torch.testing.assert_close(model.model.norm.weight, tensors["model.norm.weight"])
+            assert model.lm_head.weight is model.model.embed_tokens.weight
+    finally:
+        set_tp_context(old_context)
+
+
+def test_phi4mm_checkpoint_audit_accepts_only_documented_skips(tmp_path):
+    checkpoint = tmp_path / "source"
+    _write_checkpoint(checkpoint, _synthetic_weights(skipped=True))
+
+    audit = audit_phi4mm_checkpoint(checkpoint, num_hidden_layers=2)
+
+    assert audit.total == 18
+    assert audit.consumed == 14
+    assert audit.vision_lora_skipped == 1
+    assert audit.speech_lora_skipped == 1
+    assert audit.vision_skipped == 1
+    assert audit.audio_skipped == 1
+    assert audit.unknown == 0
+
+
+def test_phi4mm_checkpoint_audit_rejects_unknown_base_key(tmp_path):
+    tensors = _synthetic_weights()
+    tensors["model.layers.0.self_attn.foo.weight"] = torch.ones(1)
+    checkpoint = tmp_path / "source"
+    _write_checkpoint(checkpoint, tensors)
+
+    with pytest.raises(ValueError, match="unknown tensors.*self_attn.foo.weight"):
+        audit_phi4mm_checkpoint(checkpoint, num_hidden_layers=2)
+
+
+def test_phi4mm_checkpoint_audit_rejects_missing_required_key(tmp_path):
+    tensors = _synthetic_weights()
+    del tensors["model.layers.0.self_attn.qkv_proj.base_layer.weight"]
+    checkpoint = tmp_path / "source"
+    _write_checkpoint(checkpoint, tensors)
+
+    with pytest.raises(ValueError, match="missing 1 required.*qkv_proj.base_layer.weight"):
+        audit_phi4mm_checkpoint(checkpoint, num_hidden_layers=2)
+
+
+def test_phi4mm_checkpoint_rejects_wrong_packed_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARENO_CKPT_PROGRESS", "0")
+    tensors = _synthetic_weights()
+    tensors["model.layers.0.self_attn.qkv_proj.base_layer.weight"] = torch.zeros(127, 64)
+    checkpoint = tmp_path / "source"
+    _write_checkpoint(checkpoint, tensors)
+
+    with pytest.raises(ValueError, match=r"shape \(127, 64\), expected \(128, 64\)"):
+        Phi4MMAdapter().load_weights(Phi4MMAdapter().build(_tiny_config()), checkpoint)
+
+
+def test_packed_section_loader_rejects_non_divisible_sections(tmp_path):
+    checkpoint = tmp_path / "source"
+    _write_checkpoint(checkpoint, _synthetic_weights())
+    model = Phi4MMAdapter().build(_tiny_config())
+    index = SafetensorsIndex(checkpoint, progress=False)
+    try:
+        with pytest.raises(ValueError, match="cannot shard size 64 across 3 ranks"):
+            load_packed_section_column_spec(model.model.layers[0], index, "model.layers.0", QKV_SPEC, 0, 3)
+    finally:
+        index.close()
+
+
+@pytest.mark.parametrize("tp_size", [2, 4])
+def test_packed_section_save_layout_is_inverse_of_section_sharding(tp_size):
+    tensors = _synthetic_weights()
+    full = tensors["model.layers.0.self_attn.qkv_proj.base_layer.weight"]
+    q, k, v = full.split((64, 32, 32))
+    old_context = get_tp_context()
+    contributions = []
+    try:
+        for rank in range(tp_size):
+            set_tp_context(TPContext(rank=rank, world_size=tp_size, device=torch.device("cpu"), group=None))
+            layer = Phi4MMAdapter().build(_tiny_config()).model.layers[0]
+            layer.self_attn.qkv_proj.weight.data.copy_(
+                torch.cat((q.chunk(tp_size)[rank], k.chunk(tp_size)[rank], v.chunk(tp_size)[rank]))
+            )
+            store = PolicyTensorStore()
+            save_packed_section_column_spec(store, layer, "model.layers.0", QKV_SPEC)
+            layout = store["model.layers.0.self_attn.qkv_proj.base_layer.weight"].policy_layout()
+            contribution = torch.empty(layout.numel, dtype=layout.dtype)
+            layout.read_chunk(0, contribution)
+            contributions.append(contribution)
+    finally:
+        set_tp_context(old_context)
+
+    reconstructed = torch.stack(contributions).sum(dim=0).reshape_as(full)
+    torch.testing.assert_close(reconstructed, full, rtol=0, atol=0)
+
+
+def test_phi4mm_text_only_checkpoint_load_save_reload_closes(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARENO_CKPT_PROGRESS", "0")
+    source = tmp_path / "source"
+    output = tmp_path / "output"
+    tensors = _synthetic_weights(skipped=True)
+    _write_checkpoint(source, tensors)
+    first = Phi4MMAdapter().build(_tiny_config())
+    Phi4MMAdapter().load_weights(first, source)
+
+    saved_path = Phi4MMAdapter().save_weights(first, output, source)
+    second = Phi4MMAdapter().build(_tiny_config())
+    Phi4MMAdapter().load_weights(second, output)
+
+    assert saved_path == str(output)
+    assert (output / "config.json").exists()
+    assert second.lm_head.weight is second.model.embed_tokens.weight
+    for (first_name, first_parameter), (second_name, second_parameter) in zip(
+        first.named_parameters(), second.named_parameters(), strict=True
+    ):
+        assert first_name == second_name
+        torch.testing.assert_close(first_parameter, second_parameter, rtol=0, atol=0)
+    audit = audit_phi4mm_checkpoint(output, num_hidden_layers=2)
+    assert audit.total == audit.consumed == 14
+    with open(output / "model.safetensors.index.json", encoding="utf-8") as handle:
+        saved_keys = set(json.load(handle)["weight_map"])
+    assert not any("embed_tokens_extend" in key or ".lora_" in key for key in saved_keys)
+    with safe_open(output / "model-rank00000-00002-layer-00000.safetensors", framework="pt") as handle:
+        torch.testing.assert_close(
+            handle.get_tensor("model.layers.0.self_attn.qkv_proj.base_layer.weight"),
+            tensors["model.layers.0.self_attn.qkv_proj.base_layer.weight"],
+        )
+        torch.testing.assert_close(
+            handle.get_tensor("model.layers.0.mlp.gate_up_proj.base_layer.weight"),
+            tensors["model.layers.0.mlp.gate_up_proj.base_layer.weight"],
+        )

--- a/tests/test_tokenizer_api_cpu.py
+++ b/tests/test_tokenizer_api_cpu.py
@@ -60,6 +60,23 @@ class TokenizerApiTest(unittest.TestCase):
 
         self.assertEqual(ids, (1, 2, 3))
 
+    def test_eos_token_ids_prefers_generation_config_stop_tokens(self):
+        """Phi-style chat stops must precede the tokenizer's generic EOS."""
+        tokenizer = FakeTokenizer()
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "generation_config.json").write_text(
+                json.dumps({"eos_token_id": [4, 1]}),
+                encoding="utf-8",
+            )
+            Path(tmp, "config.json").write_text(
+                json.dumps({"eos_token_id": 2}),
+                encoding="utf-8",
+            )
+
+            ids = eos_token_ids(tmp, tokenizer)
+
+        self.assertEqual(ids, (4, 1, 2))
+
     def test_encode_generation_prompt_applies_template_once(self):
         """Already formatted chat prompts must not be wrapped a second time."""
         tokenizer = FakeTokenizer()


### PR DESCRIPTION
## Summary

- Add a text-only adapter for Microsoft Phi-4-Multimodal-Instruct using AReno native layers and runtime.
- Implement Phi partial LongRoPE, true tied input/output embeddings, text generation, and text-only save/reload.
- Load the official base-language checkpoint with explicit vision, speech, and LoRA classification.
- Add TP-aware packed-section mapping for fused QKV and gate/up projections, validated with TP1, TP2, and TP4.
- Honor checkpoint `generation_config.json` EOS IDs in training/agentic paths so Phi stops at `<|end|>`.
- Render OpenAI function schemas in the per-message format required by Phi's chat template.

## Validation

- Rebased onto `upstream/main` at `2737aa116e7255e75d68c73fbd77b2adad6dfca2`.
- Post-rebase Phi/checkpoint/scheduler/serve/agentic CPU regression tests: `144 passed`.
- Full repository CPU-selected suite: `760 passed, 5 skipped, 20 deselected, 11 failed`.
  - All 11 failures reproduce unchanged on clean `upstream/main` at `2737aa116e7255e75d68c73fbd77b2adad6dfca2` in the same environment.
  - They cover unavailable/newly rebuilt optimizer CUDA extension symbols, GPU-count assumptions, existing MLX log capture, MoE test fixtures, and duplicate-device NCCL setup; none are introduced by this PR.
- Available CUDA tests on an NVIDIA GeForce RTX 3090: `12 passed`.
- Ruff lint/format, all manual pre-commit hooks, `compileall`, and `git diff --check`: passed.
- Official BF16 checkpoint audit: 194 base-language keys consumed, 0 unknown keys, and 0 missing required base-language keys.
- HF/AReno parity: exact 16-token greedy and KV-cache token parity; last-token logits cosine similarity `0.999983340331`.
- Tensor parallel parity: exact greedy token parity for TP1, TP2, and TP4.
- Text-only save/reload: bitwise-equal logits and true weight tying preserved.
- TP2 Tic-Tac-Toe GSPO smoke train on two RTX 3090s completed one real step end to end
  (4 rollouts, reward, backward, gradient clipping, and Adam update). All sampled
  completions stopped at `<|end|>`; the final run parsed 4/4 tool calls.
  The local 24 GB shared-GPU environment required eager execution, TorchDynamo
  disabled, and disk optimizer-state offload.

## Known limitations

- This PR supports only the text path. Image and audio support will be submitted in follow-up PRs.
- At the Phi LongRoPE 4096-token regime boundary, the scheduler discards the short-factor KV cache and performs a full long-factor re-prefill before continuing cached generation.
