### PR TITLE
feat(example): add terminal hacking agentic demo

### DIFF
--- a/examples/agentic/terminal_hacking/README.md
+++ b/examples/agentic/terminal_hacking/README.md
@@ -1,0 +1,74 @@
+# Retro Terminal Hacking — Agentic RL
+
+An original retro-futurist word-deduction environment inspired by classic CRT terminal minigames. It reproduces the interaction grammar—memory dumps, positional word matches, limited attempts, and bracket bonuses—without shipping game logos, text, or visual assets.
+
+## How it works
+
+- Each puzzle uses 16–20 same-length candidate words, three bracket probes, and at least 18 rows of memory dump.
+- A wrong guess consumes one of three buffered attempts and returns `likeness`, the number of letters matching the password in the same positions.
+- RLVR is a single-step contextual-bandit task: one compact state goes in and one `submit_candidates` set comes out. No game action is executed inside the training rollout.
+- WebUI keeps the playable loop: it uses the exact RLVR candidate-filter prompt, randomly guesses one returned candidate, and uses a free probe at the last ambiguous attempt.
+- Hidden passwords remain in `source_record`; prompts expose only observable guesses and likeness values.
+- Reward is dense and asymmetric: extra inconsistent candidates are heavily penalized, while omitting consistent candidates receives only a small proportional penalty.
+
+## Generate 8,192 unique puzzles
+
+```bash
+python examples/agentic/terminal_hacking/dataset_generator.py \
+  --output /tmp/terminal_hacking.jsonl \
+  --count 8192 \
+  --workers 20 \
+  --seed 2026
+```
+
+The generator uses unique per-record seeds and verifies complete puzzle fingerprints, so duplicate records are regenerated rather than merely receiving different IDs.
+
+## Train
+
+```bash
+areno train \
+  --ckpt inclusionai/ling-3.0-tiny \
+  --dataset-path /tmp/terminal_hacking.jsonl \
+  --dataset-loader-fn examples/agentic/terminal_hacking/dataset_loader.py \
+  --reward-fn-path examples/agentic/terminal_hacking/reward.py \
+  --agent-fn examples/agentic/terminal_hacking/run_agent.py \
+  --algo gspo \
+  --batch-size 4 \
+  --n-samples 8 \
+  --mini-bs 1 \
+  --max-running-prompts 32 \
+  --max-context-len 8192 \
+  --max-prompt-tokens 4096 \
+  --max-new-tokens 1024
+```
+
+RLVR and the WebUI candidate-selection call use the same helper in `game.py`: candidate-filter system prompt, immutable memory-dump prompt, compact current state, and one dynamic `submit_candidates` schema. RLVR produces exactly one completion and never runs an episode. WebUI keeps candidates internal and converts them into a random visible guess; probe handling remains part of the WebUI game controller.
+
+## WebUI
+
+Manual mode:
+
+```bash
+python examples/agentic/terminal_hacking/web_ui.py --port 8771
+```
+
+Agent mode against multiple OpenAI-compatible endpoints:
+
+```bash
+python examples/agentic/terminal_hacking/web_ui.py \
+  --port 8771 \
+  --base-url http://127.0.0.1:8000/v1 https://api.example.com/v1 \
+  --api-key EMPTY "$SECOND_API_KEY" \
+  --model policy second-model
+```
+
+The three lists are zipped by position; one API key or model value may be broadcast to every base URL. Open `http://127.0.0.1:8771` and choose the inference target from the model selector. The interface also supports English/Chinese help, green/amber phosphor themes, and an `ALGO` mode that needs no endpoint.
+
+## Files
+
+- `game.py` — deterministic rules, tool schema, replay, prompt rendering
+- `dataset_generator.py` — parallel 8,192-record generator
+- `dataset_loader.py` — validation and observable prompt construction
+- `run_agent.py` — concurrent single-turn state-to-candidates rollout
+- `reward.py` — dense asymmetric candidate-set reward
+- `web_ui.py` — self-contained local CRT WebUI

--- a/examples/agentic/terminal_hacking/README_CN.md
+++ b/examples/agentic/terminal_hacking/README_CN.md
@@ -1,0 +1,63 @@
+# 复古终端入侵 Agentic RL Demo
+
+这是一个原创的复古未来主义单词推理环境。它保留双列内存转储、同位字符匹配、有限尝试次数和括号奖励，但不包含原作 Logo、原文或贴图素材。
+
+## 玩法
+
+- 每题包含 16–20 个等长候选词、3 个括号探针和至少 18 行内存转储。
+- 错误猜测消耗一次机会，并返回 `likeness`：与密码在相同位置上相同的字母数。
+- RLVR 是单步 contextual bandit：输入一个 compact state，只输出一次 `submit_candidates` 候选集合，训练 rollout 内不执行游戏 action。
+- WebUI 保留可玩 loop：候选筛选调用与 RLVR prompt 完全一致，从返回集合随机猜词，并在最后一次机会仍有歧义时使用免费 probe。
+- 密码只存在于 `source_record`；prompt 仅包含可观察猜测和 likeness。
+- reward 完全由算法计算：多报一个不一致 candidate 会被重罚，漏报一致 candidate 只按比例轻罚。
+
+## 生成 8192 条不同数据
+
+```bash
+python examples/agentic/terminal_hacking/dataset_generator.py \
+  --output /tmp/terminal_hacking.jsonl \
+  --count 8192 \
+  --workers 20 \
+  --seed 2026
+```
+
+生成器使用唯一子种子，并对完整谜题指纹去重；发生重复时会重新生成，而不是只修改文件 ID。
+
+## 训练
+
+```bash
+areno train \
+  --ckpt inclusionai/ling-3.0-tiny \
+  --dataset-path /tmp/terminal_hacking.jsonl \
+  --dataset-loader-fn examples/agentic/terminal_hacking/dataset_loader.py \
+  --reward-fn-path examples/agentic/terminal_hacking/reward.py \
+  --agent-fn examples/agentic/terminal_hacking/run_agent.py \
+  --algo gspo \
+  --batch-size 4 \
+  --n-samples 8 \
+  --mini-bs 1 \
+  --max-running-prompts 32 \
+  --max-context-len 8192 \
+  --max-prompt-tokens 4096 \
+  --max-new-tokens 1024
+```
+
+RLVR 与 WebUI 的 candidate-select 调用复用 `game.py` 中完全相同的 candidate-filter system prompt、静态 memory-dump prompt、compact 当前 state 和唯一 `submit_candidates` schema。RLVR 每个样本只生成一次 completion，不运行 episode。WebUI 不展示候选集合，而是随机转成一个可见猜词；probe 仍由 WebUI 游戏 controller 处理。
+
+## WebUI
+
+```bash
+python examples/agentic/terminal_hacking/web_ui.py --port 8771
+```
+
+连接 OpenAI 兼容推理服务：
+
+```bash
+python examples/agentic/terminal_hacking/web_ui.py \
+  --port 8771 \
+  --base-url http://127.0.0.1:8000/v1 https://api.example.com/v1 \
+  --api-key EMPTY "$SECOND_API_KEY" \
+  --model policy second-model
+```
+
+三个列表按位置配对；只传一个 API key 或 model 时会广播到全部 base URL。打开 `http://127.0.0.1:8771` 后可从模型选择器切换推理目标。页面还支持中英文说明、绿色/琥珀色荧光主题和无需推理服务的 `ALGO` 模式。

