### PR TITLE
feat: add rollout routing replay for MoE RL

### DIFF
--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -119,6 +119,7 @@ class AgentTrainBatch:
     rewards: list[float] | None
     records: list[dict[str, Any]]
     reward_records: list[RewardRecord]
+    routed_experts: list[list[list[list[int]]]] | None = None
 
 
 @dataclass(slots=True)
@@ -131,6 +132,7 @@ class AgentTrajectoryTurn:
     input_tokens: list[int] = field(default_factory=list)
     response_tokens: list[int] = field(default_factory=list)
     response_logprobs: list[float] = field(default_factory=list)
+    routed_experts: list[list[list[int]]] | None = None
     parsed_tool_calls: list[dict[str, Any]] = field(default_factory=list)
     model: str = "policy"
     tools: list[dict[str, Any]] = field(default_factory=list)
@@ -143,6 +145,7 @@ class AgentTrajectoryTurn:
         self.input_tokens = list(metadata.get("input_tokens") or [])
         self.response_tokens = list(metadata["response_tokens"])
         self.response_logprobs = [float(value) for value in metadata["response_logprobs"]]
+        self.routed_experts = metadata.get("routed_experts") or None
         self.parsed_tool_calls = _chat_response_message_tool_calls(self.response)
 
 
@@ -171,12 +174,14 @@ class _AgentSample:
     loss_mask_row: list[bool] = field(default_factory=list)
     rollout_logprobs_row: list[float] = field(default_factory=list)
     features: dict[str, Any] | None = None
+    routed_experts_row: list[list[list[int]]] | None = None
 
 
 @dataclass(slots=True)
 class _ResponseData:
     response_tokens: list[int]
     response_logprobs: list[float]
+    routed_experts: list[list[list[int]]] | None = None
 
 
 @dataclass(slots=True)
@@ -187,6 +192,7 @@ class _AgentTrainRows:
     rollout_logprobs: list[list[float]]
     features: list[dict[str, Any] | None]
     total_tokens: int
+    routed_experts: list[list[list[list[int]]]] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -403,6 +409,8 @@ class RolloutSession:
         loss_masks: list[list[bool]] = []
         rollout_logprobs: list[list[float]] = []
         features: list[dict[str, Any] | None] = []
+        routed_experts: list[list[list[list[int]]]] = []
+        route_presence: list[bool] = []
         total_tokens = 0
         for sample in samples:
             if sample.token_row:
@@ -411,6 +419,9 @@ class RolloutSession:
                 loss_masks.append(sample.loss_mask_row)
                 rollout_logprobs.append(sample.rollout_logprobs_row)
                 features.append(sample.features)
+                route_presence.append(sample.routed_experts_row is not None)
+                if sample.routed_experts_row is not None:
+                    routed_experts.append(sample.routed_experts_row)
                 total_tokens += len(sample.token_row)
                 continue
             prompt_len = len(sample.item.input_tokens)
@@ -421,7 +432,12 @@ class RolloutSession:
             loss_masks.append([False] * prompt_len + self._response_loss_mask(sample))
             rollout_logprobs.append([0.0] * prompt_len + list(sample.response_logprobs))
             features.append(sample.features)
+            route_presence.append(sample.routed_experts_row is not None)
+            if sample.routed_experts_row is not None:
+                routed_experts.append(sample.routed_experts_row)
             total_tokens += len(token_row)
+        if any(route_presence) and not all(route_presence):
+            raise ValueError("agentic routing replay must be present for every trajectory in the train batch")
         return _AgentTrainRows(
             token_rows=token_rows,
             response_masks=response_masks,
@@ -429,6 +445,7 @@ class RolloutSession:
             rollout_logprobs=rollout_logprobs,
             features=features,
             total_tokens=total_tokens,
+            routed_experts=routed_experts or None,
         )
 
     def _handler_cls(self):
@@ -539,7 +556,11 @@ class RolloutSession:
                     pending,
                     self._build_chat_response(
                         pending,
-                        _ResponseData(response_tokens=sequence.resp_tokens, response_logprobs=sequence.resp_logprobs),
+                        _ResponseData(
+                            response_tokens=sequence.resp_tokens,
+                            response_logprobs=sequence.resp_logprobs,
+                            routed_experts=sequence.routed_experts,
+                        ),
                     ),
                 )
         except BaseException as exc:
@@ -604,7 +625,11 @@ class RolloutSession:
             pending.input_tokens, pending.features = self._messages_to_tokens_and_features(pending)
         return self._sample_from_pending_chat(
             pending,
-            _ResponseData(response_tokens=list(turn.response_tokens), response_logprobs=list(turn.response_logprobs)),
+            _ResponseData(
+                response_tokens=list(turn.response_tokens),
+                response_logprobs=list(turn.response_logprobs),
+                routed_experts=turn.routed_experts,
+            ),
             tool_calls=turn.parsed_tool_calls,
         )
 
@@ -663,6 +688,7 @@ class RolloutSession:
             trace=trace,
             response_kind=response_kind,
             features=pending.features,
+            routed_experts_row=response.routed_experts,
             loss_mask_override=_tool_call_loss_mask(tokenizer, response.response_tokens) if tool_calls else None,
         )
         # The prompt tokens are the fully rendered chat context for this turn,
@@ -679,6 +705,7 @@ class RolloutSession:
             pending,
             response.response_tokens,
             response_logprobs=response.response_logprobs,
+            routed_experts=response.routed_experts,
             content=content,
             tool_calls=tool_parse.tool_calls,
         )
@@ -709,6 +736,16 @@ class RolloutSession:
             existing.response_mask_row.extend(new_sample.response_mask_row[prefix_len:])
             existing.loss_mask_row.extend(new_sample.loss_mask_row[prefix_len:])
             existing.rollout_logprobs_row.extend(new_sample.rollout_logprobs_row[prefix_len:])
+            if (new_sample.routed_experts_row is None) != (existing.routed_experts_row is None):
+                raise ValueError("agentic routing replay must be present for every trajectory turn")
+            if new_sample.routed_experts_row is not None:
+                assert existing.routed_experts_row is not None
+                route_start = len(existing.routed_experts_row)
+                if route_start != max(prefix_len - 1, 0) or route_start > len(new_sample.routed_experts_row):
+                    raise ValueError("agentic routing replay does not share the trajectory token prefix")
+                existing.routed_experts_row.extend(new_sample.routed_experts_row[route_start:])
+                if len(existing.routed_experts_row) != len(existing.token_row) - 1:
+                    raise ValueError("agentic routing replay must contain one route for every token except the final")
         elif not existing.token_row:
             existing.token_row = list(existing.item.input_tokens) + list(existing.response_tokens)
             prompt_len = len(existing.item.input_tokens)
@@ -733,6 +770,8 @@ class RolloutSession:
         sample.response_mask_row = [False] * len(prompt_tokens) + response_mask
         sample.loss_mask_row = [False] * len(prompt_tokens) + loss_mask
         sample.rollout_logprobs_row = [0.0] * len(prompt_tokens) + list(sample.response_logprobs)
+        if sample.routed_experts_row is not None and len(sample.routed_experts_row) != len(sample.token_row) - 1:
+            raise ValueError("agentic routing replay must contain one route for every token except the final token")
 
     def _build_pending_chat_response(
         self,
@@ -740,6 +779,7 @@ class RolloutSession:
         response_tokens: list[int],
         *,
         response_logprobs: list[float] | None = None,
+        routed_experts: list[list[list[int]]] | None = None,
         content: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
@@ -756,6 +796,7 @@ class RolloutSession:
             tool_call_parser=self._tool_call_parser,
             parsed_tool_calls=[list(tool_calls or [])],
             response_logprobs=[list(response_logprobs or [])],
+            routed_experts=[list(routed_experts or [])],
             include_areno_metadata=True,
             input_tokens=pending.input_tokens,
         )

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -181,7 +181,7 @@ class _AgentSample:
 class _ResponseData:
     response_tokens: list[int]
     response_logprobs: list[float]
-    routed_experts: list[list[list[int]]] | None = None
+    routed_experts: Any | None = None
 
 
 @dataclass(slots=True)
@@ -779,7 +779,7 @@ class RolloutSession:
         response_tokens: list[int],
         *,
         response_logprobs: list[float] | None = None,
-        routed_experts: list[list[list[int]]] | None = None,
+        routed_experts: Any | None = None,
         content: str | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
@@ -796,7 +796,7 @@ class RolloutSession:
             tool_call_parser=self._tool_call_parser,
             parsed_tool_calls=[list(tool_calls or [])],
             response_logprobs=[list(response_logprobs or [])],
-            routed_experts=[list(routed_experts or [])],
+            routed_experts=[_routing_to_list(routed_experts)],
             include_areno_metadata=True,
             input_tokens=pending.input_tokens,
         )
@@ -805,6 +805,13 @@ class RolloutSession:
 def _multimodal_encoding_cache_key(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> str:
     payload = json.dumps([messages, tools], sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _routing_to_list(routed_experts: Any | None) -> list[list[list[int]]]:
+    if routed_experts is None:
+        return []
+    tolist = getattr(routed_experts, "tolist", None)
+    return tolist() if callable(tolist) else list(routed_experts)
 
 
 def load_agent_run_fn(path: str) -> Callable[[RolloutSession, AgentBatch], Any]:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -137,6 +137,7 @@ class AgentTrajectoryTurn:
     model: str = "policy"
     tools: list[dict[str, Any]] = field(default_factory=list)
     tool_choice: Any = None
+    filtered: bool = False
 
     def __post_init__(self) -> None:
         if self.response is None:
@@ -146,6 +147,7 @@ class AgentTrajectoryTurn:
         self.response_tokens = list(metadata["response_tokens"])
         self.response_logprobs = [float(value) for value in metadata["response_logprobs"]]
         self.routed_experts = metadata.get("routed_experts") or None
+        self.filtered = bool(metadata.get("filtered", False))
         self.parsed_tool_calls = _chat_response_message_tool_calls(self.response)
 
 
@@ -957,6 +959,10 @@ def _filtered_chat_response(*, model: str, prompt_tokens: int, max_sequence_len:
             "input_tokens": [],
             "response_tokens": [],
             "response_logprobs": [],
+            # No model forward was executed, so this response must terminate
+            # the trajectory without becoming a route-less training turn.
+            "filtered": True,
+            "filter_reason": "max_context_len",
         },
     }
 

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -122,6 +122,7 @@ class AgentTrainBatch:
     records: list[dict[str, Any]]
     reward_records: list[RewardRecord]
     routed_experts: list[torch.Tensor] | None = None
+    row_reward_indices: list[int] | None = None
 
 
 @dataclass(slots=True)
@@ -345,6 +346,11 @@ class RolloutSession:
         """Return the OpenAI-compatible base URL."""
 
         return self.base_url
+
+    def get_tokenizer(self):
+        """Return the tokenizer used to encode agentic rollout requests."""
+
+        return self._trainer.get_tokenizer()
 
     def finish_requests(self) -> None:
         """Compatibility no-op for agents that mark request submission done."""
@@ -724,7 +730,7 @@ class RolloutSession:
         )
 
     def _append_sample_response(self, existing: _AgentSample, new_sample: _AgentSample) -> None:
-        """Append another model response to an existing multi-call trajectory."""
+        """Aggregate multi-call reward history without flattening train rows."""
 
         old_response_kind = existing.response_kind
         old_response_len = len(existing.response_tokens)
@@ -740,37 +746,6 @@ class RolloutSession:
         existing.response_logprobs.extend(new_sample.response_logprobs)
         existing.trace.extend(new_sample.trace)
         existing.messages = new_sample.messages
-        # Each later turn is rendered as: previous messages + new assistant.
-        # Append only the suffix so the training row becomes one trajectory
-        # instead of duplicating the shared prefix for every tool call.
-        prefix_len = _common_prefix_len(existing.token_row, new_sample.token_row)
-        if prefix_len < len(new_sample.token_row):
-            existing.token_row.extend(new_sample.token_row[prefix_len:])
-            existing.response_mask_row.extend(new_sample.response_mask_row[prefix_len:])
-            existing.loss_mask_row.extend(new_sample.loss_mask_row[prefix_len:])
-            existing.rollout_logprobs_row.extend(new_sample.rollout_logprobs_row[prefix_len:])
-            if (new_sample.routed_experts_row is None) != (existing.routed_experts_row is None):
-                raise ValueError("agentic routing replay must be present for every trajectory turn")
-            if new_sample.routed_experts_row is not None:
-                assert existing.routed_experts_row is not None
-                # The route at position ``prefix_len - 1`` predicts the first
-                # token in the appended suffix.  Later chat-template renders
-                # need not contain the complete previous training row as a
-                # prefix, so slicing at the old row length misaligns routes.
-                route_start = max(prefix_len - 1, 0)
-                if route_start > len(new_sample.routed_experts_row):
-                    raise ValueError("agentic routing replay is shorter than the shared trajectory token prefix")
-                existing.routed_experts_row = torch.cat(
-                    (existing.routed_experts_row, new_sample.routed_experts_row[route_start:]), dim=0
-                )
-                if len(existing.routed_experts_row) != len(existing.token_row) - 1:
-                    raise ValueError("agentic routing replay must contain one route for every token except the final")
-        elif not existing.token_row:
-            existing.token_row = list(existing.item.input_tokens) + list(existing.response_tokens)
-            prompt_len = len(existing.item.input_tokens)
-            existing.response_mask_row = [False] * prompt_len + [True] * len(existing.response_tokens)
-            existing.loss_mask_row = [False] * prompt_len + self._response_loss_mask(existing)
-            existing.rollout_logprobs_row = [0.0] * prompt_len + list(existing.response_logprobs)
         old_mask = existing.loss_mask_override
         if old_mask is None:
             old_mask = self._response_loss_mask_for_span(old_response_kind, old_response_len)
@@ -1136,16 +1111,6 @@ def _trace_with_tool_results(trace: list[RewardEvent], messages: list[dict[str, 
     if not inserted:
         augmented.extend(tool_result_events)
     return augmented
-
-
-def _common_prefix_len(left: list[int], right: list[int]) -> int:
-    """Return the shared token prefix length for incremental multi-turn rows."""
-
-    limit = min(len(left), len(right))
-    for idx in range(limit):
-        if left[idx] != right[idx]:
-            return idx
-    return limit
 
 
 def _chat_batch_key(params: Any) -> _ChatBatchKey:

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -740,9 +740,13 @@ class RolloutSession:
                 raise ValueError("agentic routing replay must be present for every trajectory turn")
             if new_sample.routed_experts_row is not None:
                 assert existing.routed_experts_row is not None
-                route_start = len(existing.routed_experts_row)
-                if route_start != max(prefix_len - 1, 0) or route_start > len(new_sample.routed_experts_row):
-                    raise ValueError("agentic routing replay does not share the trajectory token prefix")
+                # The route at position ``prefix_len - 1`` predicts the first
+                # token in the appended suffix.  Later chat-template renders
+                # need not contain the complete previous training row as a
+                # prefix, so slicing at the old row length misaligns routes.
+                route_start = max(prefix_len - 1, 0)
+                if route_start > len(new_sample.routed_experts_row):
+                    raise ValueError("agentic routing replay is shorter than the shared trajectory token prefix")
                 existing.routed_experts_row.extend(new_sample.routed_experts_row[route_start:])
                 if len(existing.routed_experts_row) != len(existing.token_row) - 1:
                     raise ValueError("agentic routing replay must contain one route for every token except the final")

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -559,7 +559,7 @@ class RolloutSession:
                         _ResponseData(
                             response_tokens=sequence.resp_tokens,
                             response_logprobs=sequence.resp_logprobs,
-                            routed_experts=sequence.routed_experts,
+                            routed_experts=getattr(sequence, "routed_experts", None),
                         ),
                     ),
                 )

--- a/areno/api/agentic.py
+++ b/areno/api/agentic.py
@@ -27,6 +27,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import torch
+
 from areno.api.multimodal import encode_multimodal_prompt, encode_processor_messages, modality_token_ids
 from areno.api.openai_chat import (
     build_chat_completion_response,
@@ -119,7 +121,7 @@ class AgentTrainBatch:
     rewards: list[float] | None
     records: list[dict[str, Any]]
     reward_records: list[RewardRecord]
-    routed_experts: list[list[list[list[int]]]] | None = None
+    routed_experts: list[torch.Tensor] | None = None
 
 
 @dataclass(slots=True)
@@ -132,7 +134,8 @@ class AgentTrajectoryTurn:
     input_tokens: list[int] = field(default_factory=list)
     response_tokens: list[int] = field(default_factory=list)
     response_logprobs: list[float] = field(default_factory=list)
-    routed_experts: list[list[list[int]]] | None = None
+    routed_experts: torch.Tensor | None = None
+    routing_replay_id: str | None = None
     parsed_tool_calls: list[dict[str, Any]] = field(default_factory=list)
     model: str = "policy"
     tools: list[dict[str, Any]] = field(default_factory=list)
@@ -146,7 +149,8 @@ class AgentTrajectoryTurn:
         self.input_tokens = list(metadata.get("input_tokens") or [])
         self.response_tokens = list(metadata["response_tokens"])
         self.response_logprobs = [float(value) for value in metadata["response_logprobs"]]
-        self.routed_experts = metadata.get("routed_experts") or None
+        self.routed_experts = _routing_to_cpu_tensor(metadata.get("routed_experts"))
+        self.routing_replay_id = metadata.get("routing_replay_id") or None
         self.filtered = bool(metadata.get("filtered", False))
         self.parsed_tool_calls = _chat_response_message_tool_calls(self.response)
 
@@ -176,7 +180,7 @@ class _AgentSample:
     loss_mask_row: list[bool] = field(default_factory=list)
     rollout_logprobs_row: list[float] = field(default_factory=list)
     features: dict[str, Any] | None = None
-    routed_experts_row: list[list[list[int]]] | None = None
+    routed_experts_row: torch.Tensor | None = None
 
 
 @dataclass(slots=True)
@@ -194,7 +198,7 @@ class _AgentTrainRows:
     rollout_logprobs: list[list[float]]
     features: list[dict[str, Any] | None]
     total_tokens: int
-    routed_experts: list[list[list[list[int]]]] | None = None
+    routed_experts: list[torch.Tensor] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -286,6 +290,7 @@ class RolloutSession:
         self._proxy_enabled = bool(proxy)
         self._multimodal_encoding_cache: dict[str, tuple[list[int], dict[str, Any] | None]] = {}
         self._multimodal_encoding_cache_limit = max(self._max_running_prompts * 2, 32)
+        self._routing_sidecar: dict[str, torch.Tensor] = {}
 
     @property
     def max_running_prompts(self) -> int:
@@ -325,6 +330,7 @@ class RolloutSession:
             if self._thread is not None:
                 self._thread.join(timeout=2.0)
         finally:
+            self._routing_sidecar.clear()
             await self._trainer.end_rollout_session_async()
 
     @property
@@ -411,7 +417,7 @@ class RolloutSession:
         loss_masks: list[list[bool]] = []
         rollout_logprobs: list[list[float]] = []
         features: list[dict[str, Any] | None] = []
-        routed_experts: list[list[list[list[int]]]] = []
+        routed_experts: list[torch.Tensor] = []
         route_presence: list[bool] = []
         total_tokens = 0
         for sample in samples:
@@ -625,12 +631,17 @@ class RolloutSession:
                     )
         else:
             pending.input_tokens, pending.features = self._messages_to_tokens_and_features(pending)
+        routed_experts = turn.routed_experts
+        if routed_experts is None and turn.routing_replay_id is not None:
+            routed_experts = self._routing_sidecar.pop(turn.routing_replay_id, None)
+            if routed_experts is None:
+                raise ValueError("agentic routing replay sidecar is missing for trajectory turn")
         return self._sample_from_pending_chat(
             pending,
             _ResponseData(
                 response_tokens=list(turn.response_tokens),
                 response_logprobs=list(turn.response_logprobs),
-                routed_experts=turn.routed_experts,
+                routed_experts=routed_experts,
             ),
             tool_calls=turn.parsed_tool_calls,
         )
@@ -690,7 +701,7 @@ class RolloutSession:
             trace=trace,
             response_kind=response_kind,
             features=pending.features,
-            routed_experts_row=response.routed_experts,
+            routed_experts_row=_routing_to_cpu_tensor(response.routed_experts),
             loss_mask_override=_tool_call_loss_mask(tokenizer, response.response_tokens) if tool_calls else None,
         )
         # The prompt tokens are the fully rendered chat context for this turn,
@@ -749,7 +760,9 @@ class RolloutSession:
                 route_start = max(prefix_len - 1, 0)
                 if route_start > len(new_sample.routed_experts_row):
                     raise ValueError("agentic routing replay is shorter than the shared trajectory token prefix")
-                existing.routed_experts_row.extend(new_sample.routed_experts_row[route_start:])
+                existing.routed_experts_row = torch.cat(
+                    (existing.routed_experts_row, new_sample.routed_experts_row[route_start:]), dim=0
+                )
                 if len(existing.routed_experts_row) != len(existing.token_row) - 1:
                     raise ValueError("agentic routing replay must contain one route for every token except the final")
         elif not existing.token_row:
@@ -791,7 +804,7 @@ class RolloutSession:
     ) -> dict[str, Any]:
         del content
         finish_reason = "tool_calls" if tool_calls else "stop"
