### PR TITLE
feat(mlx): add LoRA training support

### DIFF
--- a/areno/api/backend/mlx/backend.py
+++ b/areno/api/backend/mlx/backend.py
@@ -16,6 +16,7 @@ from areno.api.backend.common import (
 )
 from areno.api.backend.mlx.checkpoint import save_checkpoint
 from areno.api.backend.mlx.generation import ContinuousBatchScheduler, GenerationConfig
+from areno.api.backend.mlx.lora import MlxLoraState, export_peft_adapter, initialize_lora
 from areno.api.backend.mlx.losses import mlx_loss
 from areno.api.backend.mlx.numerics import selected_token_logprobs
 from areno.api.backend.mlx.optimizer import apply_optimizer_update, build_optimizer, set_group_learning_rates
@@ -47,6 +48,7 @@ class MlxBackend(Backend):
         self._rollout_scheduler: ContinuousBatchScheduler | None = None
         self._roles: dict[str, MlxRole] = {}
         self._compiled_losses: dict[tuple[str, tuple[tuple[str, object], ...]], Callable] = {}
+        self._lora_state: MlxLoraState | None = None
 
     @classmethod
     def capabilities(cls) -> BackendCapabilities:
@@ -66,10 +68,6 @@ class MlxBackend(Backend):
             config = MlxConfig()
         if not isinstance(config, MlxConfig):
             raise TypeError(f"MlxBackend requires MlxConfig, got {type(config)!r}")
-        if config.lora is not None:
-            raise NotImplementedError(
-                "MLX PEFT LoRA configuration is accepted, but adapter injection is not implemented yet"
-            )
         try:
             import mlx.core as mx
         except ImportError as exc:
@@ -95,7 +93,16 @@ class MlxBackend(Backend):
             )
         self._validate_tokenizer(ctx.tokenizer)
         optimizer_config = self.config.optimizer