--- a/examples/agentic/terminal_hacking/dataset_generator.py
+++ b/examples/agentic/terminal_hacking/dataset_generator.py
@@ -1,0 +1,140 @@
+"""Generate reproducible terminal-hacking puzzles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+WORD_BANK = {
+    5: "ALERT AMBER BLADE BRICK CABLE CACHE CHAIR CLEAN CLOUD CROWN DEPOT DREAM DRIFT EAGER FIELD FLAME FRAME GHOST GLASS GRAIN GRANT GREEN HEART INDEX LASER LAYER LIGHT METAL NIGHT NORTH OCEAN PANEL PAPER PHASE PLANT POWER RADIO RIVER ROBOT ROUGH ROUTE SOLAR SOUTH STEAM STONE STORM TABLE TRACE TRACK TRAIN VAULT WATER WHEEL WORLD".split(),
+    6: "ACCESS ACTIVE AGENTS BINARY BREACH BRIDGE BROKEN BUFFER CAMERA CIPHER COLUMN COMBAT COREUP CRATER DEVICE ENGINE FILTER FUSION GARAGE GARDEN HIDDEN JACKET MEMORY ORANGE PACKET PLANET REMOTE RESCUE ROUTER SCREEN SECRET SENSOR SHIELD SIGNAL SOCKET STATIC SYSTEM TARGET TUNNEL VECTOR VERIFY WINDOW".split(),
+    7: "ARCHIVE BARRIER BATTERY CABINET CAPTURE CENTRAL CHANNEL CIRCUIT COMMAND CONTROL CORRECT DEFENSE DISPLAY FACTORY GATEWAY HAZARDS KEYCARD MACHINE MONITOR NETWORK NUCLEAR OFFLINE OPERATE REACTOR RECOVER SHELTER STORAGE UNKNOWN VINTAGE WARNING".split(),
+}
+JUNK = "!@#$%^&*_-+=;:,.?/\\|~`'\""
+BRACKETS = [("(", ")"), ("[", "]"), ("{", "}"), ("<", ">")]
+MIN_CANDIDATES = 16
+MAX_CANDIDATES = 20
+
+
+def _make_one(index_seed: tuple[int, int]) -> dict:
+    index, seed = index_seed
+    rng = random.Random(seed)
+    word_length = rng.choice(sorted(WORD_BANK))
+    count = rng.randint(MIN_CANDIDATES, MAX_CANDIDATES)
+    candidates = rng.sample(WORD_BANK[word_length], count)
+    password = rng.choice(candidates)
+    probes = []
+    duds = [word for word in candidates if word != password]
+    for probe_index, (opening, closing) in enumerate(rng.sample(BRACKETS, 3)):
+        effect = "replenish" if probe_index == 0 else "remove_dud"
+        token = opening + "".join(rng.choice(JUNK) for _ in range(rng.randint(1, 3))) + closing
+        probes.append(
+            {
+                "id": f"P{probe_index}",
+                "token": token,
+                "effect": effect,
+                "target": duds[probe_index % len(duds)] if effect == "remove_dud" else None,
+            }
+        )
+    rng.shuffle(probes)
+    tokens = [(word, f"guess:{word}") for word in candidates] + [
+        (probe["token"], f"probe:{probe['id']}") for probe in probes
+    ]
+    rows = _build_dump(rng, tokens)
+    return {
+        "id": f"terminal-hacking-{index + 1:06d}",
+        "seed": seed,
+        "password": password,
+        "candidates": candidates,
+        "attempts": 3,
+        "probes": probes,
+        "dump_rows": rows,
+    }
+
+
+def _build_dump(rng: random.Random, tokens: list[tuple[str, str]]) -> list[dict]:
+    row_count = max(18, (len(tokens) + 1) // 2)
+    slots = [(row, side) for row in range(row_count) for side in ("left", "right")]
+    rng.shuffle(slots)
+    placed: dict[tuple[int, str], tuple[str, str]] = dict(zip(slots, tokens, strict=False))
+    base = rng.randrange(0xA000, 0xE000, 0x100)
+    rows = []
+    for row_index in range(row_count):
+        row: dict[str, object] = {}
+        for side_index, side in enumerate(("left", "right")):
+            address = base + (row_index * 2 + side_index) * 12
+            text = "".join(rng.choice(JUNK) for _ in range(12))
+            segments: list[dict[str, str]] = [{"text": text, "action": ""}]
+            token_data = placed.get((row_index, side))
+            if token_data is not None:
+                token, action = token_data
+                offset = rng.randint(0, 12 - len(token))
+                text = text[:offset] + token + text[offset + len(token) :]
+                segments = []
+                if offset:
+                    segments.append({"text": text[:offset], "action": ""})
+                segments.append({"text": token, "action": action})
+                if offset + len(token) < len(text):
+                    segments.append({"text": text[offset + len(token) :], "action": ""})
+            row[f"{side}_address"] = f"0x{address:04X}"
+            row[side] = text
+            row[f"{side}_segments"] = segments
+        rows.append(row)
+    return rows
+
+
+def _fingerprint(record: dict) -> str:
+    payload = {key: value for key, value in record.items() if key not in {"id", "seed"}}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def generate_records(count: int = 8192, *, seed: int = 2026, workers: int = 20) -> list[dict]:
+    """Generate independent deterministic puzzles, optionally in worker processes."""
+
+    master = random.Random(seed)
+    seeds: list[int] = []
+    seed_set: set[int] = set()
+    while len(seeds) < count:
+        candidate_seed = master.getrandbits(63)
+        if candidate_seed not in seed_set:
+            seed_set.add(candidate_seed)
+            seeds.append(candidate_seed)
+    jobs = list(enumerate(seeds))
+    if workers <= 1 or count <= 1:
+        records = [_make_one(job) for job in jobs]
+    else:
+        with ProcessPoolExecutor(max_workers=min(workers, count)) as pool:
+            records = list(pool.map(_make_one, jobs))
+    seen: set[str] = set()
+    for index, record in enumerate(records):
+        fingerprint = _fingerprint(record)
+        retry = 0
+        while fingerprint in seen:
+            retry += 1
+            record = _make_one((index, seeds[index] ^ (retry * 0x9E3779B97F4A7C15)))
+            fingerprint = _fingerprint(record)
+        record["id"] = f"terminal-hacking-{index + 1:06d}"
+        records[index] = record
+        seen.add(fingerprint)
+    return records
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--count", type=int, default=8192)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--workers", type=int, default=20)
+    args = parser.parse_args()
+    records = generate_records(args.count, seed=args.seed, workers=args.workers)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentic/terminal_hacking/dataset_loader.py
+++ b/examples/agentic/terminal_hacking/dataset_loader.py
@@ -1,0 +1,21 @@
+"""Dataset loader for the terminal-hacking agentic example."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import make_filter_prompt, normalize_record  # noqa: E402
+
+
+def load_training_dataset(dataset_path: str, *, default_loader, **_: object) -> list[dict]:
+    records = []
+    for index, row in enumerate(default_loader(dataset_path), start=1):
+        try:
+            record = normalize_record(dict(row))
+            record["prompt"] = make_filter_prompt(record)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid terminal-hacking record {index}: {exc}") from exc
+        records.append(record)
+    return records