-        return build_chat_completion_response(
+        response = build_chat_completion_response(
             tokenizer=self._trainer.get_tokenizer(),
             model=pending.model,
             prompt_tokens=len(pending.input_tokens),
@@ -802,10 +815,15 @@ class RolloutSession:
             tool_call_parser=self._tool_call_parser,
             parsed_tool_calls=[list(tool_calls or [])],
             response_logprobs=[list(response_logprobs or [])],
-            routed_experts=[_routing_to_list(routed_experts)],
             include_areno_metadata=True,
             input_tokens=pending.input_tokens,
         )
+        response["areno"].pop("routed_experts", None)
+        if routed_experts is not None:
+            routing_replay_id = str(response["id"])
+            self._routing_sidecar[routing_replay_id] = _routing_to_cpu_tensor(routed_experts)
+            response["areno"]["routing_replay_id"] = routing_replay_id
+        return response
 
 
 def _multimodal_encoding_cache_key(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> str:
@@ -813,11 +831,18 @@ def _multimodal_encoding_cache_key(messages: list[dict[str, Any]], tools: list[d
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def _routing_to_list(routed_experts: Any | None) -> list[list[list[int]]]:
+def _routing_to_cpu_tensor(routed_experts: Any | None) -> torch.Tensor | None:
     if routed_experts is None:
-        return []
-    tolist = getattr(routed_experts, "tolist", None)
-    return tolist() if callable(tolist) else list(routed_experts)
+        return None
+    if isinstance(routed_experts, torch.Tensor):
+        routes = routed_experts.detach().to(device="cpu", dtype=torch.int16)
+    else:
+        routes = torch.as_tensor(routed_experts, dtype=torch.int16, device="cpu")
+    if routes.numel() == 0:
+        return None
+    if routes.ndim != 3:
+        raise ValueError("agentic routing replay must have shape (tokens, layers, top_k)")
+    return routes.contiguous()
 
 
 def load_agent_run_fn(path: str) -> Callable[[RolloutSession, AgentBatch], Any]:

--- a/areno/api/backend/base.py
+++ b/areno/api/backend/base.py
@@ -200,6 +200,7 @@ class Backend(ABC):
         token_rows: list[list[int]],
         *,
         features: list[dict | None] | None = None,
+        routed_experts: list[object] | None = None,
         microbatch_size: int = 8,
     ) -> list[list[float]]:
         """Score fixed token rows with a backend-owned role."""

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -576,16 +576,20 @@ class CudaBackend(Backend):
         token_rows: list[list[int]],
         *,
         features: list[dict | None] | None = None,
+        routed_experts: list[object] | None = None,
         microbatch_size: int = 8,
     ) -> list[list[float]]:
         engine = self._require_train_engine()
         if features is not None and len(features) != len(token_rows):
             raise ValueError("features must have the same length as token_rows")
+        if routed_experts is not None and len(routed_experts) != len(token_rows):
+            raise ValueError("routed_experts must have the same length as token_rows")
         return engine.score_logprobs(
             role,
             token_rows,
             pad_token_id=pad_token_id(ctx),
             features=features,
+            routed_experts=routed_experts,
             microbatch_size=microbatch_size,
         )
 
@@ -622,7 +626,7 @@ class CudaBackend(Backend):
         # value loss path that takes (cliprange_value, value_loss_coef)).
         packs = []
         for start in range(0, len(batch_data), mini_bs):
-            packs.append(make_train_pack(batch_data[start : start + mini_bs]))
+            packs.append(make_train_pack(batch_data[start : start + mini_bs], include_routing_replay=False))
         return engine.train_values(
             role,
             packs,

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -362,7 +362,7 @@ class CudaBackend(Backend):
             RolloutSequence(
                 resp_tokens=tokens,
                 resp_logprobs=rollout.logprobs[index, : len(tokens)].tolist(),
-                routed_experts=(rollout.routed_experts[index].tolist() if rollout.routed_experts is not None else None),
+                routed_experts=(rollout.routed_experts[index] if rollout.routed_experts is not None else None),
             )
             for index, tokens in enumerate(rollout.response_ids)
         ]
@@ -475,7 +475,7 @@ class CudaBackend(Backend):
             RolloutSequence(
                 resp_tokens=tokens,
                 resp_logprobs=rollout.logprobs[index, : len(tokens)].tolist(),
-                routed_experts=(rollout.routed_experts[index].tolist() if rollout.routed_experts is not None else None),
+                routed_experts=(rollout.routed_experts[index] if rollout.routed_experts is not None else None),
             )
             for index, tokens in enumerate(rollout.response_ids)
         ]

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -359,7 +359,11 @@ class CudaBackend(Backend):
         # Repack the flat result into per-prompt groups of `n_samples`
         # completions so downstream code can iterate `for item, result`.
         sequences = [
-            RolloutSequence(resp_tokens=tokens, resp_logprobs=rollout.logprobs[index, : len(tokens)].tolist())
+            RolloutSequence(
+                resp_tokens=tokens,
+                resp_logprobs=rollout.logprobs[index, : len(tokens)].tolist(),
+                routed_experts=(rollout.routed_experts[index].tolist() if rollout.routed_experts is not None else None),
+            )
             for index, tokens in enumerate(rollout.response_ids)
         ]
         return group_rollout_sequences(
@@ -468,7 +472,11 @@ class CudaBackend(Backend):
             sampling_params=options["sampling_params"],
         )
         sequences = [
-            RolloutSequence(resp_tokens=tokens, resp_logprobs=rollout.logprobs[index, : len(tokens)].tolist())
+            RolloutSequence(
+                resp_tokens=tokens,
+                resp_logprobs=rollout.logprobs[index, : len(tokens)].tolist(),
+                routed_experts=(rollout.routed_experts[index].tolist() if rollout.routed_experts is not None else None),
+            )
             for index, tokens in enumerate(rollout.response_ids)
         ]
         return group_rollout_sequences(

--- a/areno/api/backend/cuda/roles.py
+++ b/areno/api/backend/cuda/roles.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 
 import torch
 
+from areno.api.backend.cuda.training import make_routing_replay
 from areno.engine.checkpoints.io import SafetensorsIndex
 from areno.engine.config import EngineConfig
 from areno.engine.data import to_device
@@ -15,6 +16,7 @@ from areno.engine.parallel.collectives import gather_from_sequence_parallel_regi
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.protocol import EnsureRolesPayload, ScorePayload, TrainValuesPayload
 from areno.engine.runtime.logprobs import packed_next_token_logprobs
+from areno.engine.runtime.routing_replay import routing_replay_context
 from areno.engine.runtime.train_step import _pack_train_data, _train_meta
 from areno.models.registry import config_from_hf, load_model_weights
 
@@ -377,6 +379,8 @@ class RoleManager:
         worker = self.worker
         ctx = get_tp_context()
         role_name = payload.role
+        if role_name != "actor" and payload.routing_replay_by_dp is not None:
+            raise ValueError("routing replay is only valid for actor logprob scoring")
         actor_view = role_name == "actor" or role_name in self.actor_base_roles
         base_only = role_name in self.actor_base_roles
         view = worker.adapter_registry.base_only() if base_only else nullcontext()
@@ -396,6 +400,9 @@ class RoleManager:
             try:
                 token_rows = payload.token_rows_by_dp[ctx.dp_rank]
                 features = payload.features_by_dp[ctx.dp_rank] if payload.features_by_dp is not None else None
+                routed_experts = (
+                    payload.routing_replay_by_dp[ctx.dp_rank] if payload.routing_replay_by_dp is not None else None
+                )
                 local = (
                     []
                     if not token_rows
@@ -404,6 +411,7 @@ class RoleManager:
                         token_rows,
                         payload,
                         features=features,
+                        routed_experts=routed_experts,
                         sequence_parallel=sequence_parallel,
                     )
                 )
@@ -419,6 +427,7 @@ class RoleManager:
         payload: ScorePayload,
         *,
         features: list[dict | None] | None = None,
+        routed_experts: list[object] | None = None,
         sequence_parallel: bool,
     ) -> list[list[float]]:
         """Score token logprobs in bounded microbatches."""
@@ -428,8 +437,13 @@ class RoleManager:
         for start in range(0, len(token_rows), microbatch_size):
             rows = token_rows[start : start + microbatch_size]
             row_features = features[start : start + microbatch_size] if features is not None else None
+            row_routes = routed_experts[start : start + microbatch_size] if routed_experts is not None else None
             data_pack, lengths = _pack_score_rows(
-                rows, self.worker.device, int(payload.pad_token_id), features=row_features
+                rows,
+                self.worker.device,
+                int(payload.pad_token_id),
+                features=row_features,
+                routed_experts=row_routes,
             )
             tokens = data_pack["input_ids"]
             model_kwargs = {
@@ -439,7 +453,8 @@ class RoleManager:
             }
             if data_pack.get("features") is not None:
                 model_kwargs["features"] = data_pack["features"]
-            out = model(**model_kwargs)
+            with routing_replay_context(model_kwargs["train_meta"]):
+                out = model(**model_kwargs)
             logprobs = packed_next_token_logprobs(out.logits_shard, tokens, data_pack["train_cu_seqlens"])
             local.extend(_split_packed_action_rows(logprobs, lengths))
         return local
@@ -706,6 +721,7 @@ def _pack_score_rows(
     pad_token_id: int,
     *,
     features: list[dict | None] | None = None,
+    routed_experts: list[object] | None = None,
 ) -> tuple[dict, list[int]]:
     """Build the same canonical packed representation used by training."""
 
@@ -720,6 +736,9 @@ def _pack_score_rows(
     }
     if features is not None:
         data_pack["features"] = features
+    routing_replay = make_routing_replay(token_rows, routed_experts, width=int(tokens.shape[1]))
+    if routing_replay is not None:
+        data_pack["routing_replay"] = routing_replay.to(device=device)
     return _pack_train_data(data_pack), lengths
 
 

--- a/areno/api/backend/cuda/training.py
+++ b/areno/api/backend/cuda/training.py
@@ -44,6 +44,32 @@ def make_train_pack(seqs: list[TrainSequence]) -> dict[str, torch.Tensor]:
     features = [seq.features for seq in seqs]
     if any(feature is not None for feature in features):
         pack["features"] = features
+    routed_experts = [seq.routed_experts for seq in seqs]
+    if any(routes is not None for routes in routed_experts):
+        if any(routes is None for routes in routed_experts):
+            raise ValueError("routing replay must be present for every sequence in a train microbatch")
+        route_shapes = {
+            (len(routes[0]), len(routes[0][0])) for routes in routed_experts if routes is not None and routes
+        }
+        if len(route_shapes) != 1:
+            raise ValueError("routing replay layer/top-k shape must match across the train microbatch")
+        if not route_shapes:
+            raise ValueError("routing replay cannot be empty")
+        layers, top_k = route_shapes.pop()
+        replay = torch.full((len(seqs), max_len, layers, top_k), -1, dtype=torch.int32)
+        for row, (seq, routes) in enumerate(zip(seqs, routed_experts, strict=True)):
+            assert routes is not None
+            expected = max(len(seq.tokens) - 1, 0)
+            if len(routes) != expected:
+                raise ValueError(f"routing replay token count {len(routes)} must equal len(tokens)-1 ({expected})")
+            if any(
+                len(token_routes) != layers or any(len(experts) != top_k for experts in token_routes)
+                for token_routes in routes
+            ):
+                raise ValueError("every routing replay token must use the same layer/top-k shape")
+            if routes:
+                replay[row, :expected] = torch.as_tensor(routes, dtype=torch.int32)
+        pack["routing_replay"] = replay
     return pack
 
 

--- a/areno/api/backend/cuda/training.py
+++ b/areno/api/backend/cuda/training.py
@@ -48,27 +48,28 @@ def make_train_pack(seqs: list[TrainSequence]) -> dict[str, torch.Tensor]:
     if any(routes is not None for routes in routed_experts):
         if any(routes is None for routes in routed_experts):
             raise ValueError("routing replay must be present for every sequence in a train microbatch")
-        route_shapes = {
-            (len(routes[0]), len(routes[0][0])) for routes in routed_experts if routes is not None and routes
-        }
+        route_tensors = []
+        for routes in routed_experts:
+            try:
+                route_tensor = torch.as_tensor(routes, dtype=torch.int16, device="cpu")
+            except (TypeError, ValueError) as exc:
+                raise ValueError("routing replay must be a rectangular (tokens, layers, top_k) tensor") from exc
+            if route_tensor.ndim != 3:
+                raise ValueError("routing replay must have shape (tokens, layers, top_k)")
+            if route_tensor.numel() and int(route_tensor.min().item()) < 0:
+                raise ValueError("rollout routing replay expert ids must be non-negative")
+            route_tensors.append(route_tensor)
+        route_shapes = {tuple(routes.shape[1:]) for routes in route_tensors}
         if len(route_shapes) != 1:
             raise ValueError("routing replay layer/top-k shape must match across the train microbatch")
-        if not route_shapes:
-            raise ValueError("routing replay cannot be empty")
         layers, top_k = route_shapes.pop()
-        replay = torch.full((len(seqs), max_len, layers, top_k), -1, dtype=torch.int32)
-        for row, (seq, routes) in enumerate(zip(seqs, routed_experts, strict=True)):
-            assert routes is not None
+        replay = torch.full((len(seqs), max_len, layers, top_k), -1, dtype=torch.int16)
+        for row, (seq, routes) in enumerate(zip(seqs, route_tensors, strict=True)):
             expected = max(len(seq.tokens) - 1, 0)
-            if len(routes) != expected:
-                raise ValueError(f"routing replay token count {len(routes)} must equal len(tokens)-1 ({expected})")
-            if any(
-                len(token_routes) != layers or any(len(experts) != top_k for experts in token_routes)
-                for token_routes in routes
-            ):
-                raise ValueError("every routing replay token must use the same layer/top-k shape")
-            if routes:
-                replay[row, :expected] = torch.as_tensor(routes, dtype=torch.int32)
+            if int(routes.shape[0]) != expected:
+                raise ValueError(f"routing replay token count {routes.shape[0]} must equal len(tokens)-1 ({expected})")
+            if expected:
+                replay[row, :expected].copy_(routes)
         pack["routing_replay"] = replay
     return pack
 

--- a/areno/api/backend/cuda/training.py
+++ b/areno/api/backend/cuda/training.py
@@ -12,7 +12,7 @@ from areno.api.context import Context
 from areno.api.models import TrainSequence
 
 
-def make_train_pack(seqs: list[TrainSequence]) -> dict[str, torch.Tensor]:
+def make_train_pack(seqs: list[TrainSequence], *, include_routing_replay: bool = True) -> dict[str, torch.Tensor]:
     """Pack public training rows into right-padded CUDA engine tensors."""
 
     if not seqs:
@@ -44,34 +44,50 @@ def make_train_pack(seqs: list[TrainSequence]) -> dict[str, torch.Tensor]:
     features = [seq.features for seq in seqs]
     if any(feature is not None for feature in features):
         pack["features"] = features
-    routed_experts = [seq.routed_experts for seq in seqs]
-    if any(routes is not None for routes in routed_experts):
-        if any(routes is None for routes in routed_experts):
-            raise ValueError("routing replay must be present for every sequence in a train microbatch")
-        route_tensors = []
-        for routes in routed_experts:
-            try:
-                route_tensor = torch.as_tensor(routes, dtype=torch.int16, device="cpu")
-            except (TypeError, ValueError) as exc:
-                raise ValueError("routing replay must be a rectangular (tokens, layers, top_k) tensor") from exc
-            if route_tensor.ndim != 3:
-                raise ValueError("routing replay must have shape (tokens, layers, top_k)")
-            if route_tensor.numel() and int(route_tensor.min().item()) < 0:
-                raise ValueError("rollout routing replay expert ids must be non-negative")
-            route_tensors.append(route_tensor)
-        route_shapes = {tuple(routes.shape[1:]) for routes in route_tensors}
-        if len(route_shapes) != 1:
-            raise ValueError("routing replay layer/top-k shape must match across the train microbatch")
-        layers, top_k = route_shapes.pop()
-        replay = torch.full((len(seqs), max_len, layers, top_k), -1, dtype=torch.int16)
-        for row, (seq, routes) in enumerate(zip(seqs, route_tensors, strict=True)):
-            expected = max(len(seq.tokens) - 1, 0)
-            if int(routes.shape[0]) != expected:
-                raise ValueError(f"routing replay token count {routes.shape[0]} must equal len(tokens)-1 ({expected})")
-            if expected:
-                replay[row, :expected].copy_(routes)
-        pack["routing_replay"] = replay
+    if include_routing_replay:
+        routing_replay = make_routing_replay(
+            [seq.tokens for seq in seqs], [seq.routed_experts for seq in seqs], width=max_len
+        )
+        if routing_replay is not None:
+            pack["routing_replay"] = routing_replay
     return pack
+
+
+def make_routing_replay(
+    token_rows: list[list[int]], routed_experts: list[object | None] | None, *, width: int | None = None
+) -> torch.Tensor | None:
+    """Pad compact per-row rollout routes for a packed model forward."""
+
+    if routed_experts is None or not any(routes is not None for routes in routed_experts):
+        return None
+    if len(routed_experts) != len(token_rows):
+        raise ValueError("routing replay must have the same number of rows as tokens")
+    if any(routes is None for routes in routed_experts):
+        raise ValueError("routing replay must be present for every sequence in a microbatch")
+    route_tensors = []
+    for routes in routed_experts:
+        try:
+            route_tensor = torch.as_tensor(routes, dtype=torch.int16, device="cpu")
+        except (TypeError, ValueError) as exc:
+            raise ValueError("routing replay must be a rectangular (tokens, layers, top_k) tensor") from exc
+        if route_tensor.ndim != 3:
+            raise ValueError("routing replay must have shape (tokens, layers, top_k)")
+        if route_tensor.numel() and int(route_tensor.min().item()) < 0:
+            raise ValueError("rollout routing replay expert ids must be non-negative")
+        route_tensors.append(route_tensor)
+    route_shapes = {tuple(routes.shape[1:]) for routes in route_tensors}
+    if len(route_shapes) != 1:
+        raise ValueError("routing replay layer/top-k shape must match across the microbatch")
+    layers, top_k = route_shapes.pop()
+    max_len = max((len(tokens) for tokens in token_rows), default=0) if width is None else int(width)
+    replay = torch.full((len(token_rows), max_len, layers, top_k), -1, dtype=torch.int16)
+    for row, (tokens, routes) in enumerate(zip(token_rows, route_tensors, strict=True)):
+        expected = max(len(tokens) - 1, 0)
+        if int(routes.shape[0]) != expected:
+            raise ValueError(f"routing replay token count {routes.shape[0]} must equal len(tokens)-1 ({expected})")
+        if expected:
+            replay[row, :expected].copy_(routes)
+    return replay
 
 
 def is_sft_loss_fn(loss_fn: Callable) -> bool:
@@ -183,6 +199,7 @@ def _sequence_prompt_len(seq: TrainSequence) -> int:
 __all__ = [
     "annotate_sft_token_mean_packs",
     "is_sft_loss_fn",
+    "make_routing_replay",
     "make_train_pack",
     "pad_token_id",
     "sft_target_token_count",

--- a/areno/api/backend/mlx/backend.py
+++ b/areno/api/backend/mlx/backend.py
@@ -330,12 +330,15 @@ class MlxBackend(Backend):
         token_rows: list[list[int]],
         *,
         features: list[dict | None] | None = None,
+        routed_experts: list[object] | None = None,
         microbatch_size: int = 8,
     ) -> list[list[float]]:
         """Score fixed token rows with the actor or a frozen reference model."""
 
         del ctx
         self._require_runtime()
+        if routed_experts is not None:
+            raise ValueError("MLX role scoring does not support MoE routing replay")
         if microbatch_size < 1:
             raise ValueError("microbatch_size must be positive")
         if role == "actor":

--- a/areno/api/models.py
+++ b/areno/api/models.py
@@ -58,7 +58,10 @@ class RolloutSequence(BaseModel):
 
     resp_tokens: list[int] = Field(default_factory=list)
     resp_logprobs: list[float] = Field(default_factory=list)
-    routed_experts: list[list[list[int]]] | None = Field(default=None)
+    # Kept as ``Any`` so CUDA rollouts can retain a compact CPU tensor instead
+    # of expanding every route id into millions of Python integers. Agentic
+    # OpenAI responses serialize the same value to nested lists at the edge.
+    routed_experts: Any | None = Field(default=None)
 
 
 class RolloutResult(BaseModel):
@@ -91,4 +94,4 @@ class TrainSequence(BaseModel):
     features: dict[str, Any] | list[dict[str, Any] | None] | None = Field(default=None)
     reward: float = Field(default=0.0)
     eos_token_id: int = Field(default=0)
-    routed_experts: list[list[list[int]]] | None = Field(default=None)
+    routed_experts: Any | None = Field(default=None)

--- a/areno/api/models.py
+++ b/areno/api/models.py
@@ -58,6 +58,7 @@ class RolloutSequence(BaseModel):
 
     resp_tokens: list[int] = Field(default_factory=list)
     resp_logprobs: list[float] = Field(default_factory=list)
+    routed_experts: list[list[list[int]]] | None = Field(default=None)
 
 
 class RolloutResult(BaseModel):
@@ -90,3 +91,4 @@ class TrainSequence(BaseModel):
     features: dict[str, Any] | list[dict[str, Any] | None] | None = Field(default=None)
     reward: float = Field(default=0.0)
     eos_token_id: int = Field(default=0)
+    routed_experts: list[list[list[int]]] | None = Field(default=None)

--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -143,6 +143,7 @@ def build_chat_completion_response(
     tool_call_parser: ToolCallParser | None = None,
     parsed_tool_calls: list[list[dict[str, Any]]] | None = None,
     response_logprobs: list[list[float]] | None = None,
+    routed_experts: list[list[list[list[int]]]] | None = None,
     include_areno_metadata: bool = False,
     input_tokens: list[int] | None = None,
     stop_strings: list[str] | None = None,
@@ -188,6 +189,7 @@ def build_chat_completion_response(
             "input_tokens": list(input_tokens or []),
             "response_tokens": list(response_ids[0] if response_ids else []),
             "response_logprobs": list(response_logprobs[0] if response_logprobs else []),
+            "routed_experts": list(routed_experts[0] if routed_experts else []),
         }
     return response
 

--- a/areno/api/trainer.py
+++ b/areno/api/trainer.py
@@ -482,17 +482,18 @@ class Trainer:
         token_rows: list[list[int]],
         *,
         features: list[dict | None] | None = None,
+        routed_experts: list[object] | None = None,
         microbatch_size: int | None = None,
     ) -> list[list[float]]:
         """Score fixed token sequences with a backend-owned model role."""
 
