### PR TITLE
feat(bailing-v3): add activation checkpointing

### DIFF
--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -91,7 +91,7 @@ from areno.engine.parallel.collectives import (
 )
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
-from areno.engine.runtime.recompute import checkpoint_layer
+from areno.engine.runtime.recompute import checkpoint_layer, should_checkpoint_layer
 from areno.engine.runtime.routing_replay import resolve_sigmoid_routes
 from areno.models._shared.dynamo_wrappers import (
     _areno_depthwise_causal_conv1d_silu_decode_no_compile,
@@ -326,8 +326,29 @@ class BailingSparseMoeBlock(nn.Module):
         return out
 
     def forward(self, hidden_states: torch.Tensor, num_padding_tokens: int = 0) -> torch.Tensor:
-        topk_idx, topk_weight = self.route(hidden_states, num_padding_tokens)
-        return self.forward_with_routes(hidden_states, topk_idx, topk_weight)
+        # Preserve the single-gather path used when activation recomputation
+        # is disabled. The split route/experts methods intentionally gather
+        # independently so checkpointed expert recompute can start from the
+        # local SP shard.
+        moe_sequence_parallel = is_sequence_parallel_active()
+        sequence_parallel_hidden_states = hidden_states
+        if moe_sequence_parallel:
+            hidden_states = gather_from_sequence_parallel_region(hidden_states)
+        bsz, seqlen, hidden = hidden_states.shape
+        expert_input = hidden_states.to(dtype=self.experts.linear_fc1.weight.dtype)
+        with sequence_parallel_region(False):
+            topk_idx, topk_weight, _ = self.gate(hidden_states, num_padding_tokens)
+            flat = expert_input.view(-1, hidden)
+            if self.training or not self._infer_weights_ready:
+                out = self.experts(flat, topk_idx, topk_weight).view(bsz, seqlen, hidden)
+            else:
+                out = self._forward_fused_moe(flat, topk_idx, topk_weight).view(bsz, seqlen, hidden)
+        if moe_sequence_parallel:
+            out = scatter_to_sequence_parallel_region(out)
+        if self.shared_experts is not None:
+            shared_input = sequence_parallel_hidden_states if moe_sequence_parallel else hidden_states
+            out = out + self.shared_experts(shared_input)
+        return out
 
     @torch.no_grad()
     def prepare_infer_weights(self) -> None:
@@ -1574,6 +1595,8 @@ class BailingDecoderLayer(nn.Module):
         if isinstance(self.mlp, BailingSparseMoeBlock):
             mlp_input = self.post_attention_layernorm(hidden_states)
             num_padding_tokens = train_meta.num_padding_tokens if train_meta is not None else 0
+            if not should_checkpoint_layer(train_meta, infer_meta):
+                return residual + self.mlp(mlp_input, num_padding_tokens)
             topk_idx, topk_weight = self.mlp.route(mlp_input, num_padding_tokens)
             return residual + checkpoint_layer(
                 self.mlp.forward_with_routes,

--- a/areno/models/bailing_v3/model.py
+++ b/areno/models/bailing_v3/model.py
@@ -91,6 +91,7 @@ from areno.engine.parallel.collectives import (
 )
 from areno.engine.parallel.context import get_tp_context
 from areno.engine.runtime.metadata import InferMeta, TrainMeta
+from areno.engine.runtime.recompute import checkpoint_layer
 from areno.engine.runtime.routing_replay import resolve_sigmoid_routes
 from areno.models._shared.dynamo_wrappers import (
     _areno_depthwise_causal_conv1d_silu_decode_no_compile,
@@ -286,9 +287,23 @@ class BailingSparseMoeBlock(nn.Module):
             routed_scaling_factor=self.config.routed_scaling_factor,
         )
 
-    def forward(self, hidden_states: torch.Tensor, num_padding_tokens: int = 0) -> torch.Tensor:
-        # In SP mode we need the full (un-scattered) hidden states for routing
-        # since the router weight isn't sharded along the sequence dim.
+    def route(self, hidden_states: torch.Tensor, num_padding_tokens: int = 0) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute routing once so activation recompute can reuse it."""
+
+        if is_sequence_parallel_active():
+            hidden_states = gather_from_sequence_parallel_region(hidden_states)
+        with sequence_parallel_region(False):
+            topk_idx, topk_weight, _ = self.gate(hidden_states, num_padding_tokens)
+        return topk_idx, topk_weight
+
+    def forward_with_routes(
+        self,
+        hidden_states: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run routed and shared experts with a fixed routing decision."""
+
         moe_sequence_parallel = is_sequence_parallel_active()
         sequence_parallel_hidden_states = hidden_states
         if moe_sequence_parallel:
@@ -296,7 +311,6 @@ class BailingSparseMoeBlock(nn.Module):
         bsz, seqlen, hidden = hidden_states.shape
         expert_input = hidden_states.to(dtype=self.experts.linear_fc1.weight.dtype)
         with sequence_parallel_region(False):
-            topk_idx, topk_weight, _ = self.gate(hidden_states, num_padding_tokens)
             flat = expert_input.view(-1, hidden)
             if self.training or not self._infer_weights_ready:
                 # Permute/unpermute path is autograd-friendly.
@@ -310,6 +324,10 @@ class BailingSparseMoeBlock(nn.Module):
             shared_input = sequence_parallel_hidden_states if moe_sequence_parallel else hidden_states
             out = out + self.shared_experts(shared_input)
         return out
+
+    def forward(self, hidden_states: torch.Tensor, num_padding_tokens: int = 0) -> torch.Tensor:
+        topk_idx, topk_weight = self.route(hidden_states, num_padding_tokens)
+        return self.forward_with_routes(hidden_states, topk_idx, topk_weight)
 
     @torch.no_grad()
     def prepare_infer_weights(self) -> None:
@@ -1520,6 +1538,18 @@ class BailingDecoderLayer(nn.Module):
             else BailingDenseMLP(config, config.intermediate_size)
         )
 
+    def _attention_block(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        train_meta: TrainMeta | None,
+        infer_meta: InferMeta | None,
+    ) -> torch.Tensor:
+        return self.attention(self.input_layernorm(hidden_states), position_ids, train_meta, infer_meta)
+
+    def _dense_mlp_block(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.mlp(self.post_attention_layernorm(hidden_states))
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -1527,17 +1557,38 @@ class BailingDecoderLayer(nn.Module):
         train_meta: TrainMeta | None,
         infer_meta: InferMeta | None,
     ) -> torch.Tensor:
-        # Standard pre-norm residual: norm -> sublayer -> add.
+        # Checkpoint attention for every Ling/Bailing V3 layer. Sparse MoE
+        # routing remains outside recomputation so its load counters are not
+        # accumulated twice and rollout-replayed routes stay authoritative.
         residual = hidden_states
-        hidden_states = residual + self.attention(
-            self.input_layernorm(hidden_states), position_ids, train_meta, infer_meta
+        hidden_states = residual + checkpoint_layer(
+            self._attention_block,
+            hidden_states,
+            position_ids,
+            train_meta,
+            infer_meta,
+            train_meta=train_meta,
+            infer_meta=infer_meta,
         )
         residual = hidden_states
-        mlp_input = self.post_attention_layernorm(hidden_states)
         if isinstance(self.mlp, BailingSparseMoeBlock):
+            mlp_input = self.post_attention_layernorm(hidden_states)
             num_padding_tokens = train_meta.num_padding_tokens if train_meta is not None else 0
-            return residual + self.mlp(mlp_input, num_padding_tokens)
-        return residual + self.mlp(mlp_input)
+            topk_idx, topk_weight = self.mlp.route(mlp_input, num_padding_tokens)
+            return residual + checkpoint_layer(
+                self.mlp.forward_with_routes,
+                mlp_input,
+                topk_idx,
+                topk_weight,
+                train_meta=train_meta,
+                infer_meta=infer_meta,
+            )
+        return residual + checkpoint_layer(
+            self._dense_mlp_block,
+            hidden_states,
+            train_meta=train_meta,
+            infer_meta=infer_meta,
+        )
 
 
 class BailingMoeV3ForCausalLM(nn.Module):

--- a/docs/getting-started/cuda.rst
+++ b/docs/getting-started/cuda.rst
@@ -98,7 +98,9 @@ The main CUDA controls are:
 
 ``--activation-checkpointing``
    Recomputes supported decoder activations during backward. It is enabled by
-   default.
+   default. Ling/Bailing V3 checkpoints attention in every decoder layer and
+   both dense and routed expert MLP blocks. Sparse routing remains outside
+   recomputation so routing load counters are updated exactly once.
 
 ``--optimizer-state-offload cpu``
    Moves optimizer state to host memory between train calls.

--- a/docs/models/supported.rst
+++ b/docs/models/supported.rst
@@ -27,6 +27,9 @@ family is available on both backends.
        ``qwen3_5_moe`` layouts, with Areno MoE kernels.
    * - Bailing MoE Linear v2
      - Local model adapter for Bailing MoE Linear v2 checkpoints.
+   * - Ling / Bailing MoE V3
+     - ``bailing_hybrid`` checkpoints with softmax/KDA attention, sparse MoE,
+       and activation checkpointing.
    * - Gemma4
      - Gemma4 text and conditional-generation checkpoints. Native Gemma4 and
        Gemma4 Unified processors support image, audio, and video inputs for

--- a/tests/test_moe_sequence_parallel_cpu.py
+++ b/tests/test_moe_sequence_parallel_cpu.py
@@ -221,6 +221,7 @@ def test_bailing_v3_decoder_keeps_sparse_router_outside_recompute(monkeypatch):
 
     monkeypatch.setattr(bailing_v3, "checkpoint_layer", checkpoint)
     monkeypatch.setattr(bailing_v3, "BailingSparseMoeBlock", SparseMlp)
+    monkeypatch.setattr(bailing_v3, "should_checkpoint_layer", lambda train_meta, infer_meta: True)
 
     def attention_block(states, position_ids, train_meta, infer_meta):
         del position_ids, train_meta, infer_meta
@@ -244,6 +245,48 @@ def test_bailing_v3_decoder_keeps_sparse_router_outside_recompute(monkeypatch):
     assert checkpointed == ["attention_block", "forward_with_routes"]
     assert route_calls == [1]
     assert expert_calls == [((2, 1), (2, 1))]
+    torch.testing.assert_close(output, torch.full_like(output, 12))
+
+
+def test_bailing_v3_decoder_uses_direct_sparse_path_without_checkpoint(monkeypatch):
+    pytest.importorskip("triton")
+    import areno.models.bailing_v3.model as bailing_v3
+
+    direct_calls = []
+
+    class SparseMlp:
+        def __call__(self, states, num_padding_tokens):
+            direct_calls.append(num_padding_tokens)
+            return states * 3
+
+        def route(self, states, num_padding_tokens):
+            raise AssertionError("disabled checkpointing must use the single-gather sparse path")
+
+        def forward_with_routes(self, states, topk_idx, topk_weight):
+            raise AssertionError("disabled checkpointing must use the single-gather sparse path")
+
+    monkeypatch.setattr(bailing_v3, "BailingSparseMoeBlock", SparseMlp)
+
+    def attention_block(states, position_ids, train_meta, infer_meta):
+        del position_ids, train_meta, infer_meta
+        return states * 2
+
+    layer = SimpleNamespace(
+        _attention_block=attention_block,
+        post_attention_layernorm=lambda states: states,
+        mlp=SparseMlp(),
+    )
+    hidden = torch.ones((1, 2, 2))
+
+    output = bailing_v3.BailingDecoderLayer.forward(
+        layer,
+        hidden,
+        torch.arange(2).unsqueeze(0),
+        SimpleNamespace(num_padding_tokens=1, activation_checkpointing=False),
+        None,
+    )
+
+    assert direct_calls == [1]
     torch.testing.assert_close(output, torch.full_like(output, 12))
 
 

--- a/tests/test_moe_sequence_parallel_cpu.py
+++ b/tests/test_moe_sequence_parallel_cpu.py
@@ -154,6 +154,99 @@ def test_bailing_router_load_ignores_alignment_tokens(monkeypatch):
         torch.testing.assert_close(gate.local_tokens_per_expert, torch.tensor([1.0, 2.0]))
 
 
+def test_bailing_v3_decoder_checkpoints_attention_and_dense_mlp(monkeypatch):
+    pytest.importorskip("triton")
+    import areno.models.bailing_v3.model as bailing_v3
+
+    checkpointed = []
+
+    def checkpoint(function, states, *args, train_meta=None, infer_meta=None):
+        del train_meta, infer_meta
+        checkpointed.append(function.__name__)
+        return function(states, *args)
+
+    monkeypatch.setattr(bailing_v3, "checkpoint_layer", checkpoint)
+
+    class DenseMlp:
+        pass
+
+    def attention_block(states, position_ids, train_meta, infer_meta):
+        del position_ids, train_meta, infer_meta
+        return states * 2
+
+    def dense_mlp_block(states):
+        return states * 3
+
+    layer = SimpleNamespace(
+        _attention_block=attention_block,
+        _dense_mlp_block=dense_mlp_block,
+        mlp=DenseMlp(),
+    )
+    hidden = torch.ones((1, 2, 2))
+
+    output = bailing_v3.BailingDecoderLayer.forward(
+        layer,
+        hidden,
+        torch.arange(2).unsqueeze(0),
+        SimpleNamespace(num_padding_tokens=0),
+        None,
+    )
+
+    assert checkpointed == ["attention_block", "dense_mlp_block"]
+    torch.testing.assert_close(output, torch.full_like(output, 12))
+
+
+def test_bailing_v3_decoder_keeps_sparse_router_outside_recompute(monkeypatch):
+    pytest.importorskip("triton")
+    import areno.models.bailing_v3.model as bailing_v3
+
+    checkpointed = []
+    route_calls = []
+    expert_calls = []
+
+    def checkpoint(function, states, *args, train_meta=None, infer_meta=None):
+        del train_meta, infer_meta
+        checkpointed.append(function.__name__)
+        return function(states, *args)
+
+    class SparseMlp:
+        def route(self, states, num_padding_tokens):
+            route_calls.append(num_padding_tokens)
+            count = states.numel() // states.shape[-1]
+            return torch.zeros((count, 1), dtype=torch.long), torch.ones((count, 1))
+
+        def forward_with_routes(self, states, topk_idx, topk_weight):
+            expert_calls.append((topk_idx.shape, topk_weight.shape))
+            return states * 3
+
+    monkeypatch.setattr(bailing_v3, "checkpoint_layer", checkpoint)
+    monkeypatch.setattr(bailing_v3, "BailingSparseMoeBlock", SparseMlp)
+
+    def attention_block(states, position_ids, train_meta, infer_meta):
+        del position_ids, train_meta, infer_meta
+        return states * 2
+
+    layer = SimpleNamespace(
+        _attention_block=attention_block,
+        post_attention_layernorm=lambda states: states,
+        mlp=SparseMlp(),
+    )
+    hidden = torch.ones((1, 2, 2))
+
+    output = bailing_v3.BailingDecoderLayer.forward(
+        layer,
+        hidden,
+        torch.arange(2).unsqueeze(0),
+        SimpleNamespace(num_padding_tokens=1),
+        None,
+    )
+
+    assert checkpointed == ["attention_block", "forward_with_routes"]
+    assert route_calls == [1]
+    assert expert_calls == [((2, 1), (2, 1))]
+    torch.testing.assert_close(output, torch.full_like(output, 12))
+
+
 def test_gemma4_moe_routes_local_shard_then_gathers_expert_inputs(monkeypatch):
     pytest.importorskip("triton")
     import areno.models.gemma4.model as gemma4


### PR DESCRIPTION
## Summary

- add standard activation checkpointing to Ling/Bailing V3 decoder attention blocks
- checkpoint dense MLP blocks and sparse expert execution
- compute sparse MoE routing once outside recomputation, then reuse the fixed routes during expert recompute
- document Ling/Bailing V3 activation-checkpointing support and add regression coverage

This PR intentionally does not add FP8 saved-tensor checkpointing, FP8 CLI flags, or FP8 metrics. It uses the existing `checkpoint_layer` path controlled by `--activation-checkpointing`.

## Why

Ling/Bailing V3 previously called decoder layers directly, so the default activation-checkpointing setting did not reduce its decoder activation storage. Checkpointing the full sparse layer would execute the router again during backward, duplicate expert-load accounting, and risk changing replayed routing decisions.

The implementation therefore uses these boundaries:

- checkpoint attention for every decoder layer;
- checkpoint dense MLP blocks;
- run sparse routing once outside the checkpoint;
- checkpoint routed/shared expert execution with the original `topk_idx` and `topk_weight`.

Inference and training with activation checkpointing disabled continue through `checkpoint_layer` without recomputation.

## Tests

- `python -m pytest -q tests/test_moe_sequence_parallel_cpu.py tests/test_recompute_cpu.py tests/test_registry_cpu.py -k "bailing or checkpoint or registry"`
  - 12 passed, 4 skipped, 3 deselected
- `pre-commit run --all-files --hook-stage manual`
  - passed