--- a/examples/agentic/terminal_hacking/game.py
+++ b/examples/agentic/terminal_hacking/game.py
@@ -1,0 +1,424 @@
+"""Deterministic retro-terminal word hacking environment."""
+
+from __future__ import annotations
+
+import copy
+import json
+import random
+from typing import Any
+from urllib.parse import urlparse
+
+DEFAULT_ATTEMPTS = 3
+MAX_TURNS = 8
+FILTER_SYSTEM_PROMPT = """You are a terminal password candidate filter.
+
+For every word in active_candidates, compare it with every previous guess position by position. Count a match only when both words have the same letter in the same position. Keep a word if and only if its match count equals the observed likeness for every guess clue. Preserve active_candidates order. Exclude guessed and removed words. If there are no guess clues, keep every active candidate.
+
+Probe history does not add likeness constraints. Call submit_candidates exactly once with every and only consistent candidate. Output no prose outside the tool call."""
+
+
+def tool_choice_for_base_url(base_url: object) -> str | dict[str, Any]:
+    """Use auto tool selection for DeepSeek thinking-mode API compatibility."""
+
+    hostname = (urlparse(str(base_url)).hostname or "").lower()
+    if hostname == "api.deepseek.com":
+        return "auto"
+    return "required"
+
+
+def extra_body_for_base_url(base_url: object) -> dict[str, Any] | None:
+    """Disable DeepSeek thinking mode so tool selection remains concise and compatible."""
+
+    hostname = (urlparse(str(base_url)).hostname or "").lower()
+    if hostname == "api.deepseek.com":
+        return {"thinking": {"type": "disabled"}}
+    return None
+
+
+def likeness(left: str, right: str) -> int:
+    """Return the number of equal characters in equal positions."""
+
+    if len(left) != len(right):
+        raise ValueError("words must have the same length")
+    return sum(a == b for a, b in zip(left, right, strict=True))
+
+
+def normalize_record(raw: dict[str, Any]) -> dict[str, Any]:
+    """Validate and copy a hidden puzzle record."""
+
+    record = copy.deepcopy(raw)
+    candidates = [str(word).upper() for word in record.get("candidates", [])]
+    if len(candidates) < 6 or len(candidates) != len(set(candidates)):
+        raise ValueError("candidates must contain at least six unique words")
+    word_length = len(candidates[0])
+    if word_length < 4 or any(len(word) != word_length or not word.isalpha() for word in candidates):
+        raise ValueError("candidate words must be alphabetic and have one shared length")
+    password = str(record.get("password", "")).upper()
+    if password not in candidates:
+        raise ValueError("password must be one of the candidates")
+    attempts = int(record.get("attempts", DEFAULT_ATTEMPTS))
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+    probes = []
+    seen_probe_ids: set[str] = set()
+    for raw_probe in record.get("probes", []):
+        probe = dict(raw_probe)
+        probe_id = str(probe.get("id", ""))
+        effect = str(probe.get("effect", ""))
+        token = str(probe.get("token", ""))
+        if not probe_id or probe_id in seen_probe_ids:
+            raise ValueError("probe ids must be unique and non-empty")
+        if effect not in {"remove_dud", "replenish"}:
+            raise ValueError(f"invalid probe effect: {effect}")
+        if len(token) < 2 or (token[0], token[-1]) not in {("(", ")"), ("[", "]"), ("{", "}"), ("<", ">")}:
+            raise ValueError(f"invalid bracket token: {token}")
+        target = probe.get("target")
+        if target is not None and str(target).upper() not in candidates:
+            raise ValueError("probe target must be a candidate")
+        probes.append(
+            {
+                "id": probe_id,
+                "token": token,
+                "effect": effect,
+                "target": str(target).upper() if target is not None else None,
+            }
+        )
+        seen_probe_ids.add(probe_id)
+    dump_rows = [dict(row) for row in record.get("dump_rows", [])]
+    if not dump_rows:
+        raise ValueError("dump_rows must not be empty")
+    record.update(
+        {
+            "candidates": candidates,
+            "password": password,
+            "attempts": attempts,
+            "probes": probes,
+            "dump_rows": dump_rows,
+            "word_length": word_length,
+        }
+    )
+    return record
+
+
+def candidate_tool(active_candidates: list[str]) -> dict[str, Any]:
+    """Build a closed tool schema for the predicted consistent candidate set."""
+
+    return {
+        "type": "function",
+        "function": {
+            "name": "submit_candidates",
+            "description": "Submit every active word that satisfies every observed likeness clue.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidates": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": active_candidates},
+                        "minItems": 1,
+                        "uniqueItems": True,
+                        "description": "All and only currently consistent candidates, in active_candidates order.",
+                    }
+                },
+                "required": ["candidates"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def probe_tool(available_probes: list[dict[str, str]]) -> dict[str, Any]:
+    """Build the tool schema for a model-selected bracket probe."""
+
+    actions = [f"probe:{probe['id']}" for probe in available_probes]
+    return {
+        "type": "function",
+        "function": {
+            "name": "access_terminal",
+            "description": "Use one currently available bracket probe instead of submitting candidates.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": actions,
+                        "description": "One available probe action.",
+                    }
+                },
+                "required": ["action"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def policy_tools(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the candidate and optional probe tools for one compact policy turn."""
+
+    tools = [candidate_tool(state["active_candidates"])]
+    if state["available_probes"]:
+        tools.append(probe_tool(state["available_probes"]))
+    return tools
+
+
+class TerminalHackingSession:
+    """Stateful deterministic puzzle session."""
+
+    def __init__(self, raw_record: dict[str, Any]) -> None:
+        self.record = normalize_record(raw_record)
+        self.password = self.record["password"]
+        self.attempts_max = self.record["attempts"]
+        self.attempts_remaining = self.attempts_max
+        self.guessed: list[str] = []
+        self.removed: list[str] = []
+        self.used_probes: list[str] = []
+        self.history: list[dict[str, Any]] = []
+        self.solved = False
+        self.locked = False
+
+    @property
+    def done(self) -> bool:
+        return self.solved or self.locked
+
+    def allowed_actions(self) -> list[str]:
+        if self.done:
+            return []
+        actions = [
+            f"guess:{word}"
+            for word in self.record["candidates"]
+            if word not in self.guessed and word not in self.removed
+        ]
+        actions.extend(f"probe:{probe['id']}" for probe in self.record["probes"] if probe["id"] not in self.used_probes)
+        return actions
+
+    def consistent_candidates(self) -> list[str]:
+        """Return selectable candidates satisfying every observable likeness clue."""
+
+        guesses = [event for event in self.history if event["kind"] == "guess"]
+        return [
+            word
+            for word in self.record["candidates"]
+            if word not in self.guessed
+            and word not in self.removed
+            and all(likeness(word, event["word"]) == event["likeness"] for event in guesses)
+        ]
+
+    def public_state(self) -> dict[str, Any]:
+        active = [word for word in self.record["candidates"] if word not in self.guessed and word not in self.removed]
+        return {
+            "attempts_max": self.attempts_max,
+            "attempts_remaining": self.attempts_remaining,
+            "word_length": self.record["word_length"],
+            "active_candidates": active,
+            "guessed": list(self.guessed),
+            "removed": list(self.removed),
+            "available_probes": [
+                {"id": probe["id"], "token": probe["token"]}
+                for probe in self.record["probes"]
+                if probe["id"] not in self.used_probes
+            ],
+            "history": copy.deepcopy(self.history),
+            "dump_rows": copy.deepcopy(self.record["dump_rows"]),
+            "solved": self.solved,
+            "locked": self.locked,
+            "done": self.done,
+        }
+
+    def execute(self, action: object) -> dict[str, Any]:
+        if self.done:
+            return self._result(False, str(action), "terminal session has already ended")
+        normalized = str(action)
+        if normalized not in self.allowed_actions():
+            return self._result(False, normalized, "action is not currently available")
+        if normalized.startswith("guess:"):
+            return self._guess(normalized.removeprefix("guess:"))
+        return self._probe(normalized.removeprefix("probe:"))
+
+    def _guess(self, word: str) -> dict[str, Any]:
+        self.guessed.append(word)
+        matched = likeness(word, self.password)
+        self.solved = word == self.password
+        if not self.solved:
+            self.attempts_remaining -= 1
+            self.locked = self.attempts_remaining <= 0
+        event = {
+            "kind": "guess",
+            "word": word,
+            "likeness": matched,
+            "out_of": len(self.password),
+            "solved": self.solved,
+        }
+        self.history.append(event)
+        return self._result(True, f"guess:{word}", None, event=event)
+
+    def _probe(self, probe_id: str) -> dict[str, Any]:
+        probe = next(probe for probe in self.record["probes"] if probe["id"] == probe_id)
+        self.used_probes.append(probe_id)
+        removed = None
+        if probe["effect"] == "replenish":
+            self.attempts_remaining = self.attempts_max
+        else:
+            preferred = probe.get("target")
+            candidates = [
+                word
+                for word in self.record["candidates"]
+                if word != self.password and word not in self.guessed and word not in self.removed
+            ]
+            if preferred in candidates:
+                removed = preferred
+            elif candidates:
+                removed = candidates[0]
+            if removed is not None:
+                self.removed.append(removed)
+        event = {
+            "kind": "probe",
+            "probe_id": probe_id,
+            "token": probe["token"],
+            "effect": probe["effect"],
+            "removed": removed,
+            "attempts_remaining": self.attempts_remaining,
+        }
+        self.history.append(event)
+        return self._result(True, f"probe:{probe_id}", None, event=event)
+
+    def _result(
+        self,
+        valid: bool,
+        action: str,
+        error: str | None,
+        *,
+        event: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "valid": valid,
+            "action": action,
+            "error": error,
+            "event": event,
+            "current_state": self.public_state(),
+        }
+
+
+def candidate_filter_session(raw_record: dict[str, Any]) -> TerminalHackingSession:
+    """Build one deterministic nonterminal state for single-turn candidate training."""
+
+    session = TerminalHackingSession(raw_record)
+    duds = [word for word in session.record["candidates"] if word != session.password]
+    rng = random.Random(int(session.record.get("seed", 0)) ^ 0x43414E4449444154)
+    rng.shuffle(duds)
+    clue_count = rng.randint(1, min(session.attempts_max - 1, len(duds)))
+    for word in duds[:clue_count]:
+        session.execute(f"guess:{word}")
+    return session
+
+
+def controller_rng(record: dict[str, Any]) -> random.Random:
+    """Return the deterministic controller RNG used by rollout and reward."""
+
+    return random.Random(int(record.get("seed", 0)) ^ 0x43414E4449444154)
+
+
+def candidate_controller_action(
+    session: TerminalHackingSession,
+    candidates: list[str],
+    rng: random.Random,
+) -> str:
+    """Choose the hidden environment action from a model-produced candidate set."""
+
+    if session.done:
+        raise ValueError("cannot choose an action for a completed terminal session")
+    return f"guess:{rng.choice(candidates)}"
+
+
+def probe_is_preferred(session: TerminalHackingSession) -> bool:
+    """Return whether the expert policy should choose a probe on this turn."""
+
+    state = session.public_state()
+    return (
+        session.attempts_remaining == 1 and len(session.consistent_candidates()) > 1 and bool(state["available_probes"])
+    )
+
+
+def expert_decision(
+    session: TerminalHackingSession,
+    rng: random.Random,
+) -> tuple[dict[str, Any], str]:
+    """Return the expert tool call and the hidden environment action it induces."""
+
+    if probe_is_preferred(session):
+        probe = rng.choice(session.public_state()["available_probes"])
+        action = f"probe:{probe['id']}"
+        return {"name": "access_terminal", "arguments": {"action": action}}, action
+    candidates = session.consistent_candidates()
+    return (
+        {"name": "submit_candidates", "arguments": {"candidates": candidates}},
+        candidate_controller_action(session, candidates, rng),
+    )
+
+
+def candidate_filter_request_messages(prompt: str, state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build one compact state-to-candidates training request."""
+
+    return [
+        {"role": "system", "content": FILTER_SYSTEM_PROMPT},
+        {"role": "user", "content": prompt},
+        {"role": "user", "content": "Current state: " + compact_state(state)},
+    ]
+
+
+def make_prompt(record: dict[str, Any]) -> str:
+    """Render the initial visible puzzle without revealing hidden metadata."""
+
+    session = TerminalHackingSession(record)
+    state = session.public_state()
+    dump = "\n".join(
+        f"{row['left_address']} {row['left']}  {row['right_address']} {row['right']}" for row in state["dump_rows"]
+    )
+    probes = ", ".join(f"{probe['id']}={probe['token']}" for probe in state["available_probes"])
+    return (
+        "Filter the possible passwords in this retro data terminal. Candidate words all have the same length. "
+        "A rejected guess returns likeness: the count of letters matching the password in the same positions. "
+        "For example, PAPER with likeness 0 means a possible password must differ from PAPER at all five positions. "
+        "Bracket probes remove a dud or restore attempts but do not create likeness clues. "
+        "Normally submit every and only active candidate whose same-position match count equals every observed clue; "
+        "the controller will randomly guess one submitted word. If only one attempt remains, multiple candidates are "
+        "still consistent, and a probe is available, choose one probe instead.\n\n"
+        f"Attempts: {state['attempts_remaining']}/{state['attempts_max']}\n"
+        f"Bracket probes: {probes}\n"
+        "Memory dump:\n"
+        f"{dump}"
+    )
+
+
+def make_filter_prompt(record: dict[str, Any]) -> str:
+    """Render the immutable puzzle context for state-to-candidates training."""
+
+    session = TerminalHackingSession(record)
+    state = session.public_state()
+    dump = "\n".join(
+        f"{row['left_address']} {row['left']}  {row['right_address']} {row['right']}" for row in state["dump_rows"]
+    )
+    return (
+        "Filter the possible passwords in this retro data terminal. Candidate words all have the same length. "
+        "For every rejected guess, keep a word only when its same-position match count equals the observed "
+        "likeness. Return every and only consistent active candidate in active_candidates order. "
+        "The memory dump only identifies visible words; it does not encode extra clues.\n\n"
+        "Memory dump:\n"
+        f"{dump}"
+    )
+
+
+def replay_actions(record: dict[str, Any], actions: list[object]) -> TerminalHackingSession:
+    """Replay a trajectory for deterministic reward calculation."""
+
+    session = TerminalHackingSession(record)
+    for action in actions:
+        result = session.execute(action)
+        if not result["valid"] or session.done:
+            break
+    return session
+
+
+def compact_state(state: dict[str, Any]) -> str:
+    """Serialize the changing state for compact multi-turn prompts."""
+
+    visible = {key: value for key, value in state.items() if key != "dump_rows"}
+    return json.dumps(visible, separators=(",", ":"))

--- a/examples/agentic/terminal_hacking/reward.py
+++ b/examples/agentic/terminal_hacking/reward.py
@@ -1,0 +1,47 @@
+"""Dense asymmetric reward for single-turn terminal candidate filtering."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import candidate_filter_session  # noqa: E402
+
+
+def reward_fn(record) -> float:
+    calls = list(record.tool_calls)
+    if len(calls) != 1 or calls[0].get("name") != "submit_candidates":
+        return -1.0
+    arguments = calls[0].get("arguments")
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return -1.0
+    if not isinstance(arguments, dict) or set(arguments) != {"candidates"}:
+        return -1.0
+    predicted = arguments["candidates"]
+    if (
+        not isinstance(predicted, list)
+        or not predicted
+        or any(not isinstance(word, str) for word in predicted)
+        or len(predicted) != len(set(predicted))
+    ):
+        return -1.0
+
+    session = candidate_filter_session(dict(record.source_record))
+    active = session.public_state()["active_candidates"]
+    if any(word not in active for word in predicted):
+        return -1.0
+    expected_set = set(session.consistent_candidates())
+    predicted_set = set(predicted)
+    false_positives = len(predicted_set - expected_set)
+    false_negatives = len(expected_set - predicted_set)
+    shrink_ratio = false_negatives / max(len(expected_set), 1)
+
+    # Extra inconsistent candidates are much worse than a conservative subset:
+    # one extra costs 1.5 reward, while omitting the entire true set costs 0.1.
+    score = 1.0 - 1.5 * false_positives - 0.1 * shrink_ratio
+    return max(-1.0, min(1.0, score))

--- a/examples/agentic/terminal_hacking/run_agent.py
+++ b/examples/agentic/terminal_hacking/run_agent.py
@@ -1,0 +1,124 @@
+"""Single-turn state-to-candidates rollout for terminal hacking."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from areno.api.agentic import AgentTrajectory, AgentTrajectoryTurn
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from game import (  # noqa: E402
+    candidate_filter_request_messages,
+    candidate_filter_session,
+    candidate_tool,
+    extra_body_for_base_url,
+    tool_choice_for_base_url,
+)
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+async def run_agent(ctx, batch):
+    try:
+        import httpx
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise RuntimeError("Terminal hacking requires openai and httpx") from exc
+
+    items = list(batch.iter_samples())
+    max_connections = max(len(items), ctx.max_running_prompts)
+    http_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=max_connections, max_keepalive_connections=max_connections),
+        timeout=None,
+    )
+    base_url = ctx.get_base_url()
+    client = AsyncOpenAI(base_url=base_url, api_key=ctx.api_key, http_client=http_client, max_retries=0)
+    try:
+        turns = await asyncio.gather(*(_run_filter(item, client, base_url=base_url) for item in items))
+        return AgentTrajectory(turns=list(turns))
+    finally:
+        await client.close()
+
+
+async def _run_filter(item, client, *, base_url: str = "") -> AgentTrajectoryTurn:
+    session = candidate_filter_session(item.record)
+    state = session.public_state()
+    active = state["active_candidates"]
+    tool = candidate_tool(active)
+    request_messages = candidate_filter_request_messages(item.prompt, state)
+    tool_choice = tool_choice_for_base_url(base_url)
+    request_kwargs = {
+        "model": "policy",
+        "messages": request_messages,
+        "tools": [tool],
+        "tool_choice": tool_choice,
+        "stream": False,
+    }
+    extra_body = extra_body_for_base_url(base_url)
+    if extra_body is not None:
+        request_kwargs["extra_body"] = extra_body
+    response = await client.chat.completions.create(**request_kwargs)
+    assistant = _assistant_message(response)
+    if _parse_candidates(assistant, active) is None:
+        choice = response.choices[0]
+        usage = getattr(response, "usage", None)
+        logger.warning(
+            "Terminal-hacking model returned no executable submit_candidates call: "
+            "finish_reason=%r completion_tokens=%r content=%r tool_calls=%r",
+            getattr(choice, "finish_reason", None),
+            getattr(usage, "completion_tokens", None),
+            str(assistant.get("content") or "")[-600:],
+            assistant.get("tool_calls"),
+        )
+    return AgentTrajectoryTurn(
+        item=item,
+        messages=request_messages,
+        response=response,
+        tools=[tool],
+        tool_choice=tool_choice,
+    )
+
+
+def _assistant_message(response) -> dict:
+    message = response.choices[0].message
+    return {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": call.type,
+                "function": {"name": call.function.name, "arguments": call.function.arguments},
+            }
+            for call in (message.tool_calls or [])
+        ],
+    }
+
+
+def _parse_candidates(assistant: dict, active_candidates: list[str]) -> list[str] | None:
+    calls = assistant.get("tool_calls") or []
+    if len(calls) != 1 or calls[0].get("function", {}).get("name") != "submit_candidates":
+        return None
+    try:
+        arguments = json.loads(calls[0]["function"].get("arguments") or "")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(arguments, dict) or set(arguments) != {"candidates"}:
+        return None
+    candidates = arguments["candidates"]
+    if (
+        not isinstance(candidates, list)
+        or not candidates
+        or any(not isinstance(candidate, str) for candidate in candidates)
+        or len(candidates) != len(set(candidates))
+    ):
+        return None
+    active = set(active_candidates)
+    if any(candidate not in active for candidate in candidates):
+        return None
+    return candidates