-        return self._backend.score_logprobs(
-            self._ctx,
-            role,
-            token_rows,
-            features=features,
-            microbatch_size=self._score_micro_bs if microbatch_size is None else int(microbatch_size),
-        )
+        kwargs = {
+            "features": features,
+            "microbatch_size": self._score_micro_bs if microbatch_size is None else int(microbatch_size),
+        }
+        if routed_experts is not None:
+            kwargs["routed_experts"] = routed_experts
+        return self._backend.score_logprobs(self._ctx, role, token_rows, **kwargs)
 
     def score_values(
         self, role: str, token_rows: list[list[int]], *, features: list[dict | None] | None = None

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -236,7 +236,6 @@ class RolloutTrainerConfig(TrainerConfig):
     rollout_tp_size: int | None = None
     rollout_devices: list[int] | None = None
     policy_sync_bucket_mb: int = 64
-    rollout_routing_replay: bool = False
 
     def resolved_max_running_prompts(self) -> int:
         """Return explicit or full-batch rollout concurrency."""
@@ -268,7 +267,9 @@ class RolloutTrainerConfig(TrainerConfig):
                 "optimizer_state_offload_batch_size": self.optimizer_state_offload_batch_size,
                 "eager_decode": self.eager_decode,
                 "attn_backend": self.attn_backend,
-                "rollout_routing_replay": self.rollout_routing_replay,
+                # R3 is the default CUDA path for rollout-based MoE training.
+                # EngineConfig disables it again when the checkpoint is dense.
+                "rollout_routing_replay": True,
             },
             lora=self.lora,
             reference_mode=self.reference_mode,
@@ -276,9 +277,6 @@ class RolloutTrainerConfig(TrainerConfig):
 
     def mlx_config(self):
         """Build MLX config with rollout concurrency from this trainer."""
-
-        if self.rollout_routing_replay:
-            raise ValueError("rollout routing replay is only supported by the CUDA backend")
 
         from areno.api.config import MlxConfig
 

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -236,6 +236,7 @@ class RolloutTrainerConfig(TrainerConfig):
     rollout_tp_size: int | None = None
     rollout_devices: list[int] | None = None
     policy_sync_bucket_mb: int = 64
+    rollout_routing_replay: bool = False
 
     def resolved_max_running_prompts(self) -> int:
         """Return explicit or full-batch rollout concurrency."""
@@ -267,6 +268,7 @@ class RolloutTrainerConfig(TrainerConfig):
                 "optimizer_state_offload_batch_size": self.optimizer_state_offload_batch_size,
                 "eager_decode": self.eager_decode,
                 "attn_backend": self.attn_backend,
+                "rollout_routing_replay": self.rollout_routing_replay,
             },
             lora=self.lora,
             reference_mode=self.reference_mode,
@@ -274,6 +276,9 @@ class RolloutTrainerConfig(TrainerConfig):
 
     def mlx_config(self):
         """Build MLX config with rollout concurrency from this trainer."""
+
+        if self.rollout_routing_replay:
+            raise ValueError("rollout routing replay is only supported by the CUDA backend")
 
         from areno.api.config import MlxConfig
 

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -14,6 +14,7 @@ role-management hooks; this is why the helpers are designed to be small.
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -336,6 +337,7 @@ class PolicyOnlyTrainer:
                 raise RuntimeError("agent run function must return explicit trajectories")
             agent_filtered_count = self._agent_trajectory_invalid_count(trajectories)
             samples = []
+            turn_samples_by_item = {}
             proxy_filtered_items = set()
             for turn in self._agent_trajectory_turns(ctx, trajectories):
                 item_key = (turn.item.prompt_index, turn.item.sample_index)
@@ -347,9 +349,13 @@ class PolicyOnlyTrainer:
                     proxy_filtered_items.add(item_key)
                     continue
                 sample = ctx._sample_from_trajectory_turn(turn)
+                turn_samples_by_item.setdefault(item_key, []).append(sample)
                 existing = self._find_agent_sample(samples, sample.item)
                 if existing is None:
-                    samples.append(sample)
+                    # Rewarding needs one aggregate trajectory, while training
+                    # must preserve each model call's exact causal context.
+                    # Keep the aggregate independent from the per-turn row.
+                    samples.append(copy.deepcopy(sample))
                 else:
                     ctx._append_sample_response(existing, sample)
             sampled_items = {(sample.item.prompt_index, sample.item.sample_index) for sample in samples}
@@ -362,7 +368,7 @@ class PolicyOnlyTrainer:
                     len(filtered_without_sample),
                 )
             samples, filtered_count, filter_diagnostics = self._filter_overlong_agent_samples(
-                ctx, samples, sampling_params
+                ctx, samples, sampling_params, turn_samples_by_item=turn_samples_by_item
             )
             expected = len(agent_batch)
             if len(samples) + filtered_count + agent_filtered_count != expected:
@@ -384,13 +390,24 @@ class PolicyOnlyTrainer:
                 )
             reward_records = [ctx.reward_record(sample) for sample in samples]
             rewards = self._score_reward_records(reward_records)
-            rows = ctx._train_rows_from_samples(samples)
+            train_samples = []
+            row_reward_indices = []
+            for reward_index, sample in enumerate(samples):
+                item_key = (sample.item.prompt_index, sample.item.sample_index)
+                item_turns = turn_samples_by_item.get(item_key)
+                if not item_turns:
+                    raise RuntimeError("agentic trajectory has no trainable model turns")
+                train_samples.extend(item_turns)
+                row_reward_indices.extend([reward_index] * len(item_turns))
+            rows = ctx._train_rows_from_samples(train_samples)
             tool_call_count = sum(len(record.tool_calls) for record in reward_records)
             tool_result_count = sum(len(record.tool_results) for record in reward_records)
             message_count = sum(len(record.messages) for record in reward_records)
             self.logger.info(
-                "agentic train batch built samples=%d tokens=%d messages=%d tool_calls=%d tool_results=%d",
+                "agentic train batch built samples=%d train_rows=%d tokens=%d messages=%d "
+                "tool_calls=%d tool_results=%d",
                 len(samples),
+                len(train_samples),
                 rows.total_tokens,
                 message_count,
                 tool_call_count,
@@ -406,9 +423,11 @@ class PolicyOnlyTrainer:
                 records=[sample.item.record for sample in samples],
                 reward_records=reward_records,
                 routed_experts=rows.routed_experts,
+                row_reward_indices=row_reward_indices,
             )
 
-    def _filter_overlong_agent_samples(self, ctx, samples, sampling_params):
+    def _filter_overlong_agent_samples(self, ctx, samples, sampling_params, *, turn_samples_by_item=None):
+        del sampling_params
         max_context_len = self._agent_model_context_len()
         if max_context_len is None:
             return samples, 0, {}
@@ -416,8 +435,10 @@ class PolicyOnlyTrainer:
         filtered_details = []
         all_details = []
         for sample in samples:
-            rows = ctx._train_rows_from_samples([sample])
-            token_len = len(rows.token_rows[0]) if rows.token_rows else 0
+            item_key = (sample.item.prompt_index, sample.item.sample_index)
+            train_samples = (turn_samples_by_item or {}).get(item_key, [sample])
+            rows = ctx._train_rows_from_samples(train_samples)
+            token_len = max((len(row) for row in rows.token_rows), default=0)
             detail = self._agent_sample_filter_detail(sample, token_len)
             all_details.append(detail)
             if token_len <= max_context_len:
@@ -560,25 +581,33 @@ class PolicyOnlyTrainer:
             raise ValueError("agentic policy training requires a reward_fn")
         train_batch = []
         rewards_all = [float(reward) for reward in agent_batch.rewards]
+        row_reward_indices = getattr(agent_batch, "row_reward_indices", None)
+        if row_reward_indices is None:
+            row_reward_indices = list(range(len(agent_batch.token_rows)))
+        if len(row_reward_indices) != len(agent_batch.token_rows):
+            raise ValueError("agentic row_reward_indices must align with training rows")
+        if any(index < 0 or index >= len(rewards_all) for index in row_reward_indices):
+            raise ValueError("agentic row_reward_indices contains an invalid reward index")
+        if len(agent_batch.reward_records) != len(rewards_all):
+            raise ValueError("agentic rewards must align with trajectory reward records")
         logprob_stats = _LogprobStats()
         grouped: dict[int, list[int]] = {}
         for row_idx, record in enumerate(agent_batch.reward_records):
             prompt_index = int(record.metadata.get("prompt_index", row_idx))
             grouped.setdefault(prompt_index, []).append(row_idx)
-        advantages_by_row: dict[int, float] = {}
+        advantages_by_reward: dict[int, float] = {}
         for row_indices in grouped.values():
             group_rewards = [rewards_all[row_idx] for row_idx in row_indices]
             for row_idx, advantage in zip(row_indices, compute_group_advantages(group_rewards), strict=True):
-                advantages_by_row[row_idx] = float(advantage)
+                advantages_by_reward[row_idx] = float(advantage)
         row_features = getattr(agent_batch, "features", [None] * len(agent_batch.token_rows))
         row_routes = getattr(agent_batch, "routed_experts", None) or [None] * len(agent_batch.token_rows)
-        for row_idx, (tokens, response_mask, loss_mask, logprobs, reward, features, routed_experts) in enumerate(
+        for row_idx, (tokens, response_mask, loss_mask, logprobs, features, routed_experts) in enumerate(
             zip(
                 agent_batch.token_rows,
                 agent_batch.response_masks,
                 agent_batch.loss_masks,
                 agent_batch.rollout_logprobs,
-                rewards_all,
                 row_features,
                 row_routes,
                 strict=True,
@@ -587,7 +616,9 @@ class PolicyOnlyTrainer:
             if len(tokens) != len(response_mask) or len(tokens) != len(loss_mask) or len(tokens) != len(logprobs):
                 raise ValueError("agentic train batch has misaligned token/mask/logprob rows")
             prompt_len = _agentic_prompt_len(response_mask)
-            advantage = advantages_by_row.get(row_idx, 0.0)
+            reward_index = row_reward_indices[row_idx]
+            reward = rewards_all[reward_index]
+            advantage = advantages_by_reward.get(reward_index, 0.0)
             effective_loss_mask = loss_mask if any(not item for item in loss_mask[prompt_len:]) else []
             if effective_loss_mask:
                 logprob_stats.add(lp for lp, is_loss in zip(logprobs, effective_loss_mask, strict=True) if is_loss)

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -387,6 +387,7 @@ class PolicyOnlyTrainer:
                 rewards=rewards,
                 records=[sample.item.record for sample in samples],
                 reward_records=reward_records,
+                routed_experts=rows.routed_experts,
             )
 
     def _filter_overlong_agent_samples(self, ctx, samples, sampling_params):
@@ -552,7 +553,8 @@ class PolicyOnlyTrainer:
             for row_idx, advantage in zip(row_indices, compute_group_advantages(group_rewards), strict=True):
                 advantages_by_row[row_idx] = float(advantage)
         row_features = getattr(agent_batch, "features", [None] * len(agent_batch.token_rows))
-        for row_idx, (tokens, response_mask, loss_mask, logprobs, reward, features) in enumerate(
+        row_routes = getattr(agent_batch, "routed_experts", None) or [None] * len(agent_batch.token_rows)
+        for row_idx, (tokens, response_mask, loss_mask, logprobs, reward, features, routed_experts) in enumerate(
             zip(
                 agent_batch.token_rows,
                 agent_batch.response_masks,
@@ -560,6 +562,7 @@ class PolicyOnlyTrainer:
                 agent_batch.rollout_logprobs,
                 rewards_all,
                 row_features,
+                row_routes,
                 strict=True,
             )
         ):
@@ -587,6 +590,7 @@ class PolicyOnlyTrainer:
                     returns=[],
                     values=[],
                     ref_logprobs=[],
+                    routed_experts=routed_experts,
                 )
             )
         return train_batch, rewards_all, logprob_stats
@@ -763,6 +767,7 @@ class PolicyOnlyTrainer:
                     features=item.record.get("features"),
                     reward=reward,
                     eos_token_id=tokenizer.eos_token_id,
+                    routed_experts=seq.routed_experts,
                 )
             )
         return train_batch, all_rewards, logprob_stats

--- a/areno/api/trainers/policy_only.py
+++ b/areno/api/trainers/policy_only.py
@@ -336,13 +336,31 @@ class PolicyOnlyTrainer:
                 raise RuntimeError("agent run function must return explicit trajectories")
             agent_filtered_count = self._agent_trajectory_invalid_count(trajectories)
             samples = []
+            proxy_filtered_items = set()
             for turn in self._agent_trajectory_turns(ctx, trajectories):
+                item_key = (turn.item.prompt_index, turn.item.sample_index)
+                if getattr(turn, "filtered", False):
+                    # The proxy returns a length response without running the
+                    # model when a later agent request exceeds the context
+                    # limit. Keep any earlier complete turns for this item;
+                    # there are no tokens, logprobs, or routes to append.
+                    proxy_filtered_items.add(item_key)
+                    continue
                 sample = ctx._sample_from_trajectory_turn(turn)
                 existing = self._find_agent_sample(samples, sample.item)
                 if existing is None:
                     samples.append(sample)
                 else:
                     ctx._append_sample_response(existing, sample)
+            sampled_items = {(sample.item.prompt_index, sample.item.sample_index) for sample in samples}
+            filtered_without_sample = proxy_filtered_items - sampled_items
+            agent_filtered_count += len(filtered_without_sample)
+            if proxy_filtered_items:
+                self.logger.warning(
+                    "agentic rollout stopped at proxy context limit trajectories=%d without_prior_turn=%d",
+                    len(proxy_filtered_items),
+                    len(filtered_without_sample),
+                )
             samples, filtered_count, filter_diagnostics = self._filter_overlong_agent_samples(
                 ctx, samples, sampling_params
             )

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -236,6 +236,7 @@ class PPOTrainer(PolicyOnlyTrainer):
                     features=row_features,
                     reward=float(reward),
                     eos_token_id=tokenizer.eos_token_id,
+                    routed_experts=seq.routed_experts,
                 )
             )
 
@@ -326,12 +327,25 @@ class PPOTrainer(PolicyOnlyTrainer):
         old_logprobs_all = []
         logp_diff_all = []
         row_features = token_features or [None] * len(token_rows)
-        for tokens, response_mask, loss_mask, rollout_row, features, reward, ref_logprobs, old_logprobs, values in zip(
+        row_routes = getattr(agent_batch, "routed_experts", None) or [None] * len(token_rows)
+        for (
+            tokens,
+            response_mask,
+            loss_mask,
+            rollout_row,
+            features,
+            routed_experts,
+            reward,
+            ref_logprobs,
+            old_logprobs,
+            values,
+        ) in zip(
             token_rows,
             agent_batch.response_masks,
             agent_batch.loss_masks,
             agent_batch.rollout_logprobs,
             row_features,
+            row_routes,
             rewards_all,
             ref_logprob_rows,
             old_logprob_rows,
@@ -392,6 +406,7 @@ class PPOTrainer(PolicyOnlyTrainer):
                     features=features,
                     reward=float(reward),
                     eos_token_id=tokenizer.eos_token_id,
+                    routed_experts=routed_experts,
                 )
             )
 

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -162,7 +162,13 @@ class PPOTrainer(PolicyOnlyTrainer):
         # Even though we already have rollout logprobs, PPO needs an actor
         # forward pass at the same parameters used by the upcoming update to
         # form the "old logprobs" baseline in the importance ratio.
-        old_logprob_rows = self._score_logprobs("actor", token_rows, features=token_features)
+        token_routes = [seq.routed_experts for _, seq, _, _ in row_meta]
+        old_logprob_rows = self._score_logprobs(
+            "actor",
+            token_rows,
+            features=token_features,
+            routed_experts=token_routes if any(routes is not None for routes in token_routes) else None,
+        )
         self._last_ppo_stats["actor_old_logprob_forward_time_s"] = time.perf_counter() - actor_logprob_start
         self.logger.info("role=actor stage=old_logprob_score_end rows=%d", len(token_rows))
         self._record_ppo_state(stage="old_logprob_score_end", role="actor")
@@ -311,7 +317,8 @@ class PPOTrainer(PolicyOnlyTrainer):
         self.logger.info("role=actor stage=old_logprob_score_start rows=%d", len(token_rows))
         self._record_ppo_state(stage="old_logprob_score_start", role="actor")
         actor_logprob_start = time.perf_counter()
-        old_logprob_rows = self._score_logprobs("actor", token_rows, features=token_features)
+        row_routes = getattr(agent_batch, "routed_experts", None)
+        old_logprob_rows = self._score_logprobs("actor", token_rows, features=token_features, routed_experts=row_routes)
         self._last_ppo_stats["actor_old_logprob_forward_time_s"] = time.perf_counter() - actor_logprob_start
         self.logger.info("role=actor stage=old_logprob_score_end rows=%d", len(token_rows))
         self._record_ppo_state(stage="old_logprob_score_end", role="actor")
@@ -327,7 +334,7 @@ class PPOTrainer(PolicyOnlyTrainer):
         old_logprobs_all = []
         logp_diff_all = []
         row_features = token_features or [None] * len(token_rows)