-        self.provider.configure_trainability(optimizer_config)
+        if self.config.lora is None:
+            self.provider.configure_trainability(optimizer_config)
+        else:
+            if self.provider.is_multimodal:
+                raise ValueError("MLX LoRA currently supports text-only checkpoints")
+            self._lora_state = initialize_lora(
+                self.model,
+                self.config.lora,
+                model_type=str(self.model_config.get("model_type", "")),
+            )
         self.optimizer, self._optimizer_groups = build_optimizer(
             optimizer_config,
             state_precision_for_parameter=self.provider.optimizer_state_precision,
@@ -125,6 +132,7 @@ class MlxBackend(Backend):
         self.processor = None
         self.optimizer = None
         self._optimizer_groups = []
+        self._lora_state = None
         mx.clear_cache()
 
     def begin_rollout_session(self, ctx: Context) -> None:
@@ -284,9 +292,11 @@ class MlxBackend(Backend):
         return result
 
     def save_checkpoint(self, ctx: Context, path: str) -> str:
-        """Save MLX weights plus tokenizer/config files in MLX-LM format."""
+        """Save full MLX weights, or a standard PEFT artifact in LoRA mode."""
 
         self._require_runtime()
+        if self._lora_state is not None:
+            return self.export_adapter(ctx, path)
         return save_checkpoint(
             self.provider,
             self.optimizer,
@@ -294,6 +304,18 @@ class MlxBackend(Backend):
             destination_path=path,
             policy_version=self._policy_version,
             global_step=ctx.global_step,
+        )
+
+    def export_adapter(self, ctx: Context, path: str) -> str:
+        """Export the live MLX LoRA weights as a standard PEFT adapter."""
+
+        self._require_runtime()
+        if self._lora_state is None:
+            raise RuntimeError("export_adapter requires MLX LoRA")
+        return export_peft_adapter(
+            self._lora_state,
+            path,
+            base_model_name_or_path=(self.config.base_model_name_or_path or self.config.model_path or ctx.model_path),
         )
 
     def ensure_roles(self, ctx: Context, roles: dict[str, ModelRole]) -> None:

--- a/areno/api/backend/mlx/lora.py
+++ b/areno/api/backend/mlx/lora.py
@@ -1,0 +1,226 @@
+"""PEFT-compatible LoRA injection for dense MLX-LM policies."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from areno.adapters.config import LoraConfig
+
+_PEFT_PREFIX = "base_model.model.model."
+_SUPPORTED_MODEL_TYPES = frozenset({"qwen3"})
+
+
+@dataclass(slots=True)
+class MlxLoraState:
+    """Index the MLX-LM LoRA modules that own trainable adapter arrays."""
+
+    slots: dict[str, Any]
+    config: LoraConfig
+
+
+@dataclass(frozen=True, slots=True)
+class _MlxLoraApi:
+    mx: Any
+    linear_type: type
+    quantized_linear_type: type
+    lora_linear_type: type
+    tree_flatten: Any
+    tree_unflatten: Any
+
+
+def initialize_lora(model: Any, config: LoraConfig, *, model_type: str) -> MlxLoraState:
+    """Freeze one dense Qwen3 policy and inject exact requested LoRA targets."""
+
+    if model_type not in _SUPPORTED_MODEL_TYPES:
+        supported = ", ".join(sorted(_SUPPORTED_MODEL_TYPES))
+        raise ValueError(f"MLX LoRA currently supports dense model types only: {supported}")
+
+    api = _mlx_lora_api()
+    requested = set(config.target_modules)
+    matched: set[str] = set()
+    targets: list[tuple[str, str, Any]] = []
+    for module_path, module in model.named_modules():
+        target_name = module_path.rsplit(".", 1)[-1]
+        if target_name not in requested:
+            continue
+        matched.add(target_name)
+        if not module_path.startswith("model.layers."):
+            raise ValueError(f"MLX LoRA target {module_path!r} is outside the dense transformer layers")
+        if isinstance(module, api.quantized_linear_type):
+            raise ValueError(f"MLX LoRA target {module_path!r} is quantized; QLoRA is not supported yet")
+        if not isinstance(module, api.linear_type):
+            raise TypeError(
+                f"MLX LoRA target {module_path!r} has unsupported type {type(module).__name__}; "
+                "only dense Linear layers are supported"
+            )
+        logical_name = module_path.removeprefix("model.")
+        targets.append((module_path, logical_name, module))
+
+    missing = requested - matched
+    if missing:
+        raise ValueError(f"target_modules are not present in {model_type}: {', '.join(sorted(missing))}")
+
+    model.freeze()
+    replacements = []
+    slots: dict[str, Any] = {}
+    module_paths: list[str] = []
+    for module_path, logical_name, module in sorted(targets):
+        lora_module = api.lora_linear_type.from_base(
+            module,
+            r=config.rank,
+            dropout=config.dropout,
+            scale=config.scale,
+        )
+        replacements.append((module_path, lora_module))
+        slots[logical_name] = lora_module
+        module_paths.append(module_path)
+    model.update_modules(api.tree_unflatten(replacements))
+    _validate_trainable_parameters(model, module_paths, api.tree_flatten)
+
+    state = MlxLoraState(slots=slots, config=config)
+    if config.adapter_path is not None:
+        _load_peft_adapter(state, config.adapter_path, api)
+    return state
+
+
+def load_peft_adapter(state: MlxLoraState, path: str | Path) -> None:
+    """Load one standard dense PEFT adapter into already-injected MLX slots."""
+
+    _load_peft_adapter(state, path, _mlx_lora_api())
+
+
+def export_peft_adapter(
+    state: MlxLoraState,
+    path: str | Path,
+    *,
+    base_model_name_or_path: str | None,
+) -> str:
+    """Write the live MLX LoRA arrays as one standard PEFT artifact."""
+
+    return _export_peft_adapter(
+        state,
+        path,
+        base_model_name_or_path=base_model_name_or_path,
+        api=_mlx_lora_api(),
+    )
+
+
+def _load_peft_adapter(state: MlxLoraState, path: str | Path, api: _MlxLoraApi) -> None:
+    adapter_file = Path(path) / "adapter_model.safetensors"
+    if not adapter_file.is_file():
+        raise FileNotFoundError(f"PEFT adapter weights do not exist: {adapter_file}")
+    tensors = api.mx.load(str(adapter_file))
+    expected_shapes = _expected_peft_shapes(state)
+    actual_keys = set(tensors)
+    expected_keys = set(expected_shapes)
+    if actual_keys != expected_keys:
+        missing = sorted(expected_keys - actual_keys)
+        unexpected = sorted(actual_keys - expected_keys)
+        raise ValueError(
+            "PEFT adapter tensor keys do not match the MLX LoRA registry: "
+            f"missing={missing[:3]}, unexpected={unexpected[:3]}"
+        )
+    for key, expected_shape in expected_shapes.items():
+        actual_shape = tuple(tensors[key].shape)
+        if actual_shape != expected_shape:
+            raise ValueError(f"PEFT adapter tensor {key!r} has shape {actual_shape}, expected {expected_shape}")
+
+    converted: dict[str, tuple[Any, Any]] = {}
+    for logical_name, slot in state.slots.items():
+        lora_a = tensors[_peft_key(logical_name, "A")].T.astype(slot.lora_a.dtype)
+        lora_b = tensors[_peft_key(logical_name, "B")].T.astype(slot.lora_b.dtype)
+        converted[logical_name] = (lora_a, lora_b)
+    api.mx.eval(*(array for pair in converted.values() for array in pair))
+    for logical_name, (lora_a, lora_b) in converted.items():
+        slot = state.slots[logical_name]
+        slot.lora_a = lora_a
+        slot.lora_b = lora_b
+
+
+def _export_peft_adapter(
+    state: MlxLoraState,
+    path: str | Path,
+    *,
+    base_model_name_or_path: str | None,
+    api: _MlxLoraApi,
+) -> str:
+    import numpy as np
+    from safetensors.numpy import save_file
+
+    arrays: dict[str, Any] = {}
+    for logical_name in sorted(state.slots):
+        slot = state.slots[logical_name]
+        arrays[_peft_key(logical_name, "A")] = slot.lora_a.T.astype(api.mx.float32)
+        arrays[_peft_key(logical_name, "B")] = slot.lora_b.T.astype(api.mx.float32)
+    api.mx.eval(*arrays.values())
+    tensors = {name: np.ascontiguousarray(np.array(array, copy=True)) for name, array in arrays.items()}
+
+    output_path = Path(path)
+    output_path.mkdir(parents=True, exist_ok=True)
+    config = {
+        "base_model_name_or_path": base_model_name_or_path,
+        "bias": "none",
+        "fan_in_fan_out": False,
+        "inference_mode": True,
+        "lora_alpha": state.config.alpha,
+        "lora_dropout": state.config.dropout,
+        "peft_type": "LORA",
+        "r": state.config.rank,
+        "target_modules": list(state.config.target_modules),
+        "task_type": "CAUSAL_LM",
+    }
+    with TemporaryDirectory(dir=output_path, prefix=".areno-peft-") as staging_directory:
+        staging_path = Path(staging_directory)
+        staging_config = staging_path / "adapter_config.json"
+        staging_weights = staging_path / "adapter_model.safetensors"
+        staging_config.write_text(
+            json.dumps(config, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        save_file(tensors, staging_weights)
+        staging_weights.replace(output_path / staging_weights.name)
+        staging_config.replace(output_path / staging_config.name)
+    return str(output_path)
+
+
+def _expected_peft_shapes(state: MlxLoraState) -> dict[str, tuple[int, ...]]:
+    shapes: dict[str, tuple[int, ...]] = {}
+    for logical_name, slot in state.slots.items():
+        shapes[_peft_key(logical_name, "A")] = (int(slot.lora_a.shape[1]), int(slot.lora_a.shape[0]))
+        shapes[_peft_key(logical_name, "B")] = (int(slot.lora_b.shape[1]), int(slot.lora_b.shape[0]))
+    return shapes
+
+
+def _validate_trainable_parameters(model: Any, module_paths: list[str], tree_flatten: Any) -> None:
+    expected = {f"{path}.{name}" for path in module_paths for name in ("lora_a", "lora_b")}
+    actual = {name for name, _ in tree_flatten(model.trainable_parameters())}
+    if actual != expected:
+        unexpected = sorted(actual - expected)
+        missing = sorted(expected - actual)
+        raise RuntimeError(
+            f"MLX LoRA must leave only adapter parameters trainable: missing={missing[:3]}, unexpected={unexpected[:3]}"
+        )
+
+
+def _peft_key(logical_name: str, component: str) -> str:
+    return f"{_PEFT_PREFIX}{logical_name}.lora_{component}.weight"
+
+
+def _mlx_lora_api() -> _MlxLoraApi:
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx.utils import tree_flatten, tree_unflatten
+    from mlx_lm.tuner.lora import LoRALinear
+
+    return _MlxLoraApi(
+        mx=mx,
+        linear_type=nn.Linear,
+        quantized_linear_type=nn.QuantizedLinear,
+        lora_linear_type=LoRALinear,
+        tree_flatten=tree_flatten,
+        tree_unflatten=tree_unflatten,
+    )

--- a/docs/getting-started/backends.rst
+++ b/docs/getting-started/backends.rst
@@ -21,7 +21,7 @@ runtime.
    * - Apple Silicon macOS
      - MLX
      - Single-process unified-memory runtime
-     - MLX safetensors and processor assets
+     - MLX full weights or standard PEFT LoRA adapter
 
 Linux and CUDA
 --------------
@@ -41,7 +41,8 @@ Apple Silicon and MLX
 The MLX backend owns one in-process model for rollout, scoring, and training,
 plus a long-lived continuous-batch scheduler. It installs only the Apple
 Silicon dependency set and does not require Torch or CUDA. MLX runs with
-``world-size=1`` and ``tp-size=1`` and saves native MLX checkpoints.
+``world-size=1`` and ``tp-size=1`` and saves either native full-weight
+checkpoints or standard PEFT adapters for supported LoRA training.
 
 Read :doc:`mlx` for installation, unified-memory controls, continuous-batch
 serving, checkpoint behavior, ``mlx-lm``/``mlx-vlm`` model support, and

--- a/docs/getting-started/mlx.rst
+++ b/docs/getting-started/mlx.rst
@@ -73,6 +73,35 @@ them explicitly, use ``--world-size 1 --tp-size 1``.
 training rows in one gradient microbatch. ``--gradient-accumulation-steps``
 controls how many such microbatches contribute to an optimizer update.
 
+LoRA
+~~~~
+
+Dense Qwen3 text checkpoints support the same standard PEFT-compatible LoRA
+configuration used by the CUDA backend. The base model stays frozen and only
+the requested adapter A/B arrays are optimized:
+
+.. code-block:: bash
+
+   areno train \
+     --ckpt /path/to/qwen3-model \
+     --dataset-path /path/to/train.jsonl \
+     --dataset-loader-fn /path/to/dataset_loader.py \
+     --algo sft \
+     --lora-rank 8 \
+     --lora-alpha 16 \
+     --save-path /path/to/adapters \
+     --save-interval 100
+
+Use ``--lora-adapter-path /path/to/peft-adapter`` to initialize training from
+an existing standard PEFT directory. The adapter metadata is authoritative for
+rank, alpha, dropout, and target modules. The same option can serve an exported
+adapter with ``areno serve`` while ``--model-path`` continues to identify its
+base checkpoint.
+
+MLX LoRA currently requires an unquantized Qwen3 Dense text checkpoint,
+``--lora-dropout 0``, and ``--reference-mode independent``. QLoRA, Qwen3 MoE,
+multimodal LoRA, multiple adapters, and ``reuse_actor_base`` are not supported.
+
 Memory controls
 ~~~~~~~~~~~~~~~
 
@@ -139,16 +168,26 @@ Checkpoints
 -----------
 
 The MLX providers can load compatible Hugging Face-layout and MLX-native
-checkpoints supported by ``mlx-lm`` or ``mlx-vlm``. AReno saves the trained
-policy in native MLX format, including model configuration, safetensors,
-tokenizer or processor assets, and ``areno_mlx_state.json``. Reload the saved
+checkpoints supported by ``mlx-lm`` or ``mlx-vlm``. Full-weight training saves
+the policy in native MLX format, including model configuration, safetensors,
+tokenizer or processor assets, and ``areno_mlx_state.json``. Reload that saved
 directory directly with either ``--ckpt`` or ``--model-path``.
 
-An MLX checkpoint is not advertised as a portable CUDA/Transformers export.
-Some unquantized model layouts may happen to be compatible, but MLX model
-sanitization, tensor layout, and quantization are model-family concerns. Test
-the target loader instead of renaming metadata. Optimizer and scheduler state
-are not part of the current MLX checkpoint round trip.
+LoRA training instead saves an adapter-only standard PEFT directory containing
+``adapter_config.json`` and ``adapter_model.safetensors``. The frozen base
+checkpoint is not copied. Continue adapter training with the base checkpoint
+as ``--ckpt`` plus the saved directory as ``--lora-adapter-path``; use the same
+pair with ``--model-path`` and ``--lora-adapter-path`` for serving. SDK callers
+can write the same artifact explicitly through ``Trainer.export_adapter``.
+Optimizer and scheduler state restart with the new trainer process.
+
+An MLX full-weight checkpoint is not advertised as a portable
+CUDA/Transformers export. Some unquantized model layouts may happen to be
+compatible, but MLX model sanitization, tensor layout, and quantization are
+model-family concerns. Test the target loader instead of renaming metadata.
+This restriction does not apply to the standard PEFT LoRA artifact described
+above. Optimizer and scheduler state are not part of the current MLX checkpoint
+round trip.
 
 Models and multimodal input
 ---------------------------

--- a/tests/test_adapter_imports_cpu.py
+++ b/tests/test_adapter_imports_cpu.py
@@ -17,7 +17,13 @@ import sys
 class BlockHeavyImports(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path=None, target=None):
         del path, target
-        if fullname == "torch" or fullname.startswith("torch.") or fullname == "areno.adapters.lora":
+        if (
+            fullname == "torch"
+            or fullname.startswith("torch.")
+            or fullname == "mlx"
+            or fullname.startswith("mlx.")
+            or fullname == "areno.adapters.lora"
+        ):
             raise AssertionError(f"unexpected heavy import: {fullname}")
         return None
 
@@ -26,13 +32,16 @@ sys.meta_path.insert(0, BlockHeavyImports())
 
 from areno.adapters import LoraConfig as PublicLoraConfig
 from areno.adapters.config import LoraConfig
+from areno.api.backend.mlx.lora import MlxLoraState
 from areno.api.config import MlxConfig
 from areno.api.trainer_config import TrainerConfig
 
 assert PublicLoraConfig is LoraConfig
+assert MlxLoraState.__module__ == "areno.api.backend.mlx.lora"
 assert MlxConfig(lora=LoraConfig()).lora is not None
 assert TrainerConfig(algo="sft", backend="mlx", ckpt="model", dataset_path="data").backend == "mlx"
 assert "torch" not in sys.modules
+assert "mlx" not in sys.modules
 assert "areno.adapters.lora" not in sys.modules
 """
 

--- a/tests/test_mlx_lora_cpu.py
+++ b/tests/test_mlx_lora_cpu.py
@@ -1,0 +1,322 @@
+"""CPU-only contract tests for PEFT-compatible MLX LoRA support."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from safetensors.numpy import load_file
+
+from areno.adapters import LoraConfig
+from areno.api.backend.mlx.lora import (
+    MlxLoraState,
+    export_peft_adapter,
+    initialize_lora,
+    load_peft_adapter,
+)
+
+
+class _FakeLinear:
+    def __init__(self, input_dims: int, output_dims: int) -> None:
+        self.input_dims = input_dims
+        self.output_dims = output_dims
+
+
+class _FakeQuantizedLinear(_FakeLinear):
+    pass
+
+
+class _FakeLoraLinear:
+    events: list[str] = []
+
+    def __init__(self, base: _FakeLinear, *, rank: int, dropout: float, scale: float) -> None:
+        self.linear = base
+        self.lora_a = np.zeros((base.input_dims, rank), dtype=np.float32)
+        self.lora_b = np.zeros((rank, base.output_dims), dtype=np.float32)
+        self.dropout = dropout
+        self.scale = scale
+
+    @classmethod
+    def from_base(cls, base: _FakeLinear, *, r: int, dropout: float, scale: float):
+        assert cls.events and cls.events[0] == "freeze"
+        cls.events.append("wrap")
+        return cls(base, rank=r, dropout=dropout, scale=scale)
+
+
+class _FakeModel:
+    def __init__(self, modules: dict[str, object], *, extra_trainable: str | None = None) -> None:
+        self.modules = modules
+        self.extra_trainable = extra_trainable
+        self.frozen = False
+        self.updated = False
+
+    def named_modules(self):
+        return list(self.modules.items())
+
+    def freeze(self) -> None:
+        self.frozen = True
+        _FakeLoraLinear.events.append("freeze")
+
+    def update_modules(self, replacements: dict[str, object]) -> None:
+        self.updated = True
+        self.modules.update(replacements)
+
+    def trainable_parameters(self) -> dict[str, np.ndarray]:
+        parameters = {}
+        for path, module in self.modules.items():
+            if isinstance(module, _FakeLoraLinear):
+                parameters[f"{path}.lora_a"] = module.lora_a
+                parameters[f"{path}.lora_b"] = module.lora_b
+        if self.extra_trainable is not None:
+            parameters[self.extra_trainable] = np.zeros((1,), dtype=np.float32)
+        return parameters
+
+
+def _fake_api(*, tensors: dict[str, np.ndarray] | None = None, evaluated: list | None = None):
+    def load(path: str):
+        del path
+        assert tensors is not None
+        return tensors
+
+    def evaluate(*arrays) -> None:
+        if evaluated is not None:
+            evaluated.extend(arrays)
+
+    return SimpleNamespace(
+        mx=SimpleNamespace(load=load, eval=evaluate, float32=np.float32),
+        linear_type=_FakeLinear,
+        quantized_linear_type=_FakeQuantizedLinear,
+        lora_linear_type=_FakeLoraLinear,
+        tree_flatten=lambda tree: list(tree.items()),
+        tree_unflatten=lambda pairs: dict(pairs),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_lora_events():
+    _FakeLoraLinear.events = []
+
+
+def test_initialize_lora_freezes_base_and_exposes_only_adapter_parameters(monkeypatch):
+    modules = {
+        "model.layers.0.self_attn.q_proj": _FakeLinear(4, 6),
+        "model.layers.0.self_attn.v_proj": _FakeLinear(4, 2),
+        "model.layers.0.mlp.up_proj": _FakeLinear(4, 8),
+    }
+    model = _FakeModel(modules)
+    config = LoraConfig(rank=2, alpha=8, target_modules=("q_proj", "v_proj"))
+    monkeypatch.setattr("areno.api.backend.mlx.lora._mlx_lora_api", _fake_api)
+
+    state = initialize_lora(model, config, model_type="qwen3")
+
+    assert model.frozen
+    assert model.updated
+    assert _FakeLoraLinear.events == ["freeze", "wrap", "wrap"]
+    assert set(state.slots) == {"layers.0.self_attn.q_proj", "layers.0.self_attn.v_proj"}
+    assert all(slot.scale == 4.0 for slot in state.slots.values())
+    assert all(slot.dropout == 0.0 for slot in state.slots.values())
+    assert set(model.trainable_parameters()) == {
+        "model.layers.0.self_attn.q_proj.lora_a",
+        "model.layers.0.self_attn.q_proj.lora_b",
+        "model.layers.0.self_attn.v_proj.lora_a",
+        "model.layers.0.self_attn.v_proj.lora_b",
+    }
+    assert isinstance(modules["model.layers.0.mlp.up_proj"], _FakeLinear)
+
+
+def test_initialize_lora_validates_all_targets_before_freezing(monkeypatch):
+    model = _FakeModel({"model.layers.0.self_attn.q_proj": _FakeLinear(4, 6)})
+    config = LoraConfig(rank=2, target_modules=("q_proj", "v_proj"))
+    monkeypatch.setattr("areno.api.backend.mlx.lora._mlx_lora_api", _fake_api)
+
+    with pytest.raises(ValueError, match="v_proj"):
+        initialize_lora(model, config, model_type="qwen3")
+
+    assert not model.frozen
+    assert not model.updated
+
+
+@pytest.mark.parametrize("model_type", ["qwen2", "qwen3_moe"])
+def test_initialize_lora_rejects_unsupported_model_families_before_import(monkeypatch, model_type):
+    monkeypatch.setattr(
+        "areno.api.backend.mlx.lora._mlx_lora_api",
+        lambda: pytest.fail("MLX should not be imported for an unsupported model family"),
+    )
+
+    with pytest.raises(ValueError, match="qwen3"):
+        initialize_lora(_FakeModel({}), LoraConfig(), model_type=model_type)
+
+
+def test_initialize_lora_rejects_quantized_targets_before_freezing(monkeypatch):
+    model = _FakeModel({"model.layers.0.self_attn.q_proj": _FakeQuantizedLinear(4, 6)})
+    config = LoraConfig(rank=2, target_modules=("q_proj",))
+    monkeypatch.setattr("areno.api.backend.mlx.lora._mlx_lora_api", _fake_api)
+
+    with pytest.raises(ValueError, match="QLoRA"):
+        initialize_lora(model, config, model_type="qwen3")
+
+    assert not model.frozen
+
+
+def test_initialize_lora_rejects_any_unexpected_trainable_parameter(monkeypatch):
+    model = _FakeModel(
+        {"model.layers.0.self_attn.q_proj": _FakeLinear(4, 6)},
+        extra_trainable="model.embed_tokens.weight",
+    )
+    config = LoraConfig(rank=2, target_modules=("q_proj",))
+    monkeypatch.setattr("areno.api.backend.mlx.lora._mlx_lora_api", _fake_api)
+
+    with pytest.raises(RuntimeError, match="only adapter parameters trainable"):
+        initialize_lora(model, config, model_type="qwen3")
+
+
+def test_load_peft_adapter_transposes_dense_weights_atomically(monkeypatch, tmp_path):
+    slot = _FakeLoraLinear(_FakeLinear(3, 4), rank=2, dropout=0.0, scale=1.0)
+    state = MlxLoraState(
+        slots={"layers.0.self_attn.q_proj": slot},
+        config=LoraConfig(rank=2, target_modules=("q_proj",)),
+    )
+    prefix = "base_model.model.model.layers.0.self_attn.q_proj"
+    peft_a = np.arange(6, dtype=np.float64).reshape(2, 3)
+    peft_b = np.arange(8, dtype=np.float64).reshape(4, 2)
+    tensors = {
+        f"{prefix}.lora_A.weight": peft_a,
+        f"{prefix}.lora_B.weight": peft_b,
+    }
+    evaluated = []
+    adapter_file = tmp_path / "adapter_model.safetensors"
+    adapter_file.touch()
+    monkeypatch.setattr(
+        "areno.api.backend.mlx.lora._mlx_lora_api",
+        lambda: _fake_api(tensors=tensors, evaluated=evaluated),
+    )
+
+    load_peft_adapter(state, tmp_path)
+
+    np.testing.assert_array_equal(slot.lora_a, peft_a.T.astype(np.float32))
+    np.testing.assert_array_equal(slot.lora_b, peft_b.T.astype(np.float32))
+    assert slot.lora_a.dtype == np.float32
+    assert slot.lora_b.dtype == np.float32
+    assert len(evaluated) == 2
+
+
+@pytest.mark.parametrize(
+    "tensors, match",
+    [
+        ({"unexpected": np.zeros((1,), dtype=np.float32)}, "tensor keys do not match"),
+        (
+            {
+                "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": np.zeros((3, 3), dtype=np.float32),
+                "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight": np.zeros((4, 2), dtype=np.float32),
+            },
+            "has shape",
+        ),
+    ],
+)
+def test_load_peft_adapter_prevalidates_before_mutating_slots(monkeypatch, tmp_path, tensors, match):
+    slot = _FakeLoraLinear(_FakeLinear(3, 4), rank=2, dropout=0.0, scale=1.0)
+    slot.lora_a.fill(7)
+    slot.lora_b.fill(9)
+    original_a = slot.lora_a.copy()
+    original_b = slot.lora_b.copy()
+    state = MlxLoraState(
+        slots={"layers.0.self_attn.q_proj": slot},
+        config=LoraConfig(rank=2, target_modules=("q_proj",)),
+    )
+    (tmp_path / "adapter_model.safetensors").touch()
+    monkeypatch.setattr(
+        "areno.api.backend.mlx.lora._mlx_lora_api",
+        lambda: _fake_api(tensors=tensors),
+    )
+
+    with pytest.raises(ValueError, match=match):
+        load_peft_adapter(state, tmp_path)
+
+    np.testing.assert_array_equal(slot.lora_a, original_a)
+    np.testing.assert_array_equal(slot.lora_b, original_b)
+
+
+def test_export_peft_adapter_writes_reloadable_standard_artifact(monkeypatch, tmp_path):
+    slot = _FakeLoraLinear(_FakeLinear(3, 4), rank=2, dropout=0.0, scale=4.0)
+    slot.lora_a = np.arange(6, dtype=np.float64).reshape(3, 2)
+    slot.lora_b = np.arange(8, dtype=np.float64).reshape(2, 4)
+    config = LoraConfig(rank=2, alpha=8, target_modules=("q_proj",))
+    state = MlxLoraState(slots={"layers.0.self_attn.q_proj": slot}, config=config)
+    evaluated = []
+    monkeypatch.setattr(
+        "areno.api.backend.mlx.lora._mlx_lora_api",
+        lambda: _fake_api(evaluated=evaluated),
+    )
+    output_path = tmp_path / "nested" / "adapter"
+
+    exported = export_peft_adapter(
+        state,
+        output_path,
+        base_model_name_or_path="Qwen/Qwen3-0.6B",
+    )
+
+    assert exported == str(output_path)
+    metadata = json.loads((output_path / "adapter_config.json").read_text(encoding="utf-8"))
+    assert metadata == {
+        "base_model_name_or_path": "Qwen/Qwen3-0.6B",
+        "bias": "none",
+        "fan_in_fan_out": False,
+        "inference_mode": True,
+        "lora_alpha": 8,
+        "lora_dropout": 0.0,
+        "peft_type": "LORA",
+        "r": 2,
+        "target_modules": ["q_proj"],
+        "task_type": "CAUSAL_LM",
+    }
+    tensors = load_file(output_path / "adapter_model.safetensors")
+    prefix = "base_model.model.model.layers.0.self_attn.q_proj"
+    np.testing.assert_array_equal(tensors[f"{prefix}.lora_A.weight"], slot.lora_a.T.astype(np.float32))
+    np.testing.assert_array_equal(tensors[f"{prefix}.lora_B.weight"], slot.lora_b.T.astype(np.float32))
+    assert tensors[f"{prefix}.lora_A.weight"].flags.c_contiguous
+    assert tensors[f"{prefix}.lora_B.weight"].flags.c_contiguous
+    assert len(evaluated) == 2
+    assert not list(output_path.glob(".areno-peft-*"))
+
+    reloaded_slot = _FakeLoraLinear(_FakeLinear(3, 4), rank=2, dropout=0.0, scale=4.0)
+    reloaded = MlxLoraState(slots={"layers.0.self_attn.q_proj": reloaded_slot}, config=config)
+    monkeypatch.setattr(
+        "areno.api.backend.mlx.lora._mlx_lora_api",
+        lambda: _fake_api(tensors=tensors),
+    )
+    load_peft_adapter(reloaded, output_path)
+
+    np.testing.assert_array_equal(reloaded_slot.lora_a, slot.lora_a.astype(np.float32))
+    np.testing.assert_array_equal(reloaded_slot.lora_b, slot.lora_b.astype(np.float32))
+
+
+def test_export_peft_adapter_preserves_existing_artifact_on_write_failure(monkeypatch, tmp_path):
+    import safetensors.numpy as safetensors_numpy
+
+    slot = _FakeLoraLinear(_FakeLinear(3, 4), rank=2, dropout=0.0, scale=1.0)
+    state = MlxLoraState(
+        slots={"layers.0.self_attn.q_proj": slot},
+        config=LoraConfig(rank=2, target_modules=("q_proj",)),
+    )
+    output_path = tmp_path / "adapter"
+    output_path.mkdir()
+    config_path = output_path / "adapter_config.json"
+    weights_path = output_path / "adapter_model.safetensors"
+    config_path.write_text("old config", encoding="utf-8")
+    weights_path.write_bytes(b"old weights")
+    monkeypatch.setattr("areno.api.backend.mlx.lora._mlx_lora_api", _fake_api)
+
+    def fail_save(*args, **kwargs):
+        del args, kwargs
+        raise OSError("disk")
+
+    monkeypatch.setattr(safetensors_numpy, "save_file", fail_save)
+
+    with pytest.raises(OSError, match="disk"):
+        export_peft_adapter(state, output_path, base_model_name_or_path="base")
+
+    assert config_path.read_text(encoding="utf-8") == "old config"
+    assert weights_path.read_bytes() == b"old weights"
+    assert not list(output_path.glob(".areno-peft-*"))

--- a/tests/test_mlx_lora_e2e.py
+++ b/tests/test_mlx_lora_e2e.py
@@ -1,0 +1,260 @@
+"""Opt-in Apple Silicon E2E for Qwen3 MLX LoRA training."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from areno.adapters import LoraConfig
+from areno.api import MlxConfig, Trainer, TrainSequence, sft_loss_fn
+
+
+def _require_mlx_device(mx) -> None:
+    try:
+        probe = mx.zeros((1,))
+        mx.eval(probe)
+    except RuntimeError as exc:
+        if "No Metal device available" in str(exc):
+            pytest.skip("MLX Metal device is unavailable in this environment")
+        raise
+
+
+def test_mlx_lora_backend_loads_peft_and_runs_two_synthetic_sft_steps(monkeypatch, tmp_path) -> None:
+    if os.getenv("ARENO_E2E_MLX_SYNTHETIC") != "1":
+        pytest.skip("set ARENO_E2E_MLX_SYNTHETIC=1 to run the Apple Silicon synthetic MLX LoRA E2E")
+    mx = pytest.importorskip("mlx.core")
+    nn = pytest.importorskip("mlx.nn")
+
+    from mlx.utils import tree_flatten
+    from safetensors.numpy import load_file, save_file
+
+    from areno.api.backend.mlx.backend import MlxBackend
+    from areno.api.backend.mlx.provider import MlxModelProvider
+
+    _require_mlx_device(mx)
+
+    class SelfAttention(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.q_proj = nn.Linear(8, 8, bias=False)
+            self.v_proj = nn.Linear(8, 8, bias=False)
+
+        def __call__(self, hidden_states):
+            return self.q_proj(hidden_states) + self.v_proj(hidden_states)
+
+    class Block(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.self_attn = SelfAttention()
+
+        def __call__(self, hidden_states):
+            return self.self_attn(hidden_states)
+
+    class Body(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed_tokens = nn.Embedding(16, 8)
+            self.layers = [Block()]
+
+        def __call__(self, input_ids):
+            hidden_states = self.embed_tokens(input_ids)
+            for layer in self.layers:
+                hidden_states = layer(hidden_states)
+            return hidden_states
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.model = Body()
+            self.lm_head = nn.Linear(8, 16, bias=False)
+
+        def __call__(self, input_ids):
+            return self.lm_head(self.model(input_ids))
+
+    class Tokenizer:
+        eos_token_id = 0
+
+        def encode(self, text, *, add_special_tokens):
+            del text, add_special_tokens
+            return [1, 2, 3]
+
+    model = Model()
+    base_weights = [(name, mx.array(value)) for name, value in tree_flatten(model.parameters())]
+    mx.eval(*(value for _, value in base_weights))
+    tokenizer = Tokenizer()
+    provider = MlxModelProvider(model, tokenizer, None, {"model_type": "qwen3"})
+    monkeypatch.setattr("areno.api.backend.mlx.backend.load_provider", lambda *_args, **_kwargs: provider)
+    adapter_config = {
+        "base_model_name_or_path": "synthetic",
+        "bias": "none",
+        "fan_in_fan_out": False,
+        "inference_mode": False,
+        "lora_alpha": 4,
+        "lora_dropout": 0.0,
+        "peft_type": "LORA",
+        "r": 2,
+        "target_modules": ["q_proj", "v_proj"],
+        "task_type": "CAUSAL_LM",
+    }
+    (tmp_path / "adapter_config.json").write_text(json.dumps(adapter_config), encoding="utf-8")
+    adapter_tensors = {}
+    for index, target in enumerate(adapter_config["target_modules"], start=1):
+        prefix = f"base_model.model.model.layers.0.self_attn.{target}"
+        adapter_tensors[f"{prefix}.lora_A.weight"] = np.full((2, 8), index / 10, dtype=np.float32)
+        adapter_tensors[f"{prefix}.lora_B.weight"] = np.full((8, 2), index / 20, dtype=np.float32)
+    save_file(adapter_tensors, tmp_path / "adapter_model.safetensors")
+    config = MlxConfig(
+        lora=LoraConfig(adapter_path=os.fspath(tmp_path)),
+        optimizer={
+            "lr": 1.0e-2,
+            "min_lr": 1.0e-2,
+            "lr_decay_style": "constant",
+            "weight_decay": 0.0,
+            "grad_clip_norm": 1.0,
+        },
+        compile_train_step=False,
+        gradient_checkpointing=False,
+    )
+    ctx = type(
+        "Context",
+        (),
+        {"world_size": 1, "custom_config": config, "model_path": "synthetic", "tokenizer": tokenizer, "global_step": 0},
+    )()
+    backend = MlxBackend()
+    backend.initialize(ctx)
+    try:
+        assert backend._lora_state is not None
+        slot = backend._lora_state.slots["layers.0.self_attn.q_proj"]
+        mx.eval(slot.linear.weight, slot.lora_a, slot.lora_b)
+        initial_base = np.array(slot.linear.weight)
+        initial_a = np.array(slot.lora_a)
+        initial_b = np.array(slot.lora_b)
+        prefix = "base_model.model.model.layers.0.self_attn.q_proj"
+        np.testing.assert_array_equal(initial_a, adapter_tensors[f"{prefix}.lora_A.weight"].T)
+        np.testing.assert_array_equal(initial_b, adapter_tensors[f"{prefix}.lora_B.weight"].T)
+        row = TrainSequence(tokens=[1, 2, 3, 4], prompt_mask=[True, False, False, False], eos_token_id=0)
+
+        results = []
+        for step in range(2):
+            ctx.global_step = step
+            results.append(backend.train(ctx, [row], sft_loss_fn, mini_bs=1))
+
+        trained_logprobs = backend.score_logprobs(ctx, "actor", [[1, 2, 3, 4]], microbatch_size=1)
+        mx.eval(slot.linear.weight, slot.lora_a, slot.lora_b)
+        final_base = np.array(slot.linear.weight)
+        final_a = np.array(slot.lora_a)
+        final_b = np.array(slot.lora_b)
+        exported_path = tmp_path / "exported"
+        assert backend.save_checkpoint(ctx, os.fspath(exported_path)) == os.fspath(exported_path)
+    finally:
+        backend.close()
+
+    exported = load_file(exported_path / "adapter_model.safetensors")
+    np.testing.assert_array_equal(exported[f"{prefix}.lora_A.weight"], final_a.T.astype(np.float32))
+    np.testing.assert_array_equal(exported[f"{prefix}.lora_B.weight"], final_b.T.astype(np.float32))
+    np.testing.assert_array_equal(final_base, initial_base)
+    assert not np.array_equal(final_b, initial_b)
+    assert not np.array_equal(final_a, initial_a)
+    assert all(np.isfinite(result["loss"]) for result in results)
+    assert all(np.isfinite(result["grad_norm"]) for result in results)
+
+    reloaded_model = Model()
+    reloaded_model.load_weights(base_weights)
+    reloaded_provider = MlxModelProvider(reloaded_model, tokenizer, None, {"model_type": "qwen3"})
+    monkeypatch.setattr("areno.api.backend.mlx.backend.load_provider", lambda *_args, **_kwargs: reloaded_provider)
+    reloaded_config = MlxConfig(
+        lora=LoraConfig(adapter_path=os.fspath(exported_path)),
+        optimizer=config.optimizer,
+        compile_train_step=False,
+        gradient_checkpointing=False,
+    )
+    reloaded_ctx = type(
+        "Context",
+        (),
+        {
+            "world_size": 1,
+            "custom_config": reloaded_config,
+            "model_path": "synthetic",
+            "tokenizer": tokenizer,
+            "global_step": 0,
+        },
+    )()
+    reloaded_backend = MlxBackend()
+    reloaded_backend.initialize(reloaded_ctx)
+    try:
+        assert reloaded_backend._lora_state is not None
+        reloaded_slot = reloaded_backend._lora_state.slots["layers.0.self_attn.q_proj"]
+        mx.eval(reloaded_slot.lora_a, reloaded_slot.lora_b)
+        np.testing.assert_array_equal(np.array(reloaded_slot.lora_a), final_a.astype(np.float32))
+        np.testing.assert_array_equal(np.array(reloaded_slot.lora_b), final_b.astype(np.float32))
+        reloaded_logprobs = reloaded_backend.score_logprobs(
+            reloaded_ctx,
+            "actor",
+            [[1, 2, 3, 4]],
+            microbatch_size=1,
+        )
+    finally:
+        reloaded_backend.close()
+
+    np.testing.assert_allclose(reloaded_logprobs, trained_logprobs, rtol=0.0, atol=1.0e-6)
+
+
+def test_mlx_qwen3_lora_runs_two_sft_steps() -> None:
+    model_path_value = os.getenv("ARENO_E2E_MLX_QWEN3_MODEL")
+    if not model_path_value:
+        pytest.skip("set ARENO_E2E_MLX_QWEN3_MODEL to run the Apple Silicon MLX LoRA E2E")
+    model_path = Path(model_path_value)
+    if not model_path.is_dir():
+        pytest.fail(f"ARENO_E2E_MLX_QWEN3_MODEL is not a local checkpoint directory: {model_path}")
+
+    import mlx.core as mx
+
+    _require_mlx_device(mx)
+
+    config = MlxConfig(
+        lora=LoraConfig(rank=2, alpha=4, target_modules=("q_proj", "v_proj", "up_proj")),
+        optimizer={
+            "lr": 1.0e-3,
+            "min_lr": 1.0e-3,
+            "lr_decay_style": "constant",
+            "weight_decay": 0.0,
+            "grad_clip_norm": 1.0,
+        },
+        compile_train_step=False,
+        gradient_checkpointing=False,
+    )
+    trainer = Trainer(1, os.fspath(model_path), custom_config=config)
+    trainer.init()
+    try:
+        tokenizer = trainer.get_tokenizer()
+        tokens = list(tokenizer.encode("MLX LoRA should learn this short sequence.", add_special_tokens=True))
+        if len(tokens) < 2:
+            pytest.fail("Qwen3 tokenizer returned fewer than two tokens for the MLX LoRA E2E prompt")
+        row = TrainSequence(
+            tokens=tokens,
+            prompt_mask=[True, *([False] * (len(tokens) - 1))],
+            eos_token_id=int(tokenizer.eos_token_id or 0),
+        )
+
+        backend = trainer._backend
+        assert backend is not None
+        state = backend._lora_state
+        assert state is not None
+        initial_arrays = [array for slot in state.slots.values() for array in (slot.lora_a, slot.lora_b)]
+        mx.eval(*initial_arrays)
+        initial = [np.array(array) for array in initial_arrays]
+
+        results = [trainer.train([row], sft_loss_fn, mini_bs=1) for _ in range(2)]
+        final_arrays = [array for slot in state.slots.values() for array in (slot.lora_a, slot.lora_b)]
+        mx.eval(*final_arrays)
+        final = [np.array(array) for array in final_arrays]
+    finally:
+        trainer.close()
+
+    assert all(np.isfinite(result["loss"]) for result in results)
+    assert all(np.isfinite(result["grad_norm"]) for result in results)
+    assert any(not np.array_equal(before, after) for before, after in zip(initial, final, strict=True))

--- a/tests/test_mlx_training_cpu.py
+++ b/tests/test_mlx_training_cpu.py
@@ -253,25 +253,125 @@ def test_mlx_backend_forwards_legacy_native_adapter_path(monkeypatch):
     assert backend.config is config
 
 
-def test_mlx_backend_rejects_peft_lora_before_loading_provider(monkeypatch):
+def test_mlx_backend_injects_peft_lora_before_building_optimizer(monkeypatch):
     from areno.adapters import LoraConfig
     from areno.api.backend.mlx.backend import MlxBackend
     from areno.api.config import MlxConfig
 
-    def unexpected_load(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("provider loading must not start before MLX LoRA injection exists")
+    events = []
+    mlx_module = ModuleType("mlx")
+    mlx_core_module = ModuleType("mlx.core")
+    mlx_core_module.metal = SimpleNamespace(is_available=lambda: False)
+    mlx_core_module.eval = lambda *args: events.append("eval")
+    mlx_module.core = mlx_core_module
+    monkeypatch.setitem(sys.modules, "mlx", mlx_module)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core_module)
 
-    monkeypatch.setattr("areno.api.backend.mlx.backend.load_provider", unexpected_load)
+    class FakeTokenizer:
+        def encode(self, text, *, add_special_tokens):
+            del text, add_special_tokens
+            return [1, 2, 3]
+
+    class FakeModel:
+        def parameters(self):
+            return {}
+
+        def train(self):
+            events.append("train")
+
+    model = FakeModel()
+    tokenizer = FakeTokenizer()
+    provider = SimpleNamespace(
+        model=model,
+        tokenizer=tokenizer,
+        processor=None,
+        config={"model_type": "qwen3"},
+        is_multimodal=False,
+        optimizer_state_precision=lambda path, parameter: "8bit",
+    )
+    lora_state = object()
+    optimizer = SimpleNamespace(state={})
+
+    def load_provider(model_path, *, adapter_path=None):
+        assert model_path == "model"
+        assert adapter_path is None
+        events.append("load_provider")
+        return provider
+
+    def inject(model_arg, config_arg, *, model_type):
+        assert model_arg is model
+        assert config_arg is config.lora
+        assert model_type == "qwen3"
+        events.append("initialize_lora")
+        return lora_state
+
+    def make_optimizer(optimizer_config, *, state_precision_for_parameter):
+        assert optimizer_config == {}
+        assert state_precision_for_parameter is provider.optimizer_state_precision
+        events.append("build_optimizer")
+        return optimizer, [("model", optimizer, {})]
+
+    monkeypatch.setattr("areno.api.backend.mlx.backend.load_provider", load_provider)
+    monkeypatch.setattr("areno.api.backend.mlx.backend.initialize_lora", inject)
+    monkeypatch.setattr("areno.api.backend.mlx.backend.build_optimizer", make_optimizer)
+    config = MlxConfig(lora=LoraConfig(), gradient_checkpointing=False)
     backend = MlxBackend()
     ctx = SimpleNamespace(
         world_size=1,
-        custom_config=MlxConfig(lora=LoraConfig()),
+        custom_config=config,
         model_path="model",
+        tokenizer=tokenizer,
     )
 
-    with pytest.raises(NotImplementedError, match="adapter injection is not implemented"):
-        backend.initialize(ctx)
+    backend.initialize(ctx)
+
+    assert events[:3] == ["load_provider", "initialize_lora", "build_optimizer"]
+    assert backend._lora_state is lora_state
+
+
+def test_mlx_backend_saves_and_exports_lora_as_peft(monkeypatch):
+    from areno.adapters import LoraConfig
+    from areno.api.backend.mlx.backend import MlxBackend
+    from areno.api.config import MlxConfig
+
+    calls = []
+    lora_state = object()
+
+    def export(state, path, *, base_model_name_or_path):
+        calls.append((state, path, base_model_name_or_path))
+        return path
+
+    monkeypatch.setattr("areno.api.backend.mlx.backend.export_peft_adapter", export)
+    backend = MlxBackend()
+    backend.provider = SimpleNamespace()
+    backend.model = SimpleNamespace()
+    backend.tokenizer = SimpleNamespace()
+    backend.optimizer = SimpleNamespace()
+    backend.config = MlxConfig(base_model_name_or_path="Qwen/Qwen3-0.6B", lora=LoraConfig())
+    backend._lora_state = lora_state
+    ctx = SimpleNamespace(model_path="resolved-model", global_step=2)
+
+    assert backend.save_checkpoint(ctx, "checkpoint") == "checkpoint"
+    assert backend.export_adapter(ctx, "manual-adapter") == "manual-adapter"
+    assert calls == [
+        (lora_state, "checkpoint", "Qwen/Qwen3-0.6B"),
+        (lora_state, "manual-adapter", "Qwen/Qwen3-0.6B"),
+    ]
+
+
+def test_mlx_backend_export_adapter_requires_lora():
+    from areno.api.backend.mlx.backend import MlxBackend
+    from areno.api.config import MlxConfig
+
+    backend = MlxBackend()
+    backend.provider = SimpleNamespace()
+    backend.model = SimpleNamespace()
+    backend.tokenizer = SimpleNamespace()
+    backend.optimizer = SimpleNamespace()
+    backend.config = MlxConfig()
+
+    with pytest.raises(RuntimeError, match="requires MLX LoRA"):
+        backend.export_adapter(SimpleNamespace(model_path="model"), "adapter")
 
 
 def test_adam8bit_lazy_state_remains_stable_after_zero_gradient_steps():


### PR DESCRIPTION
## What does this PR do?

Adds end-to-end LoRA training support to the MLX backend for Apple Silicon.

- Injects trainable LoRA A/B parameters into supported Qwen3 linear projections while keeping the base-model weights frozen.
- Supports standard PEFT adapter import and adapter-only export.
- Integrates LoRA parameters with MLX optimization, scoring, checkpoint save/reload, and the backend lifecycle.
- Adds CPU-safe unit coverage and opt-in MLX end-to-end tests.
- Documents supported models, constraints, training, and adapter reload behavior.

## Related issue

None.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change (public API / CLI behavior changes in a non-backward-compatible way)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test coverage improvement

## How was it tested?

Local validation:

- `.venv/bin/python -m pytest -q tests/test_adapter_imports_cpu.py tests/test_mlx_training_cpu.py tests/test_mlx_lora_cpu.py` — 33 passed.
- `ARENO_E2E_MLX_SYNTHETIC=1 .venv/bin/python -m pytest -q tests/test_mlx_lora_e2e.py -k synthetic` — 1 passed, 1 deselected.
- `/usr/local/bin/ruff check areno/api/backend/mlx/backend.py areno/api/backend/mlx/lora.py tests/test_adapter_imports_cpu.py tests/test_mlx_training_cpu.py tests/test_mlx_lora_cpu.py tests/test_mlx_lora_e2e.py` — passed.

External hardware validation:

- The existing CUDA/GPU LoRA training path was regression-tested successfully on NVIDIA DGX Spark, as reported by the contributor.

GitHub Actions validation:

- `audit`, `pre-commit`, and `check-pr-title` passed.
- CPU unit tests passed on Python 3.10, 3.11, and 3.12.

## Checklist

- [x] The PR title summarizes the contribution.
- [ ] Linked the related issue in the description (if any). Not applicable: there is no related issue.
- [x] Existing tests pass (`pytest tests/ -k cpu`). GitHub Actions CPU unit tests passed on Python 3.10, 3.11, and 3.12.
- [x] New behavior is covered by tests.
- [x] Described the test commands run and any hardware limitations.
- [x] Public API / CLI changes are additive and backward-compatible (see CONTRIBUTING.md).
