### PR TITLE
feat(mlx): wire LoRA configuration

### DIFF
--- a/areno/__init__.py
+++ b/areno/__init__.py
@@ -13,26 +13,27 @@ from __future__ import annotations
 
 import os
 
+from areno.engine.log import configure_default_logging
+
 # A single CUDA stream connection keeps NCCL collectives ordered with compute,
 # which is what areno's TP/DP all-reduce + all-gather patterns assume.
 os.environ.setdefault("CUDA_DEVICE_MAX_CONNECTIONS", "1")
 
-try:
-    import torch._dynamo as _dynamo
-except ModuleNotFoundError:
-    _dynamo = None
+def _configure_torch_runtime() -> None:
+    """Apply CUDA runtime defaults only when a Torch-backed API is requested."""
 
-if _dynamo is not None:
+    try:
+        import torch._dynamo as dynamo
+    except ModuleNotFoundError:
+        return
     # Train, prefill, decode, scoring and multiple shape buckets all produce
     # distinct compiled artifacts; raise the cache limits so recompilation does
     # not evict graphs that will be replayed across RL steps.
-    _dynamo.config.cache_size_limit = max(_dynamo.config.cache_size_limit, 64)
+    dynamo.config.cache_size_limit = max(dynamo.config.cache_size_limit, 64)
     try:
-        _dynamo.config.accumulated_cache_size_limit = max(_dynamo.config.accumulated_cache_size_limit, 256)
+        dynamo.config.accumulated_cache_size_limit = max(dynamo.config.accumulated_cache_size_limit, 256)
     except AttributeError:
         pass
-
-from areno.engine.log import configure_default_logging
 
 configure_default_logging()
 
@@ -41,10 +42,12 @@ def __getattr__(name: str):
     """Lazily expose engine symbols without importing kernel-heavy modules."""
 
     if name == "ArenoEngine":
+        _configure_torch_runtime()
         from areno.engine import ArenoEngine
 
         return ArenoEngine
     if name in {"EngineConfig", "ModelConfig", "OptimizerConfig", "RuntimeConfig"}:
+        _configure_torch_runtime()
         from areno.engine import config
 
         return getattr(config, name)
@@ -53,6 +56,7 @@ def __getattr__(name: str):
 
         return LoraConfig
     if name in {"RolloutOutput", "SamplingParams", "TrainStats"}:
+        _configure_torch_runtime()
         from areno.engine import data
 
         return getattr(data, name)

--- a/areno/__init__.py
+++ b/areno/__init__.py
@@ -19,6 +19,7 @@ from areno.engine.log import configure_default_logging
 # which is what areno's TP/DP all-reduce + all-gather patterns assume.
 os.environ.setdefault("CUDA_DEVICE_MAX_CONNECTIONS", "1")
 
+
 def _configure_torch_runtime() -> None:
     """Apply CUDA runtime defaults only when a Torch-backed API is requested."""
 
@@ -34,6 +35,7 @@ def _configure_torch_runtime() -> None:
         dynamo.config.accumulated_cache_size_limit = max(dynamo.config.accumulated_cache_size_limit, 256)
     except AttributeError:
         pass
+
 
 configure_default_logging()
 

--- a/areno/adapters/__init__.py
+++ b/areno/adapters/__init__.py
@@ -1,6 +1,28 @@
-"""Native adapter runtime exposed by AReno."""
+"""Native adapter runtime exposed by AReno.
+
+Keep the configuration type importable on MLX-only installations while
+loading the Torch-backed adapter implementation only when it is requested.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from areno.adapters.config import LoraConfig
-from areno.adapters.lora import AdapterRegistry, LoraSlot, initialize_lora
+
+if TYPE_CHECKING:
+    from areno.adapters.lora import AdapterRegistry, LoraSlot, initialize_lora
+
+
+def __getattr__(name: str) -> Any:
+    if name not in {"AdapterRegistry", "LoraSlot", "initialize_lora"}:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    implementation = import_module("areno.adapters.lora")
+    value = getattr(implementation, name)
+    globals()[name] = value
+    return value
+
 
 __all__ = ["AdapterRegistry", "LoraConfig", "LoraSlot", "initialize_lora"]

--- a/areno/api/__init__.py
+++ b/areno/api/__init__.py
@@ -56,6 +56,7 @@ def __getattr__(name: str) -> Any:
     globals()[name] = value
     return value
 
+
 __all__ = [
     "Trainer",
     "AlgorithmSpec",

--- a/areno/api/__init__.py
+++ b/areno/api/__init__.py
@@ -6,43 +6,55 @@ sampling/rollout/training schemas, and the bundled loss functions without
 having to know the internal package layout.
 """
 