-        row_routes = getattr(agent_batch, "routed_experts", None) or [None] * len(token_rows)
+        row_routes = row_routes or [None] * len(token_rows)
         for (
             tokens,
             response_mask,
@@ -462,12 +469,18 @@ class PPOTrainer(PolicyOnlyTrainer):
             self.areno.close()
 
     def _score_logprobs(
-        self, role: str, token_rows: list[list[int]], *, features: list[dict | None] | None = None
+        self,
+        role: str,
+        token_rows: list[list[int]],
+        *,
+        features: list[dict | None] | None = None,
+        routed_experts: list[object] | None = None,
     ) -> list[list[float]]:
         return self.areno.score_logprobs(
             role,
             token_rows,
             features=features,
+            routed_experts=routed_experts,
             microbatch_size=self.config.score_micro_bs,
         )
 

--- a/areno/api/trainers/ppo.py
+++ b/areno/api/trainers/ppo.py
@@ -292,20 +292,37 @@ class PPOTrainer(PolicyOnlyTrainer):
         advantages_all = []
         token_rows = agent_batch.token_rows
         token_features = getattr(agent_batch, "features", None)
+        row_reward_indices = getattr(agent_batch, "row_reward_indices", None)
+        if row_reward_indices is None:
+            row_reward_indices = list(range(len(token_rows)))
+        if len(row_reward_indices) != len(token_rows):
+            raise ValueError("agentic PPO row_reward_indices must align with training rows")
 
         if agent_batch.rewards is not None:
             self._record_ppo_state(stage="score_start", role="reward")
             rewards_all = [float(reward) for reward in agent_batch.rewards]
             self._record_ppo_state(stage="score_end", role="reward")
         else:
-            self.logger.info("role=reward stage=score_start rows=%d", len(token_rows))
+            trajectory_count = len(agent_batch.reward_records)
+            terminal_rows = [None] * trajectory_count
+            for row_index, reward_index in enumerate(row_reward_indices):
+                if reward_index < 0 or reward_index >= trajectory_count:
+                    raise ValueError("agentic PPO row_reward_indices contains an invalid reward index")
+                terminal_rows[reward_index] = row_index
+            if any(row_index is None for row_index in terminal_rows):
+                raise ValueError("agentic PPO has a trajectory without a trainable turn")
+            reward_rows = [token_rows[row_index] for row_index in terminal_rows]
+            reward_features = [token_features[row_index] for row_index in terminal_rows] if token_features else None
+            self.logger.info("role=reward stage=score_start rows=%d", len(reward_rows))
             self._record_ppo_state(stage="score_start", role="reward")
             reward_start = time.perf_counter()
-            rewards_all = [float(reward) for reward in self._score_rewards(token_rows, features=token_features)]
+            rewards_all = [float(reward) for reward in self._score_rewards(reward_rows, features=reward_features)]
             self._last_ppo_stats.update(_summary_stats("reward_model_raw_reward", rewards_all))
             self._last_ppo_stats["reward_score_time_s"] = time.perf_counter() - reward_start
-            self.logger.info("role=reward stage=score_end rows=%d", len(token_rows))
+            self.logger.info("role=reward stage=score_end rows=%d", len(reward_rows))
             self._record_ppo_state(stage="score_end", role="reward")
+        if any(index < 0 or index >= len(rewards_all) for index in row_reward_indices):
+            raise ValueError("agentic PPO row_reward_indices contains an invalid reward index")
 
         self.logger.info("role=ref stage=logprob_score_start rows=%d", len(token_rows))
         self._record_ppo_state(stage="logprob_score_start", role="ref")
@@ -335,29 +352,30 @@ class PPOTrainer(PolicyOnlyTrainer):
         logp_diff_all = []
         row_features = token_features or [None] * len(token_rows)
         row_routes = row_routes or [None] * len(token_rows)
-        for (
+        trajectory_rows = {}
+        for row_idx, (
             tokens,
             response_mask,
             loss_mask,
             rollout_row,
             features,
             routed_experts,
-            reward,
             ref_logprobs,
             old_logprobs,
             values,
-        ) in zip(
-            token_rows,
-            agent_batch.response_masks,
-            agent_batch.loss_masks,
-            agent_batch.rollout_logprobs,
-            row_features,
-            row_routes,
-            rewards_all,
-            ref_logprob_rows,
-            old_logprob_rows,
-            value_rows,
-            strict=True,
+        ) in enumerate(
+            zip(
+                token_rows,
+                agent_batch.response_masks,
+                agent_batch.loss_masks,
+                agent_batch.rollout_logprobs,
+                row_features,
+                row_routes,
+                ref_logprob_rows,
+                old_logprob_rows,
+                value_rows,
+                strict=True,
+            )
         ):
             if not (len(tokens) == len(response_mask) == len(loss_mask) == len(rollout_row)):
                 raise ValueError("agentic PPO batch has misaligned token/mask/logprob rows")
@@ -381,41 +399,78 @@ class PPOTrainer(PolicyOnlyTrainer):
                 float(old_logprob) - float(rollout_logprob)
                 for old_logprob, rollout_logprob in zip(action_old_logprobs, row_rollout_logprobs, strict=True)
             )
-            token_rewards = [0.0 for _ in range(resp_len)]
-            token_rewards[-1] = float(reward)
             action_values = values[prefix_len - 1 : prefix_len + resp_len - 1]
             if len(action_values) != resp_len:
                 raise ValueError("critic returned misaligned token values")
-            advantages, returns = self._gae_for_response(token_rewards, action_values)
-            full_advantages = [0.0] * len(tokens)
-            full_returns = [0.0] * len(tokens)
-            full_values = [0.0] * len(tokens)
-            for rel_idx, tok_idx in enumerate(response_indices):
-                if loss_mask[tok_idx]:
-                    full_advantages[tok_idx] = advantages[rel_idx]
-                full_returns[tok_idx] = returns[rel_idx]
-                full_values[tok_idx] = action_values[rel_idx]
-            prompt_mask = [not item for item in response_mask]
             ref_logprobs_all.extend(ref_logprobs[prefix_len : prefix_len + resp_len])
             critic_values_all.extend(action_values)
-            returns_all.extend(returns)
-            advantages_all.extend(advantages)
-            train_batch.append(
-                areno.api.TrainSequence(
-                    prompt_mask=prompt_mask,
-                    loss_mask=loss_mask,
-                    tokens=tokens,
-                    logprobs=[0.0] * prefix_len + action_old_logprobs,
-                    advantages=full_advantages,
-                    returns=full_returns,
-                    values=full_values,
-                    ref_logprobs=ref_logprobs,
-                    features=features,
-                    reward=float(reward),
-                    eos_token_id=tokenizer.eos_token_id,
-                    routed_experts=routed_experts,
+            reward_index = row_reward_indices[row_idx]
+            trajectory_rows.setdefault(reward_index, []).append(
+                (
+                    tokens,
+                    response_mask,
+                    loss_mask,
+                    features,
+                    routed_experts,
+                    ref_logprobs,
+                    action_old_logprobs,
+                    action_values,
+                    response_indices,
                 )
             )
+
+        # GAE spans all assistant actions in a trajectory, but each turn keeps
+        # the exact prompt/routes used by its own rollout forward.
+        for reward_index, payloads in trajectory_rows.items():
+            reward = rewards_all[reward_index]
+            trajectory_values = [value for payload in payloads for value in payload[7]]
+            token_rewards = [0.0] * len(trajectory_values)
+            token_rewards[-1] = float(reward)
+            trajectory_advantages, trajectory_returns = self._gae_for_response(token_rewards, trajectory_values)
+            offset = 0
+            for payload in payloads:
+                (
+                    tokens,
+                    response_mask,
+                    loss_mask,
+                    features,
+                    routed_experts,
+                    ref_logprobs,
+                    action_old_logprobs,
+                    action_values,
+                    response_indices,
+                ) = payload
+                resp_len = len(response_indices)
+                advantages = trajectory_advantages[offset : offset + resp_len]
+                returns = trajectory_returns[offset : offset + resp_len]
+                offset += resp_len
+                full_advantages = [0.0] * len(tokens)
+                full_returns = [0.0] * len(tokens)
+                full_values = [0.0] * len(tokens)
+                for rel_idx, tok_idx in enumerate(response_indices):
+                    if loss_mask[tok_idx]:
+                        full_advantages[tok_idx] = advantages[rel_idx]
+                    full_returns[tok_idx] = returns[rel_idx]
+                    full_values[tok_idx] = action_values[rel_idx]
+                prefix_len = response_indices[0]
+                returns_all.extend(returns)
+                advantages_all.extend(advantages)
+                train_batch.append(
+                    areno.api.TrainSequence(
+                        prompt_mask=[not item for item in response_mask],
+                        loss_mask=loss_mask,
+                        tokens=tokens,
+                        logprobs=[0.0] * prefix_len + action_old_logprobs,
+                        advantages=full_advantages,
+                        returns=full_returns,
+                        values=full_values,
+                        ref_logprobs=ref_logprobs,
+                        features=features,
+                        reward=float(reward),
+                        eos_token_id=tokenizer.eos_token_id,
+                        routed_experts=routed_experts,
+                    )
+                )
 
         if train_batch:
             self.logger.info("role=critic stage=train_start rows=%d", len(train_batch))

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -106,6 +106,7 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "rollout_tp_size",
             "rollout_devices",
             "policy_sync_bucket_mb",
+            "rollout_routing_replay",
             "n_samples",
             "max_running_prompts",
             "max_prompt_tokens",
@@ -239,6 +240,7 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
     args.rollout_devices = getattr(args, "rollout_devices", None)
     args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
+    args.rollout_routing_replay = getattr(args, "rollout_routing_replay", False)
     args.optimizer_state_offload = getattr(args, "optimizer_state_offload", "none")
     args.optimizer_state_offload_dir = getattr(args, "optimizer_state_offload_dir", None)
     args.optimizer_state_offload_batch_size = getattr(args, "optimizer_state_offload_batch_size", 1)
@@ -291,6 +293,10 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     algorithm = _algorithm_for_cli(args.algo)
     if algorithm.name == "sft" and args.dataset_loader_fn is None:
         raise click.UsageError("--dataset-loader-fn is required for --algo sft")
+    if args.rollout_routing_replay and not algorithm.requires_rollout:
+        raise click.UsageError("--rollout-routing-replay is only valid for rollout-based RL algorithms")
+    if args.rollout_routing_replay and args.backend != "cuda":
+        raise click.UsageError("--rollout-routing-replay is only supported by the CUDA backend")
     tune_params = bool(getattr(args, "tune_params", False))
     mem_frac = float(getattr(args, "mem_frac", 0.9))
     tune_max_samples = int(getattr(args, "tune_max_samples", 256))
@@ -1000,6 +1006,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             rollout_tp_size=args.rollout_tp_size,
             rollout_devices=args.rollout_devices,
             policy_sync_bucket_mb=args.policy_sync_bucket_mb,
+            rollout_routing_replay=args.rollout_routing_replay,
             batch_size=args.batch_size,
             n_samples=args.n_samples,
             mini_bs=args.mini_bs,
@@ -1069,6 +1076,7 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         rollout_tp_size=args.rollout_tp_size,
         rollout_devices=args.rollout_devices,
         policy_sync_bucket_mb=args.policy_sync_bucket_mb,
+        rollout_routing_replay=args.rollout_routing_replay,
         batch_size=args.batch_size,
         n_samples=args.n_samples,
         mini_bs=args.mini_bs,
@@ -1617,6 +1625,11 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     default=64,
     show_default=True,
     help="Maximum GPU buffer size used by direct NCCL policy synchronization.",
+)
+@click.option(
+    "--rollout-routing-replay",
+    is_flag=True,
+    help="Replay rollout-selected MoE expert ids during the RL training forward (R3).",
 )
 @click.option("--batch-size", type=int, default=32, show_default=True, help="Prompt/pair batch size.")
 @click.option(

--- a/areno/cli/train.py
+++ b/areno/cli/train.py
@@ -106,7 +106,6 @@ TRAIN_OPTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "rollout_tp_size",
             "rollout_devices",
             "policy_sync_bucket_mb",
-            "rollout_routing_replay",
             "n_samples",
             "max_running_prompts",
             "max_prompt_tokens",
@@ -240,7 +239,6 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     args.rollout_tp_size = getattr(args, "rollout_tp_size", None)
     args.rollout_devices = getattr(args, "rollout_devices", None)
     args.policy_sync_bucket_mb = getattr(args, "policy_sync_bucket_mb", 64)
-    args.rollout_routing_replay = getattr(args, "rollout_routing_replay", False)
     args.optimizer_state_offload = getattr(args, "optimizer_state_offload", "none")
     args.optimizer_state_offload_dir = getattr(args, "optimizer_state_offload_dir", None)
     args.optimizer_state_offload_batch_size = getattr(args, "optimizer_state_offload_batch_size", 1)
@@ -293,10 +291,6 @@ def _trainer_config_from_options(**options) -> TrainerConfig:
     algorithm = _algorithm_for_cli(args.algo)
     if algorithm.name == "sft" and args.dataset_loader_fn is None:
         raise click.UsageError("--dataset-loader-fn is required for --algo sft")
-    if args.rollout_routing_replay and not algorithm.requires_rollout:
-        raise click.UsageError("--rollout-routing-replay is only valid for rollout-based RL algorithms")
-    if args.rollout_routing_replay and args.backend != "cuda":
-        raise click.UsageError("--rollout-routing-replay is only supported by the CUDA backend")
     tune_params = bool(getattr(args, "tune_params", False))
     mem_frac = float(getattr(args, "mem_frac", 0.9))
     tune_max_samples = int(getattr(args, "tune_max_samples", 256))
@@ -1006,7 +1000,6 @@ def _trainer_config_from_args(args) -> TrainerConfig:
             rollout_tp_size=args.rollout_tp_size,
             rollout_devices=args.rollout_devices,
             policy_sync_bucket_mb=args.policy_sync_bucket_mb,
-            rollout_routing_replay=args.rollout_routing_replay,
             batch_size=args.batch_size,
             n_samples=args.n_samples,
             mini_bs=args.mini_bs,
@@ -1076,7 +1069,6 @@ def _trainer_config_from_args(args) -> TrainerConfig:
         rollout_tp_size=args.rollout_tp_size,
         rollout_devices=args.rollout_devices,
         policy_sync_bucket_mb=args.policy_sync_bucket_mb,
-        rollout_routing_replay=args.rollout_routing_replay,
         batch_size=args.batch_size,
         n_samples=args.n_samples,
         mini_bs=args.mini_bs,
@@ -1625,11 +1617,6 @@ def _dataset_builder_for_suffix(suffix: str) -> str:
     default=64,
     show_default=True,
     help="Maximum GPU buffer size used by direct NCCL policy synchronization.",
-)
-@click.option(
-    "--rollout-routing-replay",
-    is_flag=True,
-    help="Replay rollout-selected MoE expert ids during the RL training forward (R3).",
 )
 @click.option("--batch-size", type=int, default=32, show_default=True, help="Prompt/pair batch size.")
 @click.option(

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -83,7 +83,10 @@ def _merge_dp_rollouts_by_prompt_indices(
 
     if total_count == 0:
         return _merge_rollouts([])
-    rows: list[tuple[list[int], list[int], str, torch.Tensor] | None] = [None for _ in range(total_count)]
+    routed_experts = [] if any(output is not None and output.routed_experts is not None for output in outputs) else None
+    rows: list[tuple[list[int], list[int], str, torch.Tensor, torch.Tensor | None] | None] = [
+        None for _ in range(total_count)
+    ]
     for dp_rank, output in enumerate(outputs):
         if output is None:
             continue
@@ -97,11 +100,17 @@ def _merge_dp_rollouts_by_prompt_indices(
             if row_idx < 0 or row_idx >= total_count:
                 raise RuntimeError(f"DP rollout prompt index out of chunk range: original_idx={original_idx}")
             response = output.response_ids[local_idx]
+            routes = None
+            if routed_experts is not None:
+                if output.routed_experts is None:
+                    raise RuntimeError("routing replay is missing from one DP rollout shard")
+                routes = output.routed_experts[local_idx]
             rows[row_idx] = (
                 output.prompt_ids[local_idx],
                 response,
                 output.finish_reason[local_idx],
                 output.logprobs[local_idx, : len(response)].detach().cpu(),
+                routes,
             )
     if any(row is None for row in rows):
         missing = [idx for idx, row in enumerate(rows) if row is None]
@@ -114,6 +123,7 @@ def _merge_dp_rollouts_by_prompt_indices(
         [row[3] for row in materialized],
         metrics=None,
         adapter_version=_rollout_version(non_empty=[output for output in outputs if output is not None]),
+        routed_experts=[row[4] for row in materialized if row[4] is not None] if routed_experts is not None else None,
     )
 
 

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -597,6 +597,7 @@ class ArenoEngine:
         *,
         pad_token_id: int,
         features: list[dict[str, Any] | None] | None = None,
+        routed_experts: list[object] | None = None,
         microbatch_size: int = 8,
     ) -> list[list[float]]:
         """Score fixed token rows with a model role.
@@ -610,6 +611,8 @@ class ArenoEngine:
             return []
         if features is not None and len(features) != len(token_rows):
             raise ValueError("features must have the same length as token_rows")
+        if routed_experts is not None and len(routed_experts) != len(token_rows):
+            raise ValueError("routed_experts must have the same length as token_rows")
         results = self.cluster.call(
             Op.SCORE_LOGPROBS,
             ScorePayload(
@@ -617,6 +620,9 @@ class ArenoEngine:
                 token_rows_by_dp=split_list_by_dp(token_rows, int(self.config.dp_size)),
                 features_by_dp=split_list_by_dp(features, int(self.config.dp_size)) if features is not None else None,
                 pad_token_id=int(pad_token_id),
+                routing_replay_by_dp=(
+                    split_list_by_dp(routed_experts, int(self.config.dp_size)) if routed_experts is not None else None
+                ),
                 microbatch_size=int(microbatch_size),
             ),
         )

--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -337,6 +337,10 @@ class EngineConfig:
             raise ValueError("runtime.kv_block_size must be >= 1")
         if self.runtime.kv_block_size % 256 != 0:
             raise ValueError("runtime.kv_block_size must be a multiple of 256 for FlashAttention paged KV")
+        # CUDA rollout trainers request R3 by default. Dense checkpoints do
+        # not have router decisions to capture and retain the original path.
+        if self.runtime.rollout_routing_replay and self.model.num_experts is None:
+            self.runtime.rollout_routing_replay = False
         self.runtime.resolve_attn_backend(model=self.model, devices=self.devices)
         self.runtime.resolve_compile_model(model=self.model, devices=self.devices)
         self.runtime.resolve_eager_decode(model=self.model, lora=self.lora)

--- a/areno/engine/config.py
+++ b/areno/engine/config.py
@@ -64,6 +64,7 @@ class RuntimeConfig:
     optimizer_state_offload_dir: str | None = None
     optimizer_state_offload_batch_size: int = 1
     eager_decode: bool = False
+    rollout_routing_replay: bool = False
     decode_graph_buckets: list[int] = field(
         default_factory=lambda: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 96, 128, 192, 256]
     )

--- a/areno/engine/data/batch.py
+++ b/areno/engine/data/batch.py
@@ -52,6 +52,7 @@ class RolloutOutput:
     finish_reason: list[str]
     metrics: dict[str, float] | None = None
     adapter_version: int | None = None
+    routed_experts: list[torch.Tensor] | None = None
 
 
 def to_device(obj: Any, device: torch.device, _memo: dict[int, torch.Tensor] | None = None) -> Any:

--- a/areno/engine/data/rollout_state.py
+++ b/areno/engine/data/rollout_state.py
@@ -43,7 +43,8 @@ class InferenceBatchState:
         self.prompt_features = _normalize_prompt_features(prompt_features, len(prompts))
         self.generated = [[] for _ in prompts]
         self.logprobs = [[] for _ in prompts]
-        self.routed_experts: list[list[torch.Tensor]] = [[] for _ in prompts]
+        self._routing_buffer: torch.Tensor | None = None
+        self._routing_capacity = 0
         self.max_new_tokens = max_new_tokens
         self.finished = [False for _ in prompts]
         self.finish_reason = ["" for _ in prompts]
@@ -72,7 +73,6 @@ class InferenceBatchState:
         self.prompt_features.extend(_normalize_prompt_features(prompt_features, len(prompts)))
         self.generated.extend([] for _ in prompts)
         self.logprobs.extend([] for _ in prompts)
-        self.routed_experts.extend([] for _ in prompts)
         self.finished.extend(False for _ in prompts)
         self.finish_reason.extend("" for _ in prompts)
         return list(range(start, start + len(prompts)))
@@ -292,31 +292,77 @@ class InferenceBatchState:
         ]
 
     def record_prefill_routing(self, payload: dict, routes: torch.Tensor | None) -> None:
-        """Append packed-prefill routes to their owning rollout rows."""
+        """Record packed-prefill routes without synchronizing them to CPU."""
 
         if routes is None:
             return
+        routing_buffer = self._ensure_routing_buffer(routes)
         cu_seqlens = payload["cu_seqlens"].tolist()
         seq_ids = payload.get("prefill_seq_ids") or []
         if len(seq_ids) + 1 != len(cu_seqlens):
             raise RuntimeError("prefill routing sequence metadata is misaligned")
         if int(routes.shape[0]) != int(cu_seqlens[-1]):
             raise RuntimeError("prefill routing token count does not match packed prefill tokens")
-        routes = routes.detach().to(device="cpu", dtype=torch.int32)
         for index, seq_id in enumerate(seq_ids):
             start, end = int(cu_seqlens[index]), int(cu_seqlens[index + 1])
-            self.routed_experts[int(seq_id)].extend(routes[start:end].unbind(0))
+            token_start = int(payload["position_ids"][start].item())
+            routing_buffer[int(seq_id), token_start : token_start + end - start].copy_(
+                routes[start:end].detach().to(dtype=torch.int16)
+            )
 
-    def record_decode_routing(self, rows: torch.Tensor, routes: torch.Tensor | None) -> None:
-        """Append one decode-input route for every active rollout row."""
+    def record_decode_routing(
+        self,
+        rows: torch.Tensor,
+        positions: torch.Tensor,
+        routes: torch.Tensor | None,
+    ) -> None:
+        """Record one decode-input route per active row entirely on device."""
 
         if routes is None:
             return
+        routing_buffer = self._ensure_routing_buffer(routes)
         if int(routes.shape[0]) < int(rows.numel()):
             raise RuntimeError("decode routing capture has fewer rows than the active batch")
-        routes = routes[: rows.numel()].detach().to(device="cpu", dtype=torch.int32)
-        for row, token_routes in zip(rows.detach().cpu().tolist(), routes.unbind(0), strict=True):
-            self.routed_experts[int(row)].append(token_routes)
+        if positions.numel() != rows.numel():
+            raise RuntimeError("decode routing positions do not match the active batch")
+        routing_buffer[rows, positions.to(dtype=torch.long)] = routes[: rows.numel()].detach().to(dtype=torch.int16)
+
+    @property
+    def routing_buffer(self) -> torch.Tensor | None:
+        """Dense device-side R3 buffer used by final and continuous outputs."""
+
+        return self._routing_buffer
+
+    @property
+    def has_routing(self) -> bool:
+        return self._routing_buffer is not None
+
+    def _ensure_routing_buffer(self, routes: torch.Tensor) -> torch.Tensor:
+        if routes.ndim != 3:
+            raise RuntimeError("captured routing must have shape (tokens, layers, top_k)")
+        route_shape = tuple(routes.shape[1:])
+        if self._routing_buffer is not None and tuple(self._routing_buffer.shape[2:]) != route_shape:
+            raise RuntimeError("captured routing layer/top-k shape changed during rollout")
+        required_rows = len(self.prompts)
+        if self._routing_buffer is None:
+            capacity = max(required_rows, 1)
+            self._routing_buffer = torch.empty(
+                (capacity, self.max_cache_len, *route_shape),
+                device=routes.device,
+                dtype=torch.int16,
+            )
+            self._routing_capacity = capacity
+        elif required_rows > self._routing_capacity:
+            capacity = max(required_rows, self._routing_capacity * 2)
+            expanded = torch.empty(
+                (capacity, self.max_cache_len, *route_shape),
+                device=self._routing_buffer.device,
+                dtype=self._routing_buffer.dtype,
+            )
+            expanded[: self._routing_capacity].copy_(self._routing_buffer)
+            self._routing_buffer = expanded
+            self._routing_capacity = capacity
+        return self._routing_buffer
 
     def to_rollout(self) -> RolloutOutput:
         """Materialize Python rollout state into padded tensors for the API."""
@@ -325,18 +371,13 @@ class InferenceBatchState:
         )
         reasons = [reason or "unknown" for reason in self.finish_reason]
         routed_experts = None
-        if any(self.routed_experts):
-            routed_experts = []
-            for row, (prompt, response) in enumerate(zip(self.prompts, self.generated, strict=True)):
-                expected = max(len(prompt) + len(response) - 1, 0)
-                routes = self.routed_experts[row][:expected]
-                if len(routes) != expected:
-                    raise RuntimeError(
-                        f"rollout routing capture for row {row} has {len(routes)} tokens, expected {expected}"
-                    )
-                routed_experts.append(
-                    torch.stack(routes, dim=0).cpu() if routes else torch.empty(0, 0, 0, dtype=torch.long)
-                )
+        if self._routing_buffer is not None:
+            expected = [
+                max(len(prompt) + len(response) - 1, 0) for prompt, response in zip(self.prompts, self.generated)
+            ]
+            max_expected = max(expected, default=0)
+            materialized = self._routing_buffer[: len(self.prompts), :max_expected].cpu()
+            routed_experts = [materialized[row, :count].contiguous() for row, count in enumerate(expected)]
         return RolloutOutput(
             prompt_ids=self.prompts,
             response_ids=self.generated,

--- a/areno/engine/data/rollout_state.py
+++ b/areno/engine/data/rollout_state.py
@@ -43,6 +43,7 @@ class InferenceBatchState:
         self.prompt_features = _normalize_prompt_features(prompt_features, len(prompts))
         self.generated = [[] for _ in prompts]
         self.logprobs = [[] for _ in prompts]
+        self.routed_experts: list[list[torch.Tensor]] = [[] for _ in prompts]
         self.max_new_tokens = max_new_tokens
         self.finished = [False for _ in prompts]
         self.finish_reason = ["" for _ in prompts]
@@ -71,6 +72,7 @@ class InferenceBatchState:
         self.prompt_features.extend(_normalize_prompt_features(prompt_features, len(prompts)))
         self.generated.extend([] for _ in prompts)
         self.logprobs.extend([] for _ in prompts)
+        self.routed_experts.extend([] for _ in prompts)
         self.finished.extend(False for _ in prompts)
         self.finish_reason.extend("" for _ in prompts)
         return list(range(start, start + len(prompts)))
@@ -120,6 +122,7 @@ class InferenceBatchState:
         cache_block_offsets: list[int] = []
         recurrent_slots: list[int] = []
         active_ids: list[int] = []
+        prefill_seq_ids: list[int] = []
 
         while self._pending_seq_id < len(self.prompts):
             seq_id = self._pending_seq_id
@@ -163,10 +166,12 @@ class InferenceBatchState:
                             cache_block_offsets,
                             recurrent_slots,
                             active_ids,
+                            prefill_seq_ids,
                         )
                     )
                 blocks.append(self._free_blocks.pop(0))
             chunk = prompt[cursor : cursor + chunk_len]
+            prefill_seq_ids.append(seq_id)
             input_ids.extend(chunk)
             local_mask, local_features = _slice_prompt_image_features(
                 self.prompt_features[seq_id],
@@ -226,6 +231,7 @@ class InferenceBatchState:
             cache_block_offsets,
             recurrent_slots,
             active_ids,
+            prefill_seq_ids,
         )
 
     def _prefill_payload(
@@ -242,6 +248,7 @@ class InferenceBatchState:
         cache_block_offsets: list[int],
         recurrent_slots: list[int],
         active_ids: list[int],
+        prefill_seq_ids: list[int],
     ) -> dict:
         self._last_active_ids = active_ids
         payload = {
@@ -255,6 +262,7 @@ class InferenceBatchState:
             "cache_block_ids": torch.tensor(cache_block_ids, dtype=torch.long),
             "cache_block_offsets": torch.tensor(cache_block_offsets, dtype=torch.long),
             "recurrent_slots": torch.tensor(recurrent_slots, dtype=torch.long),
+            "prefill_seq_ids": list(prefill_seq_ids),
         }
         if any(feature_mask) or image_features or mrope_position_parts is not None:
             payload["features"] = _prefill_multimodal_features(feature_mask, image_features, mrope_position_parts)
@@ -283,12 +291,52 @@ class InferenceBatchState:
             for seq_id in seq_ids
         ]
 
+    def record_prefill_routing(self, payload: dict, routes: torch.Tensor | None) -> None:
+        """Append packed-prefill routes to their owning rollout rows."""
+
+        if routes is None:
+            return
+        cu_seqlens = payload["cu_seqlens"].tolist()
+        seq_ids = payload.get("prefill_seq_ids") or []
+        if len(seq_ids) + 1 != len(cu_seqlens):
+            raise RuntimeError("prefill routing sequence metadata is misaligned")
+        if int(routes.shape[0]) != int(cu_seqlens[-1]):
+            raise RuntimeError("prefill routing token count does not match packed prefill tokens")
+        routes = routes.detach().to(device="cpu", dtype=torch.int32)
+        for index, seq_id in enumerate(seq_ids):
+            start, end = int(cu_seqlens[index]), int(cu_seqlens[index + 1])
+            self.routed_experts[int(seq_id)].extend(routes[start:end].unbind(0))
+
+    def record_decode_routing(self, rows: torch.Tensor, routes: torch.Tensor | None) -> None:
+        """Append one decode-input route for every active rollout row."""
+
+        if routes is None:
+            return
+        if int(routes.shape[0]) < int(rows.numel()):
+            raise RuntimeError("decode routing capture has fewer rows than the active batch")
+        routes = routes[: rows.numel()].detach().to(device="cpu", dtype=torch.int32)
+        for row, token_routes in zip(rows.detach().cpu().tolist(), routes.unbind(0), strict=True):
+            self.routed_experts[int(row)].append(token_routes)
+
     def to_rollout(self) -> RolloutOutput:
         """Materialize Python rollout state into padded tensors for the API."""
         input_ids, attention_mask, response_mask, logprobs = pad_rollout_rows(
             self.prompts, self.generated, self.logprobs
         )
         reasons = [reason or "unknown" for reason in self.finish_reason]
+        routed_experts = None
+        if any(self.routed_experts):
+            routed_experts = []
+            for row, (prompt, response) in enumerate(zip(self.prompts, self.generated, strict=True)):
+                expected = max(len(prompt) + len(response) - 1, 0)
+                routes = self.routed_experts[row][:expected]
+                if len(routes) != expected:
+                    raise RuntimeError(
+                        f"rollout routing capture for row {row} has {len(routes)} tokens, expected {expected}"
+                    )
+                routed_experts.append(
+                    torch.stack(routes, dim=0).cpu() if routes else torch.empty(0, 0, 0, dtype=torch.long)
+                )
         return RolloutOutput(
             prompt_ids=self.prompts,
             response_ids=self.generated,
@@ -298,6 +346,7 @@ class InferenceBatchState:
             logprobs=logprobs,
             finish_reason=reasons,
             metrics=self.metrics,
+            routed_experts=routed_experts,
         )
 
 

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -1050,7 +1050,7 @@ class InferenceManager:
             logits_shard = graph.replay_tensors(input_ids, position_ids, cache_seqlens, block_table, recurrent_slots)[
                 0, :active_count
             ]
-            self._last_routing_capture = captured_routing(graph.meta)
+            self._last_routing_capture = graph.routing_capture
 
         if sampling_params.temperature == 0.0:
             next_tokens = _sample_greedy_sharded(

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -32,10 +32,25 @@ from areno.engine.runtime.decode_graph import (
 )
 from areno.engine.runtime.metadata import InferMeta
 from areno.engine.runtime.rollout import _empty_rollout
+from areno.engine.runtime.routing_replay import captured_routing, routing_replay_context
 
 logger = logging.getLogger(__name__)
 
-FinishedRowsCallback = Callable[[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, str, tuple[int, ...]], None]
+FinishedRowsCallback = Callable[
+    [
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        str,
+        tuple[int, ...],
+        list[list[torch.Tensor]],
+    ],
+    None,
+]
+_InternalFinishedRowsCallback = Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, str, tuple[int, ...]], None
+]
 RolloutRefillCallback = Callable[[InferenceBatchState], list[int]]
 
 
@@ -111,6 +126,7 @@ class InferenceManager:
 
     def __init__(self, worker):
         object.__setattr__(self, "worker", worker)
+        self._last_routing_capture: torch.Tensor | None = None
         if not hasattr(worker, "_decode_progress_lock"):
             worker._decode_progress_lock = threading.Lock()
             worker._decode_progress_next_time = 0.0
@@ -258,6 +274,27 @@ class InferenceManager:
             )
             sampling_params = payload.sampling_params
             cancel_indices_by_dp = payload.cancel_indices_by_dp
+            internal_finished_callback = None
+            if finished_callback is not None:
+
+                def internal_finished_callback(
+                    rows,
+                    generated,
+                    logprobs,
+                    response_lens,
+                    finish_reason,
+                    truncate_stop_token_ids,
+                ):
+                    finished_callback(
+                        rows,
+                        generated,
+                        logprobs,
+                        response_lens,
+                        finish_reason,
+                        truncate_stop_token_ids,
+                        state.routed_experts,
+                    )
+
             self._generate_rollout_tokens_no_sync(
                 state,
                 sampling_params,
@@ -266,9 +303,13 @@ class InferenceManager:
                 cancel_flags=payload.cancel_flags,
                 cancel_indices=cancel_indices_by_dp[ctx.dp_rank] if cancel_indices_by_dp is not None else None,
                 prompt_indices=prompt_indices,
-                finished_callback=finished_callback,
+                finished_callback=internal_finished_callback,
                 refill_callback=refill_callback,
             )
+            if self.config.runtime.rollout_routing_replay and not any(state.routed_experts):
+                raise ValueError(
+                    "rollout routing replay was enabled, but this model did not capture any sparse-MoE routes"
+                )
             if ctx.is_rank0:
                 return state.to_rollout()
             return None
@@ -291,7 +332,7 @@ class InferenceManager:
         cancel_flags: torch.Tensor | None = None,
         cancel_indices: list[int] | None = None,
         prompt_indices: list[int] | None = None,
-        finished_callback: FinishedRowsCallback | None = None,
+        finished_callback: _InternalFinishedRowsCallback | None = None,
         refill_callback: RolloutRefillCallback | None = None,
     ) -> None:
         """Prefill all prompts then decode up to `max_new_tokens` without DP-sync.
@@ -438,6 +479,7 @@ class InferenceManager:
                 sample_step=sample_step,
                 eos_token_id=eos_token_id,
             )
+            state.record_decode_routing(active_rows, self._last_routing_capture)
             sample_step += 1
             # Write the new tokens into the per-row response buffer using
             # advanced indexing: write_pos[k] is the next free slot for row k.
@@ -709,7 +751,7 @@ class InferenceManager:
         step: int,
         stop_token_ids: tuple[int, ...],
         stop_token_tensor: torch.Tensor | None,
-        finished_callback: FinishedRowsCallback | None,
+        finished_callback: _InternalFinishedRowsCallback | None,
         truncate_stop_token_ids: tuple[int, ...],
     ) -> (
         tuple[
@@ -742,6 +784,7 @@ class InferenceManager:
             new_rows = torch.tensor(state._last_active_ids, device=self.device, dtype=torch.long)
             if new_rows.numel() == 0:
                 self._run_prefill_payload(prefill)
+                state.record_prefill_routing(prefill.raw, self._last_routing_capture)
                 if active_count > 0:
                     return (
                         generated,
@@ -756,6 +799,7 @@ class InferenceManager:
                     )
                 continue
             new_tokens, new_logprobs = self._infer_next_token_tensor(prefill)
+            state.record_prefill_routing(prefill.raw, self._last_routing_capture)
             break
         generated[new_rows, 0] = new_tokens
         logprobs[new_rows, 0] = new_logprobs
@@ -868,10 +912,13 @@ class InferenceManager:
         infer_meta = payload.infer_meta
         if infer_meta is None:
             infer_meta = payload_to_infer_meta(payload.raw, self.device)
+        infer_meta.capture_routing = self.config.runtime.rollout_routing_replay
         model_kwargs = {"input_ids": input_ids, "position_ids": position_ids, "infer_meta": infer_meta}
         if payload.raw.get("features") is not None:
             model_kwargs["features"] = payload.raw["features"]
-        self.model(**model_kwargs)
+        with routing_replay_context(infer_meta):
+            self.model(**model_kwargs)
+        self._last_routing_capture = captured_routing(infer_meta)
 
     def _mark_rollout_finished_rows(
         self,
@@ -881,7 +928,7 @@ class InferenceManager:
         response_lens: torch.Tensor,
         finish_reason: str,
         prompt_indices: list[int] | None = None,
-        finished_callback: FinishedRowsCallback | None = None,
+        finished_callback: _InternalFinishedRowsCallback | None = None,
         truncate_stop_token_ids: tuple[int, ...] = (),
     ) -> None:
         """Finish hook; final rollout output carries completed rows."""
@@ -907,10 +954,13 @@ class InferenceManager:
         infer_meta = payload.infer_meta
         if infer_meta is None:
             infer_meta = payload_to_infer_meta(payload.raw, self.device)
+        infer_meta.capture_routing = self.config.runtime.rollout_routing_replay
         model_kwargs = {"input_ids": input_ids, "position_ids": position_ids, "infer_meta": infer_meta}
         if payload.raw.get("features") is not None:
             model_kwargs["features"] = payload.raw["features"]
-        out = self.model(**model_kwargs)
+        with routing_replay_context(infer_meta):
+            out = self.model(**model_kwargs)
+        self._last_routing_capture = captured_routing(infer_meta)
         logits_shard = out.logits_shard
         sampling_params = payload.sampling_params
         if sampling_params.temperature == 0.0:
@@ -981,12 +1031,15 @@ class InferenceManager:
                 cache_seqlens=cache_seqlens,
                 block_table=block_table,
                 recurrent_slots=recurrent_slots,
+                capture_routing=self.config.runtime.rollout_routing_replay,
             )
-            logits_shard = self.model(
-                input_ids=input_ids[:active_count].view(1, active_count),
-                position_ids=position_ids[:active_count].view(1, active_count),
-                infer_meta=infer_meta,
-            ).logits_shard[0, :active_count]
+            with routing_replay_context(infer_meta):
+                logits_shard = self.model(
+                    input_ids=input_ids[:active_count].view(1, active_count),
+                    position_ids=position_ids[:active_count].view(1, active_count),
+                    infer_meta=infer_meta,
+                ).logits_shard[0, :active_count]
+            self._last_routing_capture = captured_routing(infer_meta)
         else:
             # Graph replay path: copies inputs into the captured input buffers
             # and replays. Only the first `active_count` rows are meaningful;
@@ -995,6 +1048,7 @@ class InferenceManager:
             logits_shard = graph.replay_tensors(input_ids, position_ids, cache_seqlens, block_table, recurrent_slots)[
                 0, :active_count
             ]
+            self._last_routing_capture = captured_routing(graph.meta)
 
         if sampling_params.temperature == 0.0:
             next_tokens = _sample_greedy_sharded(
@@ -1084,6 +1138,7 @@ class InferenceManager:
                 self._scratch_block,
                 self._scratch_recurrent_slot,
                 self.device,
+                capture_routing=self.config.runtime.rollout_routing_replay,
             )
             # Warmup: run a few eager forwards at this bucket size to (a) trim
             # compiler / allocator noise and (b) measure the working-set peak

--- a/areno/engine/inference.py
+++ b/areno/engine/inference.py
@@ -44,7 +44,7 @@ FinishedRowsCallback = Callable[
         torch.Tensor,
         str,
         tuple[int, ...],
-        list[list[torch.Tensor]],
+        torch.Tensor | None,
     ],
     None,
 ]
@@ -248,6 +248,8 @@ class InferenceManager:
             # Idle-DP early return: this rank received no prompts this step.
             if not prompts:
                 return _empty_rollout() if ctx.is_rank0 else None
+            if self.config.runtime.rollout_routing_replay and int(self.config.model.num_experts or 0) > 32767:
+                raise ValueError("rollout routing replay supports at most 32767 experts per MoE layer")
             max_new_tokens = int(payload.max_new_tokens)
             eos_token_id = payload.eos_token_id
             max_cache_len = int(payload.max_cache_len)
@@ -292,7 +294,7 @@ class InferenceManager:
                         response_lens,
                         finish_reason,
                         truncate_stop_token_ids,
-                        state.routed_experts,
+                        state.routing_buffer,
                     )
 
             self._generate_rollout_tokens_no_sync(
@@ -306,7 +308,7 @@ class InferenceManager:
                 finished_callback=internal_finished_callback,
                 refill_callback=refill_callback,
             )
-            if self.config.runtime.rollout_routing_replay and not any(state.routed_experts):
+            if self.config.runtime.rollout_routing_replay and not state.has_routing:
                 raise ValueError(
                     "rollout routing replay was enabled, but this model did not capture any sparse-MoE routes"
                 )
@@ -479,7 +481,7 @@ class InferenceManager:
                 sample_step=sample_step,
                 eos_token_id=eos_token_id,
             )
