### PR TITLE
feat(experimental): add world-model VLA workflow

### DIFF
--- a/areno/experimental/world_model_vla/__init__.py
+++ b/areno/experimental/world_model_vla/__init__.py
@@ -1,0 +1,15 @@
+"""Experimental world-model-driven post-training for VLA policies."""
+
+from areno.experimental.world_model_vla.assets import create_snapshot_manifest
+from areno.experimental.world_model_vla.backend import RlinfWanBackend, TrainingStage
+from areno.experimental.world_model_vla.config import SlurmResources, WorldModelVLAConfig
+from areno.experimental.world_model_vla.workflow import WorldModelVLAWorkflow
+
+__all__ = [
+    "RlinfWanBackend",
+    "SlurmResources",
+    "TrainingStage",
+    "WorldModelVLAConfig",
+    "WorldModelVLAWorkflow",
+    "create_snapshot_manifest",
+]

--- a/areno/experimental/world_model_vla/__main__.py
+++ b/areno/experimental/world_model_vla/__main__.py
@@ -1,0 +1,6 @@
+"""Run the experimental world-model VLA workflow CLI."""
+
+from areno.experimental.world_model_vla.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/areno/experimental/world_model_vla/assets.py
+++ b/areno/experimental/world_model_vla/assets.py
@@ -1,0 +1,160 @@
+"""Manifest verification for large world-model and VLA snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class AssetVerification:
+    """Result of checking one snapshot against its manifest."""
+
+    name: str
+    verified_bytes: int
+    expected_bytes: int
+    errors: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors and self.verified_bytes == self.expected_bytes
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotManifest:
+    """Summary of a newly written snapshot manifest."""
+
+    path: Path
+    files: int
+    total_bytes: int
+    includes_sha256: bool
+
+
+def create_snapshot_manifest(
+    snapshot: str | Path, *, include_hashes: bool = True, overwrite: bool = False
+) -> SnapshotManifest:
+    """Create a deterministic size and optional SHA-256 snapshot manifest."""
+
+    root = Path(snapshot).expanduser().resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"snapshot directory not found: {root}")
+    destination = root / "snapshot_manifest.json"
+    if destination.exists() and not overwrite:
+        raise FileExistsError(f"snapshot manifest already exists: {destination}")
+
+    files = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file()
+        and destination != path
+        and not path.name.startswith("snapshot_manifest.tmp.")
+        and ".git" not in path.relative_to(root).parts
+    )
+    if not files:
+        raise ValueError(f"snapshot contains no files: {root}")
+    entries: list[dict[str, str | int]] = []
+    total_bytes = 0
+    for path in files:
+        size = path.stat().st_size
+        entry: dict[str, str | int] = {
+            "path": path.relative_to(root).as_posix(),
+            "size": size,
+        }
+        if include_hashes:
+            entry["sha256"] = file_sha256(path)
+        entries.append(entry)
+        total_bytes += size
+
+    temporary = destination.with_suffix(f".tmp.{os.getpid()}")
+    try:
+        temporary.write_text(
+            json.dumps({"schema_version": 1, "files": entries}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return SnapshotManifest(destination, len(entries), total_bytes, include_hashes)
+
+
+def file_sha256(path: Path) -> str:
+    """Return the hexadecimal SHA-256 digest for a file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(16 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_snapshot(snapshot: str | Path, *, check_hashes: bool = False) -> AssetVerification:
+    """Verify declared snapshot files by size and, when requested, hash."""
+
+    root = Path(snapshot)
+    manifest_path = root / "snapshot_manifest.json"
+    if not manifest_path.is_file():
+        return AssetVerification(root.name, 0, 0, (f"missing manifest: {manifest_path}",))
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return AssetVerification(root.name, 0, 0, (f"invalid manifest {manifest_path}: {error}",))
+    if not isinstance(manifest, dict):
+        return AssetVerification(root.name, 0, 0, (f"invalid manifest object: {manifest_path}",))
+    entries = manifest.get("files")
+    if not isinstance(entries, list):
+        return AssetVerification(root.name, 0, 0, (f"invalid manifest files list: {manifest_path}",))
+    if not entries:
+        return AssetVerification(root.name, 0, 0, (f"empty manifest files list: {manifest_path}",))
+
+    verified = 0
+    expected_total = 0
+    errors: list[str] = []
+    seen: set[Path] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or "path" not in entry or "size" not in entry:
+            errors.append(f"invalid manifest entry: {entry!r}")
+            continue
+        relative = Path(str(entry["path"]))
+        if relative.is_absolute() or ".." in relative.parts:
+            errors.append(f"unsafe manifest path: {relative}")
+            continue
+        if relative in seen:
+            errors.append(f"duplicate manifest path: {relative}")
+            continue
+        seen.add(relative)
+        try:
+            expected_size = int(entry["size"])
+        except (TypeError, ValueError):
+            errors.append(f"invalid size for {relative}: {entry['size']!r}")
+            continue
+        if expected_size < 0:
+            errors.append(f"invalid size for {relative}: {expected_size}")
+            continue
+        expected_total += expected_size
+        path = root / relative
+        if not path.is_file():
+            errors.append(f"missing: {path}")
+            continue
+        actual_size = path.stat().st_size
+        if actual_size != expected_size:
+            errors.append(f"size mismatch: {path}: expected {expected_size}, got {actual_size}")
+            continue
+        expected_hash = entry.get("sha256")
+        if check_hashes and expected_hash and file_sha256(path) != str(expected_hash).lower():
+            errors.append(f"sha256 mismatch: {path}")
+            continue
+        verified += expected_size
+    return AssetVerification(root.name, verified, expected_total, tuple(errors))
+
+
+__all__ = [
+    "AssetVerification",
+    "SnapshotManifest",
+    "create_snapshot_manifest",
+    "file_sha256",
+    "verify_snapshot",
+]

--- a/areno/experimental/world_model_vla/backend.py
+++ b/areno/experimental/world_model_vla/backend.py
@@ -1,0 +1,246 @@
+"""RLinf frozen-Wan backend for AReno's world-model VLA workflow."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from areno.experimental.world_model_vla.config import WorldModelVLAConfig
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingStage:
+    """One restartable interval in a long world-model training run."""
+
+    start_step: int
+    end_step: int
+    resume_dir: Path | None
+    checkpoint_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCheck:
+    name: str
+    ok: bool
+    detail: str
+
+
+class RlinfWanBackend:
+    """Build and validate commands for RLinf's Wan LIBERO-Spatial example."""
+
+    training_config_name = "wan_libero_spatial_grpo_openvlaoft"
+    experiment_name = "wan_libero_spatial_train"
+
+    def __init__(self, config: WorldModelVLAConfig) -> None:
+        self.config = config
+
+    @property
+    def training_config_dir(self) -> Path:
+        return self.config.rlinf_root / "examples" / "embodiment" / "config"
+
+    @property
+    def experiment_dir(self) -> Path:
+        return self.config.output_dir / self.experiment_name
+
+    @property
+    def evaluation_dir(self) -> Path:
+        return self.config.output_dir / "evaluation"
+
+    @property
+    def ray_executable(self) -> Path:
+        return self.config.rlinf_python.parent / "ray"
+
+    def stages(self) -> tuple[TrainingStage, ...]:
+        result: list[TrainingStage] = []
+        previous = 0
+        for end_step in self.config.stage_ends:
+            resume_dir = self.checkpoint_dir(previous) if previous else None
+            result.append(
+                TrainingStage(
+                    start_step=previous,
+                    end_step=end_step,
+                    resume_dir=resume_dir,
+                    checkpoint_dir=self.checkpoint_dir(end_step),
+                )
+            )
+            previous = end_step
+        return tuple(result)
+
+    def stage(self, end_step: int) -> TrainingStage:
+        for stage in self.stages():
+            if stage.end_step == end_step:
+                return stage
+        raise ValueError(f"step {end_step} is not a configured stage end")
+
+    def checkpoint_dir(self, step: int) -> Path:
+        return self.experiment_dir / "checkpoints" / f"global_step_{step}"
+
+    def full_weights_path(self, step: int) -> Path:
+        return self.checkpoint_dir(step) / "actor" / "model_state_dict" / "full_weights.pt"
+
+    def latest_full_weights(self) -> Path | None:
+        candidates: list[tuple[int, Path]] = []
+        checkpoint_root = self.experiment_dir / "checkpoints"
+        for path in checkpoint_root.glob("global_step_*/actor/model_state_dict/full_weights.pt"):
+            match = re.fullmatch(r"global_step_(\d+)", path.parents[2].name)
+            if match:
+                candidates.append((int(match.group(1)), path))
+        return max(candidates, default=(0, None), key=lambda item: item[0])[1]
+
+    def environment(self) -> dict[str, str]:
+        cache_root = self.config.cache_root
+        env = dict(os.environ)
+        python_paths = [str(self.config.rlinf_root)]
+        wan_source = self.config.rlinf_python.parent.parent / "wan"
+        if wan_source.is_dir():
+            python_paths.insert(0, str(wan_source))
+        if env.get("PYTHONPATH"):
+            python_paths.append(env["PYTHONPATH"])
+        env.update(
+            {
+                "XDG_CACHE_HOME": str(cache_root),
+                "HF_HOME": str(cache_root / "huggingface"),
+                "MODELSCOPE_CACHE": str(cache_root / "modelscope"),
+                "TORCH_HOME": str(cache_root / "torch"),
+                "MPLCONFIGDIR": str(cache_root / "matplotlib"),
+                "PYTHONPATH": os.pathsep.join(python_paths),
+                "EMBODIED_PATH": str(self.training_config_dir),
+                "REPO_PATH": str(self.config.rlinf_root),
+                "MUJOCO_GL": "egl",
+                "PYOPENGL_PLATFORM": "egl",
+                "ROBOT_PLATFORM": "LIBERO",
+                "LIBERO_TYPE": "standard",
+                "TOKENIZERS_PARALLELISM": "false",
+                "TF_CPP_MIN_LOG_LEVEL": "2",
+                "PYTHONUNBUFFERED": "1",
+            }
+        )
+        env.update(self.config.extra_env)
+        return env
+
+    def prepare_directories(self) -> None:
+        for path in (
+            self.config.output_dir,
+            self.evaluation_dir,
+            self.config.cache_root,
+            self.config.cache_root / "huggingface",
+            self.config.cache_root / "modelscope",
+            self.config.cache_root / "torch",
+            self.config.cache_root / "matplotlib",
+            self.config.output_dir / "logs",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+
+    def build_train_command(self, stage: TrainingStage) -> list[str]:
+        command = [
+            str(self.config.rlinf_python),
+            str(self.config.rlinf_root / "examples" / "embodiment" / "train_embodied_agent.py"),
+            "--config-path",
+            str(self.training_config_dir),
+            "--config-name",
+            self.training_config_name,
+            f"runner.logger.log_path={self.config.output_dir}",
+            f"runner.logger.experiment_name={self.experiment_name}",
+            f"runner.max_steps={stage.end_step}",
+            "runner.val_check_interval=-1",
+            f"runner.save_interval={stage.end_step}",
+            f"env.train.wan_wm_hf_ckpt_path={self.config.world_model_path}",
+            "env.train.video_cfg.save_video=false",
+            f"rollout.model.model_path={self.config.policy_path}",
+            f"actor.model.model_path={self.config.policy_path}",
+            f"actor.micro_batch_size={self.config.actor_micro_batch_size}",
+            "actor.fsdp_config.limit_all_gathers=true",
+            "++weight_syncer.patch.transport_device=cpu",
+        ]
+        if self.config.require_rlinf_compatibility_patchset:
+            command.append("++actor.fsdp_config.sync_module_states=false")
+        if stage.resume_dir is not None:
+            command.append(f"runner.resume_dir={stage.resume_dir}")
+        command.extend(self.config.train_overrides)
+        return command
+
+    def build_eval_command(self, checkpoint: Path | None = None) -> list[str]:
+        checkpoint = checkpoint or self.latest_full_weights()
+        if checkpoint is None:
+            raise FileNotFoundError(f"no full_weights.pt found under {self.experiment_dir / 'checkpoints'}")
+        return [
+            str(self.config.rlinf_python),
+            str(self.config.rlinf_root / "evaluations" / "eval_embodied_agent.py"),
+            "--config-path",
+            str(self.training_config_dir),
+            "--config-name",
+            self.training_config_name,
+            f"runner.logger.log_path={self.evaluation_dir}",
+            "runner.logger.experiment_name=wan_libero_spatial_eval",
+            f"runner.ckpt_path={checkpoint}",
+            f"rollout.model.model_path={self.config.policy_path}",
+            f"env.eval.total_num_envs={self.config.eval_trajectories}",
+            "env.eval.use_fixed_reset_state_ids=true",
+            "env.eval.video_cfg.save_video=false",
+            *self.config.eval_overrides,
+        ]
+
+    def runtime_checks(self) -> tuple[RuntimeCheck, ...]:
+        files = {
+            "RLinf Python": self.config.rlinf_python,
+            "RLinf Ray CLI": self.ray_executable,
+            "training entrypoint": self.config.rlinf_root / "examples" / "embodiment" / "train_embodied_agent.py",
+            "evaluation entrypoint": self.config.rlinf_root / "evaluations" / "eval_embodied_agent.py",
+            "Wan training config": self.training_config_dir / f"{self.training_config_name}.yaml",
+        }
+        directories = {
+            "world model snapshot": self.config.world_model_path,
+            "policy snapshot": self.config.policy_path,
+        }
+        checks = [RuntimeCheck(name, path.is_file(), str(path)) for name, path in files.items()]
+        for name in ("RLinf Python", "RLinf Ray CLI"):
+            path = files[name]
+            checks.append(RuntimeCheck(f"{name} executable", os.access(path, os.X_OK), str(path)))
+        checks.extend(RuntimeCheck(name, path.is_dir(), str(path)) for name, path in directories.items())
+        if self.config.setup_script is not None:
+            checks.append(
+                RuntimeCheck("setup script", self.config.setup_script.is_file(), str(self.config.setup_script))
+            )
+        if self.config.require_rlinf_compatibility_patchset:
+            checks.extend(self._compatibility_checks())
+        return tuple(checks)
+
+    def _compatibility_checks(self) -> list[RuntimeCheck]:
+        requirements = (
+            (
+                "configurable FSDP module synchronization",
+                self.config.rlinf_root / "rlinf" / "hybrid_engines" / "fsdp" / "strategy" / "fsdp.py",
+                '"sync_module_states", True',
+            ),
+            (
+                "OpenVLA SDPA declaration",
+                self.config.rlinf_root
+                / "rlinf"
+                / "models"
+                / "embodiment"
+                / "openvla_oft"
+                / "rlinf"
+                / "openvla_oft_action_model.py",
+                "_supports_sdpa = True",
+            ),
+            (
+                "OpenVLA SDPA selection",
+                self.config.rlinf_root / "rlinf" / "models" / "embodiment" / "openvla_oft" / "rlinf" / "__init__.py",
+                'attn_implementation="sdpa"',
+            ),
+            (
+                "sequential embodied worker initialization",
+                self.config.rlinf_root / "rlinf" / "runners" / "embodied_runner.py",
+                "self.rollout.init_worker().wait()",
+            ),
+        )
+        checks: list[RuntimeCheck] = []
+        for name, path, marker in requirements:
+            text = path.read_text(encoding="utf-8") if path.is_file() else ""
+            checks.append(RuntimeCheck(name, marker in text, f"{path}: requires {marker!r}"))
+        return checks
+
+
+__all__ = ["RlinfWanBackend", "RuntimeCheck", "TrainingStage"]

--- a/areno/experimental/world_model_vla/cli.py
+++ b/areno/experimental/world_model_vla/cli.py
@@ -1,0 +1,121 @@
+"""Internal command-line interface for the world-model VLA workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from areno.experimental.world_model_vla.assets import create_snapshot_manifest
+from areno.experimental.world_model_vla.config import WorldModelVLAConfig
+from areno.experimental.world_model_vla.workflow import WorldModelVLAWorkflow
+
+
+def _add_config_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--config", type=Path, required=True, help="Path to workflow JSON config.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage experimental frozen-world-model VLA post-training.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    manifest = subparsers.add_parser("manifest")
+    manifest.add_argument("--snapshot", type=Path, required=True)
+    manifest.add_argument("--sizes-only", action="store_true", help="Record sizes without computing SHA-256.")
+    manifest.add_argument("--force", action="store_true", help="Replace an existing snapshot manifest.")
+
+    for name in ("plan", "status"):
+        command = subparsers.add_parser(name)
+        _add_config_argument(command)
+
+    verify = subparsers.add_parser("verify")
+    _add_config_argument(verify)
+    verify.add_argument("--sha256", action="store_true", help="Hash files that have manifest checksums.")
+
+    for name in ("submit", "resume"):
+        command = subparsers.add_parser(name)
+        _add_config_argument(command)
+        command.add_argument("--dry-run", action="store_true", help="Print the sbatch command without submitting.")
+        command.add_argument("--force", action="store_true", help="Allow resubmitting an already recorded job.")
+
+    run_stage = subparsers.add_parser("run-stage")
+    _add_config_argument(run_stage)
+    run_stage.add_argument("--end-step", type=int, required=True)
+    run_stage.add_argument("--auto-continue", action="store_true")
+
+    run_eval = subparsers.add_parser("run-eval")
+    _add_config_argument(run_eval)
+    run_eval.add_argument("--checkpoint", type=Path)
+    return parser
+
+
+def _print_json(value: Any) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def _submission_report(job_id: str | None, command: list[str]) -> dict[str, Any]:
+    return {"job_id": job_id, "command": command}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "manifest":
+            manifest = create_snapshot_manifest(
+                args.snapshot,
+                include_hashes=not args.sizes_only,
+                overwrite=args.force,
+            )
+            _print_json(
+                {
+                    "path": str(manifest.path),
+                    "files": manifest.files,
+                    "total_bytes": manifest.total_bytes,
+                    "includes_sha256": manifest.includes_sha256,
+                }
+            )
+            return 0
+        config = WorldModelVLAConfig.from_json(args.config)
+        workflow = WorldModelVLAWorkflow(config)
+
+        if args.command == "plan":
+            _print_json(workflow.plan())
+        elif args.command == "verify":
+            report = workflow.verify(check_hashes=args.sha256)
+            _print_json(report)
+            return 0 if report["ok"] else 1
+        elif args.command == "submit":
+            job_id, command = workflow.submit_initial(dry_run=args.dry_run, force=args.force)
+            _print_json(_submission_report(job_id, command))
+        elif args.command == "resume":
+            job_id, command = workflow.submit_resume(dry_run=args.dry_run, force=args.force)
+            _print_json(_submission_report(job_id, command))
+        elif args.command == "run-stage":
+            current_job_id = os.environ.get("SLURM_JOB_ID")
+            if args.auto_continue and current_job_id is None:
+                raise RuntimeError("--auto-continue requires SLURM_JOB_ID")
+            checkpoint = workflow.run_stage(args.end_step)
+            report: dict[str, Any] = {"checkpoint": str(checkpoint)}
+            if args.auto_continue:
+                successor_id, command = workflow.submit_successor(args.end_step, current_job_id=current_job_id)
+                report["successor"] = _submission_report(successor_id, command)
+            _print_json(report)
+        elif args.command == "run-eval":
+            checkpoint = None if args.checkpoint is None else args.checkpoint.expanduser().resolve()
+            _print_json(workflow.run_evaluation(checkpoint))
+        elif args.command == "status":
+            _print_json(workflow.status())
+        else:
+            parser.error(f"unsupported command: {args.command}")
+    except Exception as error:
+        print(f"error: {type(error).__name__}: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+__all__ = ["build_parser", "main"]

--- a/areno/experimental/world_model_vla/config.py
+++ b/areno/experimental/world_model_vla/config.py
@@ -1,0 +1,186 @@
+"""Configuration for large-scale VLA post-training with a world-model backend."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SlurmResources:
+    """Single-node resources used by the staged world-model workflow."""
+
+    partition: str
+    train_qos: str | None = None
+    eval_qos: str | None = None
+    train_time_limit: str = "3-00:00:00"
+    eval_time_limit: str = "06:00:00"
+    constraint: str | None = None
+    account: str | None = None
+    gpus: int = 8
+    cpus: int = 64
+    memory: str = "500G"
+    node: str | None = None
+    disable_gpu_binding: bool = False
+
+    def validate(self) -> None:
+        if self.gpus < 1:
+            raise ValueError("slurm.gpus must be >= 1")
+        if self.cpus < 1:
+            raise ValueError("slurm.cpus must be >= 1")
+        for name in (
+            "partition",
+            "train_time_limit",
+            "eval_time_limit",
+            "memory",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"slurm.{name} must be non-empty")
+        for name in ("train_qos", "eval_qos", "constraint", "account", "node"):
+            value = getattr(self, name)
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ValueError(f"slurm.{name} must be non-empty when provided")
+
+
+@dataclass(frozen=True, slots=True)
+class WorldModelVLAConfig:
+    """Frozen-Wan/OpenVLA post-training configuration.
+
+    AReno owns the experiment lifecycle while the first backend delegates the
+    three-role distributed execution to a compatible RLinf source checkout.
+    """
+
+    rlinf_root: Path
+    rlinf_python: Path
+    world_model_path: Path
+    policy_path: Path
+    output_dir: Path
+    cache_root: Path
+    slurm: SlurmResources
+    stage_ends: tuple[int, ...] = (2, 20, 40, 60, 80, 100)
+    actor_micro_batch_size: int = 1
+    eval_trajectories: int = 496
+    target_success_rate: float = 0.775
+    ray_object_store_bytes: int = 16 * 1024**3
+    verify_sha256: bool = False
+    gpu_monitor: bool = True
+    gpu_monitor_interval: int = 2
+    require_rlinf_compatibility_patchset: bool = False
+    setup_script: Path | None = None
+    train_overrides: tuple[str, ...] = ()
+    eval_overrides: tuple[str, ...] = ()
+    extra_env: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "rlinf_root",
+            "rlinf_python",
+            "world_model_path",
+            "policy_path",
+            "output_dir",
+            "cache_root",
+        ):
+            path = Path(getattr(self, name)).expanduser()
+            # Keep the virtual-environment path so sibling commands such as
+            # bin/ray and optional sources next to the environment remain discoverable.
+            normalized = Path(os.path.abspath(path)) if name == "rlinf_python" else path.resolve()
+            object.__setattr__(self, name, normalized)
+        if self.setup_script is not None:
+            object.__setattr__(self, "setup_script", Path(self.setup_script).expanduser().resolve())
+        object.__setattr__(self, "stage_ends", tuple(int(step) for step in self.stage_ends))
+        object.__setattr__(self, "train_overrides", tuple(str(value) for value in self.train_overrides))
+        object.__setattr__(self, "eval_overrides", tuple(str(value) for value in self.eval_overrides))
+        object.__setattr__(self, "extra_env", {str(key): str(value) for key, value in self.extra_env.items()})
+        self.validate()
+
+    def validate(self) -> None:
+        self.slurm.validate()
+        previous = 0
+        if not self.stage_ends:
+            raise ValueError("stage_ends must not be empty")
+        for step in self.stage_ends:
+            if step <= previous:
+                raise ValueError("stage_ends must be a strictly increasing sequence of positive integers")
+            previous = step
+        if self.actor_micro_batch_size < 1:
+            raise ValueError("actor_micro_batch_size must be >= 1")
+        if self.eval_trajectories < 1:
+            raise ValueError("eval_trajectories must be >= 1")
+        if self.eval_trajectories % self.slurm.gpus:
+            raise ValueError("eval_trajectories must be divisible by slurm.gpus")
+        if not 0.0 <= self.target_success_rate <= 1.0:
+            raise ValueError("target_success_rate must be between 0 and 1")
+        if self.ray_object_store_bytes < 1:
+            raise ValueError("ray_object_store_bytes must be positive")
+        if self.gpu_monitor_interval < 1:
+            raise ValueError("gpu_monitor_interval must be >= 1")
+        for name in ("verify_sha256", "gpu_monitor", "require_rlinf_compatibility_patchset"):
+            if not isinstance(getattr(self, name), bool):
+                raise ValueError(f"{name} must be a boolean")
+        if any(not value.strip() for value in (*self.train_overrides, *self.eval_overrides)):
+            raise ValueError("Hydra overrides must be non-empty strings")
+        if any(not key.strip() for key in self.extra_env):
+            raise ValueError("extra_env keys must be non-empty strings")
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> WorldModelVLAConfig:
+        source = Path(path).expanduser().resolve()
+        data = json.loads(source.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("world-model VLA config must contain a JSON object")
+        data = dict(data)
+        slurm_data = data.pop("slurm", None)
+        if not isinstance(slurm_data, dict):
+            raise ValueError("slurm must contain a JSON object with at least a partition")
+        for name in (
+            "rlinf_root",
+            "rlinf_python",
+            "world_model_path",
+            "policy_path",
+            "output_dir",
+            "cache_root",
+            "setup_script",
+        ):
+            value = data.get(name)
+            if value is not None and not Path(value).expanduser().is_absolute():
+                data[name] = source.parent / Path(value).expanduser()
+        try:
+            data["slurm"] = SlurmResources(**slurm_data)
+        except TypeError as error:
+            raise ValueError(f"invalid slurm configuration: {error}") from error
+        return cls(**data)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        for name in (
+            "rlinf_root",
+            "rlinf_python",
+            "world_model_path",
+            "policy_path",
+            "output_dir",
+            "cache_root",
+            "setup_script",
+        ):
+            value = data[name]
+            data[name] = None if value is None else str(value)
+        data["stage_ends"] = list(self.stage_ends)
+        data["train_overrides"] = list(self.train_overrides)
+        data["eval_overrides"] = list(self.eval_overrides)
+        return data
+
+    def write_json(self, path: str | Path) -> None:
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_suffix(f"{destination.suffix}.tmp.{os.getpid()}")
+        try:
+            temporary.write_text(json.dumps(self.to_dict(), indent=2) + "\n", encoding="utf-8")
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+__all__ = ["SlurmResources", "WorldModelVLAConfig"]

--- a/areno/experimental/world_model_vla/metrics.py
+++ b/areno/experimental/world_model_vla/metrics.py
@@ -1,0 +1,42 @@
+"""Metric extraction for RLinf rich-text logs."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_STEP = re.compile(r"Global Step:\s*(\d+)\s*/\s*(\d+)")
+_SUCCESS = re.compile(r"(?:^|[\s│])success_once=([-+0-9.eE]+)")
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSnapshot:
+    source: Path
+    success_once: float | None
+    global_step: int | None
+    total_steps: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["source"] = str(self.source)
+        return result
+
+
+def parse_metric_log(path: str | Path) -> MetricSnapshot:
+    source = Path(path)
+    if not source.is_file():
+        return MetricSnapshot(source, None, None, None)
+    text = _ANSI.sub("", source.read_text(encoding="utf-8", errors="replace"))
+    steps = _STEP.findall(text)
+    successes = _SUCCESS.findall(text)
+    global_step = total_steps = None
+    if steps:
+        global_step, total_steps = (int(value) for value in steps[-1])
+    success_once = float(successes[-1]) if successes else None
+    return MetricSnapshot(source, success_once, global_step, total_steps)
+
+
+__all__ = ["MetricSnapshot", "parse_metric_log"]

--- a/areno/experimental/world_model_vla/slurm.py
+++ b/areno/experimental/world_model_vla/slurm.py
@@ -1,0 +1,85 @@
+"""Slurm command construction for staged world-model VLA runs."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from areno.experimental.world_model_vla.config import WorldModelVLAConfig
+
+
+class SlurmLauncher:
+    def __init__(self, config: WorldModelVLAConfig, config_path: str | Path) -> None:
+        self.config = config
+        self.config_path = Path(config_path).resolve()
+        self.worker_script = Path(__file__).with_name("worker.sbatch")
+
+    def build_stage_command(self, end_step: int, *, dependency: str | None = None) -> list[str]:
+        command = self._base_command(mode="train", dependency=dependency)
+        command.extend(self._worker_prefix())
+        command.extend(
+            [
+                "run-stage",
+                "--config",
+                str(self.config_path),
+                "--end-step",
+                str(end_step),
+                "--auto-continue",
+            ]
+        )
+        return command
+
+    def build_eval_command(self, *, dependency: str | None = None) -> list[str]:
+        command = self._base_command(mode="eval", dependency=dependency)
+        command.extend(self._worker_prefix())
+        command.extend(["run-eval", "--config", str(self.config_path)])
+        return command
+
+    def submit(self, command: list[str]) -> str:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        output = "\n".join(value for value in (result.stdout.strip(), result.stderr.strip()) if value)
+        match = re.search(r"(?:Submitted batch job\s+)?(\d+)\s*$", result.stdout.strip())
+        if match is None:
+            raise RuntimeError(f"could not parse Slurm job ID from: {output}")
+        return match.group(1)
+
+    def _base_command(self, *, mode: str, dependency: str | None) -> list[str]:
+        resources = self.config.slurm
+        qos = resources.train_qos if mode == "train" else resources.eval_qos
+        time_limit = resources.train_time_limit if mode == "train" else resources.eval_time_limit
+        logs = self.config.output_dir / "logs"
+        command = [
+            "sbatch",
+            f"--job-name=areno-wm-vla-{mode}",
+            f"--partition={resources.partition}",
+            f"--time={time_limit}",
+            "--nodes=1",
+            "--ntasks=1",
+            f"--cpus-per-task={resources.cpus}",
+            f"--mem={resources.memory}",
+            f"--gres=gpu:{resources.gpus}",
+            f"--output={logs}/%x-%j.out",
+            f"--error={logs}/%x-%j.err",
+        ]
+        if qos:
+            command.append(f"--qos={qos}")
+        if resources.constraint:
+            command.append(f"--constraint={resources.constraint}")
+        if resources.account:
+            command.append(f"--account={resources.account}")
+        if resources.disable_gpu_binding:
+            command.append("--gres-flags=disable-binding")
+        if resources.node:
+            command.append(f"--nodelist={resources.node}")
+        if dependency:
+            command.append(f"--dependency={dependency}")
+        return command
+
+    def _worker_prefix(self) -> list[str]:
+        setup_script = str(self.config.setup_script) if self.config.setup_script is not None else "-"
+        return [str(self.worker_script), sys.executable, setup_script]
+
+
+__all__ = ["SlurmLauncher"]

--- a/areno/experimental/world_model_vla/state.py
+++ b/areno/experimental/world_model_vla/state.py
@@ -1,0 +1,62 @@
+"""Atomic state tracking for restartable world-model VLA workflows."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from areno.experimental.world_model_vla.config import WorldModelVLAConfig
+
+
+class WorkflowStateStore:
+    def __init__(self, output_dir: str | Path) -> None:
+        self.path = Path(output_dir) / "workflow_state.json"
+        self.lock_path = self.path.with_suffix(".lock")
+
+    def initial_state(self, config: WorldModelVLAConfig) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "backend": "rlinf_wan",
+            "stage_ends": list(config.stage_ends),
+            "jobs": {},
+            "stages": {},
+            "evaluation": {"status": "not_submitted"},
+        }
+
+    def ensure(self, config: WorldModelVLAConfig) -> dict[str, Any]:
+        config.output_dir.mkdir(parents=True, exist_ok=True)
+
+        def validate_or_initialize(state: dict[str, Any]) -> dict[str, Any]:
+            if not state:
+                return self.initial_state(config)
+            if state.get("schema_version") != 1 or state.get("backend") != "rlinf_wan":
+                raise RuntimeError(f"incompatible workflow state: {self.path}")
+            if state.get("stage_ends") != list(config.stage_ends):
+                raise RuntimeError(f"configured stage_ends do not match existing workflow state: {self.path}")
+            return state
+
+        return self.update(validate_or_initialize)
+
+    def read(self) -> dict[str, Any]:
+        if not self.path.is_file():
+            return {}
+        return json.loads(self.path.read_text(encoding="utf-8"))
+
+    def update(self, transform: Callable[[dict[str, Any]], dict[str, Any]]) -> dict[str, Any]:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+", encoding="utf-8") as lock:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            state = self.read()
+            updated = transform(state)
+            temporary = self.path.with_suffix(f".tmp.{os.getpid()}")
+            temporary.write_text(json.dumps(updated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            temporary.replace(self.path)
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        return updated
+
+
+__all__ = ["WorkflowStateStore"]

--- a/areno/experimental/world_model_vla/worker.sbatch
+++ b/areno/experimental/world_model_vla/worker.sbatch
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+unset GREP_OPTIONS || true
+
+ARENO_PYTHON=$1
+SETUP_SCRIPT=$2
+shift 2
+
+if [[ "${SETUP_SCRIPT}" != "-" ]]; then
+    source "${SETUP_SCRIPT}"
+fi
+
+ulimit -l unlimited 2>/dev/null || true
+ulimit -n 65535 2>/dev/null || true
+ulimit -u 4125556 2>/dev/null || true
+
+exec "${ARENO_PYTHON}" -m areno.experimental.world_model_vla "$@"

--- a/areno/experimental/world_model_vla/workflow.py
+++ b/areno/experimental/world_model_vla/workflow.py
@@ -1,0 +1,363 @@
+"""Restartable lifecycle for world-model-driven VLA post-training."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from areno.experimental.world_model_vla.assets import AssetVerification, verify_snapshot
+from areno.experimental.world_model_vla.backend import RlinfWanBackend, TrainingStage
+from areno.experimental.world_model_vla.config import WorldModelVLAConfig
+from areno.experimental.world_model_vla.metrics import parse_metric_log
+from areno.experimental.world_model_vla.slurm import SlurmLauncher
+from areno.experimental.world_model_vla.state import WorkflowStateStore
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class WorldModelVLAWorkflow:
+    """Coordinate validation, execution, recovery, and real evaluation."""
+
+    def __init__(self, config: WorldModelVLAConfig) -> None:
+        self.config = config
+        self.backend = RlinfWanBackend(config)
+        self.state = WorkflowStateStore(config.output_dir)
+
+    @property
+    def persisted_config_path(self) -> Path:
+        return self.config.output_dir / "workflow_config.json"
+
+    def plan(self) -> dict[str, Any]:
+        return {
+            "backend": "rlinf_wan",
+            "roles": ["world_model_env", "policy_rollout", "fsdp_actor"],
+            "stages": [
+                {
+                    "start_step": stage.start_step,
+                    "end_step": stage.end_step,
+                    "resume_dir": None if stage.resume_dir is None else str(stage.resume_dir),
+                    "checkpoint_dir": str(stage.checkpoint_dir),
+                }
+                for stage in self.backend.stages()
+            ],
+            "evaluation": {
+                "trajectories": self.config.eval_trajectories,
+                "metric": "eval/success_once",
+                "target": self.config.target_success_rate,
+            },
+        }
+
+    def verify(self, *, check_hashes: bool | None = None) -> dict[str, Any]:
+        hash_check = self.config.verify_sha256 if check_hashes is None else check_hashes
+        runtime = self.backend.runtime_checks()
+        assets = (
+            verify_snapshot(self.config.world_model_path, check_hashes=hash_check),
+            verify_snapshot(self.config.policy_path, check_hashes=hash_check),
+        )
+        errors = [f"{check.name}: {check.detail}" for check in runtime if not check.ok]
+        for result in assets:
+            errors.extend(f"{result.name}: {error}" for error in result.errors)
+        report = {
+            "runtime": [{"name": check.name, "ok": check.ok, "detail": check.detail} for check in runtime],
+            "assets": [self._asset_report(result) for result in assets],
+            "sha256": hash_check,
+            "ok": not errors,
+            "errors": errors,
+        }
+        return report
+
+    def require_valid(self, *, check_hashes: bool | None = None) -> dict[str, Any]:
+        report = self.verify(check_hashes=check_hashes)
+        if not report["ok"]:
+            formatted = "\n".join(f"- {error}" for error in report["errors"])
+            raise RuntimeError(f"world-model VLA preflight failed:\n{formatted}")
+        return report
+
+    def persist_config(self) -> Path:
+        self.backend.prepare_directories()
+        if self.persisted_config_path.is_file():
+            persisted = json.loads(self.persisted_config_path.read_text(encoding="utf-8"))
+            if persisted != self.config.to_dict():
+                raise RuntimeError(f"configuration differs from the existing workflow: {self.persisted_config_path}")
+            return self.persisted_config_path
+        self.config.write_json(self.persisted_config_path)
+        return self.persisted_config_path
+
+    def submit_initial(self, *, dry_run: bool = False, force: bool = False) -> tuple[str | None, list[str]]:
+        self.require_valid()
+        config_path = self.persist_config()
+        self.state.ensure(self.config)
+        launcher = SlurmLauncher(self.config, config_path)
+        command = launcher.build_stage_command(self.config.stage_ends[0])
+        if dry_run:
+            return None, command
+        key = f"train_{self.config.stage_ends[0]}"
+        self._require_submission_available(key, force=force)
+        job_id = launcher.submit(command)
+        self._record_job(key, job_id)
+        return job_id, command
+
+    def submit_resume(self, *, dry_run: bool = False, force: bool = False) -> tuple[str | None, list[str]]:
+        self.require_valid()
+        config_path = self.persist_config()
+        self.state.ensure(self.config)
+        completed = self._completed_stage_prefix()
+        if completed and completed[-1] == self.config.stage_ends[-1]:
+            launcher = SlurmLauncher(self.config, config_path)
+            command = launcher.build_eval_command()
+            key = "eval"
+        else:
+            start_index = self.config.stage_ends.index(completed[-1]) + 1 if completed else 0
+            end_step = self.config.stage_ends[start_index]
+            launcher = SlurmLauncher(self.config, config_path)
+            command = launcher.build_stage_command(end_step)
+            key = f"train_{end_step}"
+        if dry_run:
+            return None, command
+        self._require_submission_available(key, force=force)
+        job_id = launcher.submit(command)
+        self._record_job(key, job_id)
+        return job_id, command
+
+    def run_stage(self, end_step: int) -> Path:
+        self.require_valid()
+        self.backend.prepare_directories()
+        self.state.ensure(self.config)
+        stage = self.backend.stage(end_step)
+        weights = self.backend.full_weights_path(end_step)
+        if weights.is_file():
+            self._record_stage(stage, status="completed", checkpoint=str(weights), reused=True)
+            return weights
+        if stage.resume_dir is not None:
+            resume_weights = self.backend.full_weights_path(stage.start_step)
+            if not stage.resume_dir.is_dir() or not resume_weights.is_file():
+                raise FileNotFoundError(
+                    f"complete resume checkpoint not found: {stage.resume_dir} "
+                    f"(expected actor weights at {resume_weights})"
+                )
+        self._record_stage(stage, status="running")
+        try:
+            self._run_with_ray(self.backend.build_train_command(stage), label=f"train-{end_step}")
+            if not weights.is_file():
+                raise RuntimeError(f"stage {end_step} exited without full actor weights: {weights}")
+            metrics = parse_metric_log(self.config.output_dir / "metrics.log")
+            self._record_stage(stage, status="completed", metrics=metrics.to_dict(), checkpoint=str(weights))
+            return weights
+        except Exception as error:
+            self._record_stage(stage, status="failed", error=f"{type(error).__name__}: {error}")
+            raise
+
+    def run_evaluation(self, checkpoint: Path | None = None) -> dict[str, Any]:
+        self.require_valid()
+        self.backend.prepare_directories()
+        self.state.ensure(self.config)
+        checkpoint = checkpoint or self.backend.latest_full_weights()
+        if checkpoint is None or not checkpoint.is_file():
+            raise FileNotFoundError(f"evaluation checkpoint not found: {checkpoint}")
+        self._record_evaluation(status="running", checkpoint=str(checkpoint))
+        try:
+            self._run_with_ray(self.backend.build_eval_command(checkpoint), label="eval")
+            metrics = parse_metric_log(self.backend.evaluation_dir / "metrics.log")
+            result = metrics.to_dict()
+            result["target_success_rate"] = self.config.target_success_rate
+            result["target_reached"] = (
+                metrics.success_once is not None and metrics.success_once >= self.config.target_success_rate
+            )
+            self._record_evaluation(status="completed", **result)
+            return result
+        except Exception as error:
+            self._record_evaluation(status="failed", error=f"{type(error).__name__}: {error}")
+            raise
+
+    def submit_successor(self, end_step: int, *, current_job_id: str) -> tuple[str, list[str]]:
+        stages = self.backend.stages()
+        index = next((index for index, stage in enumerate(stages) if stage.end_step == end_step), None)
+        if index is None:
+            raise ValueError(f"step {end_step} is not a configured stage end")
+        launcher = SlurmLauncher(self.config, self.persisted_config_path)
+        dependency = f"afterok:{current_job_id}"
+        if index + 1 < len(stages):
+            next_step = stages[index + 1].end_step
+            command = launcher.build_stage_command(next_step, dependency=dependency)
+            key = f"train_{next_step}"
+        else:
+            command = launcher.build_eval_command(dependency=dependency)
+            key = "eval"
+        self._require_submission_available(key, force=False)
+        job_id = launcher.submit(command)
+        self._record_job(key, job_id)
+        return job_id, command
+
+    def status(self) -> dict[str, Any]:
+        state = self.state.read()
+        training = parse_metric_log(self.config.output_dir / "metrics.log")
+        evaluation = parse_metric_log(self.backend.evaluation_dir / "metrics.log")
+        latest_checkpoint = self.backend.latest_full_weights()
+        return {
+            "config": str(self.persisted_config_path),
+            "state": state,
+            "latest_checkpoint": None if latest_checkpoint is None else str(latest_checkpoint),
+            "training_metrics": training.to_dict(),
+            "evaluation_metrics": evaluation.to_dict(),
+        }
+
+    @contextmanager
+    def _ray_session(self, label: str) -> Iterator[dict[str, str]]:
+        env = self.backend.environment()
+        job_id = os.environ.get("SLURM_JOB_ID", str(os.getpid()))
+        local_base = Path(os.environ.get("SLURM_TMPDIR", "/tmp")) / f"areno-wm-vla-{job_id}"
+        ray_dir = local_base / "ray"
+        plasma_dir = local_base / "plasma"
+        ray_dir.mkdir(parents=True, exist_ok=True)
+        plasma_dir.mkdir(parents=True, exist_ok=True)
+        env["RAY_TMPDIR"] = str(ray_dir)
+        env["TMPDIR"] = str(local_base)
+
+        ray = str(self.backend.ray_executable)
+        subprocess.run([ray, "stop", "--force"], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        monitor = self._start_gpu_monitor(label)
+        try:
+            subprocess.run(
+                [
+                    ray,
+                    "start",
+                    "--head",
+                    f"--temp-dir={ray_dir}",
+                    f"--plasma-directory={plasma_dir}",
+                    f"--object-store-memory={self.config.ray_object_store_bytes}",
+                    f"--num-cpus={self.config.slurm.cpus}",
+                    f"--num-gpus={self.config.slurm.gpus}",
+                    "--disable-usage-stats",
+                ],
+                check=True,
+                env=env,
+            )
+            yield env
+        finally:
+            if monitor is not None:
+                monitor.terminate()
+                try:
+                    monitor.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    monitor.kill()
+            subprocess.run([ray, "stop", "--force"], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def _run_with_ray(self, command: list[str], *, label: str) -> None:
+        with self._ray_session(label) as env:
+            subprocess.run(command, cwd=self.config.rlinf_root, env=env, check=True)
+
+    def _start_gpu_monitor(self, label: str) -> subprocess.Popen | None:
+        if not self.config.gpu_monitor or shutil.which("nvidia-smi") is None:
+            return None
+        path = self.config.output_dir / "logs" / f"gpu-memory-{label}-{os.environ.get('SLURM_JOB_ID', os.getpid())}.csv"
+        stream = path.open("w", encoding="utf-8")
+        try:
+            return subprocess.Popen(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=timestamp,index,memory.used,memory.free,utilization.gpu",
+                    "--format=csv,noheader,nounits",
+                    f"--loop={self.config.gpu_monitor_interval}",
+                ],
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+            )
+        finally:
+            stream.close()
+
+    @staticmethod
+    def _asset_report(result: AssetVerification) -> dict[str, Any]:
+        return {
+            "name": result.name,
+            "ok": result.ok,
+            "verified_bytes": result.verified_bytes,
+            "expected_bytes": result.expected_bytes,
+            "errors": list(result.errors),
+        }
+
+    def _record_job(self, key: str, job_id: str) -> None:
+        def transform(state: dict[str, Any]) -> dict[str, Any]:
+            state = state or self.state.initial_state(self.config)
+            state.setdefault("jobs", {})[key] = {
+                "job_id": job_id,
+                "status": "submitted",
+                "submitted_at": _now(),
+            }
+            return state
+
+        self.state.update(transform)
+
+    def _completed_stage_prefix(self) -> list[int]:
+        completed: list[int] = []
+        missing_seen = False
+        noncontiguous: list[int] = []
+        for step in self.config.stage_ends:
+            if self.backend.full_weights_path(step).is_file():
+                if missing_seen:
+                    noncontiguous.append(step)
+                else:
+                    completed.append(step)
+            else:
+                missing_seen = True
+        if noncontiguous:
+            raise RuntimeError(
+                "non-contiguous stage checkpoints found; refusing to resume past a missing stage: "
+                + ", ".join(str(step) for step in noncontiguous)
+            )
+        return completed
+
+    def _require_submission_available(self, key: str, *, force: bool) -> None:
+        existing = self.state.read().get("jobs", {}).get(key)
+        if existing is not None and not force:
+            job_id = existing.get("job_id", "unknown")
+            raise RuntimeError(
+                f"workflow job {key!r} was already submitted as {job_id}; use --force to submit it again"
+            )
+
+    def _record_stage(self, stage: TrainingStage, *, status: str, **values: Any) -> None:
+        def transform(state: dict[str, Any]) -> dict[str, Any]:
+            state = state or self.state.initial_state(self.config)
+            record = state.setdefault("stages", {}).setdefault(str(stage.end_step), {})
+            if status in {"running", "completed"}:
+                record.pop("error", None)
+            record.update(
+                {
+                    "start_step": stage.start_step,
+                    "end_step": stage.end_step,
+                    "status": status,
+                    "updated_at": _now(),
+                    "job_id": os.environ.get("SLURM_JOB_ID"),
+                    **values,
+                }
+            )
+            return state
+
+        self.state.update(transform)
+
+    def _record_evaluation(self, *, status: str, **values: Any) -> None:
+        def transform(state: dict[str, Any]) -> dict[str, Any]:
+            state = state or self.state.initial_state(self.config)
+            state["evaluation"] = {
+                **state.get("evaluation", {}),
+                "status": status,
+                "updated_at": _now(),
+                "job_id": os.environ.get("SLURM_JOB_ID"),
+                **values,
+            }
+            if status in {"running", "completed"}:
+                state["evaluation"].pop("error", None)
+            return state
+
+        self.state.update(transform)
+
+
+__all__ = ["WorldModelVLAWorkflow"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ AReno documentation
    CLI Reference <reference/cli>
    SDK Reference <sdk/trainer>
    Supported Models <models/supported>
+   Experimental APIs <reference/experimental>
 
 .. toctree::
    :hidden:

--- a/docs/reference/experimental.rst
+++ b/docs/reference/experimental.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Experimental and auxiliary APIs
 ===============================
 
@@ -15,3 +13,132 @@ When documenting an experimental surface:
 
 Stable public surfaces should graduate into the relevant Reference page once
 the contract is ready.
+
+World-model VLA post-training
+-----------------------------
+
+Introduced after AReno v0.0.8, this experimental, restartable workflow covers
+the frozen-Wan LIBERO-Spatial experiment. Its stability level is
+**experimental**: configuration and state formats can change before this moves
+into the stable CLI.
+
+This workflow covers the frozen-world-model result documented in RLinf's
+`Wan example <https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/wan.html>`_.
+It does not implement world-model/policy co-evolution from the
+`PACE paper <https://arxiv.org/abs/2602.13977>`_.
+
+The first backend deliberately separates orchestration from model execution:
+
+* AReno validates assets, plans checkpoint stages, submits Slurm jobs, manages
+  Ray, records state and metrics, resumes checkpoints, and launches the final
+  real-environment evaluation.
+* A compatible RLinf checkout runs the three colocated GPU roles: frozen Wan
+  world-model environment, OpenVLA-OFT rollout policy, and FSDP actor.
+* The policy is optimized with the official GRPO example. The world model is
+  frozen. This targets the documented 77.5% LIBERO-Spatial result; it is not
+  the paper's full world-model/policy co-evolution method.
+
+The implementation is owned by
+``areno.experimental.world_model_vla`` and does not modify ``TrainerConfig`` or
+the stable ``areno`` command.
+
+Inputs and compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The workflow requires:
+
+* a source checkout containing RLinf's
+  ``wan_libero_spatial_grpo_openvlaoft`` example;
+* the Python and Ray executables from an environment with RLinf's Wan and
+  OpenVLA-OFT dependencies;
+* local Wan and OpenVLA-OFT snapshots, each with a
+  ``snapshot_manifest.json`` file containing file paths, sizes, and optional
+  SHA-256 values;
+* a Slurm partition capable of allocating the configured number of colocated
+  GPUs; the reference experiment uses eight.
+
+GPU memory must cover the actor's optimizer state after the first update as
+well as the colocated rollout and world-model workers. Validate at least two
+steps on the target accelerator before scheduling a full run; 48 GiB devices
+may be insufficient even with ``actor_micro_batch_size`` set to one.
+
+The default path uses RLinf's published example without requiring source
+patches. A low-memory compatibility patchset was needed for the tested modern
+Transformers environment: configurable FSDP ``sync_module_states``, explicit
+OpenVLA SDPA support and selection, and sequential embodied-worker
+initialization. These changes are not part of a released RLinf version at the
+time of writing. Set ``require_rlinf_compatibility_patchset`` only with a
+checkout containing them; preflight then verifies all four capabilities before
+submission. The backend adds the RLinf checkout and a ``wan/`` source directory
+adjacent to the selected virtual environment to ``PYTHONPATH`` when present.
+
+The integration invokes RLinf through a subprocess and does not add it as an
+AReno runtime dependency. All caches are redirected below ``cache_root``.
+Large model snapshots, checkpoints, logs, and caches should therefore point to
+shared storage rather than a small home filesystem. Download new assets through
+ModelScope when the required repositories are available there; this workflow
+never falls back to another model hub implicitly.
+
+Configuration
+~~~~~~~~~~~~~
+
+Start from ``examples/vla/wan_libero_spatial_world_model.json``. Relative paths
+are resolved against the JSON file, not the shell's working directory. Update
+the paths and Slurm fields when the checkouts, assets, or cluster layout differ.
+``partition`` is required; ``train_qos``, ``eval_qos``, ``constraint``, and
+``account`` are optional because their availability is cluster-specific.
+
+Create manifests after downloading snapshots. SHA-256 is the default; use
+``--sizes-only`` only when integrity is established by another mechanism:
+
+.. code-block:: bash
+
+   areno-world-model-vla manifest --snapshot "$MODEL_ROOT/RLinf-Wan-LIBERO-Spatial"
+   areno-world-model-vla manifest --snapshot "$MODEL_ROOT/Openvla-oft-SFT-libero-spatial-traj1"
+
+The default stage boundaries are ``2, 20, 40, 60, 80, 100``. A successful
+stage saves the complete FSDP actor and optimizer state, then submits only its
+immediate ``afterok`` successor. This avoids exceeding clusters that limit the
+number of queued long-running jobs. The first two-step stage is the minimum GPU
+validation gate; do not treat a one-step run as proof that peak memory is safe.
+
+Use the separate experimental CLI. When running directly from a source
+checkout, the equivalent module entry point is
+``python -m areno.experimental.world_model_vla``:
+
+.. code-block:: bash
+
+   CONFIG=examples/vla/wan_libero_spatial_world_model.json
+
+   areno-world-model-vla plan --config "$CONFIG"
+   areno-world-model-vla verify --config "$CONFIG" --sha256
+   areno-world-model-vla submit --config "$CONFIG" --dry-run
+   areno-world-model-vla submit --config "$CONFIG"
+   areno-world-model-vla status --config "$CONFIG"
+
+``submit`` persists a normalized copy as ``workflow_config.json`` below the
+output directory. Later jobs use that copy, so moving or editing the original
+file cannot change a running chain. Reusing an output directory with a
+different configuration is rejected.
+
+Recovery and evaluation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Each stage is complete only when its
+``actor/model_state_dict/full_weights.pt`` exists. To recover after a failed or
+timed-out job, inspect status and submit the first stage without a complete
+checkpoint:
+
+.. code-block:: bash
+
+   areno-world-model-vla status --config "$CONFIG"
+   areno-world-model-vla resume --config "$CONFIG"
+
+Recorded jobs are not resubmitted by default. Use ``--force`` only after
+confirming that the prior Slurm job is no longer running or queued.
+
+After step 100, the chain evaluates the latest full actor weights over 496
+fixed-reset LIBERO-Spatial trajectories in the real simulator. Training
+``env/success_once`` measures imagined Wan rollouts; only the final evaluation
+``success_once`` can be compared with the 77.5% target. Workflow status and the
+raw RLinf ``metrics.log`` retain both values.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -15,3 +15,4 @@ Reference pages:
 * :doc:`cli`
 * :doc:`/sdk/trainer`
 * :doc:`/models/supported`
+* :doc:`experimental`

--- a/examples/vla/wan_libero_spatial_world_model.json
+++ b/examples/vla/wan_libero_spatial_world_model.json
@@ -1,0 +1,42 @@
+{
+  "rlinf_root": "../../../RLinf",
+  "rlinf_python": "../../../RLinf/.venv/bin/python",
+  "world_model_path": "../../../assets/models/RLinf-Wan-LIBERO-Spatial",
+  "policy_path": "../../../assets/models/Openvla-oft-SFT-libero-spatial-traj1",
+  "output_dir": "../../../runs/areno-wan-libero-spatial",
+  "cache_root": "../../../cache/areno-world-model-vla",
+  "stage_ends": [
+    2,
+    20,
+    40,
+    60,
+    80,
+    100
+  ],
+  "actor_micro_batch_size": 1,
+  "eval_trajectories": 496,
+  "target_success_rate": 0.775,
+  "ray_object_store_bytes": 17179869184,
+  "verify_sha256": false,
+  "gpu_monitor": true,
+  "gpu_monitor_interval": 2,
+  "require_rlinf_compatibility_patchset": false,
+  "setup_script": null,
+  "train_overrides": [],
+  "eval_overrides": [],
+  "extra_env": {},
+  "slurm": {
+    "partition": "gpu",
+    "train_qos": null,
+    "eval_qos": null,
+    "train_time_limit": "3-00:00:00",
+    "eval_time_limit": "06:00:00",
+    "constraint": null,
+    "account": null,
+    "gpus": 8,
+    "cpus": 64,
+    "memory": "500G",
+    "node": null,
+    "disable_gpu_binding": false
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ include = ["areno*"]
 
 [tool.setuptools.package-data]
 "areno.dashboard" = ["dist/*", "dist/assets/*"]
+"areno.experimental.world_model_vla" = ["worker.sbatch"]
 
 [project.scripts]
 areno = "areno.cli.main:main"
+areno-world-model-vla = "areno.experimental.world_model_vla.cli:main"

--- a/tests/test_world_model_vla_cpu.py
+++ b/tests/test_world_model_vla_cpu.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from areno.experimental.world_model_vla.assets import create_snapshot_manifest, verify_snapshot
+from areno.experimental.world_model_vla.backend import RlinfWanBackend
+from areno.experimental.world_model_vla.cli import main
+from areno.experimental.world_model_vla.config import SlurmResources, WorldModelVLAConfig
+from areno.experimental.world_model_vla.metrics import parse_metric_log
+from areno.experimental.world_model_vla.slurm import SlurmLauncher
+from areno.experimental.world_model_vla.state import WorkflowStateStore
+from areno.experimental.world_model_vla.workflow import WorldModelVLAWorkflow
+
+
+def _write_snapshot(path: Path, content: bytes) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "weights.bin").write_bytes(content)
+    (path / "snapshot_manifest.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "path": "weights.bin",
+                        "size": len(content),
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _config(tmp_path: Path, *, stage_ends: tuple[int, ...] = (2, 10)) -> WorldModelVLAConfig:
+    rlinf = tmp_path / "rlinf"
+    python = rlinf / ".venv" / "bin" / "python"
+    ray = python.with_name("ray")
+    (rlinf / ".venv" / "wan").mkdir(parents=True, exist_ok=True)
+    runtime_python = rlinf / "runtime" / "bin" / "python"
+    runtime_python.parent.mkdir(parents=True, exist_ok=True)
+    runtime_python.touch()
+    runtime_python.chmod(0o755)
+    python.parent.mkdir(parents=True, exist_ok=True)
+    if not python.exists():
+        python.symlink_to(runtime_python)
+    train_config = rlinf / "examples" / "embodiment" / "config"
+    compatibility_files = {
+        rlinf / "rlinf" / "hybrid_engines" / "fsdp" / "strategy" / "fsdp.py": 'get("sync_module_states", True)',
+        rlinf
+        / "rlinf"
+        / "models"
+        / "embodiment"
+        / "openvla_oft"
+        / "rlinf"
+        / "openvla_oft_action_model.py": "_supports_sdpa = True",
+        rlinf
+        / "rlinf"
+        / "models"
+        / "embodiment"
+        / "openvla_oft"
+        / "rlinf"
+        / "__init__.py": 'attn_implementation="sdpa"',
+        rlinf / "rlinf" / "runners" / "embodied_runner.py": "self.rollout.init_worker().wait()",
+    }
+    for path, content in compatibility_files.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    for path in (
+        ray,
+        rlinf / "examples" / "embodiment" / "train_embodied_agent.py",
+        rlinf / "evaluations" / "eval_embodied_agent.py",
+        train_config / "wan_libero_spatial_grpo_openvlaoft.yaml",
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    ray.chmod(0o755)
+
+    world_model = tmp_path / "world-model"
+    policy = tmp_path / "policy"
+    _write_snapshot(world_model, b"world")
+    _write_snapshot(policy, b"policy")
+    return WorldModelVLAConfig(
+        rlinf_root=rlinf,
+        rlinf_python=python,
+        world_model_path=world_model,
+        policy_path=policy,
+        output_dir=tmp_path / "output",
+        cache_root=tmp_path / "cache",
+        stage_ends=stage_ends,
+        eval_trajectories=4,
+        require_rlinf_compatibility_patchset=True,
+        slurm=SlurmResources(
+            partition="gpu",
+            train_qos="train",
+            eval_qos="short",
+            constraint="test-gpu",
+            gpus=2,
+            cpus=8,
+            memory="32G",
+        ),
+    )
+
+
+def test_config_validates_stages_and_resolves_json_paths(tmp_path: Path) -> None:
+    config_path = tmp_path / "config" / "workflow.json"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        json.dumps(
+            {
+                "rlinf_root": "../rlinf",
+                "rlinf_python": "../rlinf/python",
+                "world_model_path": "../world",
+                "policy_path": "../policy",
+                "output_dir": "../output",
+                "cache_root": "../cache",
+                "stage_ends": [2, 5],
+                "eval_trajectories": 4,
+                "slurm": {"partition": "gpu", "gpus": 2},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = WorldModelVLAConfig.from_json(config_path)
+
+    assert config.rlinf_root == (tmp_path / "rlinf").resolve()
+    assert config.stage_ends == (2, 5)
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _config(tmp_path / "invalid", stage_ends=(2, 2))
+    with pytest.raises(ValueError, match="divisible"):
+        WorldModelVLAConfig(
+            **{
+                **config.to_dict(),
+                "eval_trajectories": 3,
+                "slurm": SlurmResources(partition="gpu", gpus=2),
+            }
+        )
+    with pytest.raises(ValueError, match="slurm.gpus"):
+        WorldModelVLAConfig(
+            **{
+                **config.to_dict(),
+                "slurm": SlurmResources(partition="gpu", gpus=0),
+            }
+        )
+    with pytest.raises(ValueError, match="require_rlinf_compatibility_patchset"):
+        replace(config, require_rlinf_compatibility_patchset="false")
+
+    config_path.write_text(json.dumps({"output_dir": "output"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="slurm"):
+        WorldModelVLAConfig.from_json(config_path)
+
+
+def test_snapshot_manifest_checks_size_hash_and_unsafe_paths(tmp_path: Path) -> None:
+    snapshot = tmp_path / "snapshot"
+    _write_snapshot(snapshot, b"verified")
+
+    assert verify_snapshot(snapshot, check_hashes=True).ok
+    (snapshot / "weights.bin").write_bytes(b"corrupt!")
+    result = verify_snapshot(snapshot, check_hashes=True)
+    assert not result.ok
+    assert "sha256 mismatch" in result.errors[0]
+
+    (snapshot / "snapshot_manifest.json").write_text(
+        json.dumps({"files": [{"path": "../escape", "size": 1}]}), encoding="utf-8"
+    )
+    result = verify_snapshot(snapshot)
+    assert not result.ok
+    assert "unsafe manifest path" in result.errors[0]
+
+
+def test_snapshot_manifest_creation_hashes_files_and_protects_existing(tmp_path: Path) -> None:
+    snapshot = tmp_path / "downloaded-model"
+    (snapshot / "nested").mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}", encoding="utf-8")
+    (snapshot / "nested" / "weights.bin").write_bytes(b"weights")
+
+    created = create_snapshot_manifest(snapshot)
+
+    assert created.files == 2
+    assert created.total_bytes == 9
+    assert created.includes_sha256
+    assert verify_snapshot(snapshot, check_hashes=True).ok
+    with pytest.raises(FileExistsError, match="already exists"):
+        create_snapshot_manifest(snapshot)
+
+    replaced = create_snapshot_manifest(snapshot, include_hashes=False, overwrite=True)
+    assert not replaced.includes_sha256
+
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(ValueError, match="contains no files"):
+        create_snapshot_manifest(tmp_path / "empty")
+
+
+def test_backend_builds_staged_train_and_real_eval_commands(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    backend = RlinfWanBackend(config)
+    first, second = backend.stages()
+
+    assert first.start_step == 0
+    assert first.resume_dir is None
+    train = backend.build_train_command(second)
+    assert "runner.max_steps=10" in train
+    assert "runner.save_interval=10" in train
+    assert f"runner.resume_dir={backend.checkpoint_dir(2)}" in train
+    assert "actor.micro_batch_size=1" in train
+    assert "actor.fsdp_config.limit_all_gathers=true" in train
+    assert "++actor.fsdp_config.sync_module_states=false" in train
+    assert "++weight_syncer.patch.transport_device=cpu" in train
+
+    stock_backend = RlinfWanBackend(replace(config, require_rlinf_compatibility_patchset=False))
+    assert "++actor.fsdp_config.sync_module_states=false" not in stock_backend.build_train_command(first)
+
+    checkpoint_2 = backend.full_weights_path(2)
+    checkpoint_10 = backend.full_weights_path(10)
+    checkpoint_2.parent.mkdir(parents=True)
+    checkpoint_2.touch()
+    checkpoint_10.parent.mkdir(parents=True)
+    checkpoint_10.touch()
+
+    assert backend.latest_full_weights() == checkpoint_10
+    evaluation = backend.build_eval_command()
+    assert f"runner.ckpt_path={checkpoint_10}" in evaluation
+    assert "env.eval.total_num_envs=4" in evaluation
+    assert "env.eval.use_fixed_reset_state_ids=true" in evaluation
+
+
+def test_runtime_compatibility_and_cache_environment(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    backend = RlinfWanBackend(config)
+
+    assert all(check.ok for check in backend.runtime_checks())
+    assert config.rlinf_python == config.rlinf_root / ".venv" / "bin" / "python"
+    assert backend.ray_executable == config.rlinf_root / ".venv" / "bin" / "ray"
+    environment = backend.environment()
+    assert environment["HF_HOME"].startswith(str(config.cache_root))
+    assert environment["MODELSCOPE_CACHE"].startswith(str(config.cache_root))
+    assert environment["TORCH_HOME"].startswith(str(config.cache_root))
+    assert environment["PYTHONPATH"].split(os.pathsep)[:2] == [
+        str(config.rlinf_python.parent.parent / "wan"),
+        str(config.rlinf_root),
+    ]
+
+    patched_file = config.rlinf_root / "rlinf" / "runners" / "embodied_runner.py"
+    patched_file.unlink()
+    assert not all(check.ok for check in backend.runtime_checks())
+    stock_checks = RlinfWanBackend(replace(config, require_rlinf_compatibility_patchset=False)).runtime_checks()
+    assert all(check.ok for check in stock_checks)
+
+
+def test_metric_parser_uses_latest_rich_table_values(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.log"
+    metrics.write_text(
+        "\x1b[32m│ Global Step: 1/10 │\x1b[0m\n│success_once=0.125 │\n│ Global Step: 2/10 │\n│success_once=7.75e-1 │\n",
+        encoding="utf-8",
+    )
+
+    parsed = parse_metric_log(metrics)
+
+    assert parsed.global_step == 2
+    assert parsed.total_steps == 10
+    assert parsed.success_once == pytest.approx(0.775)
+
+
+def test_slurm_commands_include_resources_dependency_and_worker(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config_path = tmp_path / "workflow.json"
+    launcher = SlurmLauncher(config, config_path)
+
+    stage = launcher.build_stage_command(2, dependency="afterok:123")
+    evaluation = launcher.build_eval_command(dependency="afterok:456")
+
+    assert stage[0] == "sbatch"
+    assert "--gres=gpu:2" in stage
+    assert "--dependency=afterok:123" in stage
+    assert str(launcher.worker_script) in stage
+    assert sys.executable in stage
+    assert stage[-5:] == ["--config", str(config_path.resolve()), "--end-step", "2", "--auto-continue"]
+    assert "--qos=short" in evaluation
+    assert "--dependency=afterok:456" in evaluation
+    assert evaluation[-3:] == ["run-eval", "--config", str(config_path.resolve())]
+
+    portable = replace(
+        config,
+        slurm=SlurmResources(partition="gpu", gpus=2, cpus=8, memory="32G"),
+    )
+    portable_command = SlurmLauncher(portable, config_path).build_stage_command(2)
+    assert not any(value.startswith("--qos=") for value in portable_command)
+    assert not any(value.startswith("--constraint=") for value in portable_command)
+    assert not any(value.startswith("--account=") for value in portable_command)
+
+
+def test_state_store_is_atomic_and_rejects_stage_plan_changes(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    state = WorkflowStateStore(config.output_dir)
+
+    initialized = state.ensure(config)
+    updated = state.update(lambda value: {**value, "marker": 1})
+
+    assert initialized["stage_ends"] == [2, 10]
+    assert updated["marker"] == 1
+    assert json.loads(state.path.read_text(encoding="utf-8"))["marker"] == 1
+    changed = _config(tmp_path, stage_ends=(2, 20))
+    with pytest.raises(RuntimeError, match="stage_ends"):
+        state.ensure(changed)
+
+
+def test_workflow_verifies_assets_and_prevents_duplicate_submit(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    workflow = WorldModelVLAWorkflow(config)
+
+    assert workflow.verify(check_hashes=True)["ok"]
+    with patch.object(SlurmLauncher, "submit", return_value="123"):
+        job_id, command = workflow.submit_initial()
+    assert job_id == "123"
+    assert command[-1] == "--auto-continue"
+
+    with (
+        patch.object(SlurmLauncher, "submit", return_value="456"),
+        pytest.raises(RuntimeError, match="already submitted"),
+    ):
+        workflow.submit_initial()
+
+
+def test_completed_stage_is_reused_without_starting_ray(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    workflow = WorldModelVLAWorkflow(config)
+    checkpoint = workflow.backend.full_weights_path(2)
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.touch()
+
+    with patch.object(workflow, "_run_with_ray") as run:
+        assert workflow.run_stage(2) == checkpoint
+
+    run.assert_not_called()
+    assert workflow.state.read()["stages"]["2"]["reused"] is True
+
+
+def test_resume_rejects_noncontiguous_or_incomplete_checkpoints(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    workflow = WorldModelVLAWorkflow(config)
+
+    later_weights = workflow.backend.full_weights_path(10)
+    later_weights.parent.mkdir(parents=True)
+    later_weights.touch()
+    with pytest.raises(RuntimeError, match="non-contiguous"):
+        workflow.submit_resume(dry_run=True)
+
+    later_weights.unlink()
+    workflow.backend.checkpoint_dir(2).mkdir(parents=True, exist_ok=True)
+    with pytest.raises(FileNotFoundError, match="complete resume checkpoint"):
+        workflow.run_stage(10)
+
+
+def test_internal_cli_plan_and_auto_continue_guard(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    config = _config(tmp_path)
+    config_path = tmp_path / "workflow.json"
+    config.write_json(config_path)
+
+    assert main(["plan", "--config", str(config_path)]) == 0
+    assert json.loads(capsys.readouterr().out)["roles"] == [
+        "world_model_env",
+        "policy_rollout",
+        "fsdp_actor",
+    ]
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert (
+            main(
+                [
+                    "run-stage",
+                    "--config",
+                    str(config_path),
+                    "--end-step",
+                    "2",
+                    "--auto-continue",
+                ]
+            )
+            == 1
+        )
+    assert "requires SLURM_JOB_ID" in capsys.readouterr().err
+
+
+def test_internal_cli_creates_snapshot_manifest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "weights.bin").write_bytes(b"weights")
+
+    assert main(["manifest", "--snapshot", str(snapshot)]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["files"] == 1
+    assert report["includes_sha256"] is True
+    assert Path(report["path"]).is_file()


### PR DESCRIPTION
 ## What does this PR do?

  Adds an experimental frozen-world-model VLA post-training workflow.

  AReno manages configuration validation, model manifests, Slurm staging,
  workflow recovery, Ray lifecycle, checkpoint selection, metrics, and
  evaluation. RLinf remains responsible for the Wan environment, OpenVLA
  rollouts, and FSDP actor execution.

  The implementation is isolated under
  `areno.experimental.world_model_vla` and does not modify the stable
  Trainer APIs.

  ## Related issue

  None.

  ## Type of change

  - [x] ✨ New feature

  ## How was it tested?

  - `pre-commit run --all-files`
  - 13 focused CPU tests
  - CLI planning and command generation
  - clean wheel build and installed entry-point verification
  - packaged `worker.sbatch` verification
  - full SHA-256 verification of the Wan and OpenVLA model snapshots

  Full CPU suite: 733 passed, 8 skipped, 9 unrelated failures:
  7 require the optional `fla` dependency and 2 are existing MoE fixture failures.

  GPU smoke test on 8 x L40S completed training step 1
  (`env/success_once = 0.03125`). Step 2 reached CUDA OOM while unsharding
  the vision backbone. The published 77.5% result has therefore not yet
  been reproduced.

  ## Checklist

  - [x] The PR title summarizes the contribution.
  - [x] New behavior is covered by tests.
  - [x] Described the test commands run and hardware limitations.
  - [x] Public API / CLI changes are additive and backward-compatible.