-from areno.api.agentic import (
-    AgentBatch,
-    AgentItem,
-    AgentTrainBatch,
-    AgentTrajectory,
-    AgentTrajectoryTurn,
-    LossMaskPolicy,
-    RolloutSession,
-)
-from areno.api.algorithms import (
-    AlgorithmSpec,
-    dpo_loss_fn,
-    get_algorithm,
-    grpo_loss_fn,
-    gspo_loss_fn,
-    list_algorithms,
-    ppo_loss_fn,
-    register_algorithm,
-    sft_loss_fn,
-)
+from importlib import import_module
+from typing import Any
+
 from areno.api.config import CudaConfig, LoraConfig, MlxConfig, default_backend_type
-from areno.api.data import PromptBatch, PromptItem
-from areno.api.models import (
-    BackendType,
-    RolloutResult,
-    RolloutSequence,
-    SamplingParams,
-    TrainSequence,
-)
-from areno.api.rewards import RewardEvent, RewardRecord
-from areno.api.trainer import Trainer
+from areno.api.models import BackendType
 
 # Friendly aliases mirroring the BackendType enum members. The default is
 # selected from the host platform without importing either backend.
 CUDA = BackendType.CUDA
 MLX = BackendType.MLX
 DefaultBackend = default_backend_type()
