### PR TITLE
fix(api): normalize Qwen3 tool calls

### DIFF
--- a/areno/api/openai_chat.py
+++ b/areno/api/openai_chat.py
@@ -160,15 +160,18 @@ def build_chat_completion_response(
         display_text = _decode(tokenizer, token_ids, skip_special_tokens=True)
         display_text, stop_hit = _trim_stop_strings(display_text, stop_strings)
         completion_tokens += len(token_ids)
+        tool_parse = tool_call_parser.parse(raw_text, tools, tool_choice) if tools and tool_call_parser is not None else None
         tool_calls = (
             parsed_tool_calls[index] if parsed_tool_calls is not None and index < len(parsed_tool_calls) else []
         )
-        if not tool_calls and tools and tool_call_parser is not None:
-            tool_calls = tool_call_parser.parse(raw_text, tools, tool_choice).tool_calls
+        if not tool_calls and tool_parse is not None:
+            tool_calls = tool_parse.tool_calls
         finish_reason = "stop" if stop_hit or finish_reasons[index] == "stop" else "length"
         message: dict[str, Any] = {"role": "assistant", "content": display_text}
         if tool_calls:
             message = {"role": "assistant", "content": None, "tool_calls": tool_calls}
+            if tool_parse is not None and tool_parse.tool_calls and tool_parse.normal_text:
+                message["reasoning_content"] = tool_parse.normal_text
             finish_reason = "tool_calls"
         choices.append({"index": index, "message": message, "finish_reason": finish_reason})
 

--- a/areno/api/tool_call_parser.py
+++ b/areno/api/tool_call_parser.py
@@ -96,9 +96,15 @@ class QwenToolCallParser(JsonToolCallParser):
     def parse(self, content: str, tools: list[dict[str, Any]], tool_choice: Any) -> ToolCallParseResult:
         calls: list[dict[str, Any]] = []
         for block in self._block_re.findall(content):
-            calls.extend(_parse_json_tool_calls(block, tools, _chosen_tool_name(tools, tool_choice)))
-            calls.extend(_parse_angle_tool_calls(block, tools, tool_choice))
-            calls.extend(_parse_arg_key_value_tool_calls(block, tools, tool_choice))
+            block_calls = _parse_json_tool_calls(
+                block,
+                tools,
+                _chosen_tool_name(tools, tool_choice),
+                recover_unknown_name_as_chosen=True,
+            )
+            block_calls.extend(_parse_angle_tool_calls(block, tools, tool_choice))
+            block_calls.extend(_parse_arg_key_value_tool_calls(block, tools, tool_choice))
+            calls.extend(block_calls)
         if calls:
             normal = content[: content.find("<tool_call>")].strip()
             return ToolCallParseResult(normal_text=normal, tool_calls=calls)
@@ -186,7 +192,13 @@ def _read_model_type(model_path: str) -> str:
     return " ".join(part for part in (model_type, text_type, architectures) if part)
 
 
-def _parse_json_tool_calls(content: str, tools: list[dict[str, Any]], chosen_name: str | None) -> list[dict[str, Any]]:
+def _parse_json_tool_calls(
+    content: str,
+    tools: list[dict[str, Any]],
+    chosen_name: str | None,
+    *,
+    recover_unknown_name_as_chosen: bool = False,
+) -> list[dict[str, Any]]:
     obj = _load_json_object(content)
     if obj is None:
         return []
@@ -206,6 +218,19 @@ def _parse_json_tool_calls(content: str, tools: list[dict[str, Any]], chosen_nam
         name, args = parsed
         if _tool_name_allowed(name, tools, _forced_tool_choice(chosen_name)):
             calls.append(_openai_tool_call(name, args))
+            continue
+        # Qwen3 occasionally emits the selected action value as ``name`` while
+        # placing the same value correctly inside the sole function's arguments,
+        # for example ``{"name":"guess:WORD","arguments":{"action":"guess:WORD"}}``.
+        # Recover only an unknown name, only when one function was explicitly
+        # selected, and only when the arguments satisfy that function's schema.
+        if (
+            recover_unknown_name_as_chosen
+            and chosen_name is not None
+            and name not in _tool_names(tools)
+            and _arguments_match_tool_schema(chosen_name, args, tools)
+        ):
+            calls.append(_openai_tool_call(chosen_name, args))
     return calls
 
 
@@ -299,6 +324,60 @@ def _tool_function(tool: dict[str, Any]) -> dict[str, Any] | None:
             "parameters": tool.get("parameters"),
         }
     return None
+
+
+def _arguments_match_tool_schema(name: str, arguments: dict[str, Any], tools: list[dict[str, Any]]) -> bool:
+    """Return whether arguments satisfy the selected tool's relevant JSON schema."""
+
+    for tool in tools:
+        function = _tool_function(tool)
+        if not isinstance(function, dict) or function.get("name") != name:
+            continue
+        parameters = function.get("parameters")
+        return not isinstance(parameters, dict) or _value_matches_schema(arguments, parameters)
+    return False
+
+
+def _value_matches_schema(value: Any, schema: dict[str, Any]) -> bool:
+    if "const" in schema and value != schema["const"]:
+        return False
+    enum = schema.get("enum")
+    if isinstance(enum, list) and value not in enum:
+        return False
+    schema_type = schema.get("type")
+    if schema_type == "object":
+        if not isinstance(value, dict):
+            return False
+        properties = schema.get("properties") or {}
+        if not isinstance(properties, dict):
+            return False
+        required = schema.get("required") or []
+        if not isinstance(required, list) or any(key not in value for key in required):
+            return False
+        if schema.get("additionalProperties") is False and any(key not in properties for key in value):
+            return False
+        return all(
+            key not in properties
+            or not isinstance(properties[key], dict)
+            or _value_matches_schema(item, properties[key])
+            for key, item in value.items()
+        )
+    if schema_type == "array":
+        if not isinstance(value, list):
+            return False
+        items = schema.get("items")
+        return not isinstance(items, dict) or all(_value_matches_schema(item, items) for item in value)
+    if schema_type == "string":
+        return isinstance(value, str)
+    if schema_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if schema_type == "number":
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if schema_type == "boolean":
+        return isinstance(value, bool)
+    if schema_type == "null":
+        return value is None
+    return True
 
 
 def _parse_gemma4_call(inner: str) -> tuple[str, dict[str, Any]] | None:

--- a/tests/test_agentic_cpu.py
+++ b/tests/test_agentic_cpu.py
@@ -1221,6 +1221,71 @@ def test_qwen_tool_call_parser_supports_chat_completions_tools():
     assert '"direction":"right"' in parsed.tool_calls[0]["function"]["arguments"]
 
 
+def test_qwen_tool_call_parser_recovers_action_value_emitted_as_tool_name():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "access_terminal",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["guess:BATTERY", "probe:P0"],
+                        }
+                    },
+                    "required": ["action"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    parsed = QwenToolCallParser().parse(
+        "<think>Compare every candidate.</think>\n"
+        '<tool_call>{"name":"guess:BATTERY","arguments":{"action":"guess:BATTERY"}}</tool_call>',
+        tools,
+        "required",
+    )
+
+    assert parsed.normal_text == "<think>Compare every candidate.</think>"
+    assert len(parsed.tool_calls) == 1
+    assert parsed.tool_calls[0]["function"]["name"] == "access_terminal"
+    assert json.loads(parsed.tool_calls[0]["function"]["arguments"]) == {"action": "guess:BATTERY"}
+
+
+def test_qwen_tool_call_parser_rejects_misnamed_call_when_arguments_do_not_match_schema():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "access_terminal",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"action": {"type": "string", "enum": ["guess:BATTERY"]}},
+                    "required": ["action"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    invalid_enum = QwenToolCallParser().parse(
+        '<tool_call>{"name":"guess:UNKNOWN","arguments":{"action":"guess:UNKNOWN"}}</tool_call>',
+        tools,
+        "required",
+    )
+    extra_argument = QwenToolCallParser().parse(
+        '<tool_call>{"name":"guess:BATTERY","arguments":{"action":"guess:BATTERY","extra":true}}</tool_call>',
+        tools,
+        "required",
+    )
+
+    assert invalid_enum.tool_calls == []
+    assert extra_argument.tool_calls == []
+
+
 def test_qwen_tool_call_parser_supports_angle_function_blocks():
     tools = [
         {

--- a/tests/test_serve_cli_cpu.py
+++ b/tests/test_serve_cli_cpu.py
@@ -171,6 +171,58 @@ def test_serve_response_reuses_tool_call_parser():
     assert '"direction":"left"' in choice.message["tool_calls"][0]["function"]["arguments"]
 
 
+def test_serve_response_normalizes_qwen_action_value_used_as_tool_name():
+    tokenizer = _TokenTokenizer(
+        {
+            1: "<think>Compare every candidate.</think>",
+            2: "<tool_call>",
+            3: '{"name":"guess:BATTERY","arguments":{"action":"guess:BATTERY"}}',
+            4: "</tool_call>",
+        }
+    )
+    request = serve_mod.ChatCompletionRequest(
+        model="areno",
+        messages=[serve_mod.ChatMessage(role="user", content="choose")],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "access_terminal",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "enum": ["guess:BATTERY", "probe:P0"],
+                            }
+                        },
+                        "required": ["action"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        ],
+        tool_choice="required",
+    )
+
+    response = serve_mod._build_response_from(
+        tokenizer,
+        "model",
+        QwenToolCallParser(),
+        request,
+        [10, 11],
+        [[1, 2, 3, 4]],
+        ["stop"],
+    )
+
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message["content"] is None
+    assert choice.message["reasoning_content"] == "<think>Compare every candidate.</think>"
+    assert choice.message["tool_calls"][0]["function"]["name"] == "access_terminal"
+    assert choice.message["tool_calls"][0]["function"]["arguments"] == '{"action":"guess:BATTERY"}'
+
+
 def test_serve_text_response_preserves_decoded_content():
     class ThinkTokenizer:
         def decode(self, token_ids, *, skip_special_tokens=False):
@@ -224,7 +276,7 @@ def test_serve_usage_counts_prompt_tokens_once_for_multiple_completions():
     assert response.usage.total_tokens == len(prompt) + 4
 
 
-def test_serve_tool_call_response_does_not_attach_reasoning_content():
+def test_serve_tool_call_response_preserves_reasoning_content():
     tokenizer = _TokenTokenizer(
         {
             1: "<think>block the fork</think>",
@@ -257,7 +309,7 @@ def test_serve_tool_call_response_does_not_attach_reasoning_content():
 
     choice = response.choices[0]
     assert choice.message["content"] is None
-    assert "reasoning_content" not in choice.message
+    assert choice.message["reasoning_content"] == "<think>block the fork</think>"
     assert choice.message["tool_calls"][0]["function"]["name"] == "choose_move"
 
 


### PR DESCRIPTION
## Summary
- recover Qwen3 tool calls that emit an action value as the tool name when the selected tool and schema make the intent unambiguous
- validate recovered arguments against the selected tool schema
- preserve parsed reasoning content on tool-call responses
- add parser and response regression coverage

## Validation
- `git diff --check`
- Python compilation passed for changed Python modules
- targeted pytest could not collect locally because `torch` is not installed