--- a/examples/agentic/terminal_hacking/web_ui.py
+++ b/examples/agentic/terminal_hacking/web_ui.py
@@ -1,0 +1,487 @@
+"""Interactive CRT WebUI for the terminal-hacking agentic example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import threading
+import time
+from contextlib import nullcontext
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dataset_generator  # noqa: E402
+from game import (  # noqa: E402
+    TerminalHackingSession,
+    candidate_controller_action,
+    candidate_filter_request_messages,
+    candidate_tool,
+    expert_decision,
+    extra_body_for_base_url,
+    make_filter_prompt,
+    probe_is_preferred,
+    tool_choice_for_base_url,
+)
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8771
+MODEL_RETRY_INTERVAL_SECONDS = 10.0
+MODEL_WAIT_MAX_SECONDS = 300.0
+
+
+class TerminalServer(ThreadingHTTPServer):
+    def __init__(self, server_address, handler, *, args: argparse.Namespace) -> None:
+        super().__init__(server_address, handler)
+        self.args = args
+        self.rng = random.Random(args.seed)
+        self.clients: dict[tuple[int, int], Any] = {}
+        self.agent_busy = False
+        self.agent_job_id = 0
+        self.state_lock = threading.RLock()
+        self.error: str | None = None
+        self.events: list[dict[str, str]] = []
+        self.reset()
+
+    def reset(self) -> None:
+        self.agent_job_id += 1
+        self.agent_busy = False
+        clients = list(self.clients.values())
+        self.clients.clear()
+        for client in clients:
+            try:
+                client.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self.record = dataset_generator.generate_records(1, seed=self.rng.randrange(2**31), workers=1)[0]
+        self.session = TerminalHackingSession(self.record)
+        self.error = None
+        self.events = [_event("NODE READY // SELECT AN ENTRY", "节点就绪 // 请选择条目")]
+
+    def start_agent_step(self, mode: str, model_index: int = 0) -> bool:
+        """Start one agent step without holding the initiating HTTP request open."""
+
+        with self.state_lock:
+            if self.agent_busy or self.session.done:
+                return False
+            self.agent_busy = True
+            self.agent_job_id += 1
+            job_id = self.agent_job_id
+
+        def run() -> None:
+            try:
+                _agent_step(self, mode=mode, model_index=model_index, job_id=job_id)
+            finally:
+                with self.state_lock:
+                    if self.agent_job_id == job_id:
+                        self.agent_busy = False
+                    client = self.clients.pop((job_id, model_index), None)
+                if client is not None:
+                    try:
+                        client.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+
+        threading.Thread(target=run, name="terminal-hacking-agent-step", daemon=True).start()
+        return True
+
+
+class TerminalHandler(BaseHTTPRequestHandler):
+    server: TerminalServer
+
+    def do_GET(self) -> None:
+        route = _route(self.path)
+        if route == "index":
+            self._send_html(INDEX_HTML)
+        elif route == "state":
+            with self.server.state_lock:
+                self._send_json(_payload(self.server))
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def do_POST(self) -> None:
+        route = _route(self.path)
+        body = self._read_json()
+        if route == "new":
+            with self.server.state_lock:
+                self.server.reset()
+        elif route == "action":
+            with self.server.state_lock:
+                if not self.server.agent_busy:
+                    _apply(self.server, body.get("action") if isinstance(body, dict) else None, actor="OPERATOR")
+        elif route == "agent":
+            mode = body.get("mode", "algo") if isinstance(body, dict) else "algo"
+            try:
+                model_index = int(body.get("model_index", 0)) if isinstance(body, dict) else 0
+            except (TypeError, ValueError):
+                model_index = -1
+            self.server.start_agent_step(str(mode), model_index=model_index)
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+            return
+        with self.server.state_lock:
+            self._send_json(_payload(self.server))
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("terminal-hacking-web: " + fmt % args + "\n")
+
+    def _read_json(self) -> Any:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            return json.loads(self.rfile.read(length).decode("utf-8")) if length else {}
+        except (ValueError, json.JSONDecodeError):
+            return {}
+
+    def _send_html(self, html: str) -> None:
+        data = html.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_json(self, payload: Any) -> None:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def _route(raw_path: str) -> str:
+    path = urlparse(raw_path).path.rstrip("/") or "/"
+    for route in ("state", "new", "action", "agent"):
+        if path.endswith(f"/api/{route}"):
+            return route
+    if "/api/" in path:
+        return "missing"
+    return "index" if path == "/" or "." not in path.rsplit("/", 1)[-1] else "missing"
+
+
+def _event(en: str, zh: str) -> dict[str, str]:
+    return {"en": en, "zh": zh}
+
+
+def _apply(server: TerminalServer, action: object, *, actor: str) -> None:
+    server.error = None
+    result = server.session.execute(action)
+    if not result["valid"]:
+        server.error = str(result["error"])
+        server.events.insert(0, _event(f"INPUT REJECTED // {result['error']}", f"输入被拒绝 // {result['error']}"))
+        return
+    event = result["event"]
+    if event["kind"] == "guess":
+        if event["solved"]:
+            message = _event(f"{actor}: {event['word']} // ACCESS GRANTED", f"{actor}：{event['word']} // 访问授权")
+        else:
+            message = _event(
+                f"{actor}: {event['word']} // POSITIONAL MATCH {event['likeness']}/{event['out_of']}",
+                f"{actor}：{event['word']} // 同位匹配 {event['likeness']}/{event['out_of']}",
+            )
+    elif event["effect"] == "replenish":
+        message = _event(f"{actor}: ATTEMPT BUFFER RESTORED", f"{actor}：尝试次数已恢复")
+    else:
+        removed = event["removed"] or "NONE"
+        message = _event(f"{actor}: DECOY PURGED // {removed}", f"{actor}：干扰项已清除 // {removed}")
+    server.events.insert(0, message)
+    if server.session.locked:
+        server.events.insert(0, _event("NODE LOCKED // SESSION TERMINATED", "节点锁定 // 会话终止"))
+    server.events = server.events[:24]
+
+
+class _AgentStepCancelled(Exception):
+    """Internal signal used when New Node detaches an in-flight agent job."""
+
+
+def _job_is_current(server: TerminalServer, job_id: int | None) -> bool:
+    return job_id is None or server.agent_job_id == job_id
+
+
+def _server_lock(server: TerminalServer):
+    return getattr(server, "state_lock", nullcontext())
+
+
+def _agent_step(
+    server: TerminalServer,
+    *,
+    mode: str = "algo",
+    model_index: int = 0,
+    job_id: int | None = None,
+) -> None:
+    if server.session.done:
+        return
+    if mode == "algo":
+        try:
+            _target, action = expert_decision(server.session, server.rng)
+            with _server_lock(server):
+                if _job_is_current(server, job_id):
+                    _apply(server, action, actor="ALGO")
+        except (TypeError, ValueError) as exc:
+            server.error = str(exc)
+            server.events.insert(0, _event(f"ALGO ERROR // {exc}", f"算法错误 // {exc}"))
+        return
+    if mode != "model":
+        server.error = f"Unknown agent mode: {mode}"
+        return
+    targets = server.args.inference_targets
+    if not targets:
+        server.error = "Model mode requires --base-url"
+        return
+    if not 0 <= model_index < len(targets):
+        server.error = f"Invalid inference model index: {model_index}"
+        return
+    target = targets[model_index]
+    try:
+        state = server.session.public_state()
+        if probe_is_preferred(server.session):
+            probe = server.rng.choice(state["available_probes"])
+            with _server_lock(server):
+                if _job_is_current(server, job_id):
+                    _apply(server, f"probe:{probe['id']}", actor="AGENT")
+            return
+        active = state["active_candidates"]
+        if not any(event.get("kind") == "guess" for event in state["history"]):
+            with _server_lock(server):
+                if _job_is_current(server, job_id):
+                    action = candidate_controller_action(server.session, active, server.rng)
+                    _apply(server, action, actor="AGENT")
+            return
+        tool = candidate_tool(active)
+        request_kwargs = {
+            "model": target["model"],
+            "messages": candidate_filter_request_messages(
+                make_filter_prompt(server.record),
+                state,
+            ),
+            "tools": [tool],
+            "tool_choice": tool_choice_for_base_url(target["base_url"]),
+            "temperature": server.args.temperature,
+        }
+        extra_body = extra_body_for_base_url(target["base_url"])
+        if extra_body is None:
+            extra_body = {"chat_template_kwargs": {"enable_thinking": False}}
+        request_kwargs["extra_body"] = extra_body
+        response = _model_completion_with_retry(server, model_index, target, request_kwargs, job_id=job_id)
+        if not _job_is_current(server, job_id):
+            return
+        calls = response.choices[0].message.tool_calls or []
+        if len(calls) != 1 or calls[0].function.name != "submit_candidates":
+            raise ValueError(f"expected one submit_candidates call, received {len(calls)}")
+        arguments = json.loads(calls[0].function.arguments)
+        candidates = arguments.get("candidates") if set(arguments) == {"candidates"} else None
+        if (
+            not isinstance(candidates, list)
+            or not candidates
+            or any(not isinstance(candidate, str) for candidate in candidates)
+            or len(candidates) != len(set(candidates))
+            or any(candidate not in active for candidate in candidates)
+        ):
+            raise ValueError(f"invalid agent candidates: {arguments!r}")
+        with _server_lock(server):
+            if _job_is_current(server, job_id):
+                _apply(server, candidate_controller_action(server.session, candidates, server.rng), actor="AGENT")
+    except _AgentStepCancelled:
+        return
+    except Exception as exc:  # noqa: BLE001
+        with _server_lock(server):
+            if _job_is_current(server, job_id):
+                server.error = str(exc)
+                server.events.insert(0, _event(f"AGENT LINK ERROR // {exc}", f"Agent 链路错误 // {exc}"))
+
+
+def _model_completion_with_retry(
+    server: TerminalServer,
+    model_index: int,
+    target: dict[str, str],
+    request_kwargs: dict[str, Any],
+    *,
+    job_id: int | None = None,
+):
+    """Retry transient upstream failures every ten seconds for at most five minutes."""
+
+    from openai import OpenAI
+
+    deadline = time.monotonic() + MODEL_WAIT_MAX_SECONDS
+    retry_count = 0
+    client_key = (job_id if job_id is not None else -1, model_index)
+    while True:
+        if not _job_is_current(server, job_id):
+            raise _AgentStepCancelled
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("model connection did not recover within 5 minutes")
+        try:
+            if client_key not in server.clients:
+                server.clients[client_key] = OpenAI(
+                    base_url=target["base_url"],
+                    api_key=target["api_key"],
+                    timeout=None,
+                    max_retries=0,
+                )
+            client = server.clients[client_key]
+            return client.chat.completions.create(
+                **request_kwargs,
+                timeout=None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if not _job_is_current(server, job_id):
+                raise _AgentStepCancelled from exc
+            if not _is_transient_model_error(exc):
+                raise
+            retry_count += 1
+            with _server_lock(server):
+                if not _job_is_current(server, job_id):
+                    raise _AgentStepCancelled from exc
+                server.error = f"MODEL LINK RETRY {retry_count} // {exc}"
+            try:
+                server.clients[client_key].close()
+            except Exception:  # noqa: BLE001
+                pass
+            server.clients.pop(client_key, None)
+            sleep_for = min(MODEL_RETRY_INTERVAL_SECONDS, deadline - time.monotonic())
+            if sleep_for <= 0:
+                raise TimeoutError("model connection did not recover within 5 minutes") from exc
+            time.sleep(sleep_for)
+
+
+def _is_transient_model_error(exc: Exception) -> bool:
+    name = type(exc).__name__
+    if name in {
+        "APIConnectionError",
+        "APITimeoutError",
+        "ConnectError",
+        "ConnectTimeout",
+        "ReadError",
+        "ReadTimeout",
+        "RemoteProtocolError",
+    }:
+        return True
+    status_code = getattr(exc, "status_code", None)
+    return status_code in {408, 409, 429} or isinstance(status_code, int) and status_code >= 500
+
+
+def _payload(server: TerminalServer) -> dict[str, Any]:
+    return {
+        **server.session.public_state(),
+        "allowed_actions": server.session.allowed_actions(),
+        "agent_busy": server.agent_busy,
+        "inference_models": [
+            {"index": index, "label": target["label"]} for index, target in enumerate(server.args.inference_targets)
+        ],
+        "events": server.events,
+        "error": server.error,
+    }
+
+
+INDEX_HTML = r"""<!doctype html>
+<html lang="en" data-theme="phosphor">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Civil Defense Data Terminal</title>
+<style>
+:root{--void:#030805;--glass:#07110b;--phosphor:#72ff8f;--bright:#c0ffca;--dim:#2e7f42;--ghost:rgba(114,255,143,.12);--shell:#171a16;--edge:#41453c;--warning:#ffdc73;--unit:4px}
+html[data-theme="amber"]{--void:#0a0702;--glass:#151006;--phosphor:#ffba52;--bright:#ffe0a0;--dim:#9d6322;--ghost:rgba(255,186,82,.13);--warning:#fff0b2}
+*{box-sizing:border-box}html,body{margin:0;min-height:100%;background:#0b0c0a;color:var(--phosphor);font-family:"SFMono-Regular","Cascadia Mono","Liberation Mono",monospace;-webkit-font-smoothing:none}
+button,select{font:inherit}.room{min-height:100vh;display:grid;place-items:center;padding:32px;background:radial-gradient(circle at 50% 20%,#303229 0,#161813 36%,#090a08 75%)}
+.console{width:min(1180px,100%);padding:20px;border:1px solid #4b4f45;border-radius:26px;background:linear-gradient(145deg,#23261f,#11130f);box-shadow:0 28px 80px #000,0 0 0 5px #090a08, inset 0 1px #555b50}
+.hardware{height:28px;display:flex;align-items:flex-start;justify-content:space-between;color:#8f9484;font-size:10px;letter-spacing:.18em;padding:0 8px}.brand{font-weight:700}.serial{opacity:.6}
+.screen{position:relative;overflow:hidden;min-height:690px;border-radius:42px/30px;background:var(--glass);box-shadow:inset 0 0 0 2px #050805,inset 0 0 38px #000,inset 0 0 110px rgba(0,0,0,.72),0 0 0 1px #454a40;padding:34px 38px;text-shadow:0 0 7px currentColor}
+.screen:before{content:"";position:absolute;inset:0;pointer-events:none;background:repeating-linear-gradient(to bottom,transparent 0,transparent 2px,rgba(0,0,0,.28) 3px,rgba(0,0,0,.28) 4px);opacity:.7;z-index:5}
+.screen:after{content:"";position:absolute;inset:-20%;pointer-events:none;background:linear-gradient(100deg,transparent 42%,rgba(255,255,255,.035) 49%,transparent 56%);animation:sweep 8s linear infinite;z-index:6}@keyframes sweep{to{transform:translateX(45%)}}
+.topline{position:relative;z-index:2;display:flex;justify-content:space-between;gap:24px;padding-bottom:20px;border-bottom:1px dashed var(--dim)}
+.eyebrow{font-size:11px;letter-spacing:.22em;color:var(--dim)}h1{font-size:18px;line-height:1.25;margin:5px 0 0;letter-spacing:.08em;font-weight:600}.status{text-align:right;font-size:12px;line-height:1.55}.attempts{color:var(--bright);font-size:16px;letter-spacing:.14em}
+.grid{position:relative;z-index:2;display:grid;grid-template-columns:minmax(520px,1.45fr) minmax(260px,.7fr);gap:32px;padding-top:24px}.dump{font-size:14px;line-height:1.65;white-space:nowrap}.dump-row{display:grid;grid-template-columns:68px 1fr 68px 1fr;gap:8px}.address{color:var(--dim)}.bytes{letter-spacing:.03em}.entry{display:inline;padding:1px 0;border:0;color:var(--bright);background:transparent;text-shadow:inherit;cursor:pointer}.entry:hover,.entry:focus-visible{outline:0;color:var(--void);background:var(--bright);text-shadow:none}.entry:active{transform:translateY(1px)}.entry[disabled]{cursor:not-allowed;color:var(--dim);text-decoration:line-through;background:transparent}
+.side{border-left:1px dashed var(--dim);padding-left:24px;min-width:0}.side-title{font-size:11px;letter-spacing:.2em;color:var(--dim);margin-bottom:12px}.log{display:flex;flex-direction:column;gap:10px;min-height:360px;font-size:12px;line-height:1.5}.log-line{padding-left:12px;position:relative;color:var(--phosphor);overflow-wrap:anywhere}.log-line:before{content:">";position:absolute;left:0;color:var(--bright)}.log-line:first-child{color:var(--bright)}
+.controls{position:relative;z-index:2;display:flex;align-items:center;justify-content:space-between;gap:12px;border-top:1px dashed var(--dim);padding-top:18px;margin-top:22px}.control-group{display:flex;gap:8px;flex-wrap:wrap}.control{min-height:40px;padding:0 14px;border:1px solid var(--dim);background:var(--ghost);color:var(--phosphor);cursor:pointer;letter-spacing:.08em}.control:hover,.control:focus-visible{border-color:var(--bright);color:var(--bright);outline:none}.control:active{transform:scale(.97)}.control.primary{background:var(--phosphor);color:var(--void);text-shadow:none}.control[disabled]{opacity:.35;cursor:not-allowed}select.control option{background:var(--glass);color:var(--phosphor)}
+.help{font-size:11px;color:var(--dim);max-width:520px;line-height:1.55;text-align:right}.cursor{display:inline-block;width:8px;height:15px;background:var(--bright);vertical-align:-2px;animation:blink 1s steps(1) infinite}@keyframes blink{50%{opacity:0}}
+@media(max-width:850px){.room{padding:0}.console{border-radius:0;padding:0;width:100%;min-height:100vh}.hardware{display:none}.screen{border-radius:0;min-height:100vh;padding:24px 18px}.grid{grid-template-columns:1fr}.dump{font-size:11px;overflow:auto}.dump-row{grid-template-columns:56px 1fr 56px 1fr;gap:5px}.side{border-left:0;border-top:1px dashed var(--dim);padding:18px 0 0}.log{min-height:160px}.controls{align-items:flex-start;flex-direction:column}.help{text-align:left}}
+@media(prefers-reduced-motion:reduce){.screen:after,.cursor{animation:none}}
+</style>
+</head>
+<body><main class="room"><section class="console"><header class="hardware"><span class="brand">CIVIL DEFENSE DATA SYSTEMS</span><span class="serial">MODEL VT-77 // NODE 04</span></header><div class="screen">
+<header class="topline"><div><div class="eyebrow" data-i18n="eyebrow">REMOTE MEMORY ACCESS</div><h1 data-i18n="title">SECURE ARCHIVE // AUTHENTICATION</h1></div><div class="status"><div data-i18n="allowance">ATTEMPT BUFFER</div><div class="attempts" id="attempts"></div><div id="stateLabel"></div></div></header>
+<div class="grid"><div class="dump" id="dump"></div><aside class="side"><div class="side-title" data-i18n="trace">ACCESS TRACE</div><div class="log" id="log"></div></aside></div>
+<footer class="controls"><div class="control-group"><select class="control" id="agentMode" aria-label="Agent mode"><option value="algo">ALGO</option><option value="model">MODEL</option></select><select class="control" id="modelTarget" aria-label="Inference model"></select><button class="control primary" id="agent" data-i18n="agent">AGENT STEP</button><button class="control" id="reset" data-i18n="reset">NEW NODE</button><button class="control" id="theme">GREEN / AMBER</button><button class="control" id="lang">中文</button></div><div class="help" data-i18n="help">Select a word. POSITIONAL MATCH counts letters in the correct slots. Bracket sequences can purge a decoy or restore attempts.</div></footer>
+</div></section></main>
+<script>
+const copy={en:{eyebrow:'REMOTE MEMORY ACCESS',title:'SECURE ARCHIVE // AUTHENTICATION',allowance:'ATTEMPT BUFFER',trace:'ACCESS TRACE',agent:'AGENT STEP',loading:'AGENT PROCESSING...',reset:'NEW NODE',help:'Select a word. POSITIONAL MATCH counts letters in the correct slots. Bracket sequences can purge a decoy or restore attempts.',ready:'AWAITING INPUT',granted:'ACCESS GRANTED',locked:'NODE LOCKED'},zh:{eyebrow:'远程内存访问',title:'安全档案 // 身份验证',allowance:'尝试缓冲区',trace:'访问记录',agent:'AGENT 单步',loading:'AGENT 推理中...',reset:'新建节点',help:'选择一个单词。“同位匹配”表示字母与密码位置同时正确；括号序列可清除干扰项或恢复尝试次数。',ready:'等待输入',granted:'访问授权',locked:'节点锁定'}};
+let lang='en',state=null,busy=false,clientError='';
+const AGENT_POLL_MS=1000,AGENT_WAIT_MAX_MS=300000;
+const proxyPrefix=location.pathname==='/'?'':location.pathname.replace(/\/$/,'');
+function apiPath(name){return `${proxyPrefix}/api/${name}`}
+async function api(path,body){const options=body===undefined?{}:{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)};const response=await fetch(path,options);if(!response.ok)throw new Error(await response.text());return response.json()}
+function t(key){return copy[lang][key]}
+function syncModelOptions(){const select=document.getElementById('modelTarget');const signature=JSON.stringify(state.inference_models||[]);if(select.dataset.signature!==signature){const previous=select.value;select.innerHTML=(state.inference_models||[]).map(item=>`<option value="${item.index}">${escapeHtml(item.label)}</option>`).join('')||'<option value="0">NO MODEL CONFIGURED</option>';select.dataset.signature=signature;if([...select.options].some(option=>option.value===previous))select.value=previous}}
+function renderSegments(segments){return segments.map(seg=>{if(!seg.action)return escapeHtml(seg.text);const enabled=state.allowed_actions.includes(seg.action);return `<button class="entry" data-action="${escapeHtml(seg.action)}" ${enabled?'':'disabled'}>${escapeHtml(seg.text)}</button>`}).join('')}
+function escapeHtml(value){return String(value).replace(/[&<>"']/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]))}
+function render(){document.querySelectorAll('[data-i18n]').forEach(el=>el.textContent=t(el.dataset.i18n));const waiting=busy||state.agent_busy;syncModelOptions();document.getElementById('lang').textContent=lang==='en'?'中文':'EN';document.getElementById('agent').textContent=waiting?t('loading'):t('agent');document.getElementById('attempts').textContent='■ '.repeat(state.attempts_remaining)+'□ '.repeat(state.attempts_max-state.attempts_remaining);document.getElementById('stateLabel').innerHTML=(waiting?t('loading'):state.solved?t('granted'):state.locked?t('locked'):t('ready'))+' <span class="cursor"></span>';document.getElementById('dump').innerHTML=state.dump_rows.map(row=>`<div class="dump-row"><span class="address">${row.left_address}</span><span class="bytes">${renderSegments(row.left_segments)}</span><span class="address">${row.right_address}</span><span class="bytes">${renderSegments(row.right_segments)}</span></div>`).join('');const loading=waiting?`<div class="log-line">${escapeHtml(t('loading'))}</div>`:'';const errorText=clientError||state.error||'';const errors=errorText?`<div class="log-line">${escapeHtml(errorText)}</div>`:'';document.getElementById('log').innerHTML=loading+errors+state.events.map(event=>`<div class="log-line">${escapeHtml(event[lang])}</div>`).join('');document.getElementById('agent').disabled=waiting||state.done;document.getElementById('agentMode').disabled=waiting;document.getElementById('modelTarget').disabled=waiting||document.getElementById('agentMode').value!=='model';document.querySelectorAll('.entry[data-action]').forEach(button=>button.addEventListener('click',()=>act(button.dataset.action)))}
+const delay=ms=>new Promise(resolve=>setTimeout(resolve,ms));
+async function waitForAgent(){const deadline=Date.now()+AGENT_WAIT_MAX_MS;while(state.agent_busy&&Date.now()<deadline){try{state=await api(apiPath('state'));clientError='';render()}catch(error){clientError=`STATE POLL RETRY // ${error.message}`;render()}if(state.agent_busy&&Date.now()<deadline)await delay(AGENT_POLL_MS)}if(state.agent_busy)throw new Error('AGENT WAIT EXCEEDED 5 MINUTES // SERVER STEP MAY STILL BE RUNNING')}
+async function load(){state=await api(apiPath('state'));render();if(state.agent_busy){try{await waitForAgent()}catch(error){clientError=error.message;render()}}}
+async function act(action){if(busy||state.agent_busy)return;busy=true;render();try{state=await api(apiPath('action'),{action})}finally{busy=false;render()}}
+document.getElementById('agent').onclick=async()=>{if(busy||state.agent_busy)return;busy=true;clientError='';render();try{state=await api(apiPath('agent'),{mode:document.getElementById('agentMode').value,model_index:Number(document.getElementById('modelTarget').value)});busy=false;render();await waitForAgent()}catch(error){clientError=error.message}finally{busy=false;render()}};
+document.getElementById('agentMode').onchange=()=>render();
+document.getElementById('reset').onclick=async()=>{state=await api(apiPath('new'),{});render()};
+document.getElementById('theme').onclick=()=>{document.documentElement.dataset.theme=document.documentElement.dataset.theme==='amber'?'phosphor':'amber'};
+document.getElementById('lang').onclick=()=>{lang=lang==='en'?'zh':'en';render()};
+load().catch(error=>{document.getElementById('log').textContent=error.message});
+</script></body></html>"""
+
+
+def _build_inference_targets(
+    parser: argparse.ArgumentParser,
+    base_urls: list[str],
+    api_keys: list[str],
+    models: list[str],
+) -> list[dict[str, str]]:
+    """Zip parallel inference options, broadcasting one key or model when requested."""
+
+    if not base_urls:
+        return []
+    count = len(base_urls)
+    if len(api_keys) == 1:
+        api_keys = api_keys * count
+    if len(models) == 1:
+        models = models * count
+    if len(api_keys) != count or len(models) != count:
+        parser.error("--base-url, --api-key, and --model must have equal lengths (single key/model may broadcast)")
+    targets = []
+    for base_url, api_key, model in zip(base_urls, api_keys, models, strict=True):
+        hostname = urlparse(base_url).hostname or base_url
+        targets.append(
+            {
+                "base_url": base_url,
+                "api_key": api_key,
+                "model": model,
+                "label": f"{model} @ {hostname}",
+            }
+        )
+    return targets
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--base-url", nargs="+", help="One or more inference API base URLs")
+    parser.add_argument("--api-key", nargs="+", default=["EMPTY"], help="Parallel API keys; one value broadcasts")
+    parser.add_argument("--model", nargs="+", default=["policy"], help="Parallel model names; one value broadcasts")
+    parser.add_argument("--temperature", type=float, default=1.0)
+    args = parser.parse_args()
+    args.inference_targets = _build_inference_targets(parser, args.base_url or [], args.api_key, args.model)
+    server = TerminalServer((args.host, args.port), TerminalHandler, args=args)
+    print(f"Terminal hacking WebUI: http://{args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agentic_terminal_hacking_example_cpu.py
+++ b/tests/test_agentic_terminal_hacking_example_cpu.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import random
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples" / "agentic" / "terminal_hacking"
+
+
+def _load_module(name: str):
+    path = EXAMPLE_DIR / f"{name}.py"
+    previous_game = sys.modules.pop("game", None)
+    previous_agentic = sys.modules.get("areno.api.agentic")
+    if name == "run_agent":
+        sys.modules["areno.api.agentic"] = SimpleNamespace(
+            AgentTrajectory=lambda **kwargs: SimpleNamespace(**kwargs),
+            AgentTrajectoryTurn=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(f"terminal_hacking_{name}_for_tests", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        sys.modules.pop("game", None)
+        if previous_game is not None:
+            sys.modules["game"] = previous_game
+        if name == "run_agent":
+            sys.modules.pop("areno.api.agentic", None)
+            if previous_agentic is not None:
+                sys.modules["areno.api.agentic"] = previous_agentic
+
+
+def _record(seed: int = 9):
+    generator = _load_module("dataset_generator")
+    return generator.generate_records(1, seed=seed, workers=1)[0]
+
+
+def test_generator_and_session_are_reproducible_with_probes():
+    generator = _load_module("dataset_generator")
+    game = _load_module("game")
+    rows = generator.generate_records(32, seed=17, workers=1)
+    assert rows == generator.generate_records(32, seed=17, workers=1)
+    assert all(len(row["probes"]) == 3 for row in rows)
+    for row in rows:
+        first = game.TerminalHackingSession(row)
+        second = game.TerminalHackingSession(row)
+        assert first.public_state() == second.public_state()
+        assert len(first.public_state()["available_probes"]) == 3
+        assert row["password"] in first.consistent_candidates()
+
+
+def test_candidate_tool_and_parser_accept_one_valid_candidate_set():
+    game = _load_module("game")
+    run_agent = _load_module("run_agent")
+    active = ["ACCESS", "BINARY", "BRIDGE"]
+    tool = game.candidate_tool(active)
+    parameters = tool["function"]["parameters"]
+    assert tool["function"]["name"] == "submit_candidates"
+    assert parameters["properties"]["candidates"]["items"]["enum"] == active
+    assert parameters["properties"]["candidates"]["uniqueItems"] is True
+    assistant = {
+        "tool_calls": [
+            {
+                "function": {
+                    "name": "submit_candidates",
+                    "arguments": json.dumps({"candidates": ["BINARY", "BRIDGE"]}),
+                }
+            }
+        ]
+    }
+    assert run_agent._parse_candidates(assistant, active) == ["BINARY", "BRIDGE"]
+    assert run_agent._parse_candidates({"tool_calls": []}, active) is None
+    assistant["tool_calls"][0]["function"]["arguments"] = json.dumps({"candidates": ["UNKNOWN"]})
+    assert run_agent._parse_candidates(assistant, active) is None
+
+
+def test_reward_heavily_penalizes_over_inclusion_and_lightly_penalizes_shrinkage():
+    reward = _load_module("reward")
+    game = _load_module("game")
+    generator = _load_module("dataset_generator")
+    chosen = None
+    for row in generator.generate_records(256, seed=31, workers=1):
+        session = game.candidate_filter_session(row)
+        expected = session.consistent_candidates()
+        extras = [word for word in session.public_state()["active_candidates"] if word not in expected]
+        if len(expected) >= 2 and extras:
+            chosen = row, expected, extras
+            break
+    assert chosen is not None
+    row, expected, extras = chosen
+
+    def score(candidate_sets):
+        calls = [
+            {"name": "submit_candidates", "arguments": json.dumps({"candidates": candidates})}
+            for candidates in candidate_sets
+        ]
+        return reward.reward_fn(SimpleNamespace(source_record=row, tool_calls=calls))
+
+    assert score([expected]) == 1.0
+    assert 0.9 <= score([expected[:-1]]) < 1.0
+    assert score([expected + extras[:1]]) <= -0.5
+
+
+def test_agent_rollout_is_single_turn_state_to_candidates():
+    game = _load_module("game")
+    run_agent = _load_module("run_agent")
+    record = _record()
+    session = game.candidate_filter_session(record)
+
+    class FakeCompletions:
+        def __init__(self):
+            self.requests = []
+
+        async def create(self, **kwargs):
+            self.requests.append(kwargs)
+            expected = session.consistent_candidates()
+            call = SimpleNamespace(
+                id=f"call-{len(self.requests)}",
+                type="function",
+                function=SimpleNamespace(
+                    name="submit_candidates",
+                    arguments=json.dumps({"candidates": expected}),
+                ),
+            )
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[call]))])
+
+    completions = FakeCompletions()
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    item = SimpleNamespace(prompt=game.make_filter_prompt(record), record=record)
+    turn = asyncio.run(run_agent._run_filter(item, client))
+    assert turn is not None
+    assert len(completions.requests) == 1
+    for request in completions.requests:
+        assert request["tool_choice"] == "required"
+        assert [message["role"] for message in request["messages"]] == ["system", "user", "user"]
+        assert all(message["role"] != "assistant" for message in request["messages"])
+
+
+def test_rlvr_and_webui_share_candidate_protocol_without_displaying_candidates():
+    web = _load_module("web_ui")
+    assert "submit_candidates" not in web.INDEX_HTML
+
+    record = _record(91)
+    server = SimpleNamespace(
+        record=record,
+        session=web.TerminalHackingSession(record),
+        rng=random.Random(1),
+        args=SimpleNamespace(base_url=None),
+        error=None,
+        events=[],
+    )
+    web._agent_step(server, mode="algo")
+    assert len(server.session.guessed) == 1
+    assert server.error is None


### PR DESCRIPTION
## Summary
- add a single-step state-to-candidates agentic RL example with dense asymmetric reward
- keep WebUI play aligned with the candidate-filter prompt while randomly executing one returned candidate
- support asynchronous WebUI inference, endpoint/model lists, loading state, and probe-aware play
- include only the agentic/WebUI path; no SFT generator, loader, or SFT documentation is included

## Validation
- `python -m pytest -q tests/test_agentic_terminal_hacking_example_cpu.py` (5 passed)
- `git diff --check`
- Python compilation passed
