### PR TITLE
fix(rollout): keep oversized batches in worker pending queue

### DIFF
--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -281,9 +281,10 @@ class ArenoEngine:
         :class:`RolloutOutput` carries response token ids and finish reasons
         merged across DP ranks in the original input order.
 
-        Prompts are chunked by DP size and prefill-token budget so each worker
-        can run bounded prefill batches while decode continues to use a fixed
-        paged-KV allocation.
+        All prompts are submitted to the worker scheduler in one payload. The
+        worker keeps at most ``max_running_prompts`` rows active and admits
+        pending rows under the prefill-token and paged-KV budgets as slots are
+        released.
         """
 
         if not prompts:
@@ -305,12 +306,11 @@ class ArenoEngine:
         # Worst-case per-rank prefill = every local running slot prefilling its
         # full prompt. The public max_running_prompts value is global.
         max_prefill_tokens = local_max_running_prompts * rollout_max_prompt_len
-        chunks = _chunk_prompts_for_prefill_budget(
-            prompts,
-            max_running_prompts=max_running_prompts,
-            dp_size=dp_size,
-            max_prefill_tokens=max_prefill_tokens,
-        )
+        # InferenceBatchState already owns bounded admission and continuous
+        # refill. Keeping the whole request in one worker payload prevents the
+        # coordinator from serialising independent max-running-sized chunks and
+        # repeatedly paying their long decode tails.
+        chunks = [prompts]
         for chunk in chunks:
             # Global offset of this chunk inside the user's input list, used to
             # restore original indices when merging DP results.
@@ -326,10 +326,9 @@ class ArenoEngine:
             prompt_indices_by_dp = split_list_by_dp(
                 list(range(chunk_start, chunk_start + len(chunk))), int(self.config.dp_size)
             )
-            # Largest per-rank queue depth for the current chunk; floor of 1
-            # avoids zero-sized KV pools for trailing chunks.
-            current_local_running = max(max((len(rows) for rows in prompts_by_dp), default=0), 1)
-            local_max_running = current_local_running
+            # The payload may contain more pending rows than the KV pool can
+            # run at once. Keep allocation bounded by the configured capacity.
+            local_max_running = local_max_running_prompts
             # Honour per-prompt cache length if any prompt+max_new exceeds the
             # global ceiling computed from rollout_max_prompt_len.
             max_cache_len = max(max(len(prompt) + max_new_tokens for prompt in chunk), rollout_max_cache_len)
@@ -465,12 +464,10 @@ class ArenoEngine:
         dp_start = next(self._async_dp_cursor) % dp_size
         local_max_running_prompts = max(ceil_div(int(max_running_prompts), dp_size), 1)
         max_prefill_tokens = local_max_running_prompts * rollout_max_prompt_len
-        chunks = _chunk_prompts_for_prefill_budget(
-            prompts,
-            max_running_prompts=max_running_prompts,
-            dp_size=dp_size,
-            max_prefill_tokens=max_prefill_tokens,
-        )
+        # InferenceBatchState already owns bounded admission and continuous
+        # refill. Submit all rows together so pending prompts can enter a free
+        # slot without waiting for an earlier coordinator chunk to finish.
+        chunks = [prompts]
         for chunk in chunks:
             chunk_start = sum(len(output.prompt_ids) for output in outputs)
             prompts_by_dp = _split_list_by_dp_with_offset(chunk, dp_size, dp_start)
@@ -481,8 +478,7 @@ class ArenoEngine:
             prompt_indices_by_dp = _split_list_by_dp_with_offset(
                 list(range(chunk_start, chunk_start + len(chunk))), dp_size, dp_start
             )
-            current_local_running = max(max((len(rows) for rows in prompts_by_dp), default=0), 1)
-            capacity_local_running = local_max_running_prompts if cancel_flags is None else current_local_running
+            capacity_local_running = local_max_running_prompts
             max_cache_len = max(max(len(prompt) + max_new_tokens for prompt in chunk), rollout_max_cache_len)
             max_blocks_per_seq = ceil_div(max_cache_len, self.config.runtime.kv_block_size)
             payload = RolloutPayload(

--- a/areno/engine/api.py
+++ b/areno/engine/api.py
@@ -294,7 +294,6 @@ class ArenoEngine:
         if max_running_prompts < 1:
             raise ValueError("max_running_prompts must be >= 1")
         sampling_params = sampling_params or SamplingParams()
-        outputs = []
         # Cap prompt length for KV sizing; either honour caller-provided bound
         # or fall back to the longest prompt actually seen.
         rollout_max_prompt_len = (
@@ -310,68 +309,47 @@ class ArenoEngine:
         # refill. Keeping the whole request in one worker payload prevents the
         # coordinator from serialising independent max-running-sized chunks and
         # repeatedly paying their long decode tails.
-        chunks = [prompts]
-        for chunk in chunks:
-            # Global offset of this chunk inside the user's input list, used to
-            # restore original indices when merging DP results.
-            chunk_start = sum(len(output.prompt_ids) for output in outputs)
-            # Round-robin chunk rows across DP ranks; per-rank token rows.
-            prompts_by_dp = split_list_by_dp(chunk, int(self.config.dp_size))
-            chunk_features = None
-            prompt_features_by_dp = None
-            if prompt_features is not None:
-                chunk_features = prompt_features[chunk_start : chunk_start + len(chunk)]
-                prompt_features_by_dp = split_list_by_dp(chunk_features, int(self.config.dp_size))
-            # Parallel split of the global prompt indices for downstream mapping.
-            prompt_indices_by_dp = split_list_by_dp(
-                list(range(chunk_start, chunk_start + len(chunk))), int(self.config.dp_size)
-            )
-            # The payload may contain more pending rows than the KV pool can
-            # run at once. Keep allocation bounded by the configured capacity.
-            local_max_running = local_max_running_prompts
-            # Honour per-prompt cache length if any prompt+max_new exceeds the
-            # global ceiling computed from rollout_max_prompt_len.
-            max_cache_len = max(max(len(prompt) + max_new_tokens for prompt in chunk), rollout_max_cache_len)
-            max_blocks_per_seq = ceil_div(max_cache_len, self.config.runtime.kv_block_size)
-            # Blocking RPC: returns one result per rank after every prompt
-            # finishes (or the cancel flag fires).
-            results = self.cluster.call(
-                Op.INFER_ROLLOUT,
-                RolloutPayload(
-                    prompts_by_dp=prompts_by_dp,
-                    prompt_indices_by_dp=prompt_indices_by_dp,
-                    prompt_features_by_dp=prompt_features_by_dp,
-                    max_new_tokens=max_new_tokens,
-                    eos_token_id=eos_token_id,
-                    sampling_params=sampling_params,
-                    max_running_seqs=local_max_running,
-                    max_cache_len=max_cache_len,
-                    max_blocks_per_seq=max_blocks_per_seq,
-                    max_prefill_tokens=max_prefill_tokens,
-                    num_blocks=local_max_running * max_blocks_per_seq,
-                    block_size=self.config.runtime.kv_block_size,
-                    decode_progress_interval_s=decode_progress_interval_s,
-                    cancel_flags=cancel_flags,
-                    cancel_indices_by_dp=split_list_by_dp(
-                        list(range(chunk_start, chunk_start + len(chunk))),
-                        int(self.config.dp_size),
-                    )
-                    if cancel_flags is not None
-                    else None,
-                ),
-            )
-            # Drop TP duplicates (only DP rank 0 carries real results) and
-            # re-order DP-shuffled rows back into chunk input order.
-            dp_outputs = dp_rank0_results(results, self.config.tp_size, int(self.config.dp_size))
-            total_count = len(chunk)
-            outputs.append(
-                _merge_dp_rollouts_in_input_order(
-                    dp_outputs,
-                    total_count=total_count,
-                )
-            )
-        # Fast path for single-chunk inputs; otherwise concat per-chunk outputs.
-        return outputs[0] if len(outputs) == 1 else _merge_rollouts(outputs)
+        prompts_by_dp = split_list_by_dp(prompts, dp_size)
+        prompt_features_by_dp = split_list_by_dp(prompt_features, dp_size) if prompt_features is not None else None
+        # Parallel split of the global prompt indices for downstream mapping.
+        prompt_indices_by_dp = split_list_by_dp(list(range(len(prompts))), dp_size)
+        # The payload may contain more pending rows than the KV pool can run at
+        # once. Keep allocation bounded by the configured capacity.
+        max_cache_len = max(
+            max(len(prompt) + max_new_tokens for prompt in prompts),
+            rollout_max_cache_len,
+        )
+        max_blocks_per_seq = ceil_div(max_cache_len, self.config.runtime.kv_block_size)
+        # Blocking RPC: returns one result per rank after every prompt finishes
+        # (or the cancel flag fires).
+        results = self.cluster.call(
+            Op.INFER_ROLLOUT,
+            RolloutPayload(
+                prompts_by_dp=prompts_by_dp,
+                prompt_indices_by_dp=prompt_indices_by_dp,
+                prompt_features_by_dp=prompt_features_by_dp,
+                max_new_tokens=max_new_tokens,
+                eos_token_id=eos_token_id,
+                sampling_params=sampling_params,
+                max_running_seqs=local_max_running_prompts,
+                max_cache_len=max_cache_len,
+                max_blocks_per_seq=max_blocks_per_seq,
+                max_prefill_tokens=max_prefill_tokens,
+                num_blocks=local_max_running_prompts * max_blocks_per_seq,
+                block_size=self.config.runtime.kv_block_size,
+                decode_progress_interval_s=decode_progress_interval_s,
+                cancel_flags=cancel_flags,
+                cancel_indices_by_dp=split_list_by_dp(list(range(len(prompts))), dp_size)
+                if cancel_flags is not None
+                else None,
+            ),
+        )
+        # Drop TP duplicates (only DP rank 0 carries real results) and re-order
+        # DP-shuffled rows back into input order.
+        return _merge_dp_rollouts_in_input_order(
+            dp_rank0_results(results, self.config.tp_size, dp_size),
+            total_count=len(prompts),
+        )
 
     def probe_rollout_cache(
         self,
@@ -453,7 +431,6 @@ class ArenoEngine:
         if max_running_prompts < 1:
             raise ValueError("max_running_prompts must be >= 1")
         sampling_params = sampling_params or SamplingParams()
-        outputs = []
         rollout_max_prompt_len = (
             int(max_prompt_len) if max_prompt_len is not None else max(len(prompt) for prompt in prompts)
         )
@@ -467,55 +444,46 @@ class ArenoEngine:
         # InferenceBatchState already owns bounded admission and continuous
         # refill. Submit all rows together so pending prompts can enter a free
         # slot without waiting for an earlier coordinator chunk to finish.
-        chunks = [prompts]
-        for chunk in chunks:
-            chunk_start = sum(len(output.prompt_ids) for output in outputs)
-            prompts_by_dp = _split_list_by_dp_with_offset(chunk, dp_size, dp_start)
-            prompt_features_by_dp = None
-            if prompt_features is not None:
-                chunk_features = prompt_features[chunk_start : chunk_start + len(chunk)]
-                prompt_features_by_dp = _split_list_by_dp_with_offset(chunk_features, dp_size, dp_start)
-            prompt_indices_by_dp = _split_list_by_dp_with_offset(
-                list(range(chunk_start, chunk_start + len(chunk))), dp_size, dp_start
-            )
-            capacity_local_running = local_max_running_prompts
-            max_cache_len = max(max(len(prompt) + max_new_tokens for prompt in chunk), rollout_max_cache_len)
-            max_blocks_per_seq = ceil_div(max_cache_len, self.config.runtime.kv_block_size)
-            payload = RolloutPayload(
-                prompts_by_dp=prompts_by_dp,
-                prompt_indices_by_dp=prompt_indices_by_dp,
-                prompt_features_by_dp=prompt_features_by_dp,
-                max_new_tokens=max_new_tokens,
-                eos_token_id=eos_token_id,
-                sampling_params=sampling_params,
-                max_running_seqs=capacity_local_running,
-                max_cache_len=max_cache_len,
-                max_blocks_per_seq=max_blocks_per_seq,
-                max_prefill_tokens=max_prefill_tokens,
-                num_blocks=capacity_local_running * max_blocks_per_seq,
-                block_size=self.config.runtime.kv_block_size,
-                decode_progress_interval_s=decode_progress_interval_s,
-                cancel_flags=cancel_flags,
-                cancel_indices_by_dp=_split_list_by_dp_with_offset(
-                    list(range(chunk_start, chunk_start + len(chunk))), dp_size, dp_start
-                )
-                if cancel_flags is not None
-                else None,
-            )
-            results = await self.cluster.call_async(
-                Op.INFER_ROLLOUT,
-                payload,
-                result_ranks={dp_rank * int(self.config.tp_size) for dp_rank in range(dp_size)},
-            )
-            outputs.append(
-                _merge_dp_rollouts_by_prompt_indices(
-                    dp_rank0_results(results, self.config.tp_size, dp_size),
-                    prompt_indices_by_dp,
-                    chunk_start=chunk_start,
-                    total_count=len(chunk),
-                )
-            )
-        return outputs[0] if len(outputs) == 1 else _merge_rollouts(outputs)
+        prompts_by_dp = _split_list_by_dp_with_offset(prompts, dp_size, dp_start)
+        prompt_features_by_dp = (
+            _split_list_by_dp_with_offset(prompt_features, dp_size, dp_start) if prompt_features is not None else None
+        )
+        prompt_indices_by_dp = _split_list_by_dp_with_offset(list(range(len(prompts))), dp_size, dp_start)
+        max_cache_len = max(
+            max(len(prompt) + max_new_tokens for prompt in prompts),
+            rollout_max_cache_len,
+        )
+        max_blocks_per_seq = ceil_div(max_cache_len, self.config.runtime.kv_block_size)
+        payload = RolloutPayload(
+            prompts_by_dp=prompts_by_dp,
+            prompt_indices_by_dp=prompt_indices_by_dp,
+            prompt_features_by_dp=prompt_features_by_dp,
+            max_new_tokens=max_new_tokens,
+            eos_token_id=eos_token_id,
+            sampling_params=sampling_params,
+            max_running_seqs=local_max_running_prompts,
+            max_cache_len=max_cache_len,
+            max_blocks_per_seq=max_blocks_per_seq,
+            max_prefill_tokens=max_prefill_tokens,
+            num_blocks=local_max_running_prompts * max_blocks_per_seq,
+            block_size=self.config.runtime.kv_block_size,
+            decode_progress_interval_s=decode_progress_interval_s,
+            cancel_flags=cancel_flags,
+            cancel_indices_by_dp=_split_list_by_dp_with_offset(list(range(len(prompts))), dp_size, dp_start)
+            if cancel_flags is not None
+            else None,
+        )
+        results = await self.cluster.call_async(
+            Op.INFER_ROLLOUT,
+            payload,
+            result_ranks={dp_rank * int(self.config.tp_size) for dp_rank in range(dp_size)},
+        )
+        return _merge_dp_rollouts_by_prompt_indices(
+            dp_rank0_results(results, self.config.tp_size, dp_size),
+            prompt_indices_by_dp,
+            chunk_start=0,
+            total_count=len(prompts),
+        )
 
     def step(
         self, data_packs: list[dict[str, Any]], *, gradient_accumulation_steps: int | None = None
@@ -771,47 +739,6 @@ class ArenoEngine:
         """Close workers when leaving a context manager."""
 
         self.close()
-
-
-def _chunk_prompts_for_prefill_budget(
-    prompts: list[list[int]],
-    *,
-    max_running_prompts: int,
-    dp_size: int,
-    max_prefill_tokens: int,
-) -> list[list[list[int]]]:
-    """Split prompts so each DP rank stays within prefill token budget.
-
-    Greedy packer that walks the prompt list once and starts a new chunk when
-    either the per-chunk count cap (``max_running_prompts * dp_size``) or the
-    per-DP-rank token cap (``max_prefill_tokens``) would be exceeded. The
-    per-rank index is computed via round-robin position inside the chunk.
-    """
-
-    # Hard cap on prompts per chunk. max_running_prompts is a global flat
-    # rollout cap; DP splitting happens after chunking.
-    max_chunk_size = max_running_prompts
-    chunks: list[list[list[int]]] = []
-    chunk: list[list[int]] = []
-    token_sums = [0 for _ in range(dp_size)]
-    for prompt in prompts:
-        # Round-robin DP assignment matches split_list_by_dp's layout.
-        dp_rank = len(chunk) % dp_size
-        would_exceed_count = len(chunk) >= max_chunk_size
-        # token_sums[dp_rank] > 0 guard: always allow the first prompt for a
-        # rank even if it alone exceeds the prefill budget.
-        would_exceed_tokens = token_sums[dp_rank] > 0 and token_sums[dp_rank] + len(prompt) > max_prefill_tokens
-        if chunk and (would_exceed_count or would_exceed_tokens):
-            # Flush current chunk and start fresh; reset per-rank token tally.
-            chunks.append(chunk)
-            chunk = []
-            token_sums = [0 for _ in range(dp_size)]
-            dp_rank = 0
-        chunk.append(prompt)
-        token_sums[dp_rank] += len(prompt)
-    if chunk:
-        chunks.append(chunk)
-    return chunks
 
 
 def _split_list_by_dp_with_offset(items: list[Any], dp_size: int, offset: int) -> list[list[Any]]:

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -7,7 +7,7 @@ import torch
 
 import areno.engine.inference as inference_mod
 import areno.engine.worker as worker_mod
-from areno.engine.api import ArenoEngine, _chunk_prompts_for_prefill_budget, _merge_async_dp_rollouts
+from areno.engine.api import ArenoEngine, _merge_async_dp_rollouts
 from areno.engine.data import SamplingParams
 from areno.engine.data.rollout_state import InferenceBatchState
 from areno.engine.inference import InferCacheSpec, InferenceManager
@@ -478,21 +478,6 @@ def test_async_single_prompt_requests_round_robin_across_dp_ranks():
         [0, 0, 0, 1],
     ]
     assert [output.response_ids for output in outputs] == [[[10]], [[11]], [[12]], [[13]]]
-
-
-def test_prefill_chunking_uses_global_max_running_prompts():
-    """A 256-row flat rollout should stay one chunk even when dp_size is 8."""
-
-    prompts = [[idx] for idx in range(256)]
-
-    chunks = _chunk_prompts_for_prefill_budget(
-        prompts,
-        max_running_prompts=256,
-        dp_size=8,
-        max_prefill_tokens=1024,
-    )
-
-    assert [len(chunk) for chunk in chunks] == [256]
 
 
 def test_decode_progress_log_is_worker_aggregated(monkeypatch):

--- a/tests/test_inference_scheduler_cpu.py
+++ b/tests/test_inference_scheduler_cpu.py
@@ -347,6 +347,89 @@ def test_async_single_request_payload_uses_configured_local_capacity():
     assert cluster.payload.max_running_seqs == 16
 
 
+def test_async_rollout_submits_rows_beyond_running_capacity_as_worker_pending():
+    """One RL batch should not become serial coordinator-side chunks."""
+
+    class ClusterStub:
+        def __init__(self):
+            self.payloads = []
+
+        async def call_async(self, op, payload, **kwargs):
+            del kwargs
+            self.payloads.append(payload)
+            assert op is Op.INFER_ROLLOUT
+            prompts = payload.prompts_by_dp[0]
+            return [
+                _build_rollout_from_rows(
+                    prompts,
+                    [[prompt[0] + 10] for prompt in prompts],
+                    ["stop"] * len(prompts),
+                    [torch.tensor([-0.1], dtype=torch.float32) for _ in prompts],
+                    metrics=None,
+                )
+            ]
+
+    cluster = ClusterStub()
+    engine = object.__new__(ArenoEngine)
+    engine.cluster = cluster
+    engine.config = SimpleNamespace(tp_size=1, dp_size=1, runtime=SimpleNamespace(kv_block_size=16))
+
+    result = asyncio.run(
+        engine._generate_rollout_async_once(
+            [[1], [2], [3], [4]],
+            max_new_tokens=16,
+            max_running_prompts=2,
+            eos_token_id=None,
+            sampling_params=SamplingParams(),
+        )
+    )
+
+    assert len(cluster.payloads) == 1
+    assert cluster.payloads[0].prompts_by_dp == [[[1], [2], [3], [4]]]
+    assert cluster.payloads[0].max_running_seqs == 2
+    assert result.response_ids == [[11], [12], [13], [14]]
+
+
+def test_blocking_rollout_submits_rows_beyond_running_capacity_as_worker_pending():
+    """The blocking API should use the same bounded worker-side pending queue."""
+
+    class ClusterStub:
+        def __init__(self):
+            self.payloads = []
+
+        def call(self, op, payload):
+            self.payloads.append(payload)
+            assert op is Op.INFER_ROLLOUT
+            prompts = payload.prompts_by_dp[0]
+            return [
+                _build_rollout_from_rows(
+                    prompts,
+                    [[prompt[0] + 10] for prompt in prompts],
+                    ["stop"] * len(prompts),
+                    [torch.tensor([-0.1], dtype=torch.float32) for _ in prompts],
+                    metrics=None,
+                )
+            ]
+
+    cluster = ClusterStub()
+    engine = object.__new__(ArenoEngine)
+    engine.cluster = cluster
+    engine.config = SimpleNamespace(tp_size=1, dp_size=1, runtime=SimpleNamespace(kv_block_size=16))
+
+    result = engine.generate_rollout(
+        [[1], [2], [3], [4]],
+        max_new_tokens=16,
+        max_running_prompts=2,
+        eos_token_id=None,
+        sampling_params=SamplingParams(),
+    )
+
+    assert len(cluster.payloads) == 1
+    assert cluster.payloads[0].prompts_by_dp == [[[1], [2], [3], [4]]]
+    assert cluster.payloads[0].max_running_seqs == 2
+    assert result.response_ids == [[11], [12], [13], [14]]
+
+
 def test_async_single_prompt_requests_round_robin_across_dp_ranks():
     """Independent serve requests should not all land on DP rank 0."""
 


### PR DESCRIPTION
## Summary

Submit one rollout request as one worker payload, even when the request contains more rows than `max_running_prompts`.

The worker-side `InferenceBatchState` already bounds active admission by `max_running_seqs`, the prefill-token budget, and the paged-KV block budget. Keeping the remaining rows in that scheduler's pending queue allows a newly freed slot to be refilled immediately instead of waiting for every row in an earlier coordinator chunk to finish.

Both blocking and async rollout paths now use the same behavior.

## Problem

The coordinator previously split a rollout request into chunks capped by `max_running_prompts` and waited for each chunk to finish before submitting the next one.

For example, 256 generated requests with `max_running_prompts=96` were dispatched as:

```text
96 -> wait for all 96 -> 96 -> wait for all 96 -> 64
```

This serializes the long decode tail of every chunk. A short response in a chunk frees worker capacity, but a request from the next chunk cannot enter that slot until the longest response in the current chunk finishes.

## Trigger conditions

The issue is triggered when all of the following are true:

1. A single rollout API call contains more generated request rows than the global `max_running_prompts` capacity. In RL this is commonly `prompt_batch_size * n_samples > max_running_prompts`.
2. Responses have heterogeneous decode lengths or early stop/cancellation behavior, so some active slots become free before the chunk's longest response completes.
3. The call uses either the blocking `generate_rollout` path or the async rollout path; both previously performed coordinator-side chunking.

The penalty grows with the number of coordinator chunks and the response-length tail. Calls with `request_rows <= max_running_prompts` are not affected. Equal-length fixed-shape generations still trigger the old chunking path, but have a much smaller scheduling penalty because their slots become free together.

## Fix

Send all request rows in one payload and keep GPU allocation bounded by the configured capacity:

- `max_running_seqs = ceil(max_running_prompts / dp_size)` per DP rank;
- `num_blocks = max_running_seqs * max_blocks_per_seq`;
- `max_prefill_tokens = max_running_seqs * max_prompt_len`.

Only the worker pending queue can contain more rows than the active capacity. This does not increase the rollout KV-cache capacity or the number of concurrently active sequences.

With the same 256/C96 example, the worker receives all 256 rows once, runs at most 96 concurrently, and admits pending rows as active rows finish.

## Tests

Tiny V3 GPU probe, TP1/DP1, `N=8`, `C=2`, CUDA graph enabled:
  - one coordinator payload containing all 8 rows;
  - worker capacity remained `max_running_seqs=2` with two KV blocks;
  - all 8 rows completed with response lengths `[4, 4, 4, 3, 64, 2, 2, 64]`;
  - decode stayed at `active=2` while pending rows refilled free slots, then fell to `active=1` only in the final tail;
  - progress logs confirmed `cuda_graph=True`.

The CPU regression tests assert, for both blocking and async APIs, that four rows with capacity two produce exactly one worker payload, preserve capacity two, and return all rows in input order.

The GPU probe intentionally selected a stop token that ended only part of the batch early. This made the original long-tail trigger explicit while verifying that the fixed path completes rows beyond the active capacity without increasing that capacity. 

## Scope and trade-offs

- No model, CUDA kernel, LoRA, optimizer, or public configuration changes.
- GPU KV/cache memory remains bounded by `max_running_prompts`.
- The coordinator/worker payload now carries all tokenized prompts for the rollout call, so host-side payload memory is proportional to the full request size rather than one coordinator chunk.