-            state.record_decode_routing(active_rows, self._last_routing_capture)
+            state.record_decode_routing(active_rows, cache_seqlens, self._last_routing_capture)
             sample_step += 1
             # Write the new tokens into the per-row response buffer using
             # advanced indexing: write_pos[k] is the next free slot for row k.

--- a/areno/engine/protocol.py
+++ b/areno/engine/protocol.py
@@ -137,6 +137,7 @@ class ScorePayload:
     token_rows_by_dp: list[list[list[int]]]
     features_by_dp: list[list[dict[str, Any] | None]] | None
     pad_token_id: int
+    routing_replay_by_dp: list[list[torch.Tensor]] | None = None
     microbatch_size: int = 8
 
 

--- a/areno/engine/runtime/decode_graph.py
+++ b/areno/engine/runtime/decode_graph.py
@@ -14,6 +14,7 @@ import torch.distributed as dist
 
 from areno.engine.runtime.common import ceil_div as ceil_div  # noqa: F401
 from areno.engine.runtime.metadata import InferMeta
+from areno.engine.runtime.routing_replay import routing_replay_context
 
 
 def bucket_for(batch_size: int, buckets: list[int]) -> int:
@@ -77,6 +78,8 @@ class DecodeGraph:
         scratch_block: int,
         scratch_recurrent_slot: int,
         device: torch.device,
+        *,
+        capture_routing: bool = False,
     ):
         """Allocate static input buffers and the `InferMeta` baked into capture."""
 
@@ -105,6 +108,7 @@ class DecodeGraph:
             cache_seqlens=self.cache_seqlens,
             block_table=self.block_table,
             recurrent_slots=self.recurrent_slots,
+            capture_routing=capture_routing,
         )
         self.graph = torch.cuda.CUDAGraph()
         self.logits_shard: torch.Tensor | None = None
@@ -121,11 +125,12 @@ class DecodeGraph:
         stream.wait_stream(torch.cuda.current_stream(self.device))
         with torch.cuda.device(self.device), torch.cuda.stream(stream):
             for _ in range(iterations):
-                logits_shard = self.model(
-                    input_ids=self.input_ids,
-                    position_ids=self.position_ids,
-                    infer_meta=self.meta,
-                ).logits_shard
+                with routing_replay_context(self.meta):
+                    logits_shard = self.model(
+                        input_ids=self.input_ids,
+                        position_ids=self.position_ids,
+                        infer_meta=self.meta,
+                    ).logits_shard
                 del logits_shard
         torch.cuda.current_stream(self.device).wait_stream(stream)
         torch.cuda.synchronize(self.device)
@@ -139,9 +144,10 @@ class DecodeGraph:
         # and must remain alive at the same addresses for the lifetime of the
         # graph, which is exactly what `self.input_ids/...` provide.
         with torch.cuda.device(self.device), torch.cuda.graph(self.graph):
-            self.logits_shard = self.model(
-                input_ids=self.input_ids, position_ids=self.position_ids, infer_meta=self.meta
-            ).logits_shard
+            with routing_replay_context(self.meta):
+                self.logits_shard = self.model(
+                    input_ids=self.input_ids, position_ids=self.position_ids, infer_meta=self.meta
+                ).logits_shard
 
     @torch.inference_mode()
     def replay_tensors(

--- a/areno/engine/runtime/decode_graph.py
+++ b/areno/engine/runtime/decode_graph.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 
 from areno.engine.runtime.common import ceil_div as ceil_div  # noqa: F401
 from areno.engine.runtime.metadata import InferMeta
-from areno.engine.runtime.routing_replay import routing_replay_context
+from areno.engine.runtime.routing_replay import captured_routing, routing_replay_context
 
 
 def bucket_for(batch_size: int, buckets: list[int]) -> int:
@@ -112,6 +112,7 @@ class DecodeGraph:
         )
         self.graph = torch.cuda.CUDAGraph()
         self.logits_shard: torch.Tensor | None = None
+        self.routing_capture: torch.Tensor | None = None
 
     @torch.inference_mode()
     def warmup(self, iterations: int = 3) -> int:
@@ -148,6 +149,10 @@ class DecodeGraph:
                 self.logits_shard = self.model(
                     input_ids=self.input_ids, position_ids=self.position_ids, infer_meta=self.meta
                 ).logits_shard