+
+_LAZY_EXPORTS = {
+    "AgentBatch": ("areno.api.agentic", "AgentBatch"),
+    "AgentItem": ("areno.api.agentic", "AgentItem"),
+    "AgentTrainBatch": ("areno.api.agentic", "AgentTrainBatch"),
+    "AgentTrajectory": ("areno.api.agentic", "AgentTrajectory"),
+    "AgentTrajectoryTurn": ("areno.api.agentic", "AgentTrajectoryTurn"),
+    "AlgorithmSpec": ("areno.api.algorithms", "AlgorithmSpec"),
+    "LossMaskPolicy": ("areno.api.agentic", "LossMaskPolicy"),
+    "PromptBatch": ("areno.api.data", "PromptBatch"),
+    "PromptItem": ("areno.api.data", "PromptItem"),
+    "RewardEvent": ("areno.api.rewards", "RewardEvent"),
+    "RewardRecord": ("areno.api.rewards", "RewardRecord"),
+    "RolloutResult": ("areno.api.models", "RolloutResult"),
+    "RolloutSequence": ("areno.api.models", "RolloutSequence"),
+    "RolloutSession": ("areno.api.agentic", "RolloutSession"),
+    "SamplingParams": ("areno.api.models", "SamplingParams"),
+    "Trainer": ("areno.api.trainer", "Trainer"),
+    "TrainSequence": ("areno.api.models", "TrainSequence"),
+    "dpo_loss_fn": ("areno.api.algorithms", "dpo_loss_fn"),
+    "get_algorithm": ("areno.api.algorithms", "get_algorithm"),
+    "grpo_loss_fn": ("areno.api.algorithms", "grpo_loss_fn"),
+    "gspo_loss_fn": ("areno.api.algorithms", "gspo_loss_fn"),
+    "list_algorithms": ("areno.api.algorithms", "list_algorithms"),
+    "ppo_loss_fn": ("areno.api.algorithms", "ppo_loss_fn"),
+    "register_algorithm": ("areno.api.algorithms", "register_algorithm"),
+    "sft_loss_fn": ("areno.api.algorithms", "sft_loss_fn"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, symbol_name = target
+    value = getattr(import_module(module_name), symbol_name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "Trainer",

--- a/areno/api/backend/cuda/backend.py
+++ b/areno/api/backend/cuda/backend.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from pathlib import Path
 from threading import Lock
 
+from areno import _configure_torch_runtime
 from areno.api.backend.base import Backend, BackendCapabilities, register_backend
 from areno.api.backend.common import (
     expand_prompt_features,
@@ -43,6 +44,8 @@ from areno.api.config import CudaConfig
 from areno.api.context import Context
 from areno.api.models import BackendType, RolloutResult, RolloutSequence, SamplingParams, TrainSequence
 from areno.api.roles import ModelRole
+
+_configure_torch_runtime()
 
 logger = logging.getLogger(__name__)
 _SYS_PATH_LOCK = Lock()

--- a/areno/api/backend/mlx/backend.py
+++ b/areno/api/backend/mlx/backend.py
@@ -66,6 +66,10 @@ class MlxBackend(Backend):
             config = MlxConfig()
         if not isinstance(config, MlxConfig):
             raise TypeError(f"MlxBackend requires MlxConfig, got {type(config)!r}")
+        if config.lora is not None:
+            raise NotImplementedError(
+                "MLX PEFT LoRA configuration is accepted, but adapter injection is not implemented yet"
+            )
         try:
             import mlx.core as mx
         except ImportError as exc:

--- a/areno/api/config.py
+++ b/areno/api/config.py
@@ -57,9 +57,15 @@ class CudaConfig:
 
 @dataclass(slots=True)
 class MlxConfig:
-    """Configuration for the in-process MLX/MLX-LM backend."""
+    """Configuration for the in-process MLX/MLX-LM backend.
+
+    ``adapter_path`` is the legacy MLX-LM-native adapter input. ``lora`` is
+    the AReno PEFT-compatible LoRA configuration shared with the CUDA backend;
+    the two adapter mechanisms cannot be combined.
+    """
 
     model_path: str | None = None
+    base_model_name_or_path: str | None = field(default=None, kw_only=True)
     adapter_path: str | None = None
     optimizer: dict[str, Any] = field(default_factory=dict)
     max_running_prompts: int = 32
@@ -72,6 +78,19 @@ class MlxConfig:
     logits_chunk_size: int = 4096
     compile_train_step: bool = True
     gradient_checkpointing: bool = True
+    lora: LoraConfig | None = None
+    reference_mode: Literal["independent", "reuse_actor_base"] = "independent"
+
+    def __post_init__(self) -> None:
+        if self.adapter_path is not None and self.lora is not None:
+            raise ValueError("MlxConfig.adapter_path cannot be combined with MlxConfig.lora")
+        if self.reference_mode != "independent":
+            raise ValueError("MLX currently supports only reference_mode='independent'")
+        if self.lora is not None and any(
+            bool(self.optimizer.get(option))
+            for option in ("unfreeze_multimodal_tower", "unfreeze_multimodal_projector")
+        ):
+            raise ValueError("MLX LoRA cannot be combined with multimodal tower or projector unfreezing")
 
 
 BackendConfig = CudaConfig | MlxConfig

--- a/areno/api/trainer_config.py
+++ b/areno/api/trainer_config.py
@@ -121,8 +121,8 @@ class TrainerConfig:
             self.multimodal_projector_lr_decay_steps,
             self.multimodal_projector_lr_decay_style,
         )
-        if self.lora is not None and self.backend != "cuda":
-            raise ValueError("native LoRA is only supported by the CUDA backend")
+        if self.backend == "mlx" and self.reference_mode != "independent":
+            raise ValueError("MLX currently supports only reference_mode='independent'")
 
     @staticmethod
     def _validate_multimodal_optimizer_group(
@@ -188,10 +188,13 @@ class TrainerConfig:
         from areno.api.config import MlxConfig
 
         return MlxConfig(
+            base_model_name_or_path=self.base_model_name_or_path,
             optimizer=self.optimizer_config(),
             keep_rollout_state=self.keep_rollout_state,
             compile_train_step=True,
             gradient_checkpointing=self.activation_checkpointing,
+            lora=self.lora,
+            reference_mode=self.reference_mode,
         )
 
     def cuda_config(self):
@@ -282,6 +285,7 @@ class RolloutTrainerConfig(TrainerConfig):
 
         max_running = self.resolved_max_running_prompts()
         return MlxConfig(
+            base_model_name_or_path=self.base_model_name_or_path,
             optimizer=self.optimizer_config(),
             max_running_prompts=max_running,
             completion_batch_size=max_running,
@@ -289,6 +293,8 @@ class RolloutTrainerConfig(TrainerConfig):
             keep_rollout_state=self.keep_rollout_state,
             compile_train_step=True,
             gradient_checkpointing=self.activation_checkpointing,
+            lora=self.lora,
+            reference_mode=self.reference_mode,
         )
 
 

--- a/areno/cli/serve.py
+++ b/areno/cli/serve.py
@@ -257,11 +257,15 @@ class _MlxServeRuntime:
         *,
         max_running_prompts: int,
         decode_progress_interval_s: float,
+        lora: LoraConfig | None,
+        base_model_name_or_path: str | None,
     ) -> None:
         config = MlxConfig(
             model_path=model_path,
+            base_model_name_or_path=base_model_name_or_path,
             max_running_prompts=max_running_prompts,
             decode_progress_interval_s=decode_progress_interval_s,
+            lora=lora,
         )
         self._trainer = Trainer(1, model_path, backend_type=MLX, custom_config=config)
         self._trainer.init()
@@ -315,14 +319,14 @@ def _create_serve_runtime(
     base_model_name_or_path: str | None,
 ) -> _CudaServeRuntime | _MlxServeRuntime:
     if backend_type == MLX:
-        if lora is not None:
-            raise ValueError("native LoRA serving is only supported by the CUDA backend")
         if world_size != 1 or tp_size != 1:
             raise ValueError("MLX serving requires --world-size 1 and --tp-size 1")
         return _MlxServeRuntime(
             model_path,
             max_running_prompts=max_running_prompts,
             decode_progress_interval_s=decode_progress_interval_s,
+            lora=lora,
+            base_model_name_or_path=base_model_name_or_path,
         )
     del max_running_prompts
     return _CudaServeRuntime(

--- a/areno/engine/worker.py
+++ b/areno/engine/worker.py
@@ -20,6 +20,7 @@ import queue
 import torch
 import torch.distributed as dist
 
+from areno import _configure_torch_runtime
 from areno.adapters import initialize_lora
 from areno.adapters.peft import export_peft_adapter, load_peft_adapter
 from areno.api.backend.cuda.roles import RoleManager, WorkerRole
@@ -57,6 +58,7 @@ class ArenoWorker:
     """
 
     def __init__(self, config: EngineConfig):
+        _configure_torch_runtime()
         self.config = config
         ctx = get_tp_context()
         self.device = ctx.device

--- a/tests/test_adapter_imports_cpu.py
+++ b/tests/test_adapter_imports_cpu.py
@@ -1,0 +1,55 @@
+"""Import-boundary checks for backend-neutral adapter configuration."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_config_imports_do_not_load_torch_or_native_lora() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    script = r"""
+import importlib.abc
+import sys
+
+
+class BlockHeavyImports(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        del path, target
+        if fullname == "torch" or fullname.startswith("torch.") or fullname == "areno.adapters.lora":
+            raise AssertionError(f"unexpected heavy import: {fullname}")
+        return None
+
+
+sys.meta_path.insert(0, BlockHeavyImports())
+
+from areno.adapters import LoraConfig as PublicLoraConfig
+from areno.adapters.config import LoraConfig
+from areno.api.config import MlxConfig
+from areno.api.trainer_config import TrainerConfig
+
+assert PublicLoraConfig is LoraConfig
+assert MlxConfig(lora=LoraConfig()).lora is not None
+assert TrainerConfig(algo="sft", backend="mlx", ckpt="model", dataset_path="data").backend == "mlx"
+assert "torch" not in sys.modules
+assert "areno.adapters.lora" not in sys.modules
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_native_adapter_public_exports_remain_available() -> None:
+    from areno.adapters import AdapterRegistry, LoraSlot, initialize_lora
+
+    assert AdapterRegistry.__module__ == "areno.adapters.lora"
+    assert LoraSlot.__module__ == "areno.adapters.lora"
+    assert initialize_lora.__module__ == "areno.adapters.lora"

--- a/tests/test_config_data_cpu.py
+++ b/tests/test_config_data_cpu.py
@@ -294,6 +294,7 @@ class ConfigAndDataTest(unittest.TestCase):
     def test_trainer_config_propagates_lora_reference_view(self):
         config = TrainerConfig(
             algo="dpo",
+            backend="cuda",
             ckpt="actor",
             dataset_path="dataset",
             lora=LoraConfig(),
@@ -301,6 +302,73 @@ class ConfigAndDataTest(unittest.TestCase):
         )
 
         self.assertEqual(config.cuda_config().reference_mode, "reuse_actor_base")
+
+    def test_trainer_config_propagates_lora_to_mlx_config(self):
+        lora = LoraConfig(rank=4, alpha=8)
+        base_config = TrainerConfig(
+            algo="sft",
+            backend="mlx",
+            ckpt="resolved/model",
+            base_model_name_or_path="org/model",
+            dataset_path="dataset",
+            lora=lora,
+        )
+        config = RolloutTrainerConfig(
+            algo="gspo",
+            backend="mlx",
+            ckpt="resolved/model",
+            base_model_name_or_path="org/model",
+            dataset_path="dataset",
+            lora=lora,
+            batch_size=2,
+            n_samples=2,
+        )
+
+        base_mlx = base_config.mlx_config()
+        mlx = config.mlx_config()
+
+        self.assertIs(base_mlx.lora, lora)
+        self.assertEqual(base_mlx.base_model_name_or_path, "org/model")
+        self.assertIs(mlx.lora, lora)
+        self.assertEqual(mlx.base_model_name_or_path, "org/model")
+        self.assertEqual(mlx.reference_mode, "independent")
+        self.assertEqual(mlx.max_running_prompts, 4)
+
+    def test_mlx_config_rejects_ambiguous_adapter_inputs(self):
+        from areno.api.config import MlxConfig
+
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            MlxConfig(adapter_path="mlx-native-adapter", lora=LoraConfig())
+
+    def test_mlx_config_rejects_lora_with_multimodal_unfreezing(self):
+        from areno.api.config import MlxConfig
+
+        for option in ("unfreeze_multimodal_tower", "unfreeze_multimodal_projector"):
+            with self.subTest(option=option):
+                with self.assertRaisesRegex(ValueError, "cannot be combined with multimodal"):
+                    MlxConfig(lora=LoraConfig(), optimizer={option: True})
+
+    def test_mlx_trainer_rejects_unsupported_reference_and_multimodal_unfreezing(self):
+        with self.assertRaisesRegex(ValueError, "only reference_mode='independent'"):
+            TrainerConfig(
+                algo="dpo",
+                backend="mlx",
+                ckpt="actor",
+                dataset_path="dataset",
+                lora=LoraConfig(),
+                reference_mode="reuse_actor_base",
+            )
+
+        config = TrainerConfig(
+            algo="sft",
+            backend="mlx",
+            ckpt="actor",
+            dataset_path="dataset",
+            lora=LoraConfig(),
+            unfreeze_multimodal_projector=True,
+        )
+        with self.assertRaisesRegex(ValueError, "cannot be combined with multimodal"):
+            config.mlx_config()
 
     def test_adapter_path_uses_peft_metadata(self):
         """A PEFT artifact should configure non-default native slots itself."""

--- a/tests/test_import_boundaries_cpu.py
+++ b/tests/test_import_boundaries_cpu.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+from types import SimpleNamespace
+
+import pytest
 
 
 def test_public_api_imports_do_not_load_engine_heavy_modules():
@@ -37,3 +40,28 @@ def test_public_api_imports_do_not_load_engine_heavy_modules():
         [sys.executable, "-c", script],
         check=True,
     )
+
+
+def test_cuda_worker_configures_torch_runtime_before_model_build(monkeypatch):
+    """Spawned workers must restore Dynamo limits before model construction or compilation."""
+
+    from areno.engine import worker as worker_mod
+
+    events = []
+
+    class ModelBuildReached(Exception):
+        pass
+
+    def build_model(*args, **kwargs):
+        del args, kwargs
+        events.append("build_model")
+        raise ModelBuildReached
+
+    monkeypatch.setattr(worker_mod, "_configure_torch_runtime", lambda: events.append("configure_torch"))
+    monkeypatch.setattr(worker_mod, "get_tp_context", lambda: SimpleNamespace(device="cuda:0"))
+    monkeypatch.setattr(worker_mod, "build_model_on_device", build_model)
+
+    with pytest.raises(ModelBuildReached):
+        worker_mod.ArenoWorker(SimpleNamespace())
+
+    assert events == ["configure_torch", "build_model"]

--- a/tests/test_mlx_training_cpu.py
+++ b/tests/test_mlx_training_cpu.py
@@ -224,6 +224,56 @@ def test_mlx_backend_uses_default_config_before_loading_provider(monkeypatch):
     assert backend.config == MlxConfig()
 
 
+def test_mlx_backend_forwards_legacy_native_adapter_path(monkeypatch):
+    from areno.api.backend.mlx.backend import MlxBackend
+    from areno.api.config import MlxConfig
+
+    mlx_module = ModuleType("mlx")
+    mlx_core_module = ModuleType("mlx.core")
+    mlx_module.core = mlx_core_module
+    monkeypatch.setitem(sys.modules, "mlx", mlx_module)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core_module)
+
+    class ProviderLoadReached(Exception):
+        pass
+
+    def load_provider(model_path, *, adapter_path=None):
+        assert model_path == "model"
+        assert adapter_path == "mlx-native-adapter"
+        raise ProviderLoadReached
+
+    monkeypatch.setattr("areno.api.backend.mlx.backend.load_provider", load_provider)
+    config = MlxConfig(adapter_path="mlx-native-adapter")
+    backend = MlxBackend()
+    ctx = SimpleNamespace(world_size=1, custom_config=config, model_path="model")
+
+    with pytest.raises(ProviderLoadReached):
+        backend.initialize(ctx)
+
+    assert backend.config is config
+
+
+def test_mlx_backend_rejects_peft_lora_before_loading_provider(monkeypatch):
+    from areno.adapters import LoraConfig
+    from areno.api.backend.mlx.backend import MlxBackend
+    from areno.api.config import MlxConfig
+
+    def unexpected_load(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("provider loading must not start before MLX LoRA injection exists")
+
+    monkeypatch.setattr("areno.api.backend.mlx.backend.load_provider", unexpected_load)
+    backend = MlxBackend()
+    ctx = SimpleNamespace(
+        world_size=1,
+        custom_config=MlxConfig(lora=LoraConfig()),
+        model_path="model",
+    )
+
+    with pytest.raises(NotImplementedError, match="adapter injection is not implemented"):
+        backend.initialize(ctx)
+
+
 def test_adam8bit_lazy_state_remains_stable_after_zero_gradient_steps():
     mx = pytest.importorskip("mlx.core")
     nn = pytest.importorskip("mlx.nn")

--- a/tests/test_serve_cli_cpu.py
+++ b/tests/test_serve_cli_cpu.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from areno.adapters import LoraConfig
 from areno.api.tokenizer import configure_chat_template_enable_thinking
 from areno.api.tool_call_parser import QwenToolCallParser
 from areno.cli import serve as serve_mod
@@ -122,6 +123,52 @@ def test_serve_default_model_hub_is_modelscope():
     option = next(param for param in serve_mod.serve_command.params if param.name == "model_hub")
 
     assert option.default == "modelscope"
+
+
+def test_mlx_serve_runtime_receives_peft_lora_config(monkeypatch):
+    captured = {}
+
+    class FakeTrainer:
+        def __init__(self, world_size, model_path, *, backend_type, custom_config):
+            captured.update(
+                world_size=world_size,
+                model_path=model_path,
+                backend_type=backend_type,
+                custom_config=custom_config,
+            )
+
+        def init(self):
+            pass
+
+        def get_tokenizer(self):
+            return SimpleNamespace()
+
+        def get_processor(self):
+            return None
+
+        def model_context_len(self):
+            return 1024
+
+    lora = LoraConfig(rank=4, alpha=8)
+    monkeypatch.setattr(serve_mod, "Trainer", FakeTrainer)
+
+    runtime = serve_mod._create_serve_runtime(
+        model_path="resolved/model",
+        backend_type=serve_mod.MLX,
+        tp_size=1,
+        world_size=1,
+        max_running_prompts=4,
+        decode_progress_interval_s=0.5,
+        eager_decode=False,
+        attn_backend="native",
+        lora=lora,
+        base_model_name_or_path="org/model",
+    )
+
+    assert isinstance(runtime, serve_mod._MlxServeRuntime)
+    assert captured["backend_type"] == serve_mod.MLX
+    assert captured["custom_config"].lora is lora
+    assert captured["custom_config"].base_model_name_or_path == "org/model"
 
 
 def test_chat_completion_request_defaults_match_sampling_params():


### PR DESCRIPTION
## What does this PR do?

This PR implements the configuration and API-wiring foundation for MLX LoRA support.

- Adds PEFT-compatible LoRA, base-model, and reference-mode fields to `MlxConfig`.
- Propagates LoRA configuration through MLX training and serving setup while preserving the legacy MLX-LM-native `adapter_path` behavior.
- Rejects ambiguous or unsupported MLX combinations and fails fast before model loading until adapter injection is implemented in the next phase.
- Keeps backend-neutral MLX/config imports Torch-free by lazily loading Torch-backed adapter and API symbols, while preserving TorchDynamo setup for CUDA backends and spawned workers.

This is the configuration phase only. MLX adapter injection, PEFT weight conversion, adapter checkpoint export, and functional LoRA serving remain intentionally blocked by an explicit `NotImplementedError`.

## Related issue

None.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

```bash
.venv/bin/python -m pytest \
  tests/test_adapter_imports_cpu.py \
  tests/test_config_data_cpu.py::ConfigAndDataTest::test_trainer_config_propagates_lora_reference_view \
  tests/test_config_data_cpu.py::ConfigAndDataTest::test_trainer_config_propagates_lora_to_mlx_config \
  tests/test_config_data_cpu.py::ConfigAndDataTest::test_mlx_config_rejects_ambiguous_adapter_inputs \
  tests/test_config_data_cpu.py::ConfigAndDataTest::test_mlx_config_rejects_lora_with_multimodal_unfreezing \
  tests/test_config_data_cpu.py::ConfigAndDataTest::test_mlx_trainer_rejects_unsupported_reference_and_multimodal_unfreezing \
  tests/test_import_boundaries_cpu.py \
  tests/test_mlx_training_cpu.py::test_mlx_backend_forwards_legacy_native_adapter_path \
  tests/test_mlx_training_cpu.py::test_mlx_backend_rejects_peft_lora_before_loading_provider \
  tests/test_serve_cli_cpu.py::test_mlx_serve_runtime_receives_peft_lora_config
```

Result: `12 passed in 2.87s`.

Additional checks:

- Ruff passed for all changed and added Python files.
- `python -m compileall` passed for the changed Python files.
- `git diff --check` passed.

Hardware limitations: validation was performed on macOS without running Metal training or GPU tests. Functional MLX LoRA execution is outside this phase and remains explicitly disabled.

## Checklist

- [x] The PR title summarizes the contribution.
- [ ] Linked the related issue in the description (if any).
- [ ] Existing tests pass (`pytest tests/ -k cpu`).
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