+            # Stack per-layer routes while capture is active. Replay then
+            # updates this fixed contiguous tensor without launching a new
+            # stack kernel or allocating an output tensor from Python.
+            self.routing_capture = captured_routing(self.meta)
 
     @torch.inference_mode()
     def replay_tensors(

--- a/areno/engine/runtime/metadata.py
+++ b/areno/engine/runtime/metadata.py
@@ -25,6 +25,7 @@ class TrainMeta:
     sequence_parallel: bool = False
     activation_checkpointing: bool = False
     num_padding_tokens: int = 0
+    routing_replay: torch.Tensor | None = None
 
 
 @dataclass(slots=True)
@@ -45,3 +46,5 @@ class InferMeta:
     cache_block_ids: torch.Tensor | None = None
     cache_block_offsets: torch.Tensor | None = None
     recurrent_slots: torch.Tensor | None = None
+    capture_routing: bool = False
+    captured_routing: dict[int, torch.Tensor] | None = None

--- a/areno/engine/runtime/rollout.py
+++ b/areno/engine/runtime/rollout.py
@@ -29,6 +29,7 @@ def _merge_rollouts(outputs: list[RolloutOutput]) -> RolloutOutput:
             response_len = len(response)
             logprob_rows.append(output.logprobs[local_idx, :response_len])
     input_ids, attention_mask, response_mask, logprobs = pad_rollout_rows(prompt_ids, response_ids, logprob_rows)
+    routed_experts = _concat_routed_experts(outputs)
     return RolloutOutput(
         prompt_ids=prompt_ids,
         response_ids=response_ids,
@@ -39,6 +40,7 @@ def _merge_rollouts(outputs: list[RolloutOutput]) -> RolloutOutput:
         finish_reason=finish_reason,
         metrics=_merge_rollout_metrics(outputs),
         adapter_version=_merge_adapter_version(outputs),
+        routed_experts=routed_experts,
     )
 
 
@@ -52,6 +54,7 @@ def _merge_dp_rollouts_in_input_order(outputs: list[RolloutOutput | None], total
     response_ids = []
     finish_reason = []
     logprob_rows = []
+    routed_experts = [] if any(output.routed_experts is not None for output in outputs) else None
     # The split was `prompts[rank::dp_size]`, so inverse is to map
     # original_idx -> (dp_rank = original_idx % dp_size,
     #                  local_idx = original_idx // dp_size).
@@ -68,6 +71,10 @@ def _merge_dp_rollouts_in_input_order(outputs: list[RolloutOutput | None], total
         finish_reason.append(output.finish_reason[local_idx])
         response_len = len(output.response_ids[local_idx])
         logprob_rows.append(output.logprobs[local_idx, :response_len].detach().cpu())
+        if routed_experts is not None:
+            if output.routed_experts is None:
+                raise RuntimeError("routing replay is missing from one DP rollout shard")
+            routed_experts.append(output.routed_experts[local_idx])
     return _build_rollout_from_rows(
         prompt_ids,
         response_ids,
@@ -75,6 +82,7 @@ def _merge_dp_rollouts_in_input_order(outputs: list[RolloutOutput | None], total
         logprob_rows,
         metrics=_merge_rollout_metrics(outputs),
         adapter_version=_merge_adapter_version(outputs),
+        routed_experts=routed_experts,
     )
 
 
@@ -86,6 +94,7 @@ def _build_rollout_from_rows(
     *,
     metrics: dict[str, float] | None,
     adapter_version: int | None = None,
+    routed_experts: list[torch.Tensor] | None = None,
 ) -> RolloutOutput:
     """Build padded rollout tensors from variable-length Python rows."""
     if not prompt_ids:
@@ -101,6 +110,7 @@ def _build_rollout_from_rows(
         finish_reason=finish_reason,
         metrics=metrics,
         adapter_version=adapter_version,
+        routed_experts=routed_experts,
     )
 
 
@@ -136,3 +146,14 @@ def _merge_adapter_version(outputs: list[RolloutOutput]) -> int | None:
     if len(versions) != 1:
         raise RuntimeError(f"rollout shards reported different adapter versions: {versions}")
     return versions.pop()
+
+
+def _concat_routed_experts(outputs: list[RolloutOutput]) -> list[torch.Tensor] | None:
+    if not any(output.routed_experts is not None for output in outputs):
+        return None
+    rows = []
+    for output in outputs:
+        if output.routed_experts is None:
+            raise RuntimeError("routing replay is missing from one rollout chunk")
+        rows.extend(output.routed_experts)
+    return rows

--- a/areno/engine/runtime/routing_replay.py
+++ b/areno/engine/runtime/routing_replay.py
@@ -71,6 +71,11 @@ def captured_routing(meta: InferMeta) -> torch.Tensor | None:
     return torch.stack(tensors, dim=1)
 
 
+# The routing state is Python-owned and its capture dictionary mutates once per
+# MoE layer. Letting Dynamo inspect it specializes a graph for every dictionary
+# state/layer slot and quickly exhausts the compile cache on deep MoE models.
+# CUDA graph capture still records the tensor operations launched here.
+@torch._dynamo.disable
 def resolve_softmax_routes(
     layer_slot: int,
     logits: torch.Tensor,
@@ -97,6 +102,7 @@ def resolve_softmax_routes(
     return topk_idx, topk_weight
 
 
+@torch._dynamo.disable
 def resolve_sigmoid_routes(
     layer_slot: int,
     logits: torch.Tensor,

--- a/areno/engine/runtime/routing_replay.py
+++ b/areno/engine/runtime/routing_replay.py
@@ -87,10 +87,10 @@ def resolve_softmax_routes(
     replayed = _replayed_ids(state, layer_slot, logits, topk_idx)
     if replayed is not None:
         replayed_ids, replay_mask = replayed
-        scores = torch.softmax(logits.float(), dim=-1)
-        replayed_weight = scores.gather(-1, replayed_ids)
         if renormalize:
-            replayed_weight = replayed_weight / replayed_weight.sum(dim=-1, keepdim=True).clamp_min(1.0e-20)
+            replayed_weight = torch.softmax(logits.float().gather(-1, replayed_ids), dim=-1)
+        else:
+            replayed_weight = torch.softmax(logits.float(), dim=-1).gather(-1, replayed_ids)
         topk_idx = replayed_ids
         topk_weight = torch.where(replay_mask.unsqueeze(-1), replayed_weight, topk_weight)
     _capture_ids(state, layer_slot, topk_idx)
@@ -111,7 +111,7 @@ def resolve_sigmoid_routes(
     replayed = _replayed_ids(state, layer_slot, logits, topk_idx)
     if replayed is not None:
         replayed_ids, replay_mask = replayed
-        scores = torch.sigmoid(logits.float()).gather(-1, replayed_ids)
+        scores = torch.sigmoid(logits.float().gather(-1, replayed_ids))
         replayed_weight = scores / scores.sum(dim=-1, keepdim=True).clamp_min(1.0e-20)
         topk_idx = replayed_ids
         topk_weight = torch.where(replay_mask.unsqueeze(-1), replayed_weight, topk_weight)
@@ -144,11 +144,7 @@ def _replayed_ids(
         layer_replay = layer_replay.narrow(0, start, int(logits.shape[0]))
     ids = layer_replay.to(device=logits.device, dtype=torch.long)
     missing = ids < 0
-    if bool((missing.any(dim=-1) != missing.all(dim=-1)).any()):
-        raise ValueError("routing replay must mark either all or none of a token's top-k expert ids as missing")
     replay_mask = ~missing.all(dim=-1)
-    if bool((ids[replay_mask] >= logits.shape[-1]).any()):
-        raise ValueError(f"routing replay contains expert ids outside [0, {logits.shape[-1]})")
     resolved = torch.where(replay_mask.unsqueeze(-1), ids, dynamic_ids.to(dtype=torch.long))
     return resolved, replay_mask
 

--- a/areno/engine/runtime/routing_replay.py
+++ b/areno/engine/runtime/routing_replay.py
@@ -1,0 +1,163 @@
+"""Rollout-routing capture and training replay for sparse MoE routers.
+
+The runtime installs one short-lived context around a model forward.  MoE
+routers use :func:`resolve_softmax_routes` or :func:`resolve_sigmoid_routes`
+to either record their selected expert ids during rollout, or replace the
+fresh training top-k decision with the recorded ids.  Replayed weights are
+always recomputed from the current router logits so gradients still flow to
+the current router parameters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+import torch
+
+from areno.engine.parallel.context import get_tp_context
+from areno.engine.runtime.metadata import InferMeta, TrainMeta
+
+
+@dataclass(slots=True)
+class _RoutingState:
+    replay: torch.Tensor | None = None
+    captured: dict[int, torch.Tensor] = field(default_factory=dict)
+
+
+_ROUTING_STATE: ContextVar[_RoutingState | None] = ContextVar("areno_routing_replay", default=None)
+
+
+@contextmanager
+def routing_replay_context(meta: TrainMeta | InferMeta | None) -> Iterator[None]:
+    """Expose capture/replay metadata to routers for one model forward."""
+
+    replay = meta.routing_replay if isinstance(meta, TrainMeta) else None
+    capture = bool(isinstance(meta, InferMeta) and meta.capture_routing)
+    if replay is None and not capture:
+        yield
+        return
+    state = _RoutingState(replay=replay)
+    if isinstance(meta, InferMeta):
+        meta.captured_routing = None
+    token = _ROUTING_STATE.set(state)
+    try:
+        yield
+    finally:
+        _ROUTING_STATE.reset(token)
+        if isinstance(meta, InferMeta):
+            meta.captured_routing = state.captured
+
+
+def captured_routing(meta: InferMeta) -> torch.Tensor | None:
+    """Return captured routes as ``(tokens, moe_layers, top_k)``."""
+
+    captured = meta.captured_routing
+    if not captured:
+        return None
+    slots = sorted(captured)
+    if slots != list(range(len(slots))):
+        raise RuntimeError(f"MoE routing slots must be contiguous from zero, got {slots}")
+    tensors = [captured[slot] for slot in slots]
+    token_count = int(tensors[0].shape[0])
+    top_k = int(tensors[0].shape[1])
+    for slot, routes in enumerate(tensors):
+        if routes.ndim != 2 or tuple(routes.shape) != (token_count, top_k):
+            raise RuntimeError(
+                f"captured MoE routes at slot {slot} have shape {tuple(routes.shape)}, expected {(token_count, top_k)}"
+            )
+    return torch.stack(tensors, dim=1)
+
+
+def resolve_softmax_routes(
+    layer_slot: int,
+    logits: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weight: torch.Tensor,
+    *,
+    renormalize: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Capture or replay a softmax router's expert ids."""
+
+    state = _ROUTING_STATE.get()
+    if state is None:
+        return topk_idx, topk_weight
+    replayed = _replayed_ids(state, layer_slot, logits, topk_idx)
+    if replayed is not None:
+        replayed_ids, replay_mask = replayed
+        scores = torch.softmax(logits.float(), dim=-1)
+        replayed_weight = scores.gather(-1, replayed_ids)
+        if renormalize:
+            replayed_weight = replayed_weight / replayed_weight.sum(dim=-1, keepdim=True).clamp_min(1.0e-20)
+        topk_idx = replayed_ids
+        topk_weight = torch.where(replay_mask.unsqueeze(-1), replayed_weight, topk_weight)
+    _capture_ids(state, layer_slot, topk_idx)
+    return topk_idx, topk_weight
+
+
+def resolve_sigmoid_routes(
+    layer_slot: int,
+    logits: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Capture or replay a normalized sigmoid router's expert ids."""
+
+    state = _ROUTING_STATE.get()
+    if state is None:
+        return topk_idx, topk_weight
+    replayed = _replayed_ids(state, layer_slot, logits, topk_idx)
+    if replayed is not None:
+        replayed_ids, replay_mask = replayed
+        scores = torch.sigmoid(logits.float()).gather(-1, replayed_ids)
+        replayed_weight = scores / scores.sum(dim=-1, keepdim=True).clamp_min(1.0e-20)
+        topk_idx = replayed_ids
+        topk_weight = torch.where(replay_mask.unsqueeze(-1), replayed_weight, topk_weight)
+    _capture_ids(state, layer_slot, topk_idx)
+    return topk_idx, topk_weight
+
+
+def _replayed_ids(
+    state: _RoutingState,
+    layer_slot: int,
+    logits: torch.Tensor,
+    dynamic_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    replay = state.replay
+    if replay is None:
+        return None
+    if replay.ndim != 3:
+        raise ValueError(f"routing replay must have shape (tokens, layers, top_k), got {tuple(replay.shape)}")
+    if layer_slot < 0 or layer_slot >= int(replay.shape[1]):
+        raise ValueError(f"routing replay is missing MoE layer slot {layer_slot}")
+    layer_replay = replay[:, layer_slot, :]
+    if int(layer_replay.shape[0]) != int(logits.shape[0]):
+        ctx = get_tp_context()
+        if int(layer_replay.shape[0]) != int(logits.shape[0]) * ctx.world_size:
+            raise ValueError(
+                f"routing replay token count {layer_replay.shape[0]} does not match router token count "
+                f"{logits.shape[0]} (or its TP-sharded layout)"
+            )
+        start = ctx.rank * int(logits.shape[0])
+        layer_replay = layer_replay.narrow(0, start, int(logits.shape[0]))
+    ids = layer_replay.to(device=logits.device, dtype=torch.long)
+    missing = ids < 0
+    if bool((missing.any(dim=-1) != missing.all(dim=-1)).any()):
+        raise ValueError("routing replay must mark either all or none of a token's top-k expert ids as missing")
+    replay_mask = ~missing.all(dim=-1)
+    if bool((ids[replay_mask] >= logits.shape[-1]).any()):
+        raise ValueError(f"routing replay contains expert ids outside [0, {logits.shape[-1]})")
+    resolved = torch.where(replay_mask.unsqueeze(-1), ids, dynamic_ids.to(dtype=torch.long))
+    return resolved, replay_mask
+
+
+def _capture_ids(state: _RoutingState, layer_slot: int, topk_idx: torch.Tensor) -> None:
+    if state.replay is not None:
+        return
+    if layer_slot < 0:
+        raise ValueError("MoE routing layer slot must be non-negative")
+    if layer_slot in state.captured:
+        raise RuntimeError(f"MoE routing layer slot {layer_slot} was captured more than once in one forward")
+    state.captured[layer_slot] = topk_idx.detach()

--- a/areno/engine/runtime/train_step.py
+++ b/areno/engine/runtime/train_step.py
@@ -65,6 +65,7 @@ def _train_meta(data_pack: dict[str, Any], tokens: torch.Tensor, *, sequence_par
         sequence_parallel=sequence_parallel,
         activation_checkpointing=bool(data_pack.get("_activation_checkpointing_enabled", False)),
         num_padding_tokens=int(data_pack.get("packed_singleton_padding", 0)),
+        routing_replay=data_pack.get("packed_routing_replay"),
     )
 
 
@@ -136,6 +137,19 @@ def _pack_train_data(data_pack: dict[str, Any]) -> dict[str, Any]:
     has_values = isinstance(values, torch.Tensor)
     has_returns = isinstance(returns, torch.Tensor)
     packed_features = _pack_multimodal_features(features, input_ids, lengths, packed_ids.device)
+    routing_replay = data_pack.get("routing_replay")
+    packed_routing_replay = None
+    if routing_replay is not None:
+        if not isinstance(routing_replay, torch.Tensor) or routing_replay.ndim != 4:
+            raise ValueError("training routing_replay must have shape (batch, seqlen, layers, top_k)")
+        if tuple(routing_replay.shape[:2]) != tuple(input_ids.shape):
+            raise ValueError("training routing_replay batch/token shape must match input_ids")
+        packed_routing_replay = torch.full(
+            (aligned_total_tokens, *routing_replay.shape[2:]),
+            -1,
+            device=input_ids.device,
+            dtype=routing_replay.dtype,
+        )
 
     token_offset = 0
     action_offset = 0
@@ -144,6 +158,8 @@ def _pack_train_data(data_pack: dict[str, Any]) -> dict[str, Any]:
         length = int(lengths[row].item())
         max_seqlen = max(max_seqlen, length)
         packed_ids[token_offset : token_offset + length] = input_ids[row, :length]
+        if packed_routing_replay is not None:
+            packed_routing_replay[token_offset : token_offset + length] = routing_replay[row, :length]
         # Position ids restart at 0 for each packed row, so rotary embeddings
         # treat the packed sequence as a concatenation of independent sequences.
         position_ids[token_offset : token_offset + length] = torch.arange(length, device=input_ids.device)
@@ -201,6 +217,8 @@ def _pack_train_data(data_pack: dict[str, Any]) -> dict[str, Any]:
         packed["packed_values"] = packed_values
     if has_returns:
         packed["packed_returns"] = packed_returns
+    if packed_routing_replay is not None:
+        packed["packed_routing_replay"] = packed_routing_replay
     return packed
 
 

--- a/areno/engine/runtime/train_step.py
+++ b/areno/engine/runtime/train_step.py
@@ -219,6 +219,10 @@ def _pack_train_data(data_pack: dict[str, Any]) -> dict[str, Any]:
         packed["packed_returns"] = packed_returns
     if packed_routing_replay is not None:
         packed["packed_routing_replay"] = packed_routing_replay
+        # Only the compact packed view is consumed by TrainMeta. Keeping the
+        # rectangular source would copy the same routing metadata to CUDA a
+        # second time and retain both tensors for the whole microbatch.
+        packed.pop("routing_replay", None)
     return packed
 
 

--- a/areno/engine/training.py
+++ b/areno/engine/training.py
@@ -15,6 +15,7 @@ from areno.engine.runtime.logprobs import (
     packed_next_token_logprobs,
     packed_next_token_logprobs_from_hidden,
 )
+from areno.engine.runtime.routing_replay import routing_replay_context
 from areno.engine.runtime.train_step import (
     _clip_grad_norm,
     _grad_norms,
@@ -116,14 +117,15 @@ class TrainingManager:
         data_pack["_activation_checkpointing_enabled"] = worker.config.runtime.activation_checkpointing
         tokens = data_pack["input_ids"].long()
         position_ids = data_pack.get("position_ids")
+        train_meta = _train_meta(
+            data_pack,
+            tokens,
+            sequence_parallel=worker.config.effective_sequence_parallel,
+        )
         model_kwargs = {
             "input_ids": tokens,
             "position_ids": position_ids,
-            "train_meta": _train_meta(
-                data_pack,
-                tokens,
-                sequence_parallel=worker.config.effective_sequence_parallel,
-            ),
+            "train_meta": train_meta,
         }
         if data_pack.get("features") is not None:
             model_kwargs["features"] = data_pack["features"]
@@ -132,7 +134,8 @@ class TrainingManager:
         )
         if defer_lm_head:
             model_kwargs["defer_lm_head"] = True
-        out = train_model(**model_kwargs)
+        with routing_replay_context(train_meta):
+            out = train_model(**model_kwargs)
         if defer_lm_head:
             logprobs = packed_next_token_logprobs_from_hidden(
                 out.hidden_states,

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -315,7 +315,7 @@ class ArenoWorker:
             response_lens: torch.Tensor,
             finish_reason: str,
             truncate_stop_token_ids: tuple[int, ...],
-            routed_experts: list[list[torch.Tensor]],
+            routed_experts: list[list[torch.Tensor]] | None = None,
         ) -> None:
             for row in rows.detach().cpu().tolist():
                 row_idx = int(row)

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -315,6 +315,7 @@ class ArenoWorker:
             response_lens: torch.Tensor,
             finish_reason: str,
             truncate_stop_token_ids: tuple[int, ...],
+            routed_experts: list[list[torch.Tensor]],
         ) -> None:
             for row in rows.detach().cpu().tolist():
                 row_idx = int(row)
@@ -334,6 +335,7 @@ class ArenoWorker:
                         finish_reasons,
                         row_ids,
                         truncate_stop_token_ids,
+                        routed_experts,
                     )
                     result_payload = self._stamp_adapter_version(result_payload)
                 request_id = request_ids[request_idx]
@@ -746,6 +748,7 @@ def _build_rollout_from_tensor_row_ids(
     finish_reasons: list[str],
     row_ids: list[int],
     truncate_stop_token_ids: tuple[int, ...],
+    routed_experts_by_row: list[list[torch.Tensor]] | None = None,
 ) -> RolloutOutput:
     """Build a RolloutOutput for non-contiguous completed tensor rows."""
 
@@ -763,6 +766,7 @@ def _build_rollout_from_tensor_row_ids(
         torch.tensor(row[: len(response)], dtype=torch.float32)
         for row, response in zip(logprob_rows_cpu, response_ids, strict=True)
     ]
+    routed_experts = _completed_routing_rows(prompt_ids, response_ids, row_ids, routed_experts_by_row)
     input_ids, attention_mask, response_mask, padded_logprobs = pad_rollout_rows(prompt_ids, response_ids, logprob_rows)
     return RolloutOutput(
         prompt_ids=prompt_ids,
@@ -773,7 +777,30 @@ def _build_rollout_from_tensor_row_ids(
         logprobs=padded_logprobs,
         finish_reason=finish_reason,
         metrics=None,
+        routed_experts=routed_experts,
     )
+
+
+def _completed_routing_rows(
+    prompt_ids: list[list[int]],
+    response_ids: list[list[int]],
+    row_ids: list[int],
+    routed_experts_by_row: list[list[torch.Tensor]] | None,
+) -> list[torch.Tensor] | None:
+    """Materialize completed R3 rows without delaying continuous-batch replies."""
+
+    if routed_experts_by_row is None or not any(routed_experts_by_row):
+        return None
+    completed = []
+    for prompt, response, row_id in zip(prompt_ids, response_ids, row_ids, strict=True):
+        expected = max(len(prompt) + len(response) - 1, 0)
+        routes = routed_experts_by_row[row_id][:expected]
+        if len(routes) != expected:
+            raise RuntimeError(
+                f"rollout routing capture for completed row {row_id} has {len(routes)} tokens, expected {expected}"
+            )
+        completed.append(torch.stack(routes, dim=0).cpu() if routes else torch.empty(0, 0, 0, dtype=torch.long))
+    return completed
 
 
 def _build_rollout_from_tensor_rows(
@@ -835,6 +862,7 @@ def _slice_rollout_output(output: RolloutOutput, start: int, end: int) -> Rollou
         finish_reason=finish_reason,
         metrics=output.metrics,
         adapter_version=output.adapter_version,
+        routed_experts=output.routed_experts[start:end] if output.routed_experts is not None else None,
     )
 
 
@@ -858,4 +886,5 @@ def _slice_rollout_output_rows(output: RolloutOutput, rows: list[int]) -> Rollou
         finish_reason=finish_reason,
         metrics=output.metrics,
         adapter_version=output.adapter_version,
+        routed_experts=[output.routed_experts[row] for row in rows] if output.routed_experts is not None else None,
     )

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -315,7 +315,7 @@ class ArenoWorker:
             response_lens: torch.Tensor,
             finish_reason: str,
             truncate_stop_token_ids: tuple[int, ...],
-            routed_experts: list[list[torch.Tensor]] | None = None,
+            routing_buffer: torch.Tensor | None = None,
         ) -> None:
             for row in rows.detach().cpu().tolist():
                 row_idx = int(row)
@@ -335,7 +335,7 @@ class ArenoWorker:
                         finish_reasons,
                         row_ids,
                         truncate_stop_token_ids,
-                        routed_experts,
+                        routing_buffer,
                     )
                     result_payload = self._stamp_adapter_version(result_payload)
                 request_id = request_ids[request_idx]
@@ -748,7 +748,7 @@ def _build_rollout_from_tensor_row_ids(
     finish_reasons: list[str],
     row_ids: list[int],
     truncate_stop_token_ids: tuple[int, ...],
-    routed_experts_by_row: list[list[torch.Tensor]] | None = None,
+    routing_buffer: torch.Tensor | None = None,
 ) -> RolloutOutput:
     """Build a RolloutOutput for non-contiguous completed tensor rows."""
 
@@ -766,7 +766,7 @@ def _build_rollout_from_tensor_row_ids(
         torch.tensor(row[: len(response)], dtype=torch.float32)
         for row, response in zip(logprob_rows_cpu, response_ids, strict=True)
     ]
-    routed_experts = _completed_routing_rows(prompt_ids, response_ids, row_ids, routed_experts_by_row)
+    routed_experts = _completed_routing_rows(prompt_ids, response_ids, row_ids, routing_buffer)
     input_ids, attention_mask, response_mask, padded_logprobs = pad_rollout_rows(prompt_ids, response_ids, logprob_rows)
     return RolloutOutput(
         prompt_ids=prompt_ids,
@@ -785,22 +785,17 @@ def _completed_routing_rows(
     prompt_ids: list[list[int]],
     response_ids: list[list[int]],
     row_ids: list[int],
-    routed_experts_by_row: list[list[torch.Tensor]] | None,
+    routing_buffer: torch.Tensor | None,
 ) -> list[torch.Tensor] | None:
     """Materialize completed R3 rows without delaying continuous-batch replies."""
 
-    if routed_experts_by_row is None or not any(routed_experts_by_row):
+    if routing_buffer is None:
         return None
-    completed = []
-    for prompt, response, row_id in zip(prompt_ids, response_ids, row_ids, strict=True):
-        expected = max(len(prompt) + len(response) - 1, 0)
-        routes = routed_experts_by_row[row_id][:expected]
-        if len(routes) != expected:
-            raise RuntimeError(
-                f"rollout routing capture for completed row {row_id} has {len(routes)} tokens, expected {expected}"
-            )
-        completed.append(torch.stack(routes, dim=0).cpu() if routes else torch.empty(0, 0, 0, dtype=torch.long))
-    return completed
+    expected = [max(len(prompt) + len(response) - 1, 0) for prompt, response in zip(prompt_ids, response_ids)]
+    max_expected = max(expected, default=0)
+    row_index = torch.tensor(row_ids, device=routing_buffer.device, dtype=torch.long)
+    materialized = routing_buffer.index_select(0, row_index)[:, :max_expected].cpu()
+    return [materialized[row, :count].contiguous() for row, count in enumerate(expected)]
 
 
 def _build_rollout_from_tensor_rows(

--- a/areno/models/bailing/model.py
+++ b/areno/models/bailing/model.py
@@ -89,6 +89,7 @@ from areno.engine.parallel.collectives import (
 )
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.engine.runtime.routing_replay import resolve_sigmoid_routes
 from areno.models.bailing.checkpoint import CHECKPOINT_SPEC
 from areno.models.base import CausalLMOutput, ModelAdapter
 
@@ -129,7 +130,7 @@ class BailingGate(nn.Module):
     during training the bias is updated to push load back towards balance.
     """
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         if config.score_function != "sigmoid":
             raise ValueError(f"BailingGate only supports sigmoid scoring, got {config.score_function!r}")
@@ -143,6 +144,7 @@ class BailingGate(nn.Module):
         self.topk_group = config.topk_group
         self.routed_scaling_factor = config.routed_scaling_factor
         self.router_dtype = config.moe_router_dtype
+        self.routing_layer_slot = routing_layer_slot
         # Router projection: hidden_size -> num_experts logits. Replicated
         # across TP ranks (sequence-parallel on the input side) so every rank
         # sees identical routing decisions and accumulates the gradient via
@@ -170,6 +172,12 @@ class BailingGate(nn.Module):
         # the sigmoid/top-k selection.
         logits = _areno_linear_no_compile(x.to(dtype=self.weight.dtype), self.weight)
         topk_idx, topk_weight = self._forward_grouped_topk(logits)
+        topk_idx, topk_weight = resolve_sigmoid_routes(
+            self.routing_layer_slot,
+            logits,
+            topk_idx,
+            topk_weight,
+        )
         if torch.is_grad_enabled():
             # Only track load when training; eval calls keep counters cold.
             routed_tokens = topk_idx[:-num_padding_tokens] if num_padding_tokens else topk_idx
@@ -233,12 +241,12 @@ class BailingSparseMoeBlock(nn.Module):
     ``areno_fused_experts`` kernel over stacked w1/w2 weight tiles.
     """
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         self.config = config
         self.num_experts = int(config.num_experts or 0)
         self.num_experts_per_tok = config.num_experts_per_tok
-        self.gate = BailingGate(config)
+        self.gate = BailingGate(config, routing_layer_slot)
         self.experts = BailingGroupedExperts(config)
         # Shared experts always run (no routing decision) — their intermediate
         # size scales with ``num_shared_experts``. Output is added to the
@@ -1084,7 +1092,7 @@ class BailingDecoderLayer(nn.Module):
         )
         # Dense MLP for the warmup layers, sparse MoE for the rest.
         self.mlp = (
-            BailingSparseMoeBlock(config)
+            BailingSparseMoeBlock(config, layer_idx - config.first_k_dense_replace)
             if config.num_experts is not None and layer_idx >= config.first_k_dense_replace
             else BailingDenseMLP(config, config.intermediate_size)
         )

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -91,6 +91,7 @@ from areno.engine.parallel.collectives import (
 )
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.engine.runtime.routing_replay import resolve_sigmoid_routes
 from areno.models._shared.dynamo_wrappers import (
     _areno_depthwise_causal_conv1d_silu_decode_no_compile,
     _areno_depthwise_causal_conv1d_silu_no_compile,
@@ -142,7 +143,7 @@ class BailingGate(nn.Module):
     during training the bias is updated to push load back towards balance.
     """
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         if config.score_function != "sigmoid":
             raise ValueError(f"BailingGate only supports sigmoid scoring, got {config.score_function!r}")
@@ -156,6 +157,7 @@ class BailingGate(nn.Module):
         self.topk_group = config.topk_group
         self.routed_scaling_factor = config.routed_scaling_factor
         self.router_dtype = config.moe_router_dtype
+        self.routing_layer_slot = routing_layer_slot
         # Router projection: hidden_size -> num_experts logits. Replicated
         # across TP ranks (sequence-parallel on the input side) so every rank
         # sees identical routing decisions and accumulates the gradient via
@@ -183,6 +185,12 @@ class BailingGate(nn.Module):
         # the sigmoid/top-k selection.
         logits = _areno_linear_no_compile(x.to(dtype=self.weight.dtype), self.weight)
         topk_idx, topk_weight = self._forward_grouped_topk(logits)
+        topk_idx, topk_weight = resolve_sigmoid_routes(
+            self.routing_layer_slot,
+            logits,
+            topk_idx,
+            topk_weight,
+        )
         if torch.is_grad_enabled():
             # Only track load when training; eval calls keep counters cold.
             routed_tokens = topk_idx[:-num_padding_tokens] if num_padding_tokens else topk_idx
@@ -246,12 +254,12 @@ class BailingSparseMoeBlock(nn.Module):
     ``areno_fused_experts`` kernel over stacked w1/w2 weight tiles.
     """
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         self.config = config
         self.num_experts = int(config.num_experts or 0)
         self.num_experts_per_tok = config.num_experts_per_tok
-        self.gate = BailingGate(config)
+        self.gate = BailingGate(config, routing_layer_slot)
         self.experts = BailingGroupedExperts(config)
         # Shared experts always run (no routing decision) — their intermediate
         # size scales with ``num_shared_experts``. Output is added to the
@@ -1507,7 +1515,7 @@ class BailingDecoderLayer(nn.Module):
         )
         # Dense MLP for the warmup layers, sparse MoE for the rest.
         self.mlp = (
-            BailingSparseMoeBlock(config)
+            BailingSparseMoeBlock(config, layer_idx - config.first_k_dense_replace)
             if config.num_experts is not None and layer_idx >= config.first_k_dense_replace
             else BailingDenseMLP(config, config.intermediate_size)
         )

--- a/areno/models/gemma4/model.py
+++ b/areno/models/gemma4/model.py
@@ -68,6 +68,7 @@ from areno.engine.parallel.collectives import (
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.engine.runtime.recompute import checkpoint_layer
+from areno.engine.runtime.routing_replay import resolve_softmax_routes
 from areno.models.base import CausalLMOutput, ModelAdapter
 from areno.models.gemma4.checkpoint import checkpoint_spec
 from areno.models.gemma4_utils import text_embedding_ids
@@ -241,13 +242,14 @@ class Gemma4MoeMLP(nn.Module):
     parallel; router logits are produced outside this module from the residual.
     """
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         if config.num_experts is None:
             raise ValueError("Gemma4 MoE requires num_experts")
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
+        self.routing_layer_slot = routing_layer_slot
         self.per_expert_scale = nn.Parameter(torch.ones(self.num_experts, dtype=torch.float32))
         mark_tensor_parallel_parameter(self.per_expert_scale, False, sequence_parallel=False, tp_grad_allreduce=True)
         self.experts = Gemma4MoeExperts(config)
@@ -267,6 +269,13 @@ class Gemma4MoeMLP(nn.Module):
 
         topk_idx, topk_weight = _areno_topk_softmax_no_compile(
             router_logits.reshape(-1, self.num_experts), self.top_k, self.norm_topk_prob
+        )
+        topk_idx, topk_weight = resolve_softmax_routes(
+            self.routing_layer_slot,
+            router_logits.reshape(-1, self.num_experts),
+            topk_idx,
+            topk_weight,
+            renormalize=self.norm_topk_prob,
         )
         topk_weight = topk_weight * self.per_expert_scale[topk_idx].to(dtype=topk_weight.dtype)
         return topk_idx, topk_weight
@@ -504,7 +513,7 @@ class Gemma4DecoderLayer(nn.Module):
         )
         self.mlp = Gemma4MLP(config, use_double_wide_mlp)
         self.router = Gemma4Router(config) if config.enable_moe_block else None
-        self.moe = Gemma4MoeMLP(config) if config.enable_moe_block else None
+        self.moe = Gemma4MoeMLP(config, layer_idx) if config.enable_moe_block else None
         self.input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
         self.pre_feedforward_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)

--- a/areno/models/qwen3/model.py
+++ b/areno/models/qwen3/model.py
@@ -51,6 +51,7 @@ from areno.engine.parallel.collectives import (
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.engine.runtime.recompute import checkpoint_layer, checkpoint_routed_moe_layer
+from areno.engine.runtime.routing_replay import resolve_softmax_routes
 from areno.models.base import CausalLMOutput, ModelAdapter
 from areno.models.qwen3.checkpoint import CHECKPOINT_SPEC, QWEN3_MOE_CHECKPOINT_SPEC
 
@@ -203,13 +204,14 @@ class Qwen3MoeExperts(nn.Module):
 class Qwen3MoeMLP(nn.Module):
     """Qwen3-MoE router and expert block."""
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         if config.num_experts is None:
             raise ValueError("qwen3_moe requires num_experts")
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
+        self.routing_layer_slot = routing_layer_slot
         self.gate = nn.Parameter(torch.empty(self.num_experts, config.hidden_size, dtype=torch.float32))
         mark_tensor_parallel_parameter(self.gate, False, sequence_parallel=False, tp_grad_allreduce=True)
         self.experts = Qwen3MoeExperts(config)
@@ -233,7 +235,14 @@ class Qwen3MoeMLP(nn.Module):
             flat = hidden_states.reshape(-1, hidden_states.shape[-1])
             logits = _areno_linear_no_compile(flat.to(dtype=self.gate.dtype), self.gate)
             log_once("qwen3_moe_topk_softmax", "using ARENO fused topk_softmax router for Qwen3-MoE")
-            return _areno_topk_softmax_no_compile(logits, self.top_k, self.norm_topk_prob)
+            topk_idx, topk_weight = _areno_topk_softmax_no_compile(logits, self.top_k, self.norm_topk_prob)
+            return resolve_softmax_routes(
+                self.routing_layer_slot,
+                logits,
+                topk_idx,
+                topk_weight,
+                renormalize=self.norm_topk_prob,
+            )
 
     def forward_with_routes(
         self,
@@ -313,7 +322,7 @@ class Qwen3MoeDecoderLayer(QwenDecoderLayer):
 
     def __init__(self, config: ModelConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.mlp = Qwen3MoeMLP(config)
+        self.mlp = Qwen3MoeMLP(config, layer_idx)
 
     def _attention_block(
         self,

--- a/areno/models/qwen3_5/model.py
+++ b/areno/models/qwen3_5/model.py
@@ -46,6 +46,7 @@ from areno.engine.parallel.collectives import (
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.engine.runtime.recompute import checkpoint_layer
+from areno.engine.runtime.routing_replay import resolve_softmax_routes
 from areno.models._shared.dynamo_wrappers import (
     _areno_depthwise_causal_conv1d_silu_decode_no_compile,
     _areno_depthwise_causal_conv1d_silu_no_compile,
@@ -516,13 +517,14 @@ class Qwen35DecoderLayer(nn.Module):
 class Qwen35MoeMLP(nn.Module):
     """Qwen3.5-MoE router, routed experts, and dense shared expert."""
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, routing_layer_slot: int):
         super().__init__()
         if config.num_experts is None:
             raise ValueError("qwen3_5_moe requires num_experts")
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
+        self.routing_layer_slot = routing_layer_slot
         self.gate = nn.Parameter(torch.empty(self.num_experts, config.hidden_size, dtype=torch.float32))
         mark_tensor_parallel_parameter(self.gate, False, sequence_parallel=False, tp_grad_allreduce=True)
         self.experts = Qwen3MoeExperts(config)
@@ -557,6 +559,13 @@ class Qwen35MoeMLP(nn.Module):
             logits = _areno_linear_no_compile(flat.to(dtype=self.gate.dtype), self.gate)
             log_once("qwen35_moe_topk_softmax", "using ARENO fused topk_softmax router for Qwen3.5-MoE")
             topk_idx, topk_weight = _areno_topk_softmax_no_compile(logits, self.top_k, self.norm_topk_prob)
+            topk_idx, topk_weight = resolve_softmax_routes(
+                self.routing_layer_slot,
+                logits,
+                topk_idx,
+                topk_weight,
+                renormalize=self.norm_topk_prob,
+            )
             if self.training:
                 out = self.experts(flat, topk_idx.to(torch.long), topk_weight)
             else:
@@ -636,7 +645,7 @@ class Qwen35MoeDecoderLayer(Qwen35DecoderLayer):
 
     def __init__(self, config: ModelConfig, layer_idx: int):
         super().__init__(config, layer_idx)
-        self.mlp = Qwen35MoeMLP(config)
+        self.mlp = Qwen35MoeMLP(config, layer_idx)
 
     def _attention_block(
         self,

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -137,12 +137,10 @@ signal.
    training engine to the rollout engine. Default: ``64`` MiB.
    CUDA only. MLX does not copy policy weights to a second rollout model.
 
-``--rollout-routing-replay``
-   Enable R3 for sparse-MoE RL training. AReno records each token's expert ids
-   during rollout and reuses those ids in the policy training forward while
-   recomputing routing weights from the current router logits. This preserves
-   router gradients while removing rollout/train expert-selection drift.
-   Supported by the CUDA backend for rollout-based RL algorithms only.
+R3 is enabled automatically for sparse-MoE RL training on CUDA. AReno records
+each token's expert ids during rollout and reuses those ids in the policy
+training forward while recomputing routing weights from the current router
+logits. Dense models and the MLX backend retain their original paths.
 
 For example, the following uses four visible GPUs for training and two
 different visible GPUs for rollout:

--- a/docs/cli/training.rst
+++ b/docs/cli/training.rst
@@ -137,6 +137,13 @@ signal.
    training engine to the rollout engine. Default: ``64`` MiB.
    CUDA only. MLX does not copy policy weights to a second rollout model.
 
+``--rollout-routing-replay``
+   Enable R3 for sparse-MoE RL training. AReno records each token's expert ids
+   during rollout and reuses those ids in the policy training forward while
+   recomputing routing weights from the current router logits. This preserves
+   router gradients while removing rollout/train expert-selection drift.
+   Supported by the CUDA backend for rollout-based RL algorithms only.
+
 For example, the following uses four visible GPUs for training and two
 different visible GPUs for rollout:
 

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -832,8 +832,16 @@ def test_proxy_filters_prompt_exceeding_max_sequence_len_without_rollout():
     assert response["usage"]["max_sequence_len"] == 5
     assert response["areno"]["response_tokens"] == []
     assert response["areno"]["response_logprobs"] == []
+    assert response["areno"]["filtered"] is True
+    assert response["areno"]["filter_reason"] == "max_context_len"
     assert trainer.rollout_batches == []
     assert trainer.rollout_sync_count == 0
+
+    item = next(AgentBatch(records=[{}], prompts=["p"], input_tokens=[[1]], n_samples=1).iter_samples())
+    turn = AgentTrajectoryTurn(item=item, messages=[{"role": "user", "content": "long prompt"}], response=response)
+    assert turn.filtered is True
+    assert turn.response_tokens == []
+    assert turn.routed_experts is None
 
 
 def test_agentic_partial_with_logprobs_completes_http_request():

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -897,6 +897,33 @@ def test_agentic_multi_turn_calls_merge_into_one_training_sample():
     assert record.source_record == {"task": "multi"}
 
 
+def test_agentic_multi_turn_routing_starts_at_shared_prefix_boundary():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    session = RolloutSession(trainer, sampling_params=_FakeSamplingParams(), loss_mask_policy=LossMaskPolicy())
+    item = agentic.AgentItem(record={}, prompt="p", input_tokens=[1, 2], prompt_index=0, sample_index=0)
+    first = _pending_chat(0, _FakeSamplingParams())
+    first.item = item
+    first.input_tokens = [1, 2]
+    second = _pending_chat(0, _FakeSamplingParams())
+    second.item = item
+    second.input_tokens = [1, 2, 99]
+    first_routes = [[[10]], [[11]], [[12]]]
+    second_routes = [[[20]], [[21]], [[22]]]
+
+    first_sample = session._sample_from_pending_chat(
+        first, agentic._ResponseData([10, 11], [-0.1, -0.2], routed_experts=first_routes)
+    )
+    second_sample = session._sample_from_pending_chat(
+        second, agentic._ResponseData([20], [-0.3], routed_experts=second_routes)
+    )
+
+    session._append_sample_response(first_sample, second_sample)
+
+    assert first_sample.token_row == [1, 2, 10, 11, 99, 20]
+    assert first_sample.routed_experts_row == [*first_routes, *second_routes[1:]]
+    assert len(first_sample.routed_experts_row) == len(first_sample.token_row) - 1
+
+
 def test_agentic_interleaved_trajectories_do_not_cross_items():
     """Interleaved agent turns must only merge with the matching AgentItem."""
 

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -7,6 +7,8 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import torch
+
 from areno.api.agentic import AgentTrajectory as RuntimeAgentTrajectory
 from areno.api.tool_call_parser import (
     Gemma4ToolCallParser,
@@ -928,8 +930,33 @@ def test_agentic_multi_turn_routing_starts_at_shared_prefix_boundary():
     session._append_sample_response(first_sample, second_sample)
 
     assert first_sample.token_row == [1, 2, 10, 11, 99, 20]
-    assert first_sample.routed_experts_row == [[[10]], [[11]], [[12]], [[21]], [[22]]]
+    assert torch.equal(
+        first_sample.routed_experts_row,
+        torch.tensor([[[10]], [[11]], [[12]], [[21]], [[22]]], dtype=torch.int16),
+    )
     assert len(first_sample.routed_experts_row) == len(first_sample.token_row) - 1
+
+
+def test_agentic_routing_uses_compact_session_sidecar():
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    session = RolloutSession(trainer, sampling_params=_FakeSamplingParams(), loss_mask_policy=LossMaskPolicy())
+    item = agentic.AgentItem(record={}, prompt="p", input_tokens=[1, 2], prompt_index=0, sample_index=0)
+    pending = _pending_chat(0, _FakeSamplingParams())
+    pending.item = item
+    pending.input_tokens = [1, 2]
+    routes = torch.tensor([[[10]], [[11]]], dtype=torch.int16)
+
+    response = session._build_chat_response(pending, agentic._ResponseData([3], [-0.1], routed_experts=routes))
+    turn = AgentTrajectoryTurn(item=item, messages=pending.messages, response=response)
+
+    assert "routed_experts" not in response["areno"]
+    assert turn.routed_experts is None
+    assert turn.routing_replay_id in session._routing_sidecar
+
+    sample = session._sample_from_trajectory_turn(turn)
+
+    assert torch.equal(sample.routed_experts_row, routes)
+    assert turn.routing_replay_id not in session._routing_sidecar
 
 
 def test_agentic_interleaved_trajectories_do_not_cross_items():

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -920,7 +920,7 @@ def test_agentic_multi_turn_routing_starts_at_shared_prefix_boundary():
     session._append_sample_response(first_sample, second_sample)
 
     assert first_sample.token_row == [1, 2, 10, 11, 99, 20]
-    assert first_sample.routed_experts_row == [*first_routes, *second_routes[1:]]
+    assert first_sample.routed_experts_row == [[[10]], [[11]], [[12]], [[21]], [[22]]]
     assert len(first_sample.routed_experts_row) == len(first_sample.token_row) - 1
 
 

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -685,7 +685,7 @@ def test_agentic_trajectory_filter_respects_configured_max_context_len():
     assert diagnostics["top"][0]["tokens"] == 6
 
 
-def test_agentic_trajectory_filter_counts_concatenated_turns():
+def test_agentic_trajectory_filter_checks_each_exact_turn():
     trainer = _FakeTrainer(world_size=1, tp_size=1)
     session = RolloutSession(trainer, sampling_params=_FakeSamplingParams(), loss_mask_policy=LossMaskPolicy())
     item = agentic.AgentItem(record={}, prompt="p0", input_tokens=[1], prompt_index=0, sample_index=0)
@@ -700,9 +700,14 @@ def test_agentic_trajectory_filter_counts_concatenated_turns():
     policy.config = SimpleNamespace(max_context_len=4)
     policy.areno = SimpleNamespace(model_context_len=lambda: 100)
 
-    kept, filtered, diagnostics = policy._filter_overlong_agent_samples(session, [first], params)
+    kept, filtered, diagnostics = policy._filter_overlong_agent_samples(
+        session,
+        [first],
+        params,
+        turn_samples_by_item={(0, 0): [first, second]},
+    )
 
-    assert len(first.token_row) == 5
+    assert len(first.token_row) == 3
     assert kept == []
     assert filtered == 1
     assert diagnostics["top"][0]["tokens"] == 5

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -863,8 +863,8 @@ def test_agentic_partial_with_logprobs_completes_http_request():
     assert response["areno"]["response_logprobs"] == [-0.3, -0.4]
 
 
-def test_agentic_multi_turn_calls_merge_into_one_training_sample():
-    """Multiple model calls for one agent item should form one trajectory sample."""
+def test_agentic_multi_turn_calls_merge_reward_history_only():
+    """Multiple calls aggregate reward data without fabricating one token row."""
 
     trainer = _FakeTrainer(world_size=1, tp_size=1)
     session = RolloutSession(
@@ -894,10 +894,10 @@ def test_agentic_multi_turn_calls_merge_into_one_training_sample():
     rows = session._train_rows_from_samples([first_sample])
     record = session.reward_record(first_sample)
 
-    assert rows.token_rows == [[1, 2, 10, 11, 30, 31, 20]]
-    assert rows.response_masks == [[False, False, True, True, False, False, True]]
-    assert rows.loss_masks == [[False, False, True, True, False, False, True]]
-    assert rows.rollout_logprobs == [[0.0, 0.0, -0.1, -0.2, 0.0, 0.0, -0.3]]
+    assert rows.token_rows == [[1, 2, 10, 11]]
+    assert rows.response_masks == [[False, False, True, True]]
+    assert rows.loss_masks == [[False, False, True, True]]
+    assert rows.rollout_logprobs == [[0.0, 0.0, -0.1, -0.2]]
     assert record.tokens == [10, 11, 20]
     assert record.tool_results == [{"name": None, "tool_call_id": None, "content": "tool result"}]
     assert record.completion == "10 11\n20"
@@ -907,7 +907,61 @@ def test_agentic_multi_turn_calls_merge_into_one_training_sample():
     assert record.source_record == {"task": "multi"}
 
 
-def test_agentic_multi_turn_routing_starts_at_shared_prefix_boundary():
+def test_agentic_reward_aggregation_does_not_flatten_training_contexts():
+    """Reward history may aggregate turns without inventing a causal token row."""
+
+    trainer = _FakeTrainer(world_size=1, tp_size=1)
+    session = RolloutSession(trainer, sampling_params=_FakeSamplingParams(), loss_mask_policy=LossMaskPolicy())
+    item = agentic.AgentItem(record={"task": "multi"}, prompt="p", input_tokens=[1, 2], prompt_index=0, sample_index=0)
+    first = _pending_chat(0, _FakeSamplingParams())
+    first.item = item
+    first.input_tokens = [1, 2]
+    second = _pending_chat(0, _FakeSamplingParams())
+    second.item = item
+    second.input_tokens = [1, 2, 99]
+
+    aggregate = session._sample_from_pending_chat(first, agentic._ResponseData([10, 11], [-0.1, -0.2]))
+    second_sample = session._sample_from_pending_chat(second, agentic._ResponseData([20], [-0.3]))
+    session._append_sample_response(aggregate, second_sample)
+
+    assert aggregate.token_row == [1, 2, 10, 11]
+    assert aggregate.response_tokens == [10, 11, 20]
+    assert aggregate.response_logprobs == [-0.1, -0.2, -0.3]
+    assert session._train_rows_from_samples([aggregate, second_sample]).token_rows == [
+        [1, 2, 10, 11],
+        [1, 2, 99, 20],
+    ]
+
+
+def test_agentic_turn_rows_share_trajectory_advantage():
+    """Splitting turns must not count them as extra samples in group normalization."""
+
+    from areno.api.rewards import RewardRecord
+
+    batch = SimpleNamespace(
+        token_rows=[[1, 10], [1, 10, 20], [1, 30]],
+        response_masks=[[False, True], [False, False, True], [False, True]],
+        loss_masks=[[False, True], [False, False, True], [False, True]],
+        rollout_logprobs=[[0.0, -0.1], [0.0, 0.0, -0.2], [0.0, -0.3]],
+        features=[None, None, None],
+        routed_experts=None,
+        rewards=[0.0, 1.0],
+        reward_records=[
+            RewardRecord(prompt="p", completion="a", metadata={"prompt_index": 0}),
+            RewardRecord(prompt="p", completion="b", metadata={"prompt_index": 0}),
+        ],
+        row_reward_indices=[0, 0, 1],
+    )
+    policy = object.__new__(PolicyOnlyTrainer)
+
+    train_batch, rewards, _ = policy._materialize_agentic_train_batch(SimpleNamespace(eos_token_id=0), None, batch)
+
+    assert rewards == [0.0, 1.0]
+    assert [sequence.reward for sequence in train_batch] == [0.0, 0.0, 1.0]
+    assert [sequence.scalar_advantage for sequence in train_batch] == [-1.0, -1.0, 1.0]
+
+
+def test_agentic_multi_turn_routing_stays_with_exact_turn_context():
     trainer = _FakeTrainer(world_size=1, tp_size=1)
     session = RolloutSession(trainer, sampling_params=_FakeSamplingParams(), loss_mask_policy=LossMaskPolicy())
     item = agentic.AgentItem(record={}, prompt="p", input_tokens=[1, 2], prompt_index=0, sample_index=0)
@@ -929,12 +983,12 @@ def test_agentic_multi_turn_routing_starts_at_shared_prefix_boundary():
 
     session._append_sample_response(first_sample, second_sample)
 
-    assert first_sample.token_row == [1, 2, 10, 11, 99, 20]
-    assert torch.equal(
-        first_sample.routed_experts_row,
-        torch.tensor([[[10]], [[11]], [[12]], [[21]], [[22]]], dtype=torch.int16),
-    )
+    assert first_sample.token_row == [1, 2, 10, 11]
+    assert torch.equal(first_sample.routed_experts_row, torch.tensor(first_routes, dtype=torch.int16))
+    assert second_sample.token_row == [1, 2, 99, 20]
+    assert torch.equal(second_sample.routed_experts_row, torch.tensor(second_routes, dtype=torch.int16))
     assert len(first_sample.routed_experts_row) == len(first_sample.token_row) - 1
+    assert len(second_sample.routed_experts_row) == len(second_sample.token_row) - 1
 
 
 def test_agentic_routing_uses_compact_session_sidecar():

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -183,6 +183,24 @@ class ConfigAndDataTest(unittest.TestCase):
 
         self.assertEqual(cfg.dp_size, 2)
 
+    def test_engine_config_only_keeps_routing_replay_for_moe_models(self):
+        """Dense models retain their original path when rollout trainers request R3."""
+        dense_runtime = RuntimeConfig(rollout_routing_replay=True)
+        dense = ModelConfig(num_attention_heads=4, num_key_value_heads=4, intermediate_size=16, vocab_size=32)
+        EngineConfig(model=dense, devices=[0], runtime=dense_runtime)
+        self.assertFalse(dense_runtime.rollout_routing_replay)
+
+        moe_runtime = RuntimeConfig(rollout_routing_replay=True)
+        moe = ModelConfig(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=16,
+            vocab_size=32,
+            num_experts=8,
+        )
+        EngineConfig(model=moe, devices=[0], runtime=moe_runtime)
+        self.assertTrue(moe_runtime.rollout_routing_replay)
+
     def test_engine_config_resolves_sequence_parallel_override_before_model_config(self):
         model = ModelConfig(
             num_attention_heads=4,
@@ -631,6 +649,7 @@ class ConfigAndDataTest(unittest.TestCase):
         self.assertTrue(cfg.keep_rollout_state)
         self.assertEqual(cfg.optimizer_state_offload_batch_size, 1)
         self.assertTrue(cfg.cuda_config().runtime["keep_rollout_state"])
+        self.assertTrue(cfg.cuda_config().runtime["rollout_routing_replay"])
         self.assertEqual(cfg.cuda_config().runtime["optimizer_state_offload_batch_size"], 1)
         self.assertTrue(cfg.mlx_config().keep_rollout_state)
 

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -626,6 +626,7 @@ class ConfigAndDataTest(unittest.TestCase):
         )
 
         self.assertEqual(cfg.resolved_max_running_prompts(), 256)
+        self.assertTrue(cfg.cuda_config().runtime["rollout_routing_replay"])
 
     def test_rollout_config_respects_explicit_max_running_prompts(self):
         """An explicit max_running_prompts value should pass through unchanged."""
@@ -649,7 +650,6 @@ class ConfigAndDataTest(unittest.TestCase):
         self.assertTrue(cfg.keep_rollout_state)
         self.assertEqual(cfg.optimizer_state_offload_batch_size, 1)
         self.assertTrue(cfg.cuda_config().runtime["keep_rollout_state"])
-        self.assertTrue(cfg.cuda_config().runtime["rollout_routing_replay"])
         self.assertEqual(cfg.cuda_config().runtime["optimizer_state_offload_batch_size"], 1)
         self.assertTrue(cfg.mlx_config().keep_rollout_state)
 

--- a/tests/test_engine_roles_cpu.py
+++ b/tests/test_engine_roles_cpu.py
@@ -33,6 +33,34 @@ def test_score_logprobs_omits_empty_feature_rows_for_text_model():
     assert rows == [[0.0, 0.0, 0.0]]
 
 
+def test_actor_logprob_scoring_replays_rollout_routes():
+    seen = {}
+
+    class TextModel:
+        def __call__(self, *, input_ids, position_ids, train_meta):
+            del position_ids
+            seen["routes"] = train_meta.routing_replay
+            return SimpleNamespace(logits_shard=torch.zeros((*input_ids.shape, 8)))
+
+    manager = RoleManager(SimpleNamespace(device=torch.device("cpu")))
+    payload = ScorePayload(
+        role="actor",
+        token_rows_by_dp=[[[1, 2, 3]]],
+        features_by_dp=None,
+        pad_token_id=0,
+    )
+    routes = [torch.tensor([[[2, 3]], [[4, 5]]], dtype=torch.int16)]
+
+    with patch("areno.api.backend.cuda.roles.packed_next_token_logprobs", return_value=torch.zeros(2)):
+        rows = manager._score_logprob_rows(
+            TextModel(), [[1, 2, 3]], payload, routed_experts=routes, sequence_parallel=False
+        )
+
+    assert rows == [[0.0, 0.0, 0.0]]
+    assert torch.equal(seen["routes"][:2], routes[0])
+    assert torch.equal(seen["routes"][2], torch.full((1, 2), -1, dtype=torch.int16))
+
+
 def test_worker_role_onload_for_inference_prepares_derived_weights():
     calls = []
 

--- a/tests/test_routing_replay_cpu.py
+++ b/tests/test_routing_replay_cpu.py
@@ -76,6 +76,20 @@ def test_train_pack_pads_last_token_with_dynamic_route_sentinel():
     assert torch.equal(pack["routing_replay"][0, 2], torch.full((2, 2), -1))
 
 
+def test_critic_train_pack_can_drop_actor_routing_replay():
+    seq = TrainSequence(
+        tokens=[10, 11],
+        prompt_mask=[True, False],
+        logprobs=[0.0, -0.1],
+        advantages=[0.0, 1.0],
+        routed_experts=torch.tensor([[[0, 1]]], dtype=torch.int16),
+    )
+
+    pack = make_train_pack([seq], include_routing_replay=False)
+
+    assert "routing_replay" not in pack
+
+
 def test_rollout_state_aligns_prefill_decode_routes_and_trims_final_token():
     state = InferenceBatchState([[10, 11]], max_new_tokens=2, max_running_seqs=1)
     payload = state.build_prefill_payload()

--- a/tests/test_routing_replay_cpu.py
+++ b/tests/test_routing_replay_cpu.py
@@ -4,6 +4,8 @@ import torch
 
 from areno.api.backend.cuda.training import make_train_pack
 from areno.api.models import TrainSequence
+from areno.engine.api import _merge_dp_rollouts_by_prompt_indices
+from areno.engine.data import RolloutOutput
 from areno.engine.data.rollout_state import InferenceBatchState
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
 from areno.engine.runtime.routing_replay import (
@@ -90,3 +92,38 @@ def test_rollout_state_aligns_prefill_decode_routes_and_trims_final_token():
 
     assert output.routed_experts is not None
     assert output.routed_experts[0].tolist() == [[[0, 1]], [[1, 0]], [[2, 3]]]
+
+
+def test_async_dp_merge_preserves_routing_rows_in_prompt_order():
+    routes_0 = torch.tensor([[[0, 1]]], dtype=torch.int16)
+    routes_1 = torch.tensor([[[2, 3]]], dtype=torch.int16)
+    outputs = [
+        _rollout_output([10], [11], routes_0),
+        _rollout_output([20], [21], routes_1),
+    ]
+
+    merged = _merge_dp_rollouts_by_prompt_indices(
+        outputs,
+        prompt_indices_by_dp=[[1], [0]],
+        chunk_start=0,
+        total_count=2,
+    )
+
+    assert merged.prompt_ids == [[20], [10]]
+    assert merged.routed_experts is not None
+    assert torch.equal(merged.routed_experts[0], routes_1)
+    assert torch.equal(merged.routed_experts[1], routes_0)
+
+
+def _rollout_output(prompt: list[int], response: list[int], routes: torch.Tensor) -> RolloutOutput:
+    tokens = prompt + response
+    return RolloutOutput(
+        prompt_ids=[prompt],
+        response_ids=[response],
+        input_ids=torch.tensor([tokens]),
+        attention_mask=torch.ones(1, len(tokens), dtype=torch.long),
+        response_mask=torch.tensor([[False] * len(prompt) + [True] * len(response)]),
+        logprobs=torch.tensor([[-0.1]], dtype=torch.float32),
+        finish_reason=["stop"],
+        routed_experts=[routes],
+    )

--- a/tests/test_routing_replay_cpu.py
+++ b/tests/test_routing_replay_cpu.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import torch
+
+from areno.api.backend.cuda.training import make_train_pack
+from areno.api.models import TrainSequence
+from areno.engine.data.rollout_state import InferenceBatchState
+from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.engine.runtime.routing_replay import (
+    captured_routing,
+    resolve_sigmoid_routes,
+    resolve_softmax_routes,
+    routing_replay_context,
+)
+
+
+def test_softmax_routing_capture_and_replay_keeps_current_router_gradients():
+    logits = torch.tensor([[1.0, 3.0, 2.0], [3.0, 2.0, 1.0]], requires_grad=True)
+    dynamic_idx = torch.tensor([[1, 2], [0, 1]])
+    dynamic_weight = torch.softmax(logits, dim=-1).gather(-1, dynamic_idx)
+    infer_meta = InferMeta(mode="prefill", capture_routing=True)
+
+    with routing_replay_context(infer_meta):
+        resolve_softmax_routes(0, logits, dynamic_idx, dynamic_weight, renormalize=True)
+
+    assert torch.equal(captured_routing(infer_meta), dynamic_idx.unsqueeze(1))
+
+    # The first token is forced to a different route.  -1 marks the final
+    # causal input position, which was not forwarded during rollout.
+    replay = torch.tensor([[[0, 2]], [[-1, -1]]])
+    with routing_replay_context(TrainMeta(routing_replay=replay)):
+        replay_idx, replay_weight = resolve_softmax_routes(0, logits, dynamic_idx, dynamic_weight, renormalize=True)
+
+    assert replay_idx.tolist() == [[0, 2], [0, 1]]
+    (replay_weight * torch.tensor([[1.0, 2.0], [2.0, 1.0]])).sum().backward()
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+    assert bool((logits.grad[0] != 0).any())
+
+
+def test_sigmoid_routing_replay_recomputes_normalized_weights():
+    logits = torch.tensor([[0.0, 1.0, 2.0]])
+    dynamic_idx = torch.tensor([[2, 1]])
+    dynamic_weight = torch.tensor([[0.6, 0.4]])
+    replay = torch.tensor([[[0, 2]]])
+
+    with routing_replay_context(TrainMeta(routing_replay=replay)):
+        replay_idx, replay_weight = resolve_sigmoid_routes(0, logits, dynamic_idx, dynamic_weight)
+
+    expected = torch.sigmoid(logits).gather(-1, replay_idx)
+    expected = expected / expected.sum(dim=-1, keepdim=True)
+    assert replay_idx.tolist() == [[0, 2]]
+    assert torch.allclose(replay_weight, expected)
+
+
+def test_train_pack_pads_last_token_with_dynamic_route_sentinel():
+    routes = [
+        [[0, 1], [2, 3]],
+        [[1, 2], [3, 0]],
+    ]
+    seq = TrainSequence(
+        tokens=[10, 11, 12],
+        prompt_mask=[True, False, False],
+        logprobs=[0.0, -0.1, -0.2],
+        advantages=[0.0, 1.0, 1.0],
+        routed_experts=routes,
+    )
+
+    pack = make_train_pack([seq])
+
+    assert tuple(pack["routing_replay"].shape) == (1, 3, 2, 2)
+    assert torch.equal(pack["routing_replay"][0, :2], torch.tensor(routes))
+    assert torch.equal(pack["routing_replay"][0, 2], torch.full((2, 2), -1))
+
+
+def test_rollout_state_aligns_prefill_decode_routes_and_trims_final_token():
+    state = InferenceBatchState([[10, 11]], max_new_tokens=2, max_running_seqs=1)
+    payload = state.build_prefill_payload()
+    assert payload is not None
+    prefill_routes = torch.tensor([[[0, 1]], [[1, 0]]])
+    state.record_prefill_routing(payload, prefill_routes)
+    state.generated = [[12, 13]]
+    state.logprobs = [[-0.1, -0.2]]
+    state.finish_reason = ["length"]
+    # Decode forwards token 12 before sampling token 13.
+    state.record_decode_routing(torch.tensor([0]), torch.tensor([[[2, 3]]]))
+
+    output = state.to_rollout()
+
+    assert output.routed_experts is not None
+    assert output.routed_experts[0].tolist() == [[[0, 1]], [[1, 0]], [[2, 3]]]

--- a/tests/test_routing_replay_cpu.py
+++ b/tests/test_routing_replay_cpu.py
@@ -63,12 +63,13 @@ def test_train_pack_pads_last_token_with_dynamic_route_sentinel():
         prompt_mask=[True, False, False],
         logprobs=[0.0, -0.1, -0.2],
         advantages=[0.0, 1.0, 1.0],
-        routed_experts=routes,
+        routed_experts=torch.tensor(routes, dtype=torch.int16),
     )
 
     pack = make_train_pack([seq])
 
     assert tuple(pack["routing_replay"].shape) == (1, 3, 2, 2)
+    assert pack["routing_replay"].dtype == torch.int16
     assert torch.equal(pack["routing_replay"][0, :2], torch.tensor(routes))
     assert torch.equal(pack["routing_replay"][0, 2], torch.full((2, 2), -1))
 
@@ -83,7 +84,7 @@ def test_rollout_state_aligns_prefill_decode_routes_and_trims_final_token():
     state.logprobs = [[-0.1, -0.2]]
     state.finish_reason = ["length"]
     # Decode forwards token 12 before sampling token 13.
-    state.record_decode_routing(torch.tensor([0]), torch.tensor([[[2, 3]]]))
+    state.record_decode_routing(torch.tensor([0]), torch.tensor([2]), torch.tensor([[[2, 3]]]))
 
     output = state.to_rollout()
 

--- a/tests/test_runtime_utils_cpu.py
+++ b/tests/test_runtime_utils_cpu.py
@@ -165,6 +165,8 @@ class DecodeGraphUtilityTest(unittest.TestCase):
             )
         graph.logits_shard = torch.zeros(1, 4, 1)
 
+        self.assertIsNone(graph.routing_capture)
+
         graph.replay_tensors(
             input_ids=torch.tensor([11, 12]),
             position_ids=torch.tensor([3, 7]),


### PR DESCRIPTION
## Summary

- Capture MoE expert ids selected during rollout and replay them in the policy training forward.
- Recompute routing weights from current router logits, preserving router gradients while removing rollout/train expert-selection drift.
- Preserve routing metadata through continuous-batching DP merging and agentic multi-turn trajectory assembly.
- Remove host synchronization from route capture to avoid the earlier rollout and training slowdown.
- Enable R3 automatically for CUDA sparse-MoE rollout training. Dense models and MLX retain their original paths.

## Root cause

Two integration gaps made R3 ineffective for agentic RL:

1. Async DP output merging discarded `routed_experts`, so rollout paid the route-capture cost but policy training received no replay metadata.
2. Multi-turn assembly sliced newly rendered routes using the previous training-row length. Chat-template renders can share only a shorter token prefix, so this misaligned routes across turns.

The fix preserves and reorders route rows with their prompts, then appends routes from the actual shared causal-prefix boundary.

## Compatibility

- CUDA sparse-MoE rollout training: R3 enabled automatically.
- Dense models: unchanged original path.
- MLX: unchanged original path.
- Existing rollout callback mocks without routing metadata remain compatible.

## Validation

- Full manual pre-commit suite passed.
- CPU tests cover capture/replay, async DP prompt reordering, agentic prefix boundaries, and dense/MoE default resolution.
- Ling 3.0 Tiny Office agentic E2E produced replay context `(2400, 23, 8)`, `logp_abs_diff_mean=0.005596`, and `logp_diff_mean=0.001522`.

Fixes